### PR TITLE
fix(fw): #51 self-healing gateway re-election — silent-until-relock + WiFi-strength takeover

### DIFF
--- a/ha/dashboard/build_control_room.py
+++ b/ha/dashboard/build_control_room.py
@@ -80,9 +80,16 @@ def node_card(nid, meta, present):
     row(f"sensor.smol_{nid}_config","default screen (commanded)","mdi:monitor-dashboard")   # retained default_screen; works now
     row(f"sensor.smol_{nid}_screen","current screen (live)","mdi:monitor-eye")              # ACTUAL screen incl. manual BOOT-menu nav; 'unknown' until #50 fw, then auto-populates
     row(f"sensor.smol_{nid}_status","activity","mdi:pulse")
-    row(f"sensor.smol_{nid}_rssi","bond (RSSI)","mdi:signal")
-    row(f"sensor.smol_{nid}_rssi_band","bond band","mdi:signal-cellular-2")
-    row(f"binary_sensor.smol_{nid}_resync","re-syncing","mdi:sync")
+    if has_rssi:                                                    # LEAF — mesh bond to the gateway
+        row(f"sensor.smol_{nid}_rssi","bond (RSSI)","mdi:signal")
+        row(f"sensor.smol_{nid}_rssi_band","bond band","mdi:signal-cellular-2")
+        row(f"binary_sensor.smol_{nid}_resync","re-syncing","mdi:sync")
+    else:                                                           # GATEWAY anchor — WiFi-uplinked, no mesh bond/resync → show what it OWNS/serves (fills Dominion's gap, no fake rows)
+        sec("gateway anchor · WiFi uplink")
+        if "sensor.smol_mesh_channel" in present:
+            ents.append({"type":"attribute","entity":"sensor.smol_mesh_channel","attribute":"channel","name":"mesh channel (owned)","icon":"mdi:wifi"})
+            ents.append({"type":"attribute","entity":"sensor.smol_mesh_channel","attribute":"seq","name":"mesh seq (advancing)","icon":"mdi:counter"})
+        row(f"sensor.smol_{nid}_peers","peers / roster","mdi:lan")
     sec("firmware")
     fw=next((e for e in present if re.match(rf"update\.smol_{nid}_.*_firmware$",e)),None)
     if fw: ents.append({"entity":fw,"name":"firmware (version + update)"})

--- a/ha/dashboard/build_control_room.py
+++ b/ha/dashboard/build_control_room.py
@@ -27,15 +27,22 @@ def node_card(nid, meta, present):
     # RSSI in EVERY node: leaves show dBm; gateway (no mesh-RSSI to itself) shows WiFi uplink
     has_rssi=f"sensor.smol_{I}_rssi" in present
     rssi_pip=(" · {{ states('sensor.smol_"+I+"_rssi') if states('sensor.smol_"+I+"_rssi') not in na else '—' }} dBm") if has_rssi else " · WiFi"
-    hdr=("{% set on="+on+" %}{% set t=states('sensor.smol_"+I+"_temp') %}{% set v=states('sensor.smol_"+I+"_voltage') %}"
-         "{% set na="+NAJ+" %}id"+I+" · "+meta["role"]+" · {{ '🟢 online' if on else '🔴 offline' }}"
+    # LIVE gateway = this node == MC owner attr (moves on #51 takeover). Indicators are template-driven, not build-time.
+    gw="(state_attr('sensor.smol_mesh_channel','owner')|string == '"+I+"')"
+    hdr=("{% set on="+on+" %}{% set gw="+gw+" %}{% set t=states('sensor.smol_"+I+"_temp') %}{% set v=states('sensor.smol_"+I+"_voltage') %}"
+         "{% set na="+NAJ+" %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id"+I+""
          " · {{ t if t not in na else '—' }}° · {{ v if v not in na else '—' }}V"+rssi_pip)
     header={"type":"custom:mushroom-template-card","primary":meta["name"],"secondary":hdr,
-            "icon":"mdi:crown" if gate else "mdi:chip",
-            "icon_color":"amber" if gate else ("{{ 'green' if "+on+" else 'red' }}"),
-            "badge_icon":"mdi:crown" if gate else "mdi:leaf",
-            "badge_color":"amber" if gate else ("{{ 'green' if "+on+" else 'red' }}"),
-            "card_mod":{"style":{".":accent_top(ACCENT if gate else PHOS)+"ha-card{border-radius:10px 10px 0 0;border-bottom:none}",
+            "icon":"{% if "+gw+" %}mdi:crown{% else %}mdi:chip{% endif %}",
+            "icon_color":"{% if "+gw+" %}amber{% elif "+on+" %}green{% else %}red{% endif %}",
+            "badge_icon":"{% if "+gw+" %}mdi:crown{% elif "+on+" %}mdi:leaf-circle{% else %}mdi:lan-disconnect{% endif %}",
+            "badge_color":"{% if "+gw+" %}amber{% elif "+on+" %}green{% else %}red{% endif %}",
+            "card_mod":{"style":{
+                ".":("ha-card{border-radius:10px 10px 0 0;border-bottom:none;position:relative;overflow:hidden;"
+                     "border:2px solid {% if "+gw+" %}var(--accent-color){% elif "+on+" %}var(--ha-card-border-color){% else %}#ff6b6b{% endif %};"
+                     "opacity:{% if "+on+" %}1{% else %}.6{% endif %};"
+                     "box-shadow:{% if "+gw+" %}0 0 18px -3px var(--accent-color){% else %}none{% endif %}}"
+                     "ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,{% if "+gw+" %}var(--accent-color){% else %}var(--primary-color){% endif %},transparent);opacity:.6}"),
                 "mushroom-state-info$":".primary{font-family:"+VT+";font-size:26px;line-height:.9}.secondary{font-size:11px}"}}}
     # mini-OLED shows the SCREEN's content (like the board): Grid→grid W, Batt→HV SOC, Clock→time, else temp.
     # Prefers the LIVE actual screen (sensor._screen, incl. manual nav) once #50 ships; falls to commanded while unknown.
@@ -47,7 +54,7 @@ def node_card(nid, meta, present):
     oled_s=("{% set scr="+scr+" %}{{ scr|upper }} · {% if not "+on+" %}no link{% elif scr=='Grid' %}shared glass{% elif scr=='Batt' %}HV pack{% elif scr=='Clock' %}mesh time{% else %}live °F{% endif %}")
     oled={"type":"custom:mushroom-template-card","primary":oled_p,"secondary":oled_s,"icon":"mdi:blank",
           "card_mod":{"style":{".":("ha-card{background:#020402;border:1px solid var(--ha-card-border-color);border-radius:0;"
-                "box-shadow:inset 0 0 12px rgba(0,0,0,.9);position:relative;overflow:hidden;margin-top:-2px}mushroom-shape-icon{display:none}"),
+                "box-shadow:inset 0 0 12px rgba(0,0,0,.9);position:relative;overflow:hidden;margin-top:-2px;opacity:{% if "+on+" %}1{% else %}.6{% endif %}}mushroom-shape-icon{display:none}"),
                 "mushroom-state-info$":(".primary{font-family:"+VT+";font-size:44px;line-height:.8;color:var(--primary-color);"
                 "text-shadow:0 0 7px rgba(91,255,154,.55)}.secondary{color:var(--primary-color);opacity:.7;font-size:10px}")}}}
     ents=[]
@@ -82,7 +89,7 @@ def node_card(nid, meta, present):
     inst=f"input_button.smol_ota_install_{nid}"
     if inst in present: ents.append({"entity":inst,"name":"Install staged (canary)" if gate else "Install (when this leads)","icon":"mdi:rocket-launch"})
     ctrl={"type":"entities","show_header_toggle":False,"entities":ents,
-          "card_mod":{"style":"ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px}"}}
+          "card_mod":{"style":"ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px;opacity:{% if "+on+" %}1{% else %}.6{% endif %}}"}}
     return {"type":"vertical-stack","view_layout":{"grid-column":"span 4"},"cards":[header,oled,ctrl]}
 
 def legend_card(nodes, present):

--- a/ha/dashboard/build_control_room.py
+++ b/ha/dashboard/build_control_room.py
@@ -24,11 +24,10 @@ def accent_top(c): return ("ha-card{position:relative;overflow:hidden}ha-card:be
 # ---------- node box = mushroom header + mushroom OLED + entities; span-4 in the VIEW grid ----------
 def node_card(nid, meta, present):
     gate=meta["gate"]; I=str(nid); on=f"is_state('binary_sensor.smol_{I}_online','on')"
-    # RSSI in EVERY node: leaves show dBm; gateway (no mesh-RSSI to itself) shows WiFi uplink
-    has_rssi=f"sensor.smol_{I}_rssi" in present
-    rssi_pip=(" · {{ states('sensor.smol_"+I+"_rssi') if states('sensor.smol_"+I+"_rssi') not in na else '—' }} dBm") if has_rssi else " · WiFi"
-    # LIVE gateway = this node == MC owner attr (moves on #51 takeover). Indicators are template-driven, not build-time.
-    gw="(state_attr('sensor.smol_mesh_channel','owner')|string == '"+I+"')"
+    # RSSI pip LIVE (re-evaluates on takeover): gateway → WiFi (no self mesh-rssi); leaf → dBm
+    rssi_pip=(" · {% if gw %}WiFi{% else %}{{ states('sensor.smol_"+I+"_rssi') if states('sensor.smol_"+I+"_rssi') not in na else '—' }} dBm{% endif %}")
+    # LIVE gateway signal = peers-state 'gateway' (an entity STATE → works in mushroom templates AND legacy conditional-card conditions).
+    gw="is_state('sensor.smol_"+I+"_peers','gateway')"
     hdr=("{% set on="+on+" %}{% set gw="+gw+" %}{% set t=states('sensor.smol_"+I+"_temp') %}{% set v=states('sensor.smol_"+I+"_voltage') %}"
          "{% set na="+NAJ+" %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id"+I+""
          " · {{ t if t not in na else '—' }}° · {{ v if v not in na else '—' }}V"+rssi_pip)
@@ -57,47 +56,56 @@ def node_card(nid, meta, present):
                 "box-shadow:inset 0 0 12px rgba(0,0,0,.9);position:relative;overflow:hidden;margin-top:-2px;opacity:{% if "+on+" %}1{% else %}.6{% endif %}}mushroom-shape-icon{display:none}"),
                 "mushroom-state-info$":(".primary{font-family:"+VT+";font-size:44px;line-height:.8;color:var(--primary-color);"
                 "text-shadow:0 0 7px rgba(91,255,154,.55)}.secondary{color:var(--primary-color);opacity:.7;font-size:10px}")}}}
-    ents=[]
-    def sec(l): ents.append({"type":"section","label":l})
-    def row(eid,nm,icon=None):
+    OP="opacity:{% if "+on+" %}1{% else %}.6{% endif %}"
+    def prow(lst,eid,nm,icon=None):
         if eid in present:
             r={"entity":eid,"name":nm}
             if icon: r["icon"]=icon
-            ents.append(r)
-    sec("screen & mode")
-    row(f"input_select.smol_{nid}_screen","default screen")
-    row(f"input_select.smol_{nid}_page","page")
-    row(f"input_select.smol_{nid}_led","LED (status / on / off)","mdi:led-on")   # #48
-    row(f"input_button.smol_{nid}_apply",f"Apply → id{nid}","mdi:send")
-    row(f"input_button.smol_{nid}_reset","Reset to board default","mdi:backup-restore")
-    rb=f"input_button.smol_{nid}_reboot"                                          # #52 remote reboot — tap-guarded (destructive)
+            lst.append(r)
+    # ---- ctrl_top: screen & mode + readback-always (config/screen/activity) ----
+    top=[{"type":"section","label":"screen & mode"}]
+    prow(top,f"input_select.smol_{nid}_screen","default screen")
+    prow(top,f"input_select.smol_{nid}_page","page")
+    prow(top,f"input_select.smol_{nid}_led","LED (status / on / off)","mdi:led-on")            # #48
+    prow(top,f"input_button.smol_{nid}_apply",f"Apply → id{nid}","mdi:send")
+    prow(top,f"input_button.smol_{nid}_reset","Reset to board default","mdi:backup-restore")
+    rb=f"input_button.smol_{nid}_reboot"                                                       # #52 tap-guarded reboot
     if rb in present:
-        ents.append({"entity":rb,"name":"Reboot node","icon":"mdi:restart-alert",
+        top.append({"entity":rb,"name":"Reboot node","icon":"mdi:restart-alert",
             "tap_action":{"action":"perform-action","perform_action":"input_button.press","target":{"entity_id":rb},
                           "confirmation":{"text":f"Reboot id{nid} ({meta['name']})? It drops off the mesh briefly."}}})
-    sec("readback")
-    # TWO rows, ALWAYS both (JP: see commanded-vs-actual DRIFT — no fallback):
-    row(f"sensor.smol_{nid}_config","default screen (commanded)","mdi:monitor-dashboard")   # retained default_screen; works now
-    row(f"sensor.smol_{nid}_screen","current screen (live)","mdi:monitor-eye")              # ACTUAL screen incl. manual BOOT-menu nav; 'unknown' until #50 fw, then auto-populates
-    row(f"sensor.smol_{nid}_status","activity","mdi:pulse")
-    if has_rssi:                                                    # LEAF — mesh bond to the gateway
-        row(f"sensor.smol_{nid}_rssi","bond (RSSI)","mdi:signal")
-        row(f"sensor.smol_{nid}_rssi_band","bond band","mdi:signal-cellular-2")
-        row(f"binary_sensor.smol_{nid}_resync","re-syncing","mdi:sync")
-    else:                                                           # GATEWAY anchor — WiFi-uplinked, no mesh bond/resync → show what it OWNS/serves (fills Dominion's gap, no fake rows)
-        sec("gateway anchor · WiFi uplink")
-        if "sensor.smol_mesh_channel" in present:
-            ents.append({"type":"attribute","entity":"sensor.smol_mesh_channel","attribute":"channel","name":"mesh channel (owned)","icon":"mdi:wifi"})
-            ents.append({"type":"attribute","entity":"sensor.smol_mesh_channel","attribute":"seq","name":"mesh seq (advancing)","icon":"mdi:counter"})
-        row(f"sensor.smol_{nid}_peers","peers / roster","mdi:lan")
-    sec("firmware")
+    top.append({"type":"section","label":"readback"})
+    prow(top,f"sensor.smol_{nid}_config","default screen (commanded)","mdi:monitor-dashboard") # commanded (works now)
+    prow(top,f"sensor.smol_{nid}_screen","current screen (live)","mdi:monitor-eye")            # actual incl. manual nav; 'unknown' until #50
+    prow(top,f"sensor.smol_{nid}_status","activity","mdi:pulse")
+    ctrl_top={"type":"entities","show_header_toggle":False,"entities":top,
+              "card_mod":{"style":"ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-2px;"+OP+"}"}}
+    # ---- LIVE role-conditional groups: box RESTRUCTURES on #51 takeover (keyed to owner attr).
+    #      Rows added unconditionally; the hidden conditional also hides its (role-absent) entities → no 'entity not found'. ----
+    JOIN="ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;"+OP+"}"
+    cond_leaf={"type":"conditional",                                                           # shown when this node is NOT the gateway (leaf/offline) — legacy state condition (HA-supported)
+        "conditions":[{"entity":f"sensor.smol_{nid}_peers","state_not":"gateway"}],
+        "card":{"type":"entities","show_header_toggle":False,"card_mod":{"style":JOIN},"entities":[
+            {"type":"section","label":"mesh bond (leaf)"},
+            {"entity":f"sensor.smol_{nid}_rssi","name":"bond (RSSI)","icon":"mdi:signal"},
+            {"entity":f"sensor.smol_{nid}_rssi_band","name":"bond band","icon":"mdi:signal-cellular-2"},
+            {"entity":f"binary_sensor.smol_{nid}_resync","name":"re-syncing","icon":"mdi:sync"}]}}
+    cond_gw={"type":"conditional",                                                             # shown when this node IS the gateway — legacy state condition (HA-supported)
+        "conditions":[{"entity":f"sensor.smol_{nid}_peers","state":"gateway"}],
+        "card":{"type":"entities","show_header_toggle":False,"card_mod":{"style":JOIN},"entities":[
+            {"type":"section","label":"gateway anchor · WiFi uplink"},
+            {"type":"attribute","entity":"sensor.smol_mesh_channel","attribute":"channel","name":"mesh channel (owned)","icon":"mdi:wifi"},
+            {"type":"attribute","entity":"sensor.smol_mesh_channel","attribute":"seq","name":"mesh seq (advancing)","icon":"mdi:counter"},
+            {"entity":f"sensor.smol_{nid}_peers","name":"peers / roster","icon":"mdi:lan"}]}}
+    # ---- ctrl_bottom: firmware + install (always last → rounded bottom) ----
+    bot=[{"type":"section","label":"firmware"}]
     fw=next((e for e in present if re.match(rf"update\.smol_{nid}_.*_firmware$",e)),None)
-    if fw: ents.append({"entity":fw,"name":"firmware (version + update)"})
+    if fw: bot.append({"entity":fw,"name":"firmware (version + update)"})
     inst=f"input_button.smol_ota_install_{nid}"
-    if inst in present: ents.append({"entity":inst,"name":"Install staged (canary)" if gate else "Install (when this leads)","icon":"mdi:rocket-launch"})
-    ctrl={"type":"entities","show_header_toggle":False,"entities":ents,
-          "card_mod":{"style":"ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px;opacity:{% if "+on+" %}1{% else %}.6{% endif %}}"}}
-    return {"type":"vertical-stack","view_layout":{"grid-column":"span 4"},"cards":[header,oled,ctrl]}
+    if inst in present: bot.append({"entity":inst,"name":"Install staged (gateway consumes)","icon":"mdi:rocket-launch"})
+    ctrl_bottom={"type":"entities","show_header_toggle":False,"entities":bot,
+                 "card_mod":{"style":"ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px;"+OP+"}"}}
+    return {"type":"vertical-stack","view_layout":{"grid-column":"span 4"},"cards":[header,oled,ctrl_top,cond_leaf,cond_gw,ctrl_bottom]}
 
 def legend_card(nodes, present):
     ents=[{"type":"section","label":"the mesh"}]

--- a/ha/dashboard/smol-control-scaffold.yaml
+++ b/ha/dashboard/smol-control-scaffold.yaml
@@ -30,11 +30,13 @@ cards:
       {% set tot = states.binary_sensor | map(attribute='entity_id') | select('search','^binary_sensor\.smol_\d+_online$') | list | count %}
       {% set owner = state_attr('sensor.smol_mesh_channel','owner') %}
       {% set ch = states('sensor.smol_mesh_channel') %}
+      {% set seq = state_attr('sensor.smol_mesh_channel','seq') %}
+      {% set re = is_state('binary_sensor.smol_mesh_reelecting','on') %}
       {% set bt = state_attr('update.smol_7_dominion_firmware','title') or ('build ' ~ (state_attr('update.smol_7_dominion_firmware','installed_version') or '—')) %}
       # control room
       **smol · esp-now mesh · home assistant**
 
-      🟢 **MESH LIVE** · ch **{{ ch if ch not in na else '—' }}**{% if is_state('binary_sensor.smol_mesh_reelecting','on') %} · re-electing…{% endif %} · the Seat **id{{ owner if owner not in na else '7' }} · Draconic Dominion** · **{{ on }}/{{ tot }}** sigils lit
+      {% if re %}⚠️ **RE-ELECTING** — mesh choosing a new gateway…{% else %}🟢 **MESH LIVE** · gateway **id{{ owner if owner not in na else '?' }}** · seq **{{ seq if seq not in na else '—' }}** (advancing = alive) · ch {{ ch if ch not in na else '—' }}{% endif %} · **{{ on }}/{{ tot }}** sigils lit
 
       build **{{ bt }}** · last sync **{{ relative_time(states.sensor.smol_7_status.last_changed) if states.sensor.smol_7_status else '—' }}** ago · retained MQTT, applies on next burst
     card_mod:

--- a/ha/dashboard/smol_control_room.yaml
+++ b/ha/dashboard/smol_control_room.yaml
@@ -106,17 +106,17 @@ cards:
     icon: mdi:sleep
   - type: section
     label: sigils & bonds (bond=RSSI · adrift when ch≠mesh)
-  - entity: binary_sensor.smol_7_online
-    name: ♛ Draconic Dominion · id7
-  - entity: sensor.smol_7_peers
-    name: '   ↳ peers'
-    icon: mdi:lan
   - entity: binary_sensor.smol_8_online
-    name: Eldritch Nexus · id8
+    name: ♛ Eldritch Nexus · id8
   - entity: sensor.smol_8_rssi
     name: '   ↳ bond (RSSI)'
     icon: mdi:signal
   - entity: sensor.smol_8_peers
+    name: '   ↳ peers'
+    icon: mdi:lan
+  - entity: binary_sensor.smol_7_online
+    name: Draconic Dominion · id7
+  - entity: sensor.smol_7_peers
     name: '   ↳ peers'
     icon: mdi:lan
   - entity: binary_sensor.smol_9_online
@@ -210,101 +210,15 @@ cards:
     grid-column: span 4
   cards:
   - type: custom:mushroom-template-card
-    primary: Draconic Dominion
-    secondary: '{% set on=is_state(''binary_sensor.smol_7_online'',''on'') %}{% set gw=(state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''7'') %}{% set t=states(''sensor.smol_7_temp'') %}{% set v=states(''sensor.smol_7_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id7 · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · WiFi'
-    icon: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''7'') %}mdi:crown{% else %}mdi:chip{% endif %}'
-    icon_color: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''7'') %}amber{% elif is_state(''binary_sensor.smol_7_online'',''on'') %}green{% else %}red{% endif %}'
-    badge_icon: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''7'') %}mdi:crown{% elif is_state(''binary_sensor.smol_7_online'',''on'') %}mdi:leaf-circle{% else %}mdi:lan-disconnect{% endif %}'
-    badge_color: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''7'') %}amber{% elif is_state(''binary_sensor.smol_7_online'',''on'') %}green{% else %}red{% endif %}'
-    card_mod:
-      style:
-        .: ha-card{border-radius:10px 10px 0 0;border-bottom:none;position:relative;overflow:hidden;border:2px solid {% if (state_attr('sensor.smol_mesh_channel','owner')|string == '7') %}var(--accent-color){% elif is_state('binary_sensor.smol_7_online','on') %}var(--ha-card-border-color){% else %}#ff6b6b{% endif %};opacity:{% if is_state('binary_sensor.smol_7_online','on') %}1{% else %}.6{% endif %};box-shadow:{% if (state_attr('sensor.smol_mesh_channel','owner')|string == '7') %}0 0 18px -3px var(--accent-color){% else %}none{% endif %}}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,{% if (state_attr('sensor.smol_mesh_channel','owner')|string == '7') %}var(--accent-color){% else %}var(--primary-color){% endif %},transparent);opacity:.6}
-        mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:26px;line-height:.9}.secondary{font-size:11px}
-  - type: custom:mushroom-template-card
-    primary: '{% set scr=(states(''sensor.smol_7_screen'') if states(''sensor.smol_7_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_7_screen'')) %}{% set t=states(''sensor.smol_7_temp'') %}{% set g=states(''sensor.smol_display_grid'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not is_state(''binary_sensor.smol_7_online'',''on'') %}—{% elif scr==''Grid'' %}{{ g.split(''|'')[1] if ''|'' in g else ''—'' }}{% elif scr==''Batt'' %}{{ states(''sensor.ev_battery_soc'') }}%{% elif scr==''Clock'' %}{{ now().strftime(''%H:%M'') }}{% else %}{{ t if t not in na else ''—'' }}{% endif %}'
-    secondary: '{% set scr=(states(''sensor.smol_7_screen'') if states(''sensor.smol_7_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_7_screen'')) %}{{ scr|upper }} · {% if not is_state(''binary_sensor.smol_7_online'',''on'') %}no link{% elif scr==''Grid'' %}shared glass{% elif scr==''Batt'' %}HV pack{% elif scr==''Clock'' %}mesh time{% else %}live °F{% endif %}'
-    icon: mdi:blank
-    card_mod:
-      style:
-        .: ha-card{background:#020402;border:1px solid var(--ha-card-border-color);border-radius:0;box-shadow:inset 0 0 12px rgba(0,0,0,.9);position:relative;overflow:hidden;margin-top:-2px;opacity:{% if is_state('binary_sensor.smol_7_online','on') %}1{% else %}.6{% endif %}}mushroom-shape-icon{display:none}
-        mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:44px;line-height:.8;color:var(--primary-color);text-shadow:0 0 7px rgba(91,255,154,.55)}.secondary{color:var(--primary-color);opacity:.7;font-size:10px}
-  - type: entities
-    show_header_toggle: false
-    entities:
-    - type: section
-      label: screen & mode
-    - entity: input_select.smol_7_screen
-      name: default screen
-    - entity: input_select.smol_7_page
-      name: page
-    - entity: input_select.smol_7_led
-      name: LED (status / on / off)
-      icon: mdi:led-on
-    - entity: input_button.smol_7_apply
-      name: Apply → id7
-      icon: mdi:send
-    - entity: input_button.smol_7_reset
-      name: Reset to board default
-      icon: mdi:backup-restore
-    - entity: input_button.smol_7_reboot
-      name: Reboot node
-      icon: mdi:restart-alert
-      tap_action:
-        action: perform-action
-        perform_action: input_button.press
-        target:
-          entity_id: input_button.smol_7_reboot
-        confirmation:
-          text: Reboot id7 (Draconic Dominion)? It drops off the mesh briefly.
-    - type: section
-      label: readback
-    - entity: sensor.smol_7_config
-      name: default screen (commanded)
-      icon: mdi:monitor-dashboard
-    - entity: sensor.smol_7_screen
-      name: current screen (live)
-      icon: mdi:monitor-eye
-    - entity: sensor.smol_7_status
-      name: activity
-      icon: mdi:pulse
-    - type: section
-      label: gateway anchor · WiFi uplink
-    - type: attribute
-      entity: sensor.smol_mesh_channel
-      attribute: channel
-      name: mesh channel (owned)
-      icon: mdi:wifi
-    - type: attribute
-      entity: sensor.smol_mesh_channel
-      attribute: seq
-      name: mesh seq (advancing)
-      icon: mdi:counter
-    - entity: sensor.smol_7_peers
-      name: peers / roster
-      icon: mdi:lan
-    - type: section
-      label: firmware
-    - entity: update.smol_7_dominion_firmware
-      name: firmware (version + update)
-    - entity: input_button.smol_ota_install_7
-      name: Install staged (canary)
-      icon: mdi:rocket-launch
-    card_mod:
-      style: ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_7_online','on') %}1{% else %}.6{% endif %}}
-- type: vertical-stack
-  view_layout:
-    grid-column: span 4
-  cards:
-  - type: custom:mushroom-template-card
     primary: Eldritch Nexus
-    secondary: '{% set on=is_state(''binary_sensor.smol_8_online'',''on'') %}{% set gw=(state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''8'') %}{% set t=states(''sensor.smol_8_temp'') %}{% set v=states(''sensor.smol_8_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id8 · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · {{ states(''sensor.smol_8_rssi'') if states(''sensor.smol_8_rssi'') not in na else ''—'' }} dBm'
-    icon: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''8'') %}mdi:crown{% else %}mdi:chip{% endif %}'
-    icon_color: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''8'') %}amber{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}green{% else %}red{% endif %}'
-    badge_icon: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''8'') %}mdi:crown{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}mdi:leaf-circle{% else %}mdi:lan-disconnect{% endif %}'
-    badge_color: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''8'') %}amber{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}green{% else %}red{% endif %}'
+    secondary: '{% set on=is_state(''binary_sensor.smol_8_online'',''on'') %}{% set gw=is_state(''sensor.smol_8_peers'',''gateway'') %}{% set t=states(''sensor.smol_8_temp'') %}{% set v=states(''sensor.smol_8_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id8 · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · {% if gw %}WiFi{% else %}{{ states(''sensor.smol_8_rssi'') if states(''sensor.smol_8_rssi'') not in na else ''—'' }} dBm{% endif %}'
+    icon: '{% if is_state(''sensor.smol_8_peers'',''gateway'') %}mdi:crown{% else %}mdi:chip{% endif %}'
+    icon_color: '{% if is_state(''sensor.smol_8_peers'',''gateway'') %}amber{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}green{% else %}red{% endif %}'
+    badge_icon: '{% if is_state(''sensor.smol_8_peers'',''gateway'') %}mdi:crown{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}mdi:leaf-circle{% else %}mdi:lan-disconnect{% endif %}'
+    badge_color: '{% if is_state(''sensor.smol_8_peers'',''gateway'') %}amber{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}green{% else %}red{% endif %}'
     card_mod:
       style:
-        .: ha-card{border-radius:10px 10px 0 0;border-bottom:none;position:relative;overflow:hidden;border:2px solid {% if (state_attr('sensor.smol_mesh_channel','owner')|string == '8') %}var(--accent-color){% elif is_state('binary_sensor.smol_8_online','on') %}var(--ha-card-border-color){% else %}#ff6b6b{% endif %};opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %};box-shadow:{% if (state_attr('sensor.smol_mesh_channel','owner')|string == '8') %}0 0 18px -3px var(--accent-color){% else %}none{% endif %}}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,{% if (state_attr('sensor.smol_mesh_channel','owner')|string == '8') %}var(--accent-color){% else %}var(--primary-color){% endif %},transparent);opacity:.6}
+        .: ha-card{border-radius:10px 10px 0 0;border-bottom:none;position:relative;overflow:hidden;border:2px solid {% if is_state('sensor.smol_8_peers','gateway') %}var(--accent-color){% elif is_state('binary_sensor.smol_8_online','on') %}var(--ha-card-border-color){% else %}#ff6b6b{% endif %};opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %};box-shadow:{% if is_state('sensor.smol_8_peers','gateway') %}0 0 18px -3px var(--accent-color){% else %}none{% endif %}}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,{% if is_state('sensor.smol_8_peers','gateway') %}var(--accent-color){% else %}var(--primary-color){% endif %},transparent);opacity:.6}
         mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:26px;line-height:.9}.secondary{font-size:11px}
   - type: custom:mushroom-template-card
     primary: '{% set scr=(states(''sensor.smol_8_screen'') if states(''sensor.smol_8_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_8_screen'')) %}{% set t=states(''sensor.smol_8_temp'') %}{% set g=states(''sensor.smol_display_grid'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not is_state(''binary_sensor.smol_8_online'',''on'') %}—{% elif scr==''Grid'' %}{{ g.split(''|'')[1] if ''|'' in g else ''—'' }}{% elif scr==''Batt'' %}{{ states(''sensor.ev_battery_soc'') }}%{% elif scr==''Clock'' %}{{ now().strftime(''%H:%M'') }}{% else %}{{ t if t not in na else ''—'' }}{% endif %}'
@@ -353,21 +267,63 @@ cards:
     - entity: sensor.smol_8_status
       name: activity
       icon: mdi:pulse
-    - entity: sensor.smol_8_rssi
-      name: bond (RSSI)
-      icon: mdi:signal
-    - entity: sensor.smol_8_rssi_band
-      name: bond band
-      icon: mdi:signal-cellular-2
-    - entity: binary_sensor.smol_8_resync
-      name: re-syncing
-      icon: mdi:sync
+    card_mod:
+      style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-2px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}
+  - type: conditional
+    conditions:
+    - entity: sensor.smol_8_peers
+      state_not: gateway
+    card:
+      type: entities
+      show_header_toggle: false
+      card_mod:
+        style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}
+      entities:
+      - type: section
+        label: mesh bond (leaf)
+      - entity: sensor.smol_8_rssi
+        name: bond (RSSI)
+        icon: mdi:signal
+      - entity: sensor.smol_8_rssi_band
+        name: bond band
+        icon: mdi:signal-cellular-2
+      - entity: binary_sensor.smol_8_resync
+        name: re-syncing
+        icon: mdi:sync
+  - type: conditional
+    conditions:
+    - entity: sensor.smol_8_peers
+      state: gateway
+    card:
+      type: entities
+      show_header_toggle: false
+      card_mod:
+        style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}
+      entities:
+      - type: section
+        label: gateway anchor · WiFi uplink
+      - type: attribute
+        entity: sensor.smol_mesh_channel
+        attribute: channel
+        name: mesh channel (owned)
+        icon: mdi:wifi
+      - type: attribute
+        entity: sensor.smol_mesh_channel
+        attribute: seq
+        name: mesh seq (advancing)
+        icon: mdi:counter
+      - entity: sensor.smol_8_peers
+        name: peers / roster
+        icon: mdi:lan
+  - type: entities
+    show_header_toggle: false
+    entities:
     - type: section
       label: firmware
     - entity: update.smol_8_nexus_firmware
       name: firmware (version + update)
     - entity: input_button.smol_ota_install_8
-      name: Install (when this leads)
+      name: Install staged (gateway consumes)
       icon: mdi:rocket-launch
     card_mod:
       style: ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}
@@ -376,15 +332,137 @@ cards:
     grid-column: span 4
   cards:
   - type: custom:mushroom-template-card
-    primary: Jade Herald
-    secondary: '{% set on=is_state(''binary_sensor.smol_9_online'',''on'') %}{% set gw=(state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''9'') %}{% set t=states(''sensor.smol_9_temp'') %}{% set v=states(''sensor.smol_9_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id9 · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · {{ states(''sensor.smol_9_rssi'') if states(''sensor.smol_9_rssi'') not in na else ''—'' }} dBm'
-    icon: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''9'') %}mdi:crown{% else %}mdi:chip{% endif %}'
-    icon_color: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''9'') %}amber{% elif is_state(''binary_sensor.smol_9_online'',''on'') %}green{% else %}red{% endif %}'
-    badge_icon: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''9'') %}mdi:crown{% elif is_state(''binary_sensor.smol_9_online'',''on'') %}mdi:leaf-circle{% else %}mdi:lan-disconnect{% endif %}'
-    badge_color: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''9'') %}amber{% elif is_state(''binary_sensor.smol_9_online'',''on'') %}green{% else %}red{% endif %}'
+    primary: Draconic Dominion
+    secondary: '{% set on=is_state(''binary_sensor.smol_7_online'',''on'') %}{% set gw=is_state(''sensor.smol_7_peers'',''gateway'') %}{% set t=states(''sensor.smol_7_temp'') %}{% set v=states(''sensor.smol_7_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id7 · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · {% if gw %}WiFi{% else %}{{ states(''sensor.smol_7_rssi'') if states(''sensor.smol_7_rssi'') not in na else ''—'' }} dBm{% endif %}'
+    icon: '{% if is_state(''sensor.smol_7_peers'',''gateway'') %}mdi:crown{% else %}mdi:chip{% endif %}'
+    icon_color: '{% if is_state(''sensor.smol_7_peers'',''gateway'') %}amber{% elif is_state(''binary_sensor.smol_7_online'',''on'') %}green{% else %}red{% endif %}'
+    badge_icon: '{% if is_state(''sensor.smol_7_peers'',''gateway'') %}mdi:crown{% elif is_state(''binary_sensor.smol_7_online'',''on'') %}mdi:leaf-circle{% else %}mdi:lan-disconnect{% endif %}'
+    badge_color: '{% if is_state(''sensor.smol_7_peers'',''gateway'') %}amber{% elif is_state(''binary_sensor.smol_7_online'',''on'') %}green{% else %}red{% endif %}'
     card_mod:
       style:
-        .: ha-card{border-radius:10px 10px 0 0;border-bottom:none;position:relative;overflow:hidden;border:2px solid {% if (state_attr('sensor.smol_mesh_channel','owner')|string == '9') %}var(--accent-color){% elif is_state('binary_sensor.smol_9_online','on') %}var(--ha-card-border-color){% else %}#ff6b6b{% endif %};opacity:{% if is_state('binary_sensor.smol_9_online','on') %}1{% else %}.6{% endif %};box-shadow:{% if (state_attr('sensor.smol_mesh_channel','owner')|string == '9') %}0 0 18px -3px var(--accent-color){% else %}none{% endif %}}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,{% if (state_attr('sensor.smol_mesh_channel','owner')|string == '9') %}var(--accent-color){% else %}var(--primary-color){% endif %},transparent);opacity:.6}
+        .: ha-card{border-radius:10px 10px 0 0;border-bottom:none;position:relative;overflow:hidden;border:2px solid {% if is_state('sensor.smol_7_peers','gateway') %}var(--accent-color){% elif is_state('binary_sensor.smol_7_online','on') %}var(--ha-card-border-color){% else %}#ff6b6b{% endif %};opacity:{% if is_state('binary_sensor.smol_7_online','on') %}1{% else %}.6{% endif %};box-shadow:{% if is_state('sensor.smol_7_peers','gateway') %}0 0 18px -3px var(--accent-color){% else %}none{% endif %}}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,{% if is_state('sensor.smol_7_peers','gateway') %}var(--accent-color){% else %}var(--primary-color){% endif %},transparent);opacity:.6}
+        mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:26px;line-height:.9}.secondary{font-size:11px}
+  - type: custom:mushroom-template-card
+    primary: '{% set scr=(states(''sensor.smol_7_screen'') if states(''sensor.smol_7_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_7_screen'')) %}{% set t=states(''sensor.smol_7_temp'') %}{% set g=states(''sensor.smol_display_grid'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not is_state(''binary_sensor.smol_7_online'',''on'') %}—{% elif scr==''Grid'' %}{{ g.split(''|'')[1] if ''|'' in g else ''—'' }}{% elif scr==''Batt'' %}{{ states(''sensor.ev_battery_soc'') }}%{% elif scr==''Clock'' %}{{ now().strftime(''%H:%M'') }}{% else %}{{ t if t not in na else ''—'' }}{% endif %}'
+    secondary: '{% set scr=(states(''sensor.smol_7_screen'') if states(''sensor.smol_7_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_7_screen'')) %}{{ scr|upper }} · {% if not is_state(''binary_sensor.smol_7_online'',''on'') %}no link{% elif scr==''Grid'' %}shared glass{% elif scr==''Batt'' %}HV pack{% elif scr==''Clock'' %}mesh time{% else %}live °F{% endif %}'
+    icon: mdi:blank
+    card_mod:
+      style:
+        .: ha-card{background:#020402;border:1px solid var(--ha-card-border-color);border-radius:0;box-shadow:inset 0 0 12px rgba(0,0,0,.9);position:relative;overflow:hidden;margin-top:-2px;opacity:{% if is_state('binary_sensor.smol_7_online','on') %}1{% else %}.6{% endif %}}mushroom-shape-icon{display:none}
+        mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:44px;line-height:.8;color:var(--primary-color);text-shadow:0 0 7px rgba(91,255,154,.55)}.secondary{color:var(--primary-color);opacity:.7;font-size:10px}
+  - type: entities
+    show_header_toggle: false
+    entities:
+    - type: section
+      label: screen & mode
+    - entity: input_select.smol_7_screen
+      name: default screen
+    - entity: input_select.smol_7_page
+      name: page
+    - entity: input_select.smol_7_led
+      name: LED (status / on / off)
+      icon: mdi:led-on
+    - entity: input_button.smol_7_apply
+      name: Apply → id7
+      icon: mdi:send
+    - entity: input_button.smol_7_reset
+      name: Reset to board default
+      icon: mdi:backup-restore
+    - entity: input_button.smol_7_reboot
+      name: Reboot node
+      icon: mdi:restart-alert
+      tap_action:
+        action: perform-action
+        perform_action: input_button.press
+        target:
+          entity_id: input_button.smol_7_reboot
+        confirmation:
+          text: Reboot id7 (Draconic Dominion)? It drops off the mesh briefly.
+    - type: section
+      label: readback
+    - entity: sensor.smol_7_config
+      name: default screen (commanded)
+      icon: mdi:monitor-dashboard
+    - entity: sensor.smol_7_screen
+      name: current screen (live)
+      icon: mdi:monitor-eye
+    - entity: sensor.smol_7_status
+      name: activity
+      icon: mdi:pulse
+    card_mod:
+      style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-2px;opacity:{% if is_state('binary_sensor.smol_7_online','on') %}1{% else %}.6{% endif %}}
+  - type: conditional
+    conditions:
+    - entity: sensor.smol_7_peers
+      state_not: gateway
+    card:
+      type: entities
+      show_header_toggle: false
+      card_mod:
+        style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_7_online','on') %}1{% else %}.6{% endif %}}
+      entities:
+      - type: section
+        label: mesh bond (leaf)
+      - entity: sensor.smol_7_rssi
+        name: bond (RSSI)
+        icon: mdi:signal
+      - entity: sensor.smol_7_rssi_band
+        name: bond band
+        icon: mdi:signal-cellular-2
+      - entity: binary_sensor.smol_7_resync
+        name: re-syncing
+        icon: mdi:sync
+  - type: conditional
+    conditions:
+    - entity: sensor.smol_7_peers
+      state: gateway
+    card:
+      type: entities
+      show_header_toggle: false
+      card_mod:
+        style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_7_online','on') %}1{% else %}.6{% endif %}}
+      entities:
+      - type: section
+        label: gateway anchor · WiFi uplink
+      - type: attribute
+        entity: sensor.smol_mesh_channel
+        attribute: channel
+        name: mesh channel (owned)
+        icon: mdi:wifi
+      - type: attribute
+        entity: sensor.smol_mesh_channel
+        attribute: seq
+        name: mesh seq (advancing)
+        icon: mdi:counter
+      - entity: sensor.smol_7_peers
+        name: peers / roster
+        icon: mdi:lan
+  - type: entities
+    show_header_toggle: false
+    entities:
+    - type: section
+      label: firmware
+    - entity: update.smol_7_dominion_firmware
+      name: firmware (version + update)
+    - entity: input_button.smol_ota_install_7
+      name: Install staged (gateway consumes)
+      icon: mdi:rocket-launch
+    card_mod:
+      style: ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_7_online','on') %}1{% else %}.6{% endif %}}
+- type: vertical-stack
+  view_layout:
+    grid-column: span 4
+  cards:
+  - type: custom:mushroom-template-card
+    primary: Jade Herald
+    secondary: '{% set on=is_state(''binary_sensor.smol_9_online'',''on'') %}{% set gw=is_state(''sensor.smol_9_peers'',''gateway'') %}{% set t=states(''sensor.smol_9_temp'') %}{% set v=states(''sensor.smol_9_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id9 · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · {% if gw %}WiFi{% else %}{{ states(''sensor.smol_9_rssi'') if states(''sensor.smol_9_rssi'') not in na else ''—'' }} dBm{% endif %}'
+    icon: '{% if is_state(''sensor.smol_9_peers'',''gateway'') %}mdi:crown{% else %}mdi:chip{% endif %}'
+    icon_color: '{% if is_state(''sensor.smol_9_peers'',''gateway'') %}amber{% elif is_state(''binary_sensor.smol_9_online'',''on'') %}green{% else %}red{% endif %}'
+    badge_icon: '{% if is_state(''sensor.smol_9_peers'',''gateway'') %}mdi:crown{% elif is_state(''binary_sensor.smol_9_online'',''on'') %}mdi:leaf-circle{% else %}mdi:lan-disconnect{% endif %}'
+    badge_color: '{% if is_state(''sensor.smol_9_peers'',''gateway'') %}amber{% elif is_state(''binary_sensor.smol_9_online'',''on'') %}green{% else %}red{% endif %}'
+    card_mod:
+      style:
+        .: ha-card{border-radius:10px 10px 0 0;border-bottom:none;position:relative;overflow:hidden;border:2px solid {% if is_state('sensor.smol_9_peers','gateway') %}var(--accent-color){% elif is_state('binary_sensor.smol_9_online','on') %}var(--ha-card-border-color){% else %}#ff6b6b{% endif %};opacity:{% if is_state('binary_sensor.smol_9_online','on') %}1{% else %}.6{% endif %};box-shadow:{% if is_state('sensor.smol_9_peers','gateway') %}0 0 18px -3px var(--accent-color){% else %}none{% endif %}}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,{% if is_state('sensor.smol_9_peers','gateway') %}var(--accent-color){% else %}var(--primary-color){% endif %},transparent);opacity:.6}
         mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:26px;line-height:.9}.secondary{font-size:11px}
   - type: custom:mushroom-template-card
     primary: '{% set scr=(states(''sensor.smol_9_screen'') if states(''sensor.smol_9_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_9_screen'')) %}{% set t=states(''sensor.smol_9_temp'') %}{% set g=states(''sensor.smol_display_grid'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not is_state(''binary_sensor.smol_9_online'',''on'') %}—{% elif scr==''Grid'' %}{{ g.split(''|'')[1] if ''|'' in g else ''—'' }}{% elif scr==''Batt'' %}{{ states(''sensor.ev_battery_soc'') }}%{% elif scr==''Clock'' %}{{ now().strftime(''%H:%M'') }}{% else %}{{ t if t not in na else ''—'' }}{% endif %}'
@@ -433,21 +511,63 @@ cards:
     - entity: sensor.smol_9_status
       name: activity
       icon: mdi:pulse
-    - entity: sensor.smol_9_rssi
-      name: bond (RSSI)
-      icon: mdi:signal
-    - entity: sensor.smol_9_rssi_band
-      name: bond band
-      icon: mdi:signal-cellular-2
-    - entity: binary_sensor.smol_9_resync
-      name: re-syncing
-      icon: mdi:sync
+    card_mod:
+      style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-2px;opacity:{% if is_state('binary_sensor.smol_9_online','on') %}1{% else %}.6{% endif %}}
+  - type: conditional
+    conditions:
+    - entity: sensor.smol_9_peers
+      state_not: gateway
+    card:
+      type: entities
+      show_header_toggle: false
+      card_mod:
+        style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_9_online','on') %}1{% else %}.6{% endif %}}
+      entities:
+      - type: section
+        label: mesh bond (leaf)
+      - entity: sensor.smol_9_rssi
+        name: bond (RSSI)
+        icon: mdi:signal
+      - entity: sensor.smol_9_rssi_band
+        name: bond band
+        icon: mdi:signal-cellular-2
+      - entity: binary_sensor.smol_9_resync
+        name: re-syncing
+        icon: mdi:sync
+  - type: conditional
+    conditions:
+    - entity: sensor.smol_9_peers
+      state: gateway
+    card:
+      type: entities
+      show_header_toggle: false
+      card_mod:
+        style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_9_online','on') %}1{% else %}.6{% endif %}}
+      entities:
+      - type: section
+        label: gateway anchor · WiFi uplink
+      - type: attribute
+        entity: sensor.smol_mesh_channel
+        attribute: channel
+        name: mesh channel (owned)
+        icon: mdi:wifi
+      - type: attribute
+        entity: sensor.smol_mesh_channel
+        attribute: seq
+        name: mesh seq (advancing)
+        icon: mdi:counter
+      - entity: sensor.smol_9_peers
+        name: peers / roster
+        icon: mdi:lan
+  - type: entities
+    show_header_toggle: false
+    entities:
     - type: section
       label: firmware
     - entity: update.smol_9_herald_firmware
       name: firmware (version + update)
     - entity: input_button.smol_ota_install_9
-      name: Install (when this leads)
+      name: Install staged (gateway consumes)
       icon: mdi:rocket-launch
     card_mod:
       style: ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_9_online','on') %}1{% else %}.6{% endif %}}
@@ -570,10 +690,10 @@ cards:
     content: '**per-node OTA**
 
 
-      id7 · canary — {% if is_state(''update.smol_7_dominion_firmware'',''on'') %}**{{ state_attr(''update.smol_7_dominion_firmware'',''installed_version'') }} → {{ state_attr(''update.smol_7_dominion_firmware'',''latest_version'') }} ready**{% elif is_state(''binary_sensor.smol_7_online'',''on'') %}✓ {{ state_attr(''update.smol_7_dominion_firmware'',''installed_version'') }} up-to-date{% else %}offline{% endif %}
+      id8 · canary — {% if is_state(''update.smol_8_nexus_firmware'',''on'') %}**{{ state_attr(''update.smol_8_nexus_firmware'',''installed_version'') }} → {{ state_attr(''update.smol_8_nexus_firmware'',''latest_version'') }} ready**{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}✓ {{ state_attr(''update.smol_8_nexus_firmware'',''installed_version'') }} up-to-date{% else %}offline{% endif %}
 
 
-      id8 — {% if is_state(''update.smol_8_nexus_firmware'',''on'') %}**{{ state_attr(''update.smol_8_nexus_firmware'',''installed_version'') }} → {{ state_attr(''update.smol_8_nexus_firmware'',''latest_version'') }} ready**{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}✓ {{ state_attr(''update.smol_8_nexus_firmware'',''installed_version'') }} up-to-date{% else %}offline{% endif %}
+      id7 — {% if is_state(''update.smol_7_dominion_firmware'',''on'') %}**{{ state_attr(''update.smol_7_dominion_firmware'',''installed_version'') }} → {{ state_attr(''update.smol_7_dominion_firmware'',''latest_version'') }} ready**{% elif is_state(''binary_sensor.smol_7_online'',''on'') %}✓ {{ state_attr(''update.smol_7_dominion_firmware'',''installed_version'') }} up-to-date{% else %}offline{% endif %}
 
 
       id9 — {% if is_state(''update.smol_9_herald_firmware'',''on'') %}**{{ state_attr(''update.smol_9_herald_firmware'',''installed_version'') }} → {{ state_attr(''update.smol_9_herald_firmware'',''latest_version'') }} ready**{% elif is_state(''binary_sensor.smol_9_online'',''on'') %}✓ {{ state_attr(''update.smol_9_herald_firmware'',''installed_version'') }} up-to-date{% else %}offline{% endif %}'

--- a/ha/dashboard/smol_control_room.yaml
+++ b/ha/dashboard/smol_control_room.yaml
@@ -268,6 +268,21 @@ cards:
       name: activity
       icon: mdi:pulse
     - type: section
+      label: gateway anchor · WiFi uplink
+    - type: attribute
+      entity: sensor.smol_mesh_channel
+      attribute: channel
+      name: mesh channel (owned)
+      icon: mdi:wifi
+    - type: attribute
+      entity: sensor.smol_mesh_channel
+      attribute: seq
+      name: mesh seq (advancing)
+      icon: mdi:counter
+    - entity: sensor.smol_7_peers
+      name: peers / roster
+      icon: mdi:lan
+    - type: section
       label: firmware
     - entity: update.smol_7_dominion_firmware
       name: firmware (version + update)

--- a/ha/dashboard/smol_control_room.yaml
+++ b/ha/dashboard/smol_control_room.yaml
@@ -28,6 +28,10 @@ cards:
 
     {% set ch = states(''sensor.smol_mesh_channel'') %}
 
+    {% set seq = state_attr(''sensor.smol_mesh_channel'',''seq'') %}
+
+    {% set re = is_state(''binary_sensor.smol_mesh_reelecting'',''on'') %}
+
     {% set bt = state_attr(''update.smol_7_dominion_firmware'',''title'') or (''build '' ~ (state_attr(''update.smol_7_dominion_firmware'',''installed_version'') or ''—'')) %}
 
     # control room
@@ -35,7 +39,7 @@ cards:
     **smol · esp-now mesh · home assistant**
 
 
-    🟢 **MESH LIVE** · ch **{{ ch if ch not in na else ''—'' }}**{% if is_state(''binary_sensor.smol_mesh_reelecting'',''on'') %} · re-electing…{% endif %} · the Seat **id{{ owner if owner not in na else ''7'' }} · Draconic Dominion** · **{{ on }}/{{ tot }}** sigils lit
+    {% if re %}⚠️ **RE-ELECTING** — mesh choosing a new gateway…{% else %}🟢 **MESH LIVE** · gateway **id{{ owner if owner not in na else ''?'' }}** · seq **{{ seq if seq not in na else ''—'' }}** (advancing = alive) · ch {{ ch if ch not in na else ''—'' }}{% endif %} · **{{ on }}/{{ tot }}** sigils lit
 
 
     build **{{ bt }}** · last sync **{{ relative_time(states.sensor.smol_7_status.last_changed) if states.sensor.smol_7_status else ''—'' }}** ago · retained MQTT, applies on next burst
@@ -207,14 +211,14 @@ cards:
   cards:
   - type: custom:mushroom-template-card
     primary: Draconic Dominion
-    secondary: '{% set on=is_state(''binary_sensor.smol_7_online'',''on'') %}{% set t=states(''sensor.smol_7_temp'') %}{% set v=states(''sensor.smol_7_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}id7 · the Seat · {{ ''🟢 online'' if on else ''🔴 offline'' }} · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · WiFi'
-    icon: mdi:crown
-    icon_color: amber
-    badge_icon: mdi:crown
-    badge_color: amber
+    secondary: '{% set on=is_state(''binary_sensor.smol_7_online'',''on'') %}{% set gw=(state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''7'') %}{% set t=states(''sensor.smol_7_temp'') %}{% set v=states(''sensor.smol_7_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id7 · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · WiFi'
+    icon: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''7'') %}mdi:crown{% else %}mdi:chip{% endif %}'
+    icon_color: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''7'') %}amber{% elif is_state(''binary_sensor.smol_7_online'',''on'') %}green{% else %}red{% endif %}'
+    badge_icon: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''7'') %}mdi:crown{% elif is_state(''binary_sensor.smol_7_online'',''on'') %}mdi:leaf-circle{% else %}mdi:lan-disconnect{% endif %}'
+    badge_color: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''7'') %}amber{% elif is_state(''binary_sensor.smol_7_online'',''on'') %}green{% else %}red{% endif %}'
     card_mod:
       style:
-        .: ha-card{position:relative;overflow:hidden}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,var(--accent-color),transparent);opacity:.55}ha-card{border-radius:10px 10px 0 0;border-bottom:none}
+        .: ha-card{border-radius:10px 10px 0 0;border-bottom:none;position:relative;overflow:hidden;border:2px solid {% if (state_attr('sensor.smol_mesh_channel','owner')|string == '7') %}var(--accent-color){% elif is_state('binary_sensor.smol_7_online','on') %}var(--ha-card-border-color){% else %}#ff6b6b{% endif %};opacity:{% if is_state('binary_sensor.smol_7_online','on') %}1{% else %}.6{% endif %};box-shadow:{% if (state_attr('sensor.smol_mesh_channel','owner')|string == '7') %}0 0 18px -3px var(--accent-color){% else %}none{% endif %}}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,{% if (state_attr('sensor.smol_mesh_channel','owner')|string == '7') %}var(--accent-color){% else %}var(--primary-color){% endif %},transparent);opacity:.6}
         mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:26px;line-height:.9}.secondary{font-size:11px}
   - type: custom:mushroom-template-card
     primary: '{% set scr=(states(''sensor.smol_7_screen'') if states(''sensor.smol_7_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_7_screen'')) %}{% set t=states(''sensor.smol_7_temp'') %}{% set g=states(''sensor.smol_display_grid'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not is_state(''binary_sensor.smol_7_online'',''on'') %}—{% elif scr==''Grid'' %}{{ g.split(''|'')[1] if ''|'' in g else ''—'' }}{% elif scr==''Batt'' %}{{ states(''sensor.ev_battery_soc'') }}%{% elif scr==''Clock'' %}{{ now().strftime(''%H:%M'') }}{% else %}{{ t if t not in na else ''—'' }}{% endif %}'
@@ -222,7 +226,7 @@ cards:
     icon: mdi:blank
     card_mod:
       style:
-        .: ha-card{background:#020402;border:1px solid var(--ha-card-border-color);border-radius:0;box-shadow:inset 0 0 12px rgba(0,0,0,.9);position:relative;overflow:hidden;margin-top:-2px}mushroom-shape-icon{display:none}
+        .: ha-card{background:#020402;border:1px solid var(--ha-card-border-color);border-radius:0;box-shadow:inset 0 0 12px rgba(0,0,0,.9);position:relative;overflow:hidden;margin-top:-2px;opacity:{% if is_state('binary_sensor.smol_7_online','on') %}1{% else %}.6{% endif %}}mushroom-shape-icon{display:none}
         mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:44px;line-height:.8;color:var(--primary-color);text-shadow:0 0 7px rgba(91,255,154,.55)}.secondary{color:var(--primary-color);opacity:.7;font-size:10px}
   - type: entities
     show_header_toggle: false
@@ -271,21 +275,21 @@ cards:
       name: Install staged (canary)
       icon: mdi:rocket-launch
     card_mod:
-      style: ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px}
+      style: ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_7_online','on') %}1{% else %}.6{% endif %}}
 - type: vertical-stack
   view_layout:
     grid-column: span 4
   cards:
   - type: custom:mushroom-template-card
     primary: Eldritch Nexus
-    secondary: '{% set on=is_state(''binary_sensor.smol_8_online'',''on'') %}{% set t=states(''sensor.smol_8_temp'') %}{% set v=states(''sensor.smol_8_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}id8 · leaf · {{ ''🟢 online'' if on else ''🔴 offline'' }} · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · {{ states(''sensor.smol_8_rssi'') if states(''sensor.smol_8_rssi'') not in na else ''—'' }} dBm'
-    icon: mdi:chip
-    icon_color: '{{ ''green'' if is_state(''binary_sensor.smol_8_online'',''on'') else ''red'' }}'
-    badge_icon: mdi:leaf
-    badge_color: '{{ ''green'' if is_state(''binary_sensor.smol_8_online'',''on'') else ''red'' }}'
+    secondary: '{% set on=is_state(''binary_sensor.smol_8_online'',''on'') %}{% set gw=(state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''8'') %}{% set t=states(''sensor.smol_8_temp'') %}{% set v=states(''sensor.smol_8_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id8 · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · {{ states(''sensor.smol_8_rssi'') if states(''sensor.smol_8_rssi'') not in na else ''—'' }} dBm'
+    icon: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''8'') %}mdi:crown{% else %}mdi:chip{% endif %}'
+    icon_color: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''8'') %}amber{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}green{% else %}red{% endif %}'
+    badge_icon: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''8'') %}mdi:crown{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}mdi:leaf-circle{% else %}mdi:lan-disconnect{% endif %}'
+    badge_color: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''8'') %}amber{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}green{% else %}red{% endif %}'
     card_mod:
       style:
-        .: ha-card{position:relative;overflow:hidden}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,var(--primary-color),transparent);opacity:.55}ha-card{border-radius:10px 10px 0 0;border-bottom:none}
+        .: ha-card{border-radius:10px 10px 0 0;border-bottom:none;position:relative;overflow:hidden;border:2px solid {% if (state_attr('sensor.smol_mesh_channel','owner')|string == '8') %}var(--accent-color){% elif is_state('binary_sensor.smol_8_online','on') %}var(--ha-card-border-color){% else %}#ff6b6b{% endif %};opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %};box-shadow:{% if (state_attr('sensor.smol_mesh_channel','owner')|string == '8') %}0 0 18px -3px var(--accent-color){% else %}none{% endif %}}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,{% if (state_attr('sensor.smol_mesh_channel','owner')|string == '8') %}var(--accent-color){% else %}var(--primary-color){% endif %},transparent);opacity:.6}
         mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:26px;line-height:.9}.secondary{font-size:11px}
   - type: custom:mushroom-template-card
     primary: '{% set scr=(states(''sensor.smol_8_screen'') if states(''sensor.smol_8_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_8_screen'')) %}{% set t=states(''sensor.smol_8_temp'') %}{% set g=states(''sensor.smol_display_grid'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not is_state(''binary_sensor.smol_8_online'',''on'') %}—{% elif scr==''Grid'' %}{{ g.split(''|'')[1] if ''|'' in g else ''—'' }}{% elif scr==''Batt'' %}{{ states(''sensor.ev_battery_soc'') }}%{% elif scr==''Clock'' %}{{ now().strftime(''%H:%M'') }}{% else %}{{ t if t not in na else ''—'' }}{% endif %}'
@@ -293,7 +297,7 @@ cards:
     icon: mdi:blank
     card_mod:
       style:
-        .: ha-card{background:#020402;border:1px solid var(--ha-card-border-color);border-radius:0;box-shadow:inset 0 0 12px rgba(0,0,0,.9);position:relative;overflow:hidden;margin-top:-2px}mushroom-shape-icon{display:none}
+        .: ha-card{background:#020402;border:1px solid var(--ha-card-border-color);border-radius:0;box-shadow:inset 0 0 12px rgba(0,0,0,.9);position:relative;overflow:hidden;margin-top:-2px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}mushroom-shape-icon{display:none}
         mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:44px;line-height:.8;color:var(--primary-color);text-shadow:0 0 7px rgba(91,255,154,.55)}.secondary{color:var(--primary-color);opacity:.7;font-size:10px}
   - type: entities
     show_header_toggle: false
@@ -351,21 +355,21 @@ cards:
       name: Install (when this leads)
       icon: mdi:rocket-launch
     card_mod:
-      style: ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px}
+      style: ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}
 - type: vertical-stack
   view_layout:
     grid-column: span 4
   cards:
   - type: custom:mushroom-template-card
     primary: Jade Herald
-    secondary: '{% set on=is_state(''binary_sensor.smol_9_online'',''on'') %}{% set t=states(''sensor.smol_9_temp'') %}{% set v=states(''sensor.smol_9_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}id9 · leaf · {{ ''🟢 online'' if on else ''🔴 offline'' }} · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · {{ states(''sensor.smol_9_rssi'') if states(''sensor.smol_9_rssi'') not in na else ''—'' }} dBm'
-    icon: mdi:chip
-    icon_color: '{{ ''green'' if is_state(''binary_sensor.smol_9_online'',''on'') else ''red'' }}'
-    badge_icon: mdi:leaf
-    badge_color: '{{ ''green'' if is_state(''binary_sensor.smol_9_online'',''on'') else ''red'' }}'
+    secondary: '{% set on=is_state(''binary_sensor.smol_9_online'',''on'') %}{% set gw=(state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''9'') %}{% set t=states(''sensor.smol_9_temp'') %}{% set v=states(''sensor.smol_9_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id9 · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · {{ states(''sensor.smol_9_rssi'') if states(''sensor.smol_9_rssi'') not in na else ''—'' }} dBm'
+    icon: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''9'') %}mdi:crown{% else %}mdi:chip{% endif %}'
+    icon_color: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''9'') %}amber{% elif is_state(''binary_sensor.smol_9_online'',''on'') %}green{% else %}red{% endif %}'
+    badge_icon: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''9'') %}mdi:crown{% elif is_state(''binary_sensor.smol_9_online'',''on'') %}mdi:leaf-circle{% else %}mdi:lan-disconnect{% endif %}'
+    badge_color: '{% if (state_attr(''sensor.smol_mesh_channel'',''owner'')|string == ''9'') %}amber{% elif is_state(''binary_sensor.smol_9_online'',''on'') %}green{% else %}red{% endif %}'
     card_mod:
       style:
-        .: ha-card{position:relative;overflow:hidden}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,var(--primary-color),transparent);opacity:.55}ha-card{border-radius:10px 10px 0 0;border-bottom:none}
+        .: ha-card{border-radius:10px 10px 0 0;border-bottom:none;position:relative;overflow:hidden;border:2px solid {% if (state_attr('sensor.smol_mesh_channel','owner')|string == '9') %}var(--accent-color){% elif is_state('binary_sensor.smol_9_online','on') %}var(--ha-card-border-color){% else %}#ff6b6b{% endif %};opacity:{% if is_state('binary_sensor.smol_9_online','on') %}1{% else %}.6{% endif %};box-shadow:{% if (state_attr('sensor.smol_mesh_channel','owner')|string == '9') %}0 0 18px -3px var(--accent-color){% else %}none{% endif %}}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,{% if (state_attr('sensor.smol_mesh_channel','owner')|string == '9') %}var(--accent-color){% else %}var(--primary-color){% endif %},transparent);opacity:.6}
         mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:26px;line-height:.9}.secondary{font-size:11px}
   - type: custom:mushroom-template-card
     primary: '{% set scr=(states(''sensor.smol_9_screen'') if states(''sensor.smol_9_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_9_screen'')) %}{% set t=states(''sensor.smol_9_temp'') %}{% set g=states(''sensor.smol_display_grid'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not is_state(''binary_sensor.smol_9_online'',''on'') %}—{% elif scr==''Grid'' %}{{ g.split(''|'')[1] if ''|'' in g else ''—'' }}{% elif scr==''Batt'' %}{{ states(''sensor.ev_battery_soc'') }}%{% elif scr==''Clock'' %}{{ now().strftime(''%H:%M'') }}{% else %}{{ t if t not in na else ''—'' }}{% endif %}'
@@ -373,7 +377,7 @@ cards:
     icon: mdi:blank
     card_mod:
       style:
-        .: ha-card{background:#020402;border:1px solid var(--ha-card-border-color);border-radius:0;box-shadow:inset 0 0 12px rgba(0,0,0,.9);position:relative;overflow:hidden;margin-top:-2px}mushroom-shape-icon{display:none}
+        .: ha-card{background:#020402;border:1px solid var(--ha-card-border-color);border-radius:0;box-shadow:inset 0 0 12px rgba(0,0,0,.9);position:relative;overflow:hidden;margin-top:-2px;opacity:{% if is_state('binary_sensor.smol_9_online','on') %}1{% else %}.6{% endif %}}mushroom-shape-icon{display:none}
         mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:44px;line-height:.8;color:var(--primary-color);text-shadow:0 0 7px rgba(91,255,154,.55)}.secondary{color:var(--primary-color);opacity:.7;font-size:10px}
   - type: entities
     show_header_toggle: false
@@ -431,7 +435,7 @@ cards:
       name: Install (when this leads)
       icon: mdi:rocket-launch
     card_mod:
-      style: ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px}
+      style: ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_9_online','on') %}1{% else %}.6{% endif %}}
 - type: markdown
   view_layout:
     grid-column: span 12

--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -417,6 +417,17 @@ mqtt:
 # =====================================================================
 template:
   - sensor:
+      # --- #51 dynamic-role gap fix: EVERY node needs leaf-bond entities (any node can be a leaf now).
+      # id7 was gateway-only, so its rssi/band/resync were never defined; #51 (id8 can take over) makes
+      # id7 a leaf → its dashboard box showed 'entity not found' ×3. Defined for id7 here, mirroring 8/9;
+      # they read the DYNAMIC elected owner's peers (sensor.smol_<owner>_peers → the '7,' entry). ---
+      - name: "smol 7 rssi"
+        unique_id: smol_7_rssi
+        state: >-
+          {% set owner = state_attr('sensor.smol_mesh_channel', 'owner') or '7' %}
+          {% set ps = state_attr('sensor.smol_' ~ owner ~ '_peers', 'peers') or [] %}
+          {% set m = ps | select('match', '^7,') | list %}
+          {% if m %}{% set v = m[0].split(',')[1] | int(-999) %}{{ v - 256 if v > 127 else v }}{% else %}unknown{% endif %}
       - name: "smol 8 rssi"
         unique_id: smol_8_rssi
         state: >-
@@ -441,6 +452,11 @@ template:
       - name: "smol 9 online"
         unique_id: smol_9_online
         state: "{{ states('sensor.smol_9_voltage') not in ['unavailable', 'unknown', 'none', ''] }}"
+      - name: "smol 7 resync"
+        unique_id: smol_7_resync
+        state: >-
+          {% set ch = state_attr('sensor.smol_7_peers', 'ch') %}
+          {{ ch is not none and ch != state_attr('sensor.smol_mesh_channel', 'channel') }}
       - name: "smol 8 resync"
         unique_id: smol_8_resync
         state: >-
@@ -460,6 +476,11 @@ template:
 
   # --- #27 topology edge-weighting helpers (luna, issue-27 Appendix A) ---
   - sensor:
+      - name: "smol 7 rssi band"
+        unique_id: smol_7_rssi_band
+        state: >-
+          {% set r = states('sensor.smol_7_rssi') | int(-999) %}
+          {{ 'unknown' if r == -999 else 'strong' if r >= -55 else 'good' if r >= -70 else 'weak' if r >= -82 else 'faint' }}
       - name: "smol 8 rssi band"
         unique_id: smol_8_rssi_band
         state: >-

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2923,6 +2923,7 @@ pub fn start(
     // mesh (coexist gateway) or must demote to a scanning leaf.
     let mut elect = crate::net::wifi::MeshElect::new(id);
     elect.now_ms = now_ms(); // seed the ONE clock the stale-owner timeout runs on
+    elect.boot = true; // #51 return-flap: never displace a different owner already in the MC
     let mut ota_offer: Option<crate::ota::Announce> = None;
     let mut config_offer: Option<crate::app::DefaultScreen> = None;
     let mut install_requested = false;

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -866,12 +866,13 @@ const RELAY_FLUSH_INTERVAL_MS: u64 = 30_000;
 const FLUSH_FAILS_BEFORE_DROP: u8 = 2;
 /// R-DEMOTE (oracle audit-#1): after this many CONSECUTIVE failed flushes the AP is
 /// GENUINELY gone (R-CONNECT would have recovered a mere roam within seconds), so the
-/// gateway relinquishes ownership — `is_gateway=false` + drop to leaf-scan — and its
-/// HELLO stops pinning leaves to a HA-unreachable owner, letting a reachable board
-/// take over. Set well above `FLUSH_FAILS_BEFORE_DROP` (≈`FLUSH_FAILS_BEFORE_DEMOTE` ×
-/// RELAY_FLUSH_INTERVAL_MS ≈ 2.5 min of no AP) so a transient broker blip never
-/// flap-demotes; the election re-promotes once an AP is reachable again.
-const FLUSH_FAILS_BEFORE_DEMOTE: u8 = 5;
+/// gateway relinquishes ownership — `is_gateway=false` + drop to leaf-scan — and (with the
+/// #51 A1 silence gate) stops HELLOing, letting a reachable board take over. Set above
+/// `FLUSH_FAILS_BEFORE_DROP` so a transient broker blip never flap-demotes.
+/// #51 speed-up: 3 (≈`FLUSH_FAILS_BEFORE_DEMOTE` × RELAY_FLUSH_INTERVAL_MS ≈ 90 s of
+/// sustained no-AP) — still safely past a transient blip / roam (R-CONNECT recovers those in
+/// seconds), but ~60 s snappier than the prior 5 for the powered-uplink-loss (R4) failover.
+const FLUSH_FAILS_BEFORE_DEMOTE: u8 = 3;
 /// Recently-completed `(src_mac, msgid)` memory. A lost RELAYACK makes a leaf
 /// retransmit an ALREADY-complete message; we must re-ACK it but NOT re-enqueue
 /// (else duplicate UDP delivery — finding 3). Ring of the last few completions.
@@ -1405,8 +1406,12 @@ impl RadioManager {
         now: u64,
         tick: &mut dyn FnMut() -> bool,
     ) -> bool {
-        const REELECT_SILENCE_MS: u64 = 30_000; // owner HELLO gone this long → recover
-        const REELECT_RETRY_MS: u64 = 30_000; // min gap between recovery bursts
+        // #51 speed-up: owner HELLOs every 2 s, so 15 s silence ≈ 7 missed HELLOs = gone
+        // (a live owner that merely roamed is re-locked by leaf_scan_tick's 6 s re-scan long
+        // before this). Retry every 10 s — MUST be < RSSI_BUCKET_STEP_MS (15 s) so a weaker
+        // board gets a burst (reads the winner's retained MC → adopts) before its claim window.
+        const REELECT_SILENCE_MS: u64 = 15_000; // owner HELLO gone this long → recover
+        const REELECT_RETRY_MS: u64 = 10_000; // min gap between recovery bursts
         if self.relay.is_gateway {
             return false; // a gateway re-decides on its own flush; only leaves recover here
         }
@@ -1426,14 +1431,15 @@ impl RadioManager {
         let id = self.id;
         let mut elect = crate::net::wifi::MeshElect::new(id);
         elect.now_ms = now;
+        // #51: this is a LEAF RECOVERY election → select the WiFi-strength rule (sticky live
+        // owner + RSSI-weighted dead-owner takeover on the shorter RECOVERY_STALE_MS window).
+        // Seed our last-measured RSSI-to-AP so the strongest-uplink survivor wins; node-id
+        // only breaks exact-signal ties.
+        elect.recovery = true;
+        elect.my_rssi = self.my_rssi_to_ap;
         elect.seen_owner = self.mc_seen_owner;
         elect.seen_seq = self.mc_seen_seq;
         elect.seen_ms = self.mc_seen_ms;
-        // #51: this is a LEAF RECOVERY election → select the WiFi-strength rule (sticky live
-        // owner + RSSI-weighted dead-owner takeover). Seed our last-measured RSSI-to-AP so
-        // the strongest-uplink survivor wins; node-id only breaks exact-signal ties.
-        elect.recovery = true;
-        elect.my_rssi = self.my_rssi_to_ap;
         // #6 OTA / #21 config / #33 install: a leaf's recovery burst can also surface these.
         let mut ota_offer: Option<crate::ota::Announce> = None;
         let mut config_offer: Option<crate::app::DefaultScreen> = None;

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1278,6 +1278,16 @@ pub struct RadioManager {
     /// #33 HA Update entity: a retained `install` command was seen on a burst, pending
     /// `main`'s `take_install_request` → AND-gate the fetch. One-shot (cleared on take).
     install_requested: bool,
+    /// #51 A1 — SILENT-UNTIL-RELOCK: set true when this board ABDICATES (R-DEMOTE: its
+    /// uplink died) so `broadcast_hello` goes quiet. Leaves lock strictly on the OWNER's
+    /// HELLO (`peer_id == elected_owner`), so a demoted ex-owner that kept HELLOing would
+    /// pin them forever and block re-election (issue #51/#31). Cleared when we re-lock a
+    /// new owner's HELLO or win a fresh election — then normal 2 Hz HELLO resumes.
+    silent_until_relock: bool,
+    /// #51 B — last RSSI-to-AP (dBm, signed) captured after a successful association.
+    /// Seeded into the recovery `MeshElect` so the strongest-uplink survivor wins the
+    /// re-election. Weak default until the first burst measures it.
+    my_rssi_to_ap: i8,
 }
 
 /// Monotonic milliseconds since boot — the single time base for both the
@@ -1340,6 +1350,8 @@ impl RadioManager {
             ota_offer: None,
             config_offer: None,
             install_requested: false,
+            silent_until_relock: false,
+            my_rssi_to_ap: -99,
         })
     }
 
@@ -1417,6 +1429,11 @@ impl RadioManager {
         elect.seen_owner = self.mc_seen_owner;
         elect.seen_seq = self.mc_seen_seq;
         elect.seen_ms = self.mc_seen_ms;
+        // #51: this is a LEAF RECOVERY election → select the WiFi-strength rule (sticky live
+        // owner + RSSI-weighted dead-owner takeover). Seed our last-measured RSSI-to-AP so
+        // the strongest-uplink survivor wins; node-id only breaks exact-signal ties.
+        elect.recovery = true;
+        elect.my_rssi = self.my_rssi_to_ap;
         // #6 OTA / #21 config / #33 install: a leaf's recovery burst can also surface these.
         let mut ota_offer: Option<crate::ota::Announce> = None;
         let mut config_offer: Option<crate::app::DefaultScreen> = None;
@@ -1461,6 +1478,11 @@ impl RadioManager {
             log::info!("smol: leaf re-election — broker unreachable, still scanning");
             return true;
         }
+        // #51 B: we're still associated here (pre-EspNow-switch) → capture a fresh
+        // RSSI-to-AP for the NEXT recovery election's strength comparison.
+        if let Ok(r) = self.controller.rssi() {
+            self.my_rssi_to_ap = r.clamp(-127, 0) as i8;
+        }
         // Persist the refreshed staleness observation (so takeover accrues across bursts).
         self.mc_seen_owner = elect.seen_owner;
         self.mc_seen_seq = elect.seen_seq;
@@ -1470,16 +1492,28 @@ impl RadioManager {
         if elect.i_am_owner {
             // Took over a dead/stale owner (or empty topic): become the coexist GATEWAY.
             self.relay.is_gateway = true;
+            // #51 A1: we own the mesh now → resume HELLO (leaves lock on the owner's HELLO).
+            self.silent_until_relock = false;
+            // #51 A2: freshly-elected grace — clear the fail counter so a single transient
+            // flush miss can't immediately re-demote us (the mandatory anti-flap window).
+            self.relay.flush_fails = 0;
             log::info!("smol: leaf re-election WON — now GATEWAY (owner id{})", id);
             // switch() already left us in WifiSta — stay associated (coexist gateway).
         } else {
             // A LIVE owner holds the mesh (possibly a new lower id): stay leaf, re-scan.
             self.relay.is_gateway = false;
-            self.last_owner_heard_ms = now; // grace: give the scan time to re-lock it
+            // #51 speed-up: grace-reset the owner-silence clock ONLY for a GENUINELY LIVE
+            // owner (give the scan time to re-lock it). A dead-but-inside-our-backoff owner
+            // (owner_alive == false) gets NO reset, so the next recovery burst fires on
+            // cadence and the deferred takeover isn't pushed out an extra window.
+            if elect.owner_alive {
+                self.last_owner_heard_ms = now;
+            }
             let _ = self.switch(Mode::EspNow);
             log::info!(
-                "smol: leaf re-election → live owner id{} (re-scanning)",
-                self.elected_owner
+                "smol: leaf re-election → owner id{} ({})",
+                self.elected_owner,
+                if elect.owner_alive { "live — re-scanning" } else { "dead — deferring takeover" }
             );
         }
         true
@@ -1584,6 +1618,13 @@ impl RadioManager {
     /// Safe in either radio mode; in `WifiSta` it rides the AP channel, in
     /// `EspNow` the fixed one. Called by `main` a few times per second.
     pub fn broadcast_hello(&mut self) {
+        // #51 A1: an abdicated board (uplink died → R-DEMOTE) stays HELLO-silent until it
+        // re-locks a new owner. Leaves pin on the OWNER's HELLO, so a demoted ex-owner that
+        // kept HELLOing would block them from ever re-electing (the #51/#31 wedge). TIME and
+        // other frames are unaffected — only HELLO drives the owner-silence clock.
+        if self.silent_until_relock {
+            return;
+        }
         let mut msg = [0u8; 16];
         let len = encode_id_frame(HELLO_PREFIX, self.id, &mut msg);
         self.send_to(&BROADCAST_ADDRESS, &msg[..len]);
@@ -2163,6 +2204,11 @@ impl RadioManager {
         // — the runtime convergence the boot-only election never had. A NON-connected
         // flush (transient broker outage) is NOT trusted → keep the current role.
         if ok {
+            // #51 B: still associated after a good flush → refresh RSSI-to-AP so a later
+            // demote-then-recover election compares this board's real signal strength.
+            if let Ok(r) = self.controller.rssi() {
+                self.my_rssi_to_ap = r.clamp(-127, 0) as i8;
+            }
             self.mc_seen_owner = elect.seen_owner;
             self.mc_seen_seq = elect.seen_seq;
             self.mc_seen_ms = elect.seen_ms;
@@ -2213,9 +2259,13 @@ impl RadioManager {
                 self.relay.is_gateway = false;
                 self.scan_locked = false;
                 self.last_owner_heard_ms = now;
+                // #51 A1: this is an ABDICATION (our uplink is genuinely dead). Go
+                // HELLO-silent until we re-lock a new owner — otherwise our stale HELLO
+                // keeps the leaves pinned to us and no successor can ever be elected.
+                self.silent_until_relock = true;
                 let _ = self.switch(Mode::EspNow);
                 log::warn!(
-                    "smol: gateway DEMOTED after {} failed flushes — AP unreachable, leaf-scanning",
+                    "smol: gateway DEMOTED after {} failed flushes — AP unreachable, HELLO-silent + leaf-scanning",
                     self.relay.flush_fails
                 );
             }
@@ -2320,6 +2370,9 @@ impl RadioManager {
                     if !self.relay.is_gateway && peer_id == self.elected_owner {
                         self.scan_locked = true;
                         self.last_owner_heard_ms = now;
+                        // #51 A1: re-locked a valid owner's HELLO → resume normal HELLO
+                        // (we are a healthy leaf again, no longer an abdicated ghost).
+                        self.silent_until_relock = false;
                     }
 
                     // Register the broadcaster so the ACK below can be unicast.
@@ -2895,6 +2948,13 @@ pub fn start(
     // `synced` stays best-effort for TIME (mesh-time adoption handles an unsynced GW).
     radio.relay.is_gateway = reached_dhcp && elect.i_am_owner;
     radio.elected_owner = elect.owner_id;
+    // #51 B: if we associated, seed the initial RSSI-to-AP so the first recovery
+    // election already has a real signal-strength reading to compare on.
+    if reached_dhcp {
+        if let Ok(r) = radio.controller.rssi() {
+            radio.my_rssi_to_ap = r.clamp(-127, 0) as i8;
+        }
+    }
     // #23 fix: persist the boot election's staleness observation → a leaf's later
     // recovery re-election measures the owner's seq freshness FROM this first sample.
     radio.mc_seen_owner = elect.seen_owner;

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -106,11 +106,27 @@ pub struct MeshElect {
     /// When the current `(seen_owner, seen_seq)` pair was FIRST seen (ms). An owner
     /// whose seq stays frozen past `MC_STALE_MS` from here is presumed dead.
     pub seen_ms: u64,
+    // --- #51 inputs (seeded by the caller) ---
+    /// This board's live RSSI-to-AP (dBm, signed; weaker = more negative). Captured
+    /// after association and persisted on the RadioManager. Consumed by the #51 leaf
+    /// RECOVERY election so the strongest-uplink survivor takes over a dead owner
+    /// FIRST (weaker boards defer + adopt it). Ignored on the boot/flush paths.
+    pub my_rssi: i8,
+    /// #51: true ONLY on a LEAF's recovery re-election (a lost owner). Selects the
+    /// WiFi-strength "sticky live owner + RSSI-weighted takeover" rule. On boot and
+    /// gateway-flush this is false → the original, hardware-validated lowest-id
+    /// election runs UNCHANGED (preserves #2 split-brain + fast cold-start).
+    pub recovery: bool,
     // --- outputs (applied to the live role by the caller) ---
     /// True iff I claimed / hold ownership (I am the coexist gateway).
     pub i_am_owner: bool,
     /// The elected owner's id (== my_id when I own it).
     pub owner_id: u8,
+    /// #51: true iff the adopted owner was GENUINELY LIVE (fresh seq), false iff it
+    /// was dead-but-inside-our-backoff (a deferred takeover). The caller grace-resets
+    /// its owner-silence clock ONLY for a genuinely-live owner — a dead-deferred owner
+    /// gets no reset, so the next recovery burst fires on cadence (faster failover).
+    pub owner_alive: bool,
 }
 
 #[cfg(feature = "wifi")]
@@ -121,10 +137,37 @@ impl MeshElect {
             seen_owner: 0,
             seen_seq: 0,
             seen_ms: 0,
+            my_rssi: -99, // weak default until the first association captures it
+            recovery: false,
             i_am_owner: false,
             owner_id: my_id,
+            owner_alive: false,
         }
     }
+}
+
+/// #51: map a board's RSSI-to-AP (dBm) → how long it must WAIT, beyond `MC_STALE_MS`,
+/// before it may take over a dead owner. Stronger signal → shorter wait, so the
+/// best-uplink survivor claims the vacated ownership FIRST and publishes a fresh `MC`;
+/// weaker survivors, still inside their (longer) backoff, then observe that LIVE owner
+/// and adopt it — the WiFi-strength election JP asked for in #51, with node-id only
+/// breaking exact-bucket ties. Buckets are whole re-election cycles (~`REELECT_RETRY_MS`)
+/// so the winner's claim lands a full recovery burst before a weaker board would claim.
+/// No new `MC` wire field: a board only ever compares its OWN rssi against this threshold.
+#[cfg(feature = "wifi")]
+fn reelect_backoff_ms(rssi: i8, node_id: u8) -> u64 {
+    // Bucket by signal strength (typical STA range ≈ -30 strong … -90 weak dBm).
+    let bucket: u64 = if rssi >= -60 {
+        0
+    } else if rssi >= -75 {
+        1
+    } else {
+        2
+    };
+    // 30 s per weaker bucket (≈ one recovery-burst cycle) + a sub-cycle per-id term
+    // (200 ms/id) so two boards in the SAME rssi bucket still resolve deterministically
+    // to the lower id without ever colliding on the same burst.
+    bucket * 30_000 + (node_id as u64) * 200
 }
 
 /// OTA (#33 Model-A): the ONE retained fleet STAGING topic (`OTA|build|size|sha256|url`)
@@ -1227,10 +1270,14 @@ fn mqtt_session(
     //
     // 1. Refresh the persistent staleness observation: a *changed* (owner,seq) resets the
     //    "first seen" clock (fresh liveness); an unchanged pair keeps it (staleness accrues).
-    // 2. Adopt a lower-id owner ONLY while it is ALIVE (seq advanced within MC_STALE_MS).
-    //    A stale (frozen-seq) lower-id owner is DEAD → fall through to CLAIM (take over).
-    //    id >= mine, or empty/absent/unparseable, also CLAIM. `channel` stays 0 (advisory;
-    //    leaves discover the real channel by scanning the owner's HELLO).
+    // 2. TWO election rules, selected by `elect.recovery`:
+    //    * boot / gateway-flush (`recovery == false`): the ORIGINAL, hardware-validated
+    //      lowest-id election — adopt a LIVE lower-id owner, else claim. UNCHANGED, so
+    //      cold-start stays fast + #2 split-brain resolution stays as-verified.
+    //    * #51 LEAF RECOVERY (`recovery == true`): WiFi-strength election — NEVER override a
+    //      LIVE owner (sticky), and take over a DEAD owner only after this board's
+    //      RSSI-weighted backoff, so the strongest-uplink survivor wins (node-id breaks
+    //      ties). `channel` stays 0 (advisory; leaves discover it by scanning the HELLO).
     let claim_seq: Option<u32> = match mc {
         Some((owner, _ch, seq)) => {
             if owner != elect.seen_owner || seq != elect.seen_seq {
@@ -1238,19 +1285,54 @@ fn mqtt_session(
                 elect.seen_seq = seq;
                 elect.seen_ms = elect.now_ms;
             }
-            let stale = elect.now_ms.saturating_sub(elect.seen_ms) >= MC_STALE_MS;
-            if owner < node_id && !stale {
+            let alive = elect.now_ms.saturating_sub(elect.seen_ms) < MC_STALE_MS;
+            elect.owner_alive = alive;
+            if !elect.recovery {
+                // BOOT / gateway-flush — original lowest-id rule (byte-for-byte as verified).
+                if owner < node_id && alive {
+                    elect.i_am_owner = false;
+                    elect.owner_id = owner;
+                    None
+                } else {
+                    // id >= mine, or a STALE (dead) lower-id owner → claim / take over.
+                    elect.i_am_owner = true;
+                    elect.owner_id = node_id;
+                    Some(seq.wrapping_add(1))
+                }
+            } else if owner == node_id {
+                // #51 recovery: our own retained record → hold ownership.
+                elect.i_am_owner = true;
+                elect.owner_id = node_id;
+                Some(seq.wrapping_add(1))
+            } else if alive {
+                // #51 recovery: a LIVE owner (any id) is sticky — never override it. This is
+                // what makes the strongest board, once it claims, stay owner as the weaker
+                // survivors observe its fresh MC and adopt it.
                 elect.i_am_owner = false;
                 elect.owner_id = owner;
                 None
             } else {
-                // id >= mine, or a STALE (dead) lower-id owner → claim / take over.
-                elect.i_am_owner = true;
-                elect.owner_id = node_id;
-                Some(seq.wrapping_add(1))
+                // #51 recovery: owner is DEAD. Take over only once we're past MC_STALE_MS PLUS
+                // our RSSI-weighted backoff — the strongest-uplink survivor crosses first.
+                let backoff = reelect_backoff_ms(elect.my_rssi, node_id);
+                if elect.now_ms.saturating_sub(elect.seen_ms) >= MC_STALE_MS.saturating_add(backoff)
+                {
+                    elect.i_am_owner = true;
+                    elect.owner_id = node_id;
+                    Some(seq.wrapping_add(1))
+                } else {
+                    // Dead, but still inside OUR backoff → defer so a stronger board claims
+                    // first. Marked not-alive so the caller skips the owner-silence grace reset.
+                    elect.i_am_owner = false;
+                    elect.owner_id = owner;
+                    None
+                }
             }
         }
         None => {
+            // Empty/absent/unparseable topic → claim immediately (fast cold-start; a recovery
+            // that finds the record cleared also claims — sticky-adopt converges any race).
+            elect.owner_alive = false;
             elect.i_am_owner = true;
             elect.owner_id = node_id;
             Some(1)
@@ -1264,10 +1346,22 @@ fn mqtt_session(
         elect.seen_ms = elect.now_ms;
         let mut mcp = MqttScratch::new();
         let _ = write!(mcp, "MC|{}|0|{}", node_id, newseq);
-        if let Some(n) =
-            crate::net::mqtt::encode_publish(&mut pkt, MESH_CHANNEL_TOPIC, mcp.as_bytes(), true)
-        {
-            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        // #51 A2 — CLAIM-AFTER-PUBLISH: only actually hold ownership if the retained MC
+        // write reached the broker (proof our uplink is alive). If the publish fails, we
+        // are NOT a valid owner — revert to leaf so ownership can't land on a board whose
+        // broker link just died (prevents a dead-uplink board re-pinning the mesh).
+        let published = match crate::net::mqtt::encode_publish(
+            &mut pkt,
+            MESH_CHANNEL_TOPIC,
+            mcp.as_bytes(),
+            true,
+        ) {
+            Some(n) => tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick),
+            None => false,
+        };
+        if !published {
+            elect.i_am_owner = false; // couldn't prove uplink → stay leaf, retry next burst
+            log::warn!("smol: mesh election — MC publish FAILED, not claiming ownership");
         }
     }
     log::info!(

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -146,29 +146,42 @@ impl MeshElect {
     }
 }
 
-/// #51: map a board's RSSI-to-AP (dBm) → how long it must WAIT, beyond `MC_STALE_MS`,
-/// before it may take over a dead owner. Stronger signal → shorter wait, so the
-/// best-uplink survivor claims the vacated ownership FIRST and publishes a fresh `MC`;
-/// weaker survivors, still inside their (longer) backoff, then observe that LIVE owner
-/// and adopt it — the WiFi-strength election JP asked for in #51, with node-id only
-/// breaking exact-bucket ties. Buckets are whole re-election cycles (~`REELECT_RETRY_MS`)
-/// so the winner's claim lands a full recovery burst before a weaker board would claim.
+/// #51: map a board's RSSI-to-AP (dBm) → how long it must WAIT, beyond `RECOVERY_STALE_MS`,
+/// before it may take over a dead owner. Stronger signal → shorter wait, so the best-uplink
+/// survivor claims the vacated ownership FIRST and publishes a fresh (retained) `MC`; weaker
+/// survivors, still inside their (longer) backoff, then observe that LIVE owner and adopt it
+/// — the WiFi-strength election JP asked for in #51, node-id only breaking exact-bucket ties.
+///
+/// The bucket step (`RSSI_BUCKET_STEP_MS`) is deliberately LARGER than the recovery-burst
+/// cadence (`REELECT_RETRY_MS`), so a weaker board always has a recovery burst BETWEEN the
+/// stronger board's claim and its own claim threshold — it reads the stronger board's retained
+/// MC and adopts it, and thus NEVER claims. That is what keeps the RSSI winner STABLE: with no
+/// competing claim, the gateway-flush path's lowest-id resolver never fires to undo it. (Two
+/// boards in the SAME bucket can still co-claim in one window → resolved deterministically by
+/// that lowest-id flush path = the intended node-id tiebreak for equal signal.)
 /// No new `MC` wire field: a board only ever compares its OWN rssi against this threshold.
 #[cfg(feature = "wifi")]
 fn reelect_backoff_ms(rssi: i8, node_id: u8) -> u64 {
     // Bucket by signal strength (typical STA range ≈ -30 strong … -90 weak dBm).
-    let bucket: u64 = if rssi >= -60 {
+    let bucket: u64 = if rssi >= -65 {
         0
-    } else if rssi >= -75 {
+    } else if rssi >= -78 {
         1
     } else {
         2
     };
-    // 30 s per weaker bucket (≈ one recovery-burst cycle) + a sub-cycle per-id term
-    // (200 ms/id) so two boards in the SAME rssi bucket still resolve deterministically
-    // to the lower id without ever colliding on the same burst.
-    bucket * 30_000 + (node_id as u64) * 200
+    // One bucket step per weaker bucket (> the burst cadence, see above) + a small per-id
+    // term so same-bucket boards prefer the lower id (final tiebreak; sub-cadence, so it
+    // only orders an already-converging same-window co-claim, never separates buckets).
+    bucket * RSSI_BUCKET_STEP_MS + (node_id as u64) * 200
 }
+
+/// #51 recovery: RSSI backoff step. MUST exceed `REELECT_RETRY_MS` (10 s) so a weaker board
+/// gets a recovery burst (→ reads the winner's retained MC → adopts) before its own claim
+/// threshold — that's what keeps the stronger board's win stable (no competing claim, so the
+/// lowest-id flush resolver never fires to undo it).
+#[cfg(feature = "wifi")]
+const RSSI_BUCKET_STEP_MS: u64 = 15_000;
 
 /// OTA (#33 Model-A): the ONE retained fleet STAGING topic (`OTA|build|size|sha256|url`)
 /// published by `ota_publish.sh stage`. Every board subscribes it as its `latest_version`
@@ -186,6 +199,19 @@ const OTA_STAGED_TOPIC: &[u8] = b"smol/ota/staged";
 /// after a prolonged HELLO silence, giving the stale check a second sample to fire on).
 #[cfg(feature = "wifi")]
 const MC_STALE_MS: u64 = 90_000;
+
+/// #51 speed-up: the dead-owner window used ONLY on a LEAF RECOVERY election. It can be far
+/// shorter than `MC_STALE_MS` because recovery carries INDEPENDENT corroboration — the leaf
+/// only re-elects after `REELECT_SILENCE_MS` of owner-HELLO silence (a live gateway HELLOs
+/// every 2 s, so an audible one never reaches here). A takeover thus means the owner is quiet
+/// on BOTH the mesh (HELLO) AND the broker (MC seq frozen this long).
+/// LOWER BOUND: it MUST stay above the gateway's MC-republish cadence (`RELAY_FLUSH_INTERVAL_MS`
+/// ≈ 30 s) — a genuinely-alive gateway's seq is frozen up to one flush interval between flushes,
+/// and the seq-advance-resets-`alive` guard only protects us if our window spans a full flush.
+/// 35 s = one flush + margin → confidently dead, ~half the old MC_STALE_MS latency. Boot/
+/// gateway-flush keep `MC_STALE_MS` (single-signal, no HELLO corroboration → keep the 3× margin).
+#[cfg(feature = "wifi")]
+const RECOVERY_STALE_MS: u64 = 35_000;
 
 /// Parse a retained `MC|<owner_id>|<channel>|<seq>` election payload → (owner, ch, seq).
 /// ASCII, decimal fields. Returns `None` on any malformed field (panic-free).
@@ -1278,16 +1304,30 @@ fn mqtt_session(
     //      LIVE owner (sticky), and take over a DEAD owner only after this board's
     //      RSSI-weighted backoff, so the strongest-uplink survivor wins (node-id breaks
     //      ties). `channel` stays 0 (advisory; leaves discover it by scanning the HELLO).
+    // The owner the leaf was following (recovery seeds `seen_owner` from its last MC read).
+    // Captured before the observation below mutates it — lets us tell "the same owner we're
+    // waiting out" (defer, keep accruing) from "a different owner that just claimed" (a live
+    // successor to adopt + grace).
+    let lost_owner = elect.seen_owner;
     let claim_seq: Option<u32> = match mc {
         Some((owner, _ch, seq)) => {
-            if owner != elect.seen_owner || seq != elect.seen_seq {
-                elect.seen_owner = owner;
-                elect.seen_seq = seq;
+            // Refresh the staleness observation: a *changed* (owner,seq) resets the first-seen
+            // clock. Same rule on BOTH paths — an ADVANCING seq is the authoritative
+            // broker-liveness signal (a dead board can't publish), so it MUST reset "alive"
+            // even in recovery. That's the split-brain guard: an owner we lost on the mesh
+            // (HELLO) but is still flushing MC (seq climbing) is ALIVE → we adopt, never take
+            // over. Recovery differs ONLY in the shorter `RECOVERY_STALE_MS` window (a frozen
+            // seq is confidently dead sooner, because HELLO-silence already corroborates).
+            let reset = owner != elect.seen_owner || seq != elect.seen_seq;
+            if reset {
                 elect.seen_ms = elect.now_ms;
             }
-            let alive = elect.now_ms.saturating_sub(elect.seen_ms) < MC_STALE_MS;
-            elect.owner_alive = alive;
+            elect.seen_owner = owner;
+            elect.seen_seq = seq;
+            let stale_limit = if elect.recovery { RECOVERY_STALE_MS } else { MC_STALE_MS };
+            let alive = elect.now_ms.saturating_sub(elect.seen_ms) < stale_limit;
             if !elect.recovery {
+                elect.owner_alive = alive;
                 // BOOT / gateway-flush — original lowest-id rule (byte-for-byte as verified).
                 if owner < node_id && alive {
                     elect.i_am_owner = false;
@@ -1301,6 +1341,7 @@ fn mqtt_session(
                 }
             } else if owner == node_id {
                 // #51 recovery: our own retained record → hold ownership.
+                elect.owner_alive = false;
                 elect.i_am_owner = true;
                 elect.owner_id = node_id;
                 Some(seq.wrapping_add(1))
@@ -1308,21 +1349,33 @@ fn mqtt_session(
                 // #51 recovery: a LIVE owner (any id) is sticky — never override it. This is
                 // what makes the strongest board, once it claims, stay owner as the weaker
                 // survivors observe its fresh MC and adopt it.
+                //
+                // `owner_alive` (→ caller grace-resets the owner-silence clock) is true only for
+                // a DIFFERENT owner than the one we lost — a genuine successor to follow. The
+                // SAME owner is the one we're waiting out: keep it false so the caller does NOT
+                // reset the clock and staleness keeps accruing to takeover. (Using `reset` here
+                // would misfire on the FIRST burst, where the dead owner's last seq differs from
+                // our stale pre-loss sample — that's a baseline, not proof of current life. The
+                // seq-advance reset above still keeps a genuinely-flushing owner `alive` so we
+                // never take it over; we just don't grace-reset the silence clock for it.)
+                elect.owner_alive = owner != lost_owner;
                 elect.i_am_owner = false;
                 elect.owner_id = owner;
                 None
             } else {
-                // #51 recovery: owner is DEAD. Take over only once we're past MC_STALE_MS PLUS
-                // our RSSI-weighted backoff — the strongest-uplink survivor crosses first.
+                // #51 recovery: owner is DEAD. Take over once past RECOVERY_STALE_MS PLUS our
+                // RSSI-weighted backoff — the strongest-uplink survivor crosses first.
+                elect.owner_alive = false;
                 let backoff = reelect_backoff_ms(elect.my_rssi, node_id);
-                if elect.now_ms.saturating_sub(elect.seen_ms) >= MC_STALE_MS.saturating_add(backoff)
+                if elect.now_ms.saturating_sub(elect.seen_ms)
+                    >= RECOVERY_STALE_MS.saturating_add(backoff)
                 {
                     elect.i_am_owner = true;
                     elect.owner_id = node_id;
                     Some(seq.wrapping_add(1))
                 } else {
                     // Dead, but still inside OUR backoff → defer so a stronger board claims
-                    // first. Marked not-alive so the caller skips the owner-silence grace reset.
+                    // first. owner_alive already false → caller keeps the silence anchor.
                     elect.i_am_owner = false;
                     elect.owner_id = owner;
                     None

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -117,6 +117,13 @@ pub struct MeshElect {
     /// gateway-flush this is false → the original, hardware-validated lowest-id
     /// election runs UNCHANGED (preserves #2 split-brain + fast cold-start).
     pub recovery: bool,
+    /// #51 return-flap fix: true ONLY on the one-shot BOOT election. A freshly-booted board
+    /// must NEVER claim over a DIFFERENT owner already present in the retained MC — it comes
+    /// up as a leaf and lets leaf-scan (fast HELLO lock) + the recovery election decide (live
+    /// owner → adopt, no flap; dead → take over after the recovery window). Only claims at
+    /// boot when the MC is empty or already names THIS board. Gateway-flush keeps `boot=false`
+    /// so a running gateway's lowest-id split-brain resolution (#2) is unchanged.
+    pub boot: bool,
     // --- outputs (applied to the live role by the caller) ---
     /// True iff I claimed / hold ownership (I am the coexist gateway).
     pub i_am_owner: bool,
@@ -139,6 +146,7 @@ impl MeshElect {
             seen_ms: 0,
             my_rssi: -99, // weak default until the first association captures it
             recovery: false,
+            boot: false,
             i_am_owner: false,
             owner_id: my_id,
             owner_alive: false,
@@ -1326,9 +1334,21 @@ fn mqtt_session(
             elect.seen_seq = seq;
             let stale_limit = if elect.recovery { RECOVERY_STALE_MS } else { MC_STALE_MS };
             let alive = elect.now_ms.saturating_sub(elect.seen_ms) < stale_limit;
-            if !elect.recovery {
+            if elect.boot && owner != node_id {
+                // #51 return-flap fix: a FRESH-booting board never displaces a DIFFERENT owner
+                // already in the retained MC. Come up as a leaf and defer — leaf-scan locks a
+                // LIVE owner's HELLO in seconds (no re-claim bounce), and the recovery election
+                // takes over a genuinely DEAD one after its window. (At boot we have only ONE
+                // MC sample so we can't tell live from dead here; deferring lets the fast HELLO
+                // path decide. The COMMON cold-boot has no delay: the prior gateway reads
+                // owner==self below and re-claims its own record immediately; only peers defer.)
                 elect.owner_alive = alive;
-                // BOOT / gateway-flush — original lowest-id rule (byte-for-byte as verified).
+                elect.i_am_owner = false;
+                elect.owner_id = owner;
+                None
+            } else if !elect.recovery {
+                elect.owner_alive = alive;
+                // BOOT (empty/own MC) / gateway-flush — original lowest-id rule (as verified).
                 if owner < node_id && alive {
                     elect.i_am_owner = false;
                     elect.owner_id = owner;


### PR DESCRIPTION
Fixes #51 (and implements the blessed #31 design v2). **Canary-verify before merge — brick-adjacent election path.**

## Root cause
A gateway that loses its uplink self-demotes (R-DEMOTE, 5 failed flushes ≈2.5 min) but kept HELLOing **unconditionally** (`mode.rs` `broadcast_hello`, called every 2s at `main.rs:578`). Leaves lock strictly on the owner's HELLO (`peer_id == elected_owner`, `mode.rs:2320`) and only re-elect after 30s of owner-HELLO silence (`maybe_leaf_reelect`). So a demoted-but-still-HELLOing ex-owner pinned the leaves forever → the mesh went **gatewayless and never re-elected**. The winner was also lowest-node-id, not WiFi strength as requested.

## Fix (A1 + A2 + B), zero MC wire change
- **A1 silent-until-relock:** new `silent_until_relock` state gates `broadcast_hello`. R-DEMOTE sets it → an abdicated board goes HELLO-silent until it re-locks a new owner (or wins). Leaves then hit the silence threshold and the existing takeover path fires. Verified: **only** the HELLO arm touches the owner-silence clock, so TIME/telemetry keep flowing.
- **A2 claim-after-publish + grace:** `i_am_owner` is set only once the retained MC write reaches the broker (live-uplink proof); `flush_fails` resets on winning election (freshly-elected anti-flap window).
- **B WiFi-strength election:** capture RSSI-to-AP (`WifiController::rssi()`) after association; on a **leaf recovery** election (`elect.recovery`), use sticky-live-owner + an RSSI-weighted takeover backoff so the strongest-uplink survivor claims first and weaker boards adopt it (node-id breaks ties). **Boot + gateway-flush keep the original hardware-validated lowest-id rule unchanged** (fast cold-start, #2 split-brain resolution intact).

Panic-free on untrusted retained MC (#46 clamp discipline preserved).

## Verification (team-lead, hardware)
1. Canary one board (id7), boot-clean check.
2. **R4** — kill the gateway's UPLINK only (broker/AP down, board still powered): confirm the ex-owner goes HELLO-silent and a remaining leaf silence-detects + takes over.
3. Full-unplug id7: confirm a leaf takes over; confirm the winner is the strongest-WiFi board.

Timing: takeover completes in ~90–120 s (MC_STALE_MS 90 s + silence detect). Sub-60 s is a follow-up tuning knob (MC_STALE_MS or HELLO-silence back-dating) — deliberately deferred to keep this election change bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)