### PR TITLE
feat(fw+ha): #64 gateway WiFi-uplink RSSI (+ fixes dead #51 tiebreak)

### DIFF
--- a/ha/dashboard/.gitignore
+++ b/ha/dashboard/.gitignore
@@ -1,0 +1,3 @@
+# Generated at deploy time by build_control_room.py — not source.
+lovelace_PRESAVE_backup.json
+smol-topology.svg

--- a/ha/dashboard/build_control_room.py
+++ b/ha/dashboard/build_control_room.py
@@ -5,13 +5,16 @@
 # glass/power/forge which render). Node cards stay LIVE mushroom boxes (header + OLED + entities).
 # If mushroom still doesn't render un-nested → it's mushroom, swap to SVG faceplate then.
 #   HA_TOKEN=<your-ha-long-lived-token> python3 build_control_room.py
-import asyncio, json, os, re, subprocess, hashlib, yaml, websockets
+import asyncio, json, os, re, ssl, subprocess, hashlib, yaml, websockets
 try:
     from defusedxml.minidom import parseString as xml_parse
 except ImportError:
     from xml.dom.minidom import parseString as xml_parse
-URI="wss://homeassistant.local:8123/api/websocket"; TOKEN=os.environ["HA_TOKEN"]; DASH="dashboard-dashboard"
-HA="user@homeassistant.local"; WWW="/config/www/luna-cards"; LOCAL="/local/luna-cards"
+URI=os.environ.get("HA_WS_URI","wss://homeassistant.local:8123/api/websocket"); TOKEN=os.environ["HA_TOKEN"]; DASH="dashboard-dashboard"
+SSLCTX=ssl.create_default_context()  # verifies by default
+if os.environ.get("HA_WS_INSECURE"):  # explicit opt-out for a LAN self-signed HA cert (like curl -k)
+    SSLCTX.check_hostname=False; SSLCTX.verify_mode=ssl.CERT_NONE
+HA=os.environ.get("HA_SSH","user@homeassistant.local"); WWW="/config/www/luna-cards"; LOCAL="/local/luna-cards"
 KNOWN={7:{"name":"Draconic Dominion","role":"the Seat","gate":True},
        8:{"name":"Eldritch Nexus","role":"leaf"},
        9:{"name":"Jade Herald","role":"leaf"}}
@@ -24,8 +27,13 @@ def accent_top(c): return ("ha-card{position:relative;overflow:hidden}ha-card:be
 # ---------- node box = mushroom header + mushroom OLED + entities; span-4 in the VIEW grid ----------
 def node_card(nid, meta, present):
     gate=meta["gate"]; I=str(nid); on=f"is_state('binary_sensor.smol_{I}_online','on')"
-    # RSSI pip LIVE (re-evaluates on takeover): gateway → WiFi (no self mesh-rssi); leaf → dBm
-    rssi_pip=(" · {% if gw %}WiFi{% else %}{{ states('sensor.smol_"+I+"_rssi') if states('sensor.smol_"+I+"_rssi') not in na else '—' }} dBm{% endif %}")
+    # #64: the gateway's WiFi-uplink RSSI entity is device-name-derived (HA discovery names
+    # it sensor.smol_<id>_<noun>_uplink, where <noun> is the fantasy noun = last name word).
+    up=f"sensor.smol_{nid}_{meta['name'].split()[-1].lower()}_uplink"
+    # RSSI pip LIVE (re-evaluates on takeover): gateway → its WiFi-uplink dBm (#64, falls to
+    # 'WiFi' until the first burst publishes it); leaf → mesh-bond dBm.
+    rssi_pip=(" · {% if gw %}{% set u=states('"+up+"') %}{% if u not in na %}{{ u }} dBm ↑{% else %}WiFi{% endif %}"
+              "{% else %}{{ states('sensor.smol_"+I+"_rssi') if states('sensor.smol_"+I+"_rssi') not in na else '—' }} dBm{% endif %}")
     # LIVE gateway signal = peers-state 'gateway' (an entity STATE → works in mushroom templates AND legacy conditional-card conditions).
     gw="is_state('sensor.smol_"+I+"_peers','gateway')"
     hdr=("{% set on="+on+" %}{% set gw="+gw+" %}{% set t=states('sensor.smol_"+I+"_temp') %}{% set v=states('sensor.smol_"+I+"_voltage') %}"
@@ -94,6 +102,7 @@ def node_card(nid, meta, present):
         "conditions":[{"entity":f"sensor.smol_{nid}_peers","state":"gateway"}],
         "card":{"type":"entities","show_header_toggle":False,"card_mod":{"style":JOIN},"entities":[
             {"type":"section","label":"gateway anchor · WiFi uplink"},
+            {"entity":up,"name":"WiFi uplink (RSSI)","icon":"mdi:wifi-arrow-up"},  # #64: gateway AP-uplink RSSI (sensor.smol_<id>_<noun>_uplink)
             {"type":"attribute","entity":"sensor.smol_mesh_channel","attribute":"channel","name":"mesh channel (owned)","icon":"mdi:wifi"},
             {"type":"attribute","entity":"sensor.smol_mesh_channel","attribute":"seq","name":"mesh seq (advancing)","icon":"mdi:counter"},
             {"entity":f"sensor.smol_{nid}_peers","name":"peers / roster","icon":"mdi:lan"}]}}
@@ -170,7 +179,7 @@ async def rpc(ws,m,_i=[1]):
 
 async def main():
     view=yaml.safe_load(open("smol-control-scaffold.yaml"))
-    async with websockets.connect(URI,max_size=16*1024*1024) as ws:
+    async with websockets.connect(URI,max_size=16*1024*1024,ssl=SSLCTX) as ws:
         json.loads(await ws.recv()); await ws.send(json.dumps({"type":"auth","access_token":TOKEN})); await ws.recv()
         st={s["entity_id"]:s for s in (await rpc(ws,{"type":"get_states"}))["result"]}; present=set(st)
         ids=sorted(int(m.group(1)) for e in present if (m:=re.match(r"binary_sensor\.smol_(\d+)_online$",e))) or [7,8,9]

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2143,6 +2143,11 @@ impl RadioManager {
         elect.seen_owner = self.mc_seen_owner;
         elect.seen_seq = self.mc_seen_seq;
         elect.seen_ms = self.mc_seen_ms;
+        // #64: carry the last-good RSSI-to-AP into the burst so the gateway PUBLISHES its
+        // WiFi-uplink signal. Captured post-flush below (#51 B) → this is the previous
+        // good flush's reading (~one heartbeat of lag, fine for a display value); -99
+        // until the first good flush, which mqtt_session's publish guard skips.
+        elect.my_rssi = self.my_rssi_to_ap;
         // #6 OTA: capture any gated retained announce this flush surfaces.
         let mut ota_offer: Option<crate::ota::Announce> = None;
         // #21: capture any default-screen config this flush surfaces.
@@ -2210,10 +2215,13 @@ impl RadioManager {
         // — the runtime convergence the boot-only election never had. A NON-connected
         // flush (transient broker outage) is NOT trusted → keep the current role.
         if ok {
-            // #51 B: still associated after a good flush → refresh RSSI-to-AP so a later
-            // demote-then-recover election compares this board's real signal strength.
-            if let Ok(r) = self.controller.rssi() {
-                self.my_rssi_to_ap = r.clamp(-127, 0) as i8;
+            // #64 fix: the RSSI-to-AP is now captured DURING the burst (run_mqtt_burst, while
+            // is_connected()==true) into elect.my_rssi — persist it here across bursts for the
+            // leaf-reelect path. The old post-burst self.controller.rssi() ran when the STA
+            // state was unreliable → returned Err → my_rssi_to_ap stuck at -99 (dead #51
+            // tiebreak + no #64 uplink publish).
+            if elect.my_rssi > -99 {
+                self.my_rssi_to_ap = elect.my_rssi;
             }
             self.mc_seen_owner = elect.seen_owner;
             self.mc_seen_seq = elect.seen_seq;

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1118,6 +1118,45 @@ fn mqtt_session(
         }
     }
 
+    // #64: publish THIS gateway's WiFi-uplink RSSI (RSSI-to-AP). Only the associated
+    // gateway has it — leaves are ESP-NOW-only — so it's published for `node_id` (self)
+    // alone, not per queued leaf. `elect.my_rssi` carries the caller's last-good capture;
+    // -99 = "never associated" sentinel → skip (a real gateway link is never that weak).
+    // Transient value topic + a RETAINED discovery config auto-creates
+    // `sensor.smol_<id>_uplink`; `expire_after` clears a demoted node's stale reading, so
+    // the value follows the crown across #51 role swaps with no dynamic-owner template.
+    if elect.my_rssi > -99 {
+        let mut utopic = MqttScratch::new();
+        let _ = write!(utopic, "smol/{}/uplink", node_id);
+        let mut uval = MqttScratch::new();
+        let _ = write!(uval, "{}", elect.my_rssi);
+        if let Some(n) =
+            crate::net::mqtt::encode_publish(&mut pkt, utopic.as_bytes(), uval.as_bytes(), false)
+        {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
+        let mut dtopic = MqttScratch::new();
+        let _ = write!(dtopic, "homeassistant/sensor/smol{}/uplink/config", node_id);
+        let unoun = crate::net::names::name_for_id(node_id).1;
+        // F1 discipline: build the config in the .bss JsonScratch (512), not on-stack.
+        let json = unsafe { &mut *core::ptr::addr_of_mut!(MQTT_JSON) };
+        json.clear();
+        let _ = write!(
+            json,
+            // Mirror the telemetry discovery pattern EXACTLY (terse name + object_id, NO
+            // entity_category) so HA derives the clean entity_id `sensor.smol_<id>_uplink`
+            // from object_id instead of the device-name-concatenated form. unique_id bumped
+            // (_uplk) to force HA to re-derive the entity_id for the corrected config.
+            "{{\"unique_id\":\"smol{}_uplk\",\"object_id\":\"smol_{}_uplink\",\"has_entity_name\":true,\"name\":\"Uplink\",\"state_topic\":\"smol/{}/uplink\",\"unit_of_measurement\":\"dBm\",\"device_class\":\"signal_strength\",\"expire_after\":120,\"device\":{{\"identifiers\":[\"smol{}\"],\"name\":\"smol {} {}\"}}}}",
+            node_id, node_id, node_id, node_id, node_id, unoun
+        );
+        if let Some(n) =
+            crate::net::mqtt::encode_publish(&mut pkt, dtopic.as_bytes(), json.as_bytes(), true)
+        {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
+    }
+
     // #27: publish this node's serialized roster as RETAINED `smol/<id>/peers`, if any.
     // GATEWAY-primary — the caller (`flush_telemetry`) serializes the roster and passes
     // it; leaves / the boot + election-only bursts pass an empty slice (skipped here).
@@ -1615,6 +1654,16 @@ pub fn run_mqtt_burst(
     // MQTT stream (the old UDP path only needed the ARP reply). Same reasoning,
     // same placement (must be AFTER the reconnect). Tradeoff: higher idle draw.
     let _ = controller.set_power_saving(esp_wifi::config::PowerSaveMode::None);
+
+    // #64: capture the WiFi-uplink RSSI HERE — the STA is confirmed connected (the loop
+    // above waited for is_connected()==Ok(true)), so esp_wifi_sta_get_rssi has a live
+    // association to read. The old #51 capture ran AFTER the whole burst returned, where
+    // the STA state was unreliable, so it errored and my_rssi stayed at its -99 sentinel
+    // (dead election tiebreak + no #64 publish). Set elect.my_rssi so mqtt_session
+    // publishes it this same burst and the caller persists it for #51's tiebreak.
+    if let Ok(r) = controller.rssi() {
+        elect.my_rssi = r.clamp(-127, 0) as i8;
+    }
 
     // Fresh DHCP lease each burst (the interface was just rebuilt).
     loop {


### PR DESCRIPTION
Closes the last dynamic-role gap from #51: the gateway now surfaces its **WiFi-uplink RSSI**.

## What
- **fw**: capture RSSI-to-AP **inside `run_mqtt_burst`** (right after `is_connected()==Ok(true)`) → `elect.my_rssi` → `mqtt_session` publishes `smol/<id>/uplink` + an auto-discovery sensor; `flush_telemetry` persists it.
- **ha**: Control Room shows the uplink on whichever node is the gateway (crown-box row + header pip `dBm ↑`), following the dynamic #51 role. Generator made env-configurable (`HA_WS_URI`/`HA_WS_INSECURE`/`HA_SSH`), TLS verifies by default.

## Latent bug found + fixed
The old #51 capture ran **after** the burst returned, where the STA wasn't connected → `esp_wifi_sta_get_rssi` errored → `my_rssi` stuck at its **-99 sentinel**. So #51's RSSI election **tiebreak was silently dead** (always fell back to lowest-id). Capturing mid-burst fixes both #64 and the tiebreak.

## Verified
Hardware: id8 (gateway) publishes **-74 dBm**, live on the dashboard. Flashed id7 + id8 via USB (MAC-guarded).

## Not in this PR
id9/Herald is USB-unreachable and currently a leaf — it needs #64 via **OTA while it's the gateway** (leaf-OTA is #40, unbuilt). Tracked separately.