### PR TITLE
#40 leaf-mesh-OTA — signed firmware to ESP-NOW-only leaves over the mesh

### DIFF
--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -353,6 +353,29 @@ mqtt:
       json_attributes_topic: "smol/9/status"
       json_attributes_template: "{% set p = value.split('|') %}{{ ({'build': p[2]} if p | length >= 3 else {}) | tojson }}"
       icon: "mdi:chip"
+    # --- #40 running BUILD# as a first-class device-merged value (JP ask 2026-07-11) ---
+    # Promotes the `build` attr of smol_<id>_screen to a plain visible sensor so the
+    # leaf-mesh-OTA canary is verifiable HEADLESS in HA (build# flipping = update stuck;
+    # the ESP32-C3 USB-JTAG boards give no reliable headless serial). Same
+    # STAT|<screen>:<page>|<build> source; length-guarded split (panic-free).
+    - name: "smol 7 build"
+      unique_id: smol_7_build_mirror
+      state_topic: "smol/7/status"
+      value_template: "{% set p = value.split('|') %}{{ p[2] if p | length >= 3 else 'unknown' }}"
+      entity_category: diagnostic
+      icon: "mdi:tag-text"
+    - name: "smol 8 build"
+      unique_id: smol_8_build_mirror
+      state_topic: "smol/8/status"
+      value_template: "{% set p = value.split('|') %}{{ p[2] if p | length >= 3 else 'unknown' }}"
+      entity_category: diagnostic
+      icon: "mdi:tag-text"
+    - name: "smol 9 build"
+      unique_id: smol_9_build_mirror
+      state_topic: "smol/9/status"
+      value_template: "{% set p = value.split('|') %}{{ p[2] if p | length >= 3 else 'unknown' }}"
+      entity_category: diagnostic
+      icon: "mdi:tag-text"
     # --- #48 LED mode — mirror of the retained smol/<id>/config/led (commanded value) ---
     - name: "smol 7 LED"
       unique_id: smol_7_led_mirror

--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -376,6 +376,28 @@ mqtt:
       value_template: "{% set p = value.split('|') %}{{ p[2] if p | length >= 3 else 'unknown' }}"
       entity_category: diagnostic
       icon: "mdi:tag-text"
+    # --- #40 leaf-mesh-OTA relay PHASE (headless diag) — gateway publishes on its next burst
+    # after relaying to this leaf: confirmed / rolled-back / fetch-failed / relay-failed /
+    # leaf-timeout / mac-unknown. The mesh-only leaf has no serial, so this retained topic is
+    # the ONLY window into a relay attempt's outcome. `none` until a relay is attempted.
+    - name: "smol 7 ota diag"
+      unique_id: smol_7_ota_diag_mirror
+      state_topic: "smol/7/ota/diag"
+      value_template: "{{ value if value else 'none' }}"
+      entity_category: diagnostic
+      icon: "mdi:cloud-upload-outline"
+    - name: "smol 8 ota diag"
+      unique_id: smol_8_ota_diag_mirror
+      state_topic: "smol/8/ota/diag"
+      value_template: "{{ value if value else 'none' }}"
+      entity_category: diagnostic
+      icon: "mdi:cloud-upload-outline"
+    - name: "smol 9 ota diag"
+      unique_id: smol_9_ota_diag_mirror
+      state_topic: "smol/9/ota/diag"
+      value_template: "{{ value if value else 'none' }}"
+      entity_category: diagnostic
+      icon: "mdi:cloud-upload-outline"
     # --- #48 LED mode — mirror of the retained smol/<id>/config/led (commanded value) ---
     - name: "smol 7 LED"
       unique_id: smol_7_led_mirror

--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -398,6 +398,28 @@ mqtt:
       value_template: "{{ value if value else 'none' }}"
       entity_category: diagnostic
       icon: "mdi:cloud-upload-outline"
+    # --- #40 leaf-mesh-OTA ARM-CHAIN trace (headless) — the GATEWAY dumps this every flush:
+    # "install-caught=<id|none> pending=<id|none> staged_raw=<build|none> leaf_ota=<0|1>".
+    # Pinpoints which arm link is null in one reflash (the C3 has no serial). Published by
+    # whichever node is currently the gateway; the others read `none`.
+    - name: "smol 7 ota armdiag"
+      unique_id: smol_7_ota_armdiag_mirror
+      state_topic: "smol/7/ota/armdiag"
+      value_template: "{{ value if value else 'none' }}"
+      entity_category: diagnostic
+      icon: "mdi:link-variant"
+    - name: "smol 8 ota armdiag"
+      unique_id: smol_8_ota_armdiag_mirror
+      state_topic: "smol/8/ota/armdiag"
+      value_template: "{{ value if value else 'none' }}"
+      entity_category: diagnostic
+      icon: "mdi:link-variant"
+    - name: "smol 9 ota armdiag"
+      unique_id: smol_9_ota_armdiag_mirror
+      state_topic: "smol/9/ota/armdiag"
+      value_template: "{{ value if value else 'none' }}"
+      entity_category: diagnostic
+      icon: "mdi:link-variant"
     # --- #48 LED mode — mirror of the retained smol/<id>/config/led (commanded value) ---
     - name: "smol 7 LED"
       unique_id: smol_7_led_mirror

--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -420,6 +420,111 @@ mqtt:
       value_template: "{{ value if value else 'none' }}"
       entity_category: diagnostic
       icon: "mdi:link-variant"
+    # --- #40 leaf-mesh-OTA RELAY PROGRESS (Luna · JP ask 2026-07-11) — the gateway publishes
+    # smol/<id>/ota/relaydiag on each burst while relaying the image to this leaf:
+    #   "rx=N otan=M last_wb=W/T otam_tx=A/B settle=S leaf=HxVyNzch<c>"
+    # last_wb=W/T is the LITERAL image-transfer progress (e.g. 4288/4343 = 98.7%). STATE = that
+    # percentage (numeric %, drives the dashboard progress bar); the raw fields ride as attributes
+    # so a stalling/tailing relay is diagnosable HEADLESS (the mesh-only leaf has no serial).
+    # Retained + STICKY: last_wb persists at 100% after a completed transfer — the dashboard gates
+    # visibility on build#-behind-staged / non-clean phase, NOT on this number alone. Length- and
+    # divide-guarded (panic-free): 'unknown' until a relay publishes a parseable last_wb.
+    - name: "smol 7 ota relaydiag"
+      unique_id: smol_7_ota_relaydiag_mirror
+      state_topic: "smol/7/ota/relaydiag"
+      unit_of_measurement: "%"
+      entity_category: diagnostic
+      icon: "mdi:progress-upload"
+      value_template: >-
+        {% set ns = namespace(w=0, t=0, ok=false) %}
+        {% for tok in value.split() %}
+          {% if tok.startswith('last_wb=') and '/' in tok %}
+            {% set f = tok.split('=', 1)[1].split('/') %}
+            {% set ns.w = f[0] | int(0) %}{% set ns.t = f[1] | int(0) %}{% set ns.ok = true %}
+          {% endif %}
+        {% endfor %}
+        {% if ns.ok and ns.t > 0 %}{{ (100.0 * ns.w / ns.t) | round(1) }}{% else %}unknown{% endif %}
+      json_attributes_topic: "smol/7/ota/relaydiag"
+      json_attributes_template: >-
+        {% set ns = namespace(rx='', otan='', wb='', otam='', settle='', leaf='') %}
+        {% for t in value.split() %}
+          {% if t.startswith('rx=') %}{% set ns.rx = t[3:] %}
+          {% elif t.startswith('otan=') %}{% set ns.otan = t[5:] %}
+          {% elif t.startswith('last_wb=') %}{% set ns.wb = t[8:] %}
+          {% elif t.startswith('otam_tx=') %}{% set ns.otam = t[8:] %}
+          {% elif t.startswith('settle=') %}{% set ns.settle = t[7:] %}
+          {% elif t.startswith('leaf=') %}{% set ns.leaf = t[5:] %}
+          {% endif %}
+        {% endfor %}
+        {% set wp = ns.wb.split('/') %}
+        {{ {'rx': ns.rx, 'otan': ns.otan, 'last_wb': ns.wb,
+            'wb_done': (wp[0] | int(0)) if wp | length == 2 else 0,
+            'wb_total': (wp[1] | int(0)) if wp | length == 2 else 0,
+            'otam_tx': ns.otam, 'settle': ns.settle, 'leaf': ns.leaf, 'raw': value} | tojson }}
+    - name: "smol 8 ota relaydiag"
+      unique_id: smol_8_ota_relaydiag_mirror
+      state_topic: "smol/8/ota/relaydiag"
+      unit_of_measurement: "%"
+      entity_category: diagnostic
+      icon: "mdi:progress-upload"
+      value_template: >-
+        {% set ns = namespace(w=0, t=0, ok=false) %}
+        {% for tok in value.split() %}
+          {% if tok.startswith('last_wb=') and '/' in tok %}
+            {% set f = tok.split('=', 1)[1].split('/') %}
+            {% set ns.w = f[0] | int(0) %}{% set ns.t = f[1] | int(0) %}{% set ns.ok = true %}
+          {% endif %}
+        {% endfor %}
+        {% if ns.ok and ns.t > 0 %}{{ (100.0 * ns.w / ns.t) | round(1) }}{% else %}unknown{% endif %}
+      json_attributes_topic: "smol/8/ota/relaydiag"
+      json_attributes_template: >-
+        {% set ns = namespace(rx='', otan='', wb='', otam='', settle='', leaf='') %}
+        {% for t in value.split() %}
+          {% if t.startswith('rx=') %}{% set ns.rx = t[3:] %}
+          {% elif t.startswith('otan=') %}{% set ns.otan = t[5:] %}
+          {% elif t.startswith('last_wb=') %}{% set ns.wb = t[8:] %}
+          {% elif t.startswith('otam_tx=') %}{% set ns.otam = t[8:] %}
+          {% elif t.startswith('settle=') %}{% set ns.settle = t[7:] %}
+          {% elif t.startswith('leaf=') %}{% set ns.leaf = t[5:] %}
+          {% endif %}
+        {% endfor %}
+        {% set wp = ns.wb.split('/') %}
+        {{ {'rx': ns.rx, 'otan': ns.otan, 'last_wb': ns.wb,
+            'wb_done': (wp[0] | int(0)) if wp | length == 2 else 0,
+            'wb_total': (wp[1] | int(0)) if wp | length == 2 else 0,
+            'otam_tx': ns.otam, 'settle': ns.settle, 'leaf': ns.leaf, 'raw': value} | tojson }}
+    - name: "smol 9 ota relaydiag"
+      unique_id: smol_9_ota_relaydiag_mirror
+      state_topic: "smol/9/ota/relaydiag"
+      unit_of_measurement: "%"
+      entity_category: diagnostic
+      icon: "mdi:progress-upload"
+      value_template: >-
+        {% set ns = namespace(w=0, t=0, ok=false) %}
+        {% for tok in value.split() %}
+          {% if tok.startswith('last_wb=') and '/' in tok %}
+            {% set f = tok.split('=', 1)[1].split('/') %}
+            {% set ns.w = f[0] | int(0) %}{% set ns.t = f[1] | int(0) %}{% set ns.ok = true %}
+          {% endif %}
+        {% endfor %}
+        {% if ns.ok and ns.t > 0 %}{{ (100.0 * ns.w / ns.t) | round(1) }}{% else %}unknown{% endif %}
+      json_attributes_topic: "smol/9/ota/relaydiag"
+      json_attributes_template: >-
+        {% set ns = namespace(rx='', otan='', wb='', otam='', settle='', leaf='') %}
+        {% for t in value.split() %}
+          {% if t.startswith('rx=') %}{% set ns.rx = t[3:] %}
+          {% elif t.startswith('otan=') %}{% set ns.otan = t[5:] %}
+          {% elif t.startswith('last_wb=') %}{% set ns.wb = t[8:] %}
+          {% elif t.startswith('otam_tx=') %}{% set ns.otam = t[8:] %}
+          {% elif t.startswith('settle=') %}{% set ns.settle = t[7:] %}
+          {% elif t.startswith('leaf=') %}{% set ns.leaf = t[5:] %}
+          {% endif %}
+        {% endfor %}
+        {% set wp = ns.wb.split('/') %}
+        {{ {'rx': ns.rx, 'otan': ns.otan, 'last_wb': ns.wb,
+            'wb_done': (wp[0] | int(0)) if wp | length == 2 else 0,
+            'wb_total': (wp[1] | int(0)) if wp | length == 2 else 0,
+            'otam_tx': ns.otam, 'settle': ns.settle, 'leaf': ns.leaf, 'raw': value} | tojson }}
     # --- #48 LED mode — mirror of the retained smol/<id>/config/led (commanded value) ---
     - name: "smol 7 LED"
       unique_id: smol_7_led_mirror

--- a/rust/clock/src/about.rs
+++ b/rust/clock/src/about.rs
@@ -89,7 +89,7 @@ impl Plugin for About {
         ctx.display.clear(BinaryColor::Off).ok();
 
         // WHO — the node noun (identity), matching the menu title + boot splash.
-        let noun = crate::net::names::name_for_id(crate::NODE_ID).1;
+        let noun = crate::net::names::name_for_id(crate::node_id()).1;
         Text::with_baseline(noun, Point::new(2, 0), title, Baseline::Top)
             .draw(ctx.display)
             .ok();

--- a/rust/clock/src/clock.rs
+++ b/rust/clock/src/clock.rs
@@ -104,7 +104,7 @@ fn draw_clock<D>(
     // No radio -> no peer chatter, so the bottom line is simply our own name (the
     // node's noun, derived from its id). Matches the espnow build's idle label.
     #[cfg(not(feature = "espnow"))]
-    let label: &str = crate::net::names::name_for_id(crate::NODE_ID).1;
+    let label: &str = crate::net::names::name_for_id(crate::node_id()).1;
 
     let bottom: &str = if show_sensors {
         sensor_line.as_str()

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -836,7 +836,7 @@ fn main() -> ! {
                     // relay the staged image to that leaf over ESP-NOW (canary-one-leaf; the
                     // relay does its own WiFi fetch then an ESP-NOW relay, minutes-scale +
                     // mesh-degrading, UI-alive + long-press abortable). Skipped if the leaf's
-                    // MAC hasn't been learned from its HELLOs yet (retry on the next install).
+                    // MAC has NEVER been learned (retry on the next install once it HELLOs).
                     if let Some((leaf_id, ann)) = leaf_ota.take() {
                         // #1 DECOUPLE: latch "a leaf relay is owed" the moment this flush
                         // surfaces the leaf install. It persists across loop iterations (cleared
@@ -844,7 +844,15 @@ fn main() -> ! {
                         // gate (`do_install`) stays suppressed until the relay resolves — even
                         // across the mac-unknown retry path below, which also keeps it latched.
                         r.note_leaf_ota_armed();
-                        if let Some(mac) = r.mac_for_id(leaf_id) {
+                        // #3 STICKY MAC: the roster is a bounded 16-slot LRU with NO staleness
+                        // reaping — but during the minutes-long mesh-deaf relay the gateway stops
+                        // hearing this leaf, so it becomes the LRU victim and is EVICTED when any
+                        // new MAC arrives → a plain `mac_for_id` reverts to None → `mac-unknown`
+                        // churn (the canary's dominant diag). `mac_for_id_sticky` caches the MAC
+                        // the moment it's ever addressable and holds it for the install session
+                        // (cleared on a terminal `record_leaf_ota`), so eviction can't strand the
+                        // relay. Root-caused from the a5d9b33 canary: mac-unknown ↔ brief relay.
+                        if let Some(mac) = r.mac_for_id_sticky(leaf_id) {
                             let mut relay_draw_ms = 0u64;
                             let mut relay_abort = false;
                             let outcome = r.run_leaf_ota_relay(leaf_id, mac, &ann, &mut || {

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -198,6 +198,20 @@ const FLUSH_DEFER_CAP_MS: u64 = 120_000;
 /// the actual rotation is confirmed when flashing.
 const DISPLAY_ROTATION: DisplayRotation = DisplayRotation::Rotate180;
 
+/// #40 self-test §5: max unconfirmed (New) boots before the app forces a rollback to the
+/// good slot. Bounds a boots-but-crashes image to K reboots then auto-recovery (bootloader
+/// auto-revert is OFF). RTC-fast counter; cleared on a confirm / power-loss.
+#[cfg(feature = "espnow")]
+const OTA_MAX_UNCONFIRMED_BOOTS: u32 = 3;
+
+/// #40 HOLE-1 §2: the leaf post-OTA self-test window (ms). A freshly-activated LEAF image
+/// must hear ≥1 valid inbound SMOLv1 frame within this window (its mesh-terms health proof,
+/// the analog of `reached_dhcp` a credential-less leaf never hits) or it rolls back. 60 s
+/// is generous vs the ~10 s HELLO cadence → several chances, minimizing a false-fail on a
+/// quiet mesh. (A genuinely isolated leaf can't prove RX health → rolls back; documented.)
+#[cfg(feature = "espnow")]
+const LEAF_SELFTEST_WINDOW_MS: u64 = 60_000;
+
 /// Monotonic milliseconds since boot — the single time base for the clock, the
 /// button debounce, Snake movement, the LED blink phase, and BENCH rates.
 /// (`net::mode::now_ms` is the same value; this is the always-available copy.)
@@ -231,6 +245,27 @@ fn main() -> ! {
         v_noun,
         env!("BUILD_HASH"),
     );
+
+    // --- #40 leaf-mesh-OTA: EARLIEST-boot self-test bookkeeping ---------------
+    // Runs BEFORE any subsystem that can panic (I2C/display/radio) so an early-init
+    // crash still trips the crash-loop bound. Only fires when otadata is New/Pending
+    // (a freshly-activated image on its first boot):
+    //   • §3C freshness FLOOR — raise fresh_floor to this build (idempotent, power-loss
+    //     safe; closes the signed-intermediate / rolled-back-build mesh replay).
+    //   • §C#5 K-counter — bump the unconfirmed-boot counter; at K, force the app-side
+    //     rollback NOW (a New image that panics before the deferred self-test would
+    //     otherwise boot-loop the bad slot forever, bootloader auto-revert being OFF).
+    // A confirmed (Valid) boot resets the counter. `boot_confirm(false)` reboots.
+    #[cfg(feature = "espnow")]
+    if ota::otadata_unconfirmed() {
+        ota::fresh_floor_bump(ota::BUILD_NUMBER);
+        if ota::unconfirmed_boot_bump() >= OTA_MAX_UNCONFIRMED_BOOTS {
+            log::warn!("smol #40: {} unconfirmed boots — forcing app-side rollback", OTA_MAX_UNCONFIRMED_BOOTS);
+            ota::boot_confirm(false); // flips to the good slot + resets — never returns
+        }
+    } else {
+        ota::unconfirmed_boot_reset();
+    }
 
     // --- I2C bus to the OLED -------------------------------------------------
     let i2c = I2c::new(
@@ -370,6 +405,15 @@ fn main() -> ! {
     // can re-anchor them on adoption; nothing mutates them in the smaller builds
     // (hence the cfg'd `allow(unused_mut)`).
     let boot_ms = millis();
+
+    // #40 HOLE-1: deferred LEAF self-test. `otadata` is still unconfirmed here iff the
+    // boot burst did NOT confirm it (a leaf that never reached DHCP — `mode::start` only
+    // confirms a DHCP-reaching node). For such a leaf the main loop runs the mesh-terms
+    // self-test (below): confirm on the first heard SMOLv1 frame, else roll back after N s.
+    // A gateway / DHCP-reached board already confirmed at boot → this is false → no-op.
+    #[cfg(feature = "espnow")]
+    let mut leaf_selftest_pending = ota::otadata_unconfirmed();
+
     #[cfg_attr(not(feature = "espnow"), allow(unused_mut))]
     let mut base_unix: u32 = match synced {
         Some(unix) => {
@@ -483,6 +527,25 @@ fn main() -> ! {
         if let Some(r) = radio.as_mut() {
             if let Some(text) = r.service() {
                 bottom_line = text;
+            }
+
+            // #40 HOLE-1: LEAF post-OTA self-test (mesh-terms, NOT DHCP). A freshly
+            // mesh-OTA'd leaf must prove radio+parse+RX work on the NEW image by hearing
+            // ≥1 valid inbound SMOLv1 frame within LEAF_SELFTEST_WINDOW_MS → confirm
+            // (otadata Valid, the update sticks). No frame in the window → app-side
+            // rollback to the good slot (`boot_confirm(false)` flips + resets). Runs at
+            // most once; a gateway/DHCP board already confirmed at boot (pending=false).
+            if leaf_selftest_pending {
+                if r.heard_valid_frame() {
+                    ota::unconfirmed_boot_reset();
+                    leaf_selftest_pending = false;
+                    log::info!("smol #40: leaf self-test PASS (heard a mesh peer) — image CONFIRMED");
+                    ota::boot_confirm(true);
+                } else if now.saturating_sub(boot_ms) >= LEAF_SELFTEST_WINDOW_MS {
+                    leaf_selftest_pending = false;
+                    log::warn!("smol #40: leaf self-test FAIL (no mesh peer in {} ms) — ROLLING BACK", LEAF_SELFTEST_WINDOW_MS);
+                    ota::boot_confirm(false); // flips to the good slot + resets — never returns
+                }
             }
             // #23 stage 2: a LEAF scans 1/6/11 for the elected gateway's HELLO and
             // locks onto its channel (a no-op on the gateway, which rides its AP ch).

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -670,15 +670,6 @@ fn main() -> ! {
             // 2000 ms / SUBTICK_MS aligned via the monotonic clock.
             if (now / 2000) != ((now.saturating_sub(SUBTICK_MS as u64)) / 2000) {
                 r.broadcast_hello();
-                // #40 #3: leaf-only OTA RX-diag beacon on the HELLO cadence, so a relaying
-                // gateway captures the leaf's `on_meta` verdict / OTAM-heard / OTAN-sent counts
-                // LIVE (folded into `smol/<leaf>/ota/relaydiag`) — names WHY a relay had otan=0.
-                // espnow-only: the LDBG frame + leaf receive-session self-report are mesh-build.
-                #[cfg(feature = "espnow")]
-                if !r.is_gateway() {
-                    let (dh, dv, dn) = r.ota_leaf_dbg();
-                    r.broadcast_ldbg(dh, dv, dn);
-                }
                 // Advertise our current Unix time + the sync it descends from on
                 // the SAME tick, so a peer with an older sync can adopt ours.
                 // (A separate frame from HELLO — the LED handshake wire format is
@@ -693,6 +684,21 @@ fn main() -> ! {
                 if matches!(app, App::Bench(_)) {
                     r.broadcast_beacon();
                 }
+            }
+
+            // #40 #3: leaf OTA RX-diag beacon (LDBG) on its OWN ~2 s tick, phase-OFFSET 1 s from
+            // the HELLO burst above. Root cause of the f6f7a28 canary's `leaf=none`: the leaf sent
+            // HELLO→LDBG→TIME back-to-back and the gateway systematically caught the HELLO (rx>0)
+            // but DROPPED the 2nd-of-burst LDBG (TX radio still busy on the rapid 2nd send / RX
+            // overrun). A standalone, temporally-separated tick lets the radio settle so a relaying
+            // gateway reliably captures one → `smol/<leaf>/ota/relaydiag leaf=HxVxNx`. Leaf-only,
+            // unconditional (reports the lifetime dbg counters), mesh build.
+            #[cfg(feature = "espnow")]
+            if !r.is_gateway()
+                && ((now + 1000) / 2000) != ((now.saturating_sub(SUBTICK_MS as u64) + 1000) / 2000)
+            {
+                let (dh, dv, dn) = r.ota_leaf_dbg();
+                r.broadcast_ldbg(dh, dv, dn);
             }
 
             // COEXIST SOAK (#23 PART 1): beacon 1/s (independent of the 2 s HELLO) so

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -266,7 +266,7 @@ fn main() -> ! {
     #[cfg(feature = "espnow")]
     if ota::otadata_unconfirmed() {
         ota::fresh_floor_bump(ota::BUILD_NUMBER); // floor tracks any booted build (USB or OTA)
-        if ota::ota_was_activated()
+        if ota::ota_was_activated_for(ota::BUILD_NUMBER)
             && ota::unconfirmed_boot_bump() >= OTA_MAX_UNCONFIRMED_BOOTS
         {
             log::warn!("smol #40: {} unconfirmed OTA boots — forcing app-side rollback", OTA_MAX_UNCONFIRMED_BOOTS);
@@ -423,7 +423,8 @@ fn main() -> ! {
     // Only a GENUINE mesh-OTA boot (activated) runs the deferred self-test; a USB-flashed
     // `New` image is accepted as-is by `boot_confirm` and never reaches here as pending.
     #[cfg(feature = "espnow")]
-    let mut leaf_selftest_pending = ota::otadata_unconfirmed() && ota::ota_was_activated();
+    let mut leaf_selftest_pending =
+        ota::otadata_unconfirmed() && ota::ota_was_activated_for(ota::BUILD_NUMBER);
 
     #[cfg_attr(not(feature = "espnow"), allow(unused_mut))]
     let mut base_unix: u32 = match synced {

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -261,12 +261,16 @@ fn main() -> ! {
     //     rollback NOW (a New image that panics before the deferred self-test would
     //     otherwise boot-loop the bad slot forever, bootloader auto-revert being OFF).
     // A confirmed (Valid) boot resets the counter. `boot_confirm(false)` reboots.
+    // The K-counter only counts GENUINE OTA boots (`ota_was_activated`) — a USB flash boots
+    // as New too but isn't a crash-looping OTA image, so it must not trip the flip.
     #[cfg(feature = "espnow")]
     if ota::otadata_unconfirmed() {
-        ota::fresh_floor_bump(ota::BUILD_NUMBER);
-        if ota::unconfirmed_boot_bump() >= OTA_MAX_UNCONFIRMED_BOOTS {
-            log::warn!("smol #40: {} unconfirmed boots — forcing app-side rollback", OTA_MAX_UNCONFIRMED_BOOTS);
-            ota::boot_confirm(false); // flips to the good slot + resets — never returns
+        ota::fresh_floor_bump(ota::BUILD_NUMBER); // floor tracks any booted build (USB or OTA)
+        if ota::ota_was_activated()
+            && ota::unconfirmed_boot_bump() >= OTA_MAX_UNCONFIRMED_BOOTS
+        {
+            log::warn!("smol #40: {} unconfirmed OTA boots — forcing app-side rollback", OTA_MAX_UNCONFIRMED_BOOTS);
+            ota::boot_confirm(false); // brick-safe flip to the good slot + reset — never returns
         }
     } else {
         ota::unconfirmed_boot_reset();
@@ -416,8 +420,10 @@ fn main() -> ! {
     // confirms a DHCP-reaching node). For such a leaf the main loop runs the mesh-terms
     // self-test (below): confirm on the first heard SMOLv1 frame, else roll back after N s.
     // A gateway / DHCP-reached board already confirmed at boot → this is false → no-op.
+    // Only a GENUINE mesh-OTA boot (activated) runs the deferred self-test; a USB-flashed
+    // `New` image is accepted as-is by `boot_confirm` and never reaches here as pending.
     #[cfg(feature = "espnow")]
-    let mut leaf_selftest_pending = ota::otadata_unconfirmed();
+    let mut leaf_selftest_pending = ota::otadata_unconfirmed() && ota::ota_was_activated();
 
     #[cfg_attr(not(feature = "espnow"), allow(unused_mut))]
     let mut base_unix: u32 = match synced {

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -422,9 +422,16 @@ fn main() -> ! {
     // A gateway / DHCP-reached board already confirmed at boot → this is false → no-op.
     // Only a GENUINE mesh-OTA boot (activated) runs the deferred self-test; a USB-flashed
     // `New` image is accepted as-is by `boot_confirm` and never reaches here as pending.
+    // #2 (oscillation fix): gate on `ota_activated_is_leaf()` — ONLY a LEAF mesh-OTA confirms
+    // via hear-a-frame here. A SELF-OTA image confirms via reached-DHCP in `mode::start`; if it
+    // transiently misses DHCP at one boot it stays `New` + running (self-heals next boot), and
+    // is NEVER rolled back by the hear-a-frame path on a quiet mesh (which was the 113↔114
+    // gateway loop). The OTA type — not the ambiguous runtime role at a flaky-DHCP boot — is
+    // the correct discriminator.
     #[cfg(feature = "espnow")]
-    let mut leaf_selftest_pending =
-        ota::otadata_unconfirmed() && ota::ota_was_activated_for(ota::BUILD_NUMBER);
+    let mut leaf_selftest_pending = ota::otadata_unconfirmed()
+        && ota::ota_was_activated_for(ota::BUILD_NUMBER)
+        && ota::ota_activated_is_leaf();
 
     #[cfg_attr(not(feature = "espnow"), allow(unused_mut))]
     let mut base_unix: u32 = match synced {
@@ -594,7 +601,12 @@ fn main() -> ! {
             // (default false) is the single legacy-auto-install toggle. Heavy + mesh-deaf
             // + abortable → same responsive tick as a flush; success reboots inside the
             // burst, failure/abort leaves the good image running (HA re-offers = retry).
-            let do_install = crate::ota::OTA_AUTO_INSTALL || r.take_install_request();
+            // #1 DECOUPLE: suppress the gateway's OWN self-OTA while a leaf-OTA relay is
+            // pending — else the self-OTA reboots the gateway mid-session and the two OTAs
+            // collide/thrash the fleet. Short-circuit BEFORE `take_install_request()` so the
+            // gateway's install is PRESERVED (not consumed) and fires once the relay resolves.
+            let do_install = !r.leaf_ota_pending()
+                && (crate::ota::OTA_AUTO_INSTALL || r.take_install_request());
             if do_install {
                 if let Some(announce) = r.take_ota_offer() {
                     let mut ota_draw_ms = 0u64;
@@ -826,6 +838,12 @@ fn main() -> ! {
                     // mesh-degrading, UI-alive + long-press abortable). Skipped if the leaf's
                     // MAC hasn't been learned from its HELLOs yet (retry on the next install).
                     if let Some((leaf_id, ann)) = leaf_ota.take() {
+                        // #1 DECOUPLE: latch "a leaf relay is owed" the moment this flush
+                        // surfaces the leaf install. It persists across loop iterations (cleared
+                        // only by a TERMINAL `record_leaf_ota`), so the gateway's own self-OTA
+                        // gate (`do_install`) stays suppressed until the relay resolves — even
+                        // across the mac-unknown retry path below, which also keeps it latched.
+                        r.note_leaf_ota_armed();
                         if let Some(mac) = r.mac_for_id(leaf_id) {
                             let mut relay_draw_ms = 0u64;
                             let mut relay_abort = false;

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -829,10 +829,15 @@ fn main() -> ! {
                                 }
                                 relay_abort
                             });
-                            log::info!("smol #40: leaf id{} OTA relay outcome = {:?}", leaf_id, outcome);
+                            // #40: record the phase → published to smol/<leaf>/ota/diag on the
+                            // next burst + drives the install clear/retry policy.
+                            r.record_leaf_ota(leaf_id, outcome);
                             redraw = true;
                         } else {
-                            log::warn!("smol #40: leaf id{} install requested but its MAC isn't known yet — skipped (retry after it HELLOs)", leaf_id);
+                            // MAC not learned yet (no HELLO heard) → record MacUnknown; the
+                            // install is LEFT retained (not cleared) → retried on a later flush
+                            // once the leaf HELLOs. Diag published so it's visible headless.
+                            r.record_leaf_ota(leaf_id, crate::ota_mesh::LeafOtaOutcome::MacUnknown);
                         }
                     }
                     // Coexist soak (#23 PART 1): the during-window RX loss — how many

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -206,11 +206,16 @@ const OTA_MAX_UNCONFIRMED_BOOTS: u32 = 3;
 
 /// #40 HOLE-1 §2: the leaf post-OTA self-test window (ms). A freshly-activated LEAF image
 /// must hear ≥1 valid inbound SMOLv1 frame within this window (its mesh-terms health proof,
-/// the analog of `reached_dhcp` a credential-less leaf never hits) or it rolls back. 60 s
-/// is generous vs the ~10 s HELLO cadence → several chances, minimizing a false-fail on a
-/// quiet mesh. (A genuinely isolated leaf can't prove RX health → rolls back; documented.)
+/// the analog of `reached_dhcp` a credential-less leaf never hits) or it rolls back.
+/// ⚠️ 180 s (was 60): a just-mesh-OTA'd leaf boots WHILE its gateway is still mesh-deaf —
+/// relaying, then in its ~120 s Tier-2 confirm loop (not HELLOing). A 60 s window expired
+/// before the gateway resumed HELLOs → the leaf heard nothing → FALSE rollback of a GOOD
+/// image. 180 s outlasts the gateway's confirm loop so the leaf catches a post-confirm HELLO.
+/// (Even so, a false-fail is now BRICK-SAFE — `boot_confirm` refuses to roll back to a slot
+/// with no valid image; see `ota::slot_has_valid_image`.) A gateway post-OTA HELLO burst is
+/// the cleaner follow-up.
 #[cfg(feature = "espnow")]
-const LEAF_SELFTEST_WINDOW_MS: u64 = 60_000;
+const LEAF_SELFTEST_WINDOW_MS: u64 = 180_000;
 
 /// Monotonic milliseconds since boot — the single time base for the clock, the
 /// button debounce, Snake movement, the LED blink phase, and BENCH rates.

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -792,7 +792,10 @@ fn main() -> ! {
                     let (_, soak_rx0, soak_lost0, _) = r.soak_counts();
                     let mut flush_abort = false;
                     let mut flush_draw_ms = 0u64;
-                    r.flush_telemetry(own.as_bytes(), stat.as_bytes(), &mut batt_cache, &mut grid_cache, &mut || {
+                    // #40: a flush that hears a leaf's retained OTA install surfaces
+                    // `(leaf_id, staged announce)` here → relayed below.
+                    let mut leaf_ota: Option<(u8, ota::Announce)> = None;
+                    r.flush_telemetry(own.as_bytes(), stat.as_bytes(), &mut batt_cache, &mut grid_cache, &mut leaf_ota, &mut || {
                         let t = millis();
                         led.apply(led::LedState::WifiSync, t);
                         if matches!(button.poll(t), Some(input::Press::Long)) {
@@ -805,6 +808,33 @@ fn main() -> ! {
                         flush_abort
                     });
                     flush_defer_since_ms = 0;
+                    // #40 leaf-mesh-OTA orchestration: the flush surfaced a leaf install →
+                    // relay the staged image to that leaf over ESP-NOW (canary-one-leaf; the
+                    // relay does its own WiFi fetch then an ESP-NOW relay, minutes-scale +
+                    // mesh-degrading, UI-alive + long-press abortable). Skipped if the leaf's
+                    // MAC hasn't been learned from its HELLOs yet (retry on the next install).
+                    if let Some((leaf_id, ann)) = leaf_ota.take() {
+                        if let Some(mac) = r.mac_for_id(leaf_id) {
+                            let mut relay_draw_ms = 0u64;
+                            let mut relay_abort = false;
+                            let outcome = r.run_leaf_ota_relay(leaf_id, mac, &ann, &mut || {
+                                let t = millis();
+                                led.apply(led::LedState::WifiSync, t);
+                                if matches!(button.poll(t), Some(input::Press::Long)) {
+                                    relay_abort = true;
+                                }
+                                if t.saturating_sub(relay_draw_ms) >= SYNC_REDRAW_MS {
+                                    relay_draw_ms = t;
+                                    draw_syncing(&mut display, (t / SYNC_REDRAW_MS) as u8);
+                                }
+                                relay_abort
+                            });
+                            log::info!("smol #40: leaf id{} OTA relay outcome = {:?}", leaf_id, outcome);
+                            redraw = true;
+                        } else {
+                            log::warn!("smol #40: leaf id{} install requested but its MAC isn't known yet — skipped (retry after it HELLOs)", leaf_id);
+                        }
+                    }
                     // Coexist soak (#23 PART 1): the during-window RX loss — how many
                     // leaf BEACONs the gateway's 10-deep ESP-NOW RX queue dropped while
                     // the CPU-blocking flush starved `service()`. THIS is the number.

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -125,6 +125,12 @@ mod grid;
 #[cfg(feature = "wifi")]
 mod ota;
 
+// #40 leaf-mesh-OTA transport (OTAM/OTAD/OTAN wire codec + leaf receive session +
+// gateway relay orchestration). espnow-only (the mesh + the ed25519 verify live there);
+// the default/wifi-only builds link NONE of it.
+#[cfg(feature = "espnow")]
+mod ota_mesh;
+
 // LOCAL git-ignored WiFi credentials, used by the `wifi`/`espnow` radio bring-up.
 #[cfg(feature = "wifi")]
 mod secrets;

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -142,6 +142,38 @@ mod secrets;
 mod board;
 pub(crate) use board::{DEFAULT_APP, DEFAULT_PAGE, NODE_ID};
 
+/// #40 IDENTITY (runtime): the node's LOGICAL id. In the DEFAULT build this is EXACTLY
+/// the compile-time `NODE_ID` const — no flash, no new symbols — so the guaranteed-green
+/// baseline is byte-unaffected (prove via symbol absence, not the git-stamped ELF bytes).
+/// In wifi/espnow builds the id is read ONCE from the `nvs` partition (seeded from the
+/// baked const on first boot after an erase-flash) and cached — so a SINGLE shared OTA
+/// image can serve the whole fleet without any node stealing the baked default id.
+#[cfg(not(feature = "wifi"))]
+#[inline(always)]
+pub(crate) fn node_id() -> u8 {
+    NODE_ID
+}
+
+/// See the `not(wifi)` twin above. rv32imc has no atomics, so the one-time-init cache is a
+/// `static mut` — alias-safe because it is read/written ONLY from the single-threaded boot
+/// path + main loop (no ISR touches it), the same discipline as the OTA scratch statics.
+#[cfg(feature = "wifi")]
+pub(crate) fn node_id() -> u8 {
+    static mut NODE_ID_CACHE: Option<u8> = None;
+    // SAFETY: single-caller (boot/main loop, never an ISR) → the read-modify-write is
+    // race-free; `addr_of_mut!` avoids forming a reference to the `static mut`.
+    unsafe {
+        let p = core::ptr::addr_of_mut!(NODE_ID_CACHE);
+        if let Some(id) = *p {
+            id
+        } else {
+            let id = ota::resolve_node_id();
+            *p = Some(id);
+            id
+        }
+    }
+}
+
 use app::{App, Ctx, Transition};
 use input::Button;
 
@@ -238,11 +270,11 @@ fn main() -> ! {
     // short hash baked in by build.rs. The full "Adjective Noun" of each appears
     // ONLY in this log; the OLED (splash + menu) shows the noun handles. `env!`
     // reads the build.rs-emitted vars (archive builds pass SMOL_GIT_HASH/_NUMBER).
-    let (my_adj, my_noun) = net::names::name_for_id(NODE_ID);
+    let (my_adj, my_noun) = net::names::name_for_id(node_id());
     let (v_adj, v_noun) = net::names::version_name();
     log::info!(
         "smol id{} \"{} {}\" · build {} \"{} {}\" ({})",
-        NODE_ID,
+        node_id(),
         my_adj,
         my_noun,
         env!("BUILD_NUMBER"),
@@ -391,8 +423,10 @@ fn main() -> ! {
                 wifi: peripherals.WIFI,
             },
             // This unit's short id (see NODE_ID) — embedded in HELLO/ACK/BEACON/TIME
-            // frames and the single source of truth shared with the node's name.
-            NODE_ID,
+            // frames + the single source of truth shared with the node's name. Runtime
+            // `node_id()` (NVS, seeded from the baked const) so a shared OTA image never
+            // steals the default id (#40 identity fix).
+            node_id(),
             &mut boot_tick,
             &mut batt_cache,
             &mut grid_cache,
@@ -967,7 +1001,7 @@ fn main() -> ! {
             sensors: &mut sensors,
             now_ms: now,
             unix_now,
-            node_id: NODE_ID,
+            node_id: node_id(),
             redraw,
             #[cfg(feature = "wifi")]
             batt: &batt_cache,

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -717,7 +717,11 @@ fn main() -> ! {
                 && (now / 10_000) != ((now.saturating_sub(SUBTICK_MS as u64)) / 10_000)
             {
                 let (live_kind, live_page) = app.live_screen();
-                let val = alloc::format!("{}:{}", live_kind.as_wire(), live_page);
+                // #40 §C#3: append the running build# as a 2nd '|'-field → the gateway's
+                // Tier-2 confirm ("STAT.build == pushed build") + HA installed_version read
+                // from ONE frame. Additive: `<screen>:<page>` stays split('|')[0], so the
+                // #50 screen template is unaffected.
+                let val = alloc::format!("{}:{}|{}", live_kind.as_wire(), live_page, ota::BUILD_NUMBER);
                 r.broadcast_stat(val.as_bytes());
             }
 
@@ -773,7 +777,10 @@ fn main() -> ! {
                     // config, the stopgap JP rejected). Published retained as
                     // `smol/<id>/status` for the HA live-screen readback.
                     let (live_kind, live_page) = app.live_screen();
-                    let stat = alloc::format!("STAT|{}:{}", live_kind.as_wire(), live_page);
+                    // #40 §C#3: append the running build# (2nd '|'-field) so a GATEWAY's own
+                    // `smol/<id>/status` also carries build → uniform installed_version across
+                    // self + relayed leaves. Additive (screen stays split('|')[0]).
+                    let stat = alloc::format!("STAT|{}:{}|{}", live_kind.as_wire(), live_page, ota::BUILD_NUMBER);
                     // #20 (1b RESPONSIVE): the tick keeps the UI alive during the
                     // burst — LED blink + throttled "Syncing…" spinner + a LATCHING
                     // long-press ABORT. Abort returns the burst's fail value (queue

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -670,6 +670,15 @@ fn main() -> ! {
             // 2000 ms / SUBTICK_MS aligned via the monotonic clock.
             if (now / 2000) != ((now.saturating_sub(SUBTICK_MS as u64)) / 2000) {
                 r.broadcast_hello();
+                // #40 #3: leaf-only OTA RX-diag beacon on the HELLO cadence, so a relaying
+                // gateway captures the leaf's `on_meta` verdict / OTAM-heard / OTAN-sent counts
+                // LIVE (folded into `smol/<leaf>/ota/relaydiag`) — names WHY a relay had otan=0.
+                // espnow-only: the LDBG frame + leaf receive-session self-report are mesh-build.
+                #[cfg(feature = "espnow")]
+                if !r.is_gateway() {
+                    let (dh, dv, dn) = r.ota_leaf_dbg();
+                    r.broadcast_ldbg(dh, dv, dn);
+                }
                 // Advertise our current Unix time + the sync it descends from on
                 // the SAME tick, so a peer with an older sync can adopt ours.
                 // (A separate frame from HELLO — the LED handshake wire format is

--- a/rust/clock/src/menu.rs
+++ b/rust/clock/src/menu.rs
@@ -78,7 +78,7 @@ impl Menu {
         // The noun (<= 8 chars for fantasy) fits the 6x10 title within 72 px.
         // Static per boot, so it rides the normal `redraw` with no extra
         // invalidation, and it needs no radio — works in EVERY build.
-        let noun = crate::net::names::name_for_id(crate::NODE_ID).1;
+        let noun = crate::net::names::name_for_id(crate::node_id()).1;
         Text::with_baseline(noun, Point::new(1, 0), title, Baseline::Top)
             .draw(display)
             .ok();

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1326,6 +1326,19 @@ pub struct RadioManager {
     /// self-OTA (`do_install`) so a relay is never interrupted by the gateway rebooting into a
     /// fresh build mid-session (and the two OTAs never collide/thrash the fleet).
     leaf_ota_pending: bool,
+    /// #40 #3 STICKY MAC: `(leaf_id, mac)` captured the moment an armed leaf became addressable,
+    /// held for the whole install session (cleared on a terminal `record_leaf_ota`). The roster
+    /// is a bounded 16-slot LRU that EVICTS this leaf while the mesh-deaf relay stops hearing it
+    /// → `mac_for_id` reverts to None (canary `mac-unknown` churn); this cache survives eviction.
+    leaf_ota_mac: Option<(u8, [u8; 6])>,
+    /// #40 #3 RELAY RX-DIAG (instrumentation): from the last `run_leaf_ota_relay` —
+    /// `(leaf_id, rx_frames_from_leaf, valid_otan, last_window_reached, total_windows)`.
+    /// Published to retained `smol/<leaf>/ota/relaydiag` on the next flush so a headless
+    /// `relay-failed` says WHETHER the leaf NAK'd at all (valid_otan>0) and HOW FAR it got
+    /// (last_wb/total): rx=0 → gateway heard nothing from the leaf (leaf offline / OTAD not
+    /// landing); rx>0,otan=0 → leaf alive but never NAK'd this session; otan>0,last_wb<total →
+    /// chunk-loss stall. `last_wb` is in chunk units (matches `total = om::total_chunks`).
+    leaf_relay_rx: Option<(u8, u16, u16, u16, u16)>,
     /// #40: consecutive non-terminal (transient) relay attempts for the current install —
     /// caps the auto-retry so a persistently-failing leaf can't loop the mesh-deaf relay.
     leaf_ota_retries: u8,
@@ -1410,6 +1423,8 @@ impl RadioManager {
             leaf_ota_diag: None,
             leaf_ota_retries: 0,
             leaf_ota_pending: false,
+            leaf_ota_mac: None,
+            leaf_relay_rx: None,
             config_offer: None,
             install_requested: false,
             silent_until_relock: false,
@@ -1528,6 +1543,7 @@ impl RadioManager {
                     &mut None, // #40: a leaf's recovery burst never relays a leaf OTA
                     &mut None, // #40: recovery burst carries no persistent staged
                     &mut None, // #40: recovery burst publishes no relay diag
+                    &mut None, // #3: recovery burst publishes no relay RX-diag
                     tick,
                 )
             }
@@ -2202,8 +2218,11 @@ impl RadioManager {
         // #1 DECOUPLE: the relay session is done for this install iff we're clearing it
         // (terminal outcome or retry cap). While NOT cleared (transient retry) it stays
         // pending so the gateway keeps suppressing its own self-OTA until the leaf resolves.
+        // #3: the sticky MAC is likewise session-scoped — drop it on the same terminal edge so
+        // a FUTURE install re-learns the (possibly re-homed) leaf from a live roster hit.
         if clear {
             self.leaf_ota_pending = false;
+            self.leaf_ota_mac = None;
         }
     }
 
@@ -2300,6 +2319,11 @@ impl RadioManager {
         };
         let mut otad = [0u8; om::OTAD_FRAME_MAX];
 
+        // #3 RX-DIAG counters: rx_any = frames heard FROM this leaf during the relay windows;
+        // otan_valid = valid advancing/NAK OTANs for the live session. Stored into
+        // `leaf_relay_rx` at each terminal exit → published next flush to `…/ota/relaydiag`.
+        let mut rx_any: u16 = 0;
+        let mut otan_valid: u16 = 0;
         let mut wb: u32 = 0;
         while wb < total {
             if tick() {
@@ -2313,6 +2337,7 @@ impl RadioManager {
             let read_len = ((window_bytes as u32).div_ceil(4) * 4) as usize;
             if !reader.read(window_off, &mut gwbuf[..read_len]) {
                 log::error!("smol #40: slot readback failed at window {} — aborting", wb);
+                self.leaf_relay_rx = Some((leaf_id, rx_any, otan_valid, wb as u16, total as u16));
                 let _ = self.switch(Mode::EspNow);
                 return LeafOtaOutcome::RelayFailed;
             }
@@ -2345,10 +2370,12 @@ impl RadioManager {
                 while now_ms() < deadline {
                     if let Some(recv) = self.esp_now.receive() {
                         if recv.info.src_address == leaf_mac {
+                            rx_any = rx_any.saturating_add(1); // #3: heard SOMETHING from the leaf
                             if let Some(om::OtaFrame::Nak { origin, session: s, window_base, bitmap }) =
                                 om::parse_ota_frame(recv.data())
                             {
                                 if origin == leaf_id && s == session && window_base as u32 == wb {
+                                    otan_valid = otan_valid.saturating_add(1); // #3: valid OTAN
                                     let miss = om::bitmap_to_u64(bitmap) & full;
                                     if miss == 0 {
                                         advanced = true;
@@ -2372,13 +2399,18 @@ impl RadioManager {
                 rounds += 1;
                 if rounds > GW_WINDOW_ROUNDS_MAX {
                     log::error!(
-                        "smol #40: window {} exceeded {} retransmit rounds — aborting (R2 bound)",
-                        wb, GW_WINDOW_ROUNDS_MAX
+                        "smol #40: window {} exceeded {} retransmit rounds (rx_any={} otan={}) — aborting (R2 bound)",
+                        wb, GW_WINDOW_ROUNDS_MAX, rx_any, otan_valid
                     );
+                    self.leaf_relay_rx = Some((leaf_id, rx_any, otan_valid, wb as u16, total as u16));
                     return LeafOtaOutcome::RelayFailed;
                 }
             }
         }
+        // #3 RX-DIAG: relay TX phase COMPLETE — all chunks delivered + acked (wb==total). Record
+        // the full-progress RX evidence for the relaydiag; the confirm outcome (below) is the
+        // separate Tier-2 verdict published to `…/ota/diag`.
+        self.leaf_relay_rx = Some((leaf_id, rx_any, otan_valid, total as u16, total as u16));
 
         // --- CONFIRMING (Tier-2, build-matched): sample the leaf's SETTLED build over the
         // full confirm window. The leaf runs the NEW image immediately post-activate, so it
@@ -2532,6 +2564,7 @@ impl RadioManager {
                     leaf_ota, // #40: surface a pending leaf-OTA install for main to relay
                     &mut self.staged_raw, // #40: persist the staged across flushes (pair-safe)
                     &mut self.leaf_ota_diag, // #40: publish smol/<leaf>/ota/diag + clear/retry
+                    &mut self.leaf_relay_rx, // #3: publish smol/<leaf>/ota/relaydiag (RX evidence)
                     tick,
                 )
             }
@@ -3032,6 +3065,23 @@ impl RadioManager {
     /// gateway can unicast an OTA relay to it. `None` until the leaf has been heard.
     pub fn mac_for_id(&self, id: u8) -> Option<[u8; 6]> {
         self.roster.mac_for_id(id)
+    }
+
+    /// #40 #3: eviction-proof MAC lookup for the armed leaf-OTA install. Prefers the LIVE
+    /// roster (refreshing the sticky cache whenever the leaf is addressable), and falls back
+    /// to the cached `(leaf_id, mac)` when the LRU roster has EVICTED the leaf during the
+    /// mesh-deaf relay. The cache is set here on first sight and cleared by `record_leaf_ota`
+    /// on a terminal/exhausted outcome — so it holds for exactly one install session. This is
+    /// the fix for the a5d9b33 canary's `mac-unknown` dominance (relay could rarely even start).
+    pub fn mac_for_id_sticky(&mut self, id: u8) -> Option<[u8; 6]> {
+        if let Some(mac) = self.mac_for_id(id) {
+            self.leaf_ota_mac = Some((id, mac)); // freshest wins; refresh the session cache
+            return Some(mac);
+        }
+        match self.leaf_ota_mac {
+            Some((cid, mac)) if cid == id => Some(mac), // roster evicted it → use the cache
+            _ => None,
+        }
     }
 
     /// Current peer-link state as an [`LedState`], evaluated at `now_ms`.

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2530,7 +2530,7 @@ impl RadioManager {
         }
 
         let mut wb: u32 = 0;
-        while wb < total {
+        'windows: while wb < total {
             if tick() {
                 return LeafOtaOutcome::Aborted;
             }
@@ -2637,17 +2637,31 @@ impl RadioManager {
                 }
                 rounds += 1;
                 if rounds > GW_WINDOW_ROUNDS_MAX {
+                    // #3b TAIL FIX: the LAST window never gets an advance-ack — the leaf
+                    // finalizes+Completes it (ota_mesh on_data sends the all-zero ack ONLY for
+                    // non-last windows, then reboots into the new image). So the gateway CANNOT
+                    // hear an advance for the last window; "exhaustion" here is EXPECTED, not a
+                    // failure. The blind full-window resends across these rounds delivered the
+                    // last chunks (98.8%→100% at the tail); the leaf's real completion signal is
+                    // its REBOOT (build flip), which the CONFIRM phase below detects. So fall
+                    // THROUGH to confirm — returning RelayFailed here failed even a perfect
+                    // transfer (canary 7ee3982: 4288/4341, last window, leaf never confirmed).
+                    if wb + WINDOW_CHUNKS as u32 >= total {
+                        log::info!(
+                            "smol #40: last window {} sent {} rounds (rx_any={} otan={}) — leaf finalizes w/o advance-ack → CONFIRM",
+                            wb, GW_WINDOW_ROUNDS_MAX, rx_any, otan_valid
+                        );
+                        break 'windows;
+                    }
                     log::error!(
                         "smol #40: window {} exceeded {} retransmit rounds (rx_any={} otan={}) — aborting (R2 bound)",
                         wb, GW_WINDOW_ROUNDS_MAX, rx_any, otan_valid
                     );
                     self.leaf_relay_rx = Some(crate::net::wifi::RelayDiag {
-                    leaf_id, rx_any, otan_valid, last_wb: wb as u16, total: total as u16,
-                    leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
-                    otam_tx, otam_ok,
-                    settle,
-                    leaf_ch: ldbg_ch,
-                });
+                        leaf_id, rx_any, otan_valid, last_wb: wb as u16, total: total as u16,
+                        leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
+                        otam_tx, otam_ok, settle, leaf_ch: ldbg_ch,
+                    });
                     return LeafOtaOutcome::RelayFailed;
                 }
             }

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -188,6 +188,10 @@ const GW_WINDOW_ROUNDS_MAX: u32 = 16;
 /// WINDOW_MS` ≈ 60 s) + a STAT cadence (~10 s) so a late self-test rollback is observed
 /// before the gateway declares Confirmed.
 const GW_CONFIRM_TIMEOUT_MS: u64 = 120_000;
+/// #40: max consecutive TRANSIENT (mac-unknown / fetch / relay / timeout) relay attempts
+/// for one retained install before the gateway gives up + clears it — bounds the auto-retry
+/// so a persistently-failing leaf can't loop the (mesh-deaf) relay every flush forever.
+const LEAF_OTA_MAX_RETRIES: u8 = 3;
 /// One-window relay readback buffer (off the stack, in `.bss`). Alias-safe: a gateway
 /// relays to ONE leaf at a time (serial canary), and never runs a leaf receive session.
 static mut GW_OTA_WINDOW: [u8; crate::ota_mesh::WINDOW_BYTES] =
@@ -1310,6 +1314,16 @@ pub struct RadioManager {
     /// relay never armed" race (the staged and install are separate retained topics with
     /// independent drain timing). Persists the current staged image for every leaf relay.
     staged_raw: Option<crate::ota::Announce>,
+    /// #40 headless observability + clear/retry: the LAST leaf-OTA attempt's `(leaf_id,
+    /// phase, clear_install)`, set by `main` after `run_leaf_ota_relay`, PUBLISHED to
+    /// `smol/<leaf>/ota/diag` on the gateway's next burst and used to drive the install
+    /// clear (terminal/exhausted) vs retry (transient). `None` when nothing is pending.
+    /// The phase is stored as the rendered `&'static str` (not the espnow-only enum) so the
+    /// shared `wifi::mqtt_session` signature stays buildable in the wifi-only profile.
+    leaf_ota_diag: Option<(u8, &'static str, bool)>,
+    /// #40: consecutive non-terminal (transient) relay attempts for the current install —
+    /// caps the auto-retry so a persistently-failing leaf can't loop the mesh-deaf relay.
+    leaf_ota_retries: u8,
     /// #21 node-manager: the parsed default-screen command surfaced by a burst,
     /// pending `main`'s `take_config_offer` → apply. `None` when nothing is pending.
     config_offer: Option<crate::app::DefaultScreen>,
@@ -1388,6 +1402,8 @@ impl RadioManager {
             last_reelect_ms: 0,
             ota_offer: None,
             staged_raw: None,
+            leaf_ota_diag: None,
+            leaf_ota_retries: 0,
             config_offer: None,
             install_requested: false,
             silent_until_relock: false,
@@ -1505,6 +1521,7 @@ impl RadioManager {
                     None, // #50b: recovery burst republishes no cached leaf status
                     &mut None, // #40: a leaf's recovery burst never relays a leaf OTA
                     &mut None, // #40: recovery burst carries no persistent staged
+                    &mut None, // #40: recovery burst publishes no relay diag
                     tick,
                 )
             }
@@ -2154,6 +2171,30 @@ impl RadioManager {
         }
     }
 
+    /// #40: record a leaf-OTA attempt's outcome (called by `main` after `run_leaf_ota_relay`,
+    /// or with `MacUnknown` when the MAC wasn't in the roster). Decides whether to CLEAR the
+    /// retained install (terminal — the leaf installed or rolled back — or the transient-retry
+    /// cap is hit) vs LEAVE it retained to retry (mac-unknown / fetch / relay / timeout). The
+    /// phase is published to `smol/<leaf>/ota/diag` on the next burst (headless observability).
+    pub fn record_leaf_ota(&mut self, leaf_id: u8, outcome: crate::ota_mesh::LeafOtaOutcome) {
+        let clear = if outcome.is_terminal() {
+            self.leaf_ota_retries = 0;
+            true
+        } else {
+            self.leaf_ota_retries = self.leaf_ota_retries.saturating_add(1);
+            let exhausted = self.leaf_ota_retries >= LEAF_OTA_MAX_RETRIES;
+            if exhausted {
+                self.leaf_ota_retries = 0;
+            }
+            exhausted
+        };
+        log::info!(
+            "smol #40: leaf id{} OTA phase={} (clear_install={}, retries={})",
+            leaf_id, outcome.as_str(), clear, self.leaf_ota_retries
+        );
+        self.leaf_ota_diag = Some((leaf_id, outcome.as_str(), clear));
+    }
+
     /// #40 GATEWAY leaf-mesh-OTA orchestration (§B4). Fetch the staged image (WiFi) into
     /// THIS gateway's inactive slot → relay it over ESP-NOW to ONE leaf (windowed-NAK) →
     /// watch for the leaf's Tier-2 STAT reappearance at the NEW build. CANARY-ONE-LEAF:
@@ -2196,13 +2237,14 @@ impl RadioManager {
         };
         let staged = if fetched { staged } else { None };
         let Some(slot) = staged else {
-            log::error!("smol #40: relay fetch/stage failed — aborting (leaf untouched)");
+            log::error!("smol #40: relay FETCH/stage failed — aborting (leaf untouched)");
             let _ = self.switch(Mode::EspNow);
-            return LeafOtaOutcome::RelayFailed;
+            return LeafOtaOutcome::FetchFailed;
         };
         let Some(reader) = crate::ota::SlotReader::open(slot) else {
+            log::error!("smol #40: relay slot-open failed — aborting");
             let _ = self.switch(Mode::EspNow);
-            return LeafOtaOutcome::RelayFailed;
+            return LeafOtaOutcome::FetchFailed;
         };
 
         // --- RELAY (ESP-NOW) — windowed-NAK to the ONE leaf MAC. ---
@@ -2456,6 +2498,7 @@ impl RadioManager {
                     Some(&self.stat_cache), // #50b: gateway republishes cached leaf statuses
                     leaf_ota, // #40: surface a pending leaf-OTA install for main to relay
                     &mut self.staged_raw, // #40: persist the staged across flushes (pair-safe)
+                    &mut self.leaf_ota_diag, // #40: publish smol/<leaf>/ota/diag + clear/retry
                     tick,
                 )
             }

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2226,6 +2226,15 @@ impl RadioManager {
         );
 
         // --- FETCH (WiFi) → stage+verify into THIS gateway's inactive slot (no activate).
+        // CRITICAL: `run_leaf_ota_relay` is called IMMEDIATELY after `flush_telemetry`, which
+        // leaves the radio in WifiSta. `switch()` is a NO-OP when already in-mode → it would
+        // NOT issue a fresh `connect()`, but `run_ota_fetch` ASSUMES the caller's switch just
+        // connect()'d (its own contract). If the flush's association has gone stale, the fetch
+        // then spins its whole 5-min budget waiting for `is_connected` (no SYN, mesh-deaf) —
+        // exactly the observed "no fetch + long offline". Self-OTA avoids this because it runs
+        // from EspNow mode (its switch DOES connect). So force a fresh association here:
+        // EspNow (drop the stale link) → WifiSta (issue a real connect), mirroring self-OTA.
+        let _ = self.switch(Mode::EspNow);
         let _ = self.switch(Mode::WifiSta);
         let rng = self.rng;
         let mut staged: Option<Slot> = None;

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1879,12 +1879,14 @@ impl RadioManager {
     /// `espnow`-scoped: the `LDBG` frame + `ota_leaf` self-report only exist in the mesh build.
     #[cfg(feature = "espnow")]
     pub fn broadcast_ldbg(&mut self, heard: u16, verdict: u8, sent: u16) {
+        let ch = self.current_channel(); // #3b: 0 = scanning/unlocked, else the locked channel
         let mut msg = [0u8; crate::ota_mesh::LDBG_FRAME_LEN];
         let base = encode_id_frame(crate::ota_mesh::LDBG_PREFIX, self.id, &mut msg);
         msg[base..base + 2].copy_from_slice(&heard.to_le_bytes());
         msg[base + 2] = verdict;
         msg[base + 3..base + 5].copy_from_slice(&sent.to_le_bytes());
-        self.send_to(&BROADCAST_ADDRESS, &msg[..base + 5]);
+        msg[base + 5] = ch;
+        self.send_to(&BROADCAST_ADDRESS, &msg[..base + 6]);
     }
 
     /// #21 leaf-relay: GATEWAY-only. Broadcast one `SMOLv1 CFG` per CACHED leaf
@@ -2377,6 +2379,7 @@ impl RadioManager {
         let mut ldbg_heard: u16 = 0;
         let mut ldbg_verdict: u8 = 255;
         let mut ldbg_sent: u16 = 0;
+        let mut ldbg_ch: u8 = 0; // #3b: leaf's channel at beacon time (0=scanning, 6=locked ch6)
         // #3b OTAM TX-diag: broadcast sends attempted vs returned-Ok (queued + TX-callback ok).
         let mut otam_tx: u16 = 0;
         let mut otam_ok: u16 = 0;
@@ -2398,6 +2401,7 @@ impl RadioManager {
                     leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
                     otam_tx, otam_ok,
                     settle,
+                    leaf_ch: ldbg_ch,
                 });
                 let _ = self.switch(Mode::EspNow);
                 return LeafOtaOutcome::RelayFailed;
@@ -2454,10 +2458,11 @@ impl RadioManager {
                             rx_any = rx_any.saturating_add(1); // #3: heard SOMETHING from the leaf
                             // #3: capture the leaf's LDBG self-report (latest wins) — names WHY
                             // otan=0 without needing the leaf back online post-relay.
-                            if let Some((h, v, n)) = om::parse_ldbg(recv.data(), leaf_id) {
+                            if let Some((h, v, n, c)) = om::parse_ldbg(recv.data(), leaf_id) {
                                 ldbg_heard = h;
                                 ldbg_verdict = v;
                                 ldbg_sent = n;
+                                ldbg_ch = c;
                             }
                             if let Some(om::OtaFrame::Nak { origin, session: s, window_base, bitmap }) =
                                 om::parse_ota_frame(recv.data())
@@ -2495,6 +2500,7 @@ impl RadioManager {
                     leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
                     otam_tx, otam_ok,
                     settle,
+                    leaf_ch: ldbg_ch,
                 });
                     return LeafOtaOutcome::RelayFailed;
                 }
@@ -2507,6 +2513,7 @@ impl RadioManager {
             leaf_id, rx_any, otan_valid, last_wb: total as u16, total: total as u16,
             leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
             otam_tx, otam_ok, settle,
+            leaf_ch: ldbg_ch,
         });
 
         // --- CONFIRMING (Tier-2, build-matched): sample the leaf's SETTLED build over the

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1446,11 +1446,18 @@ impl RadioManager {
         if self.relay.is_gateway {
             return; // gateway owns its channel via association; never scans
         }
-        if self.scan_locked && now.saturating_sub(self.last_owner_heard_ms) > SCAN_SILENCE_MS {
-            self.scan_locked = false;
-            log::info!("smol: leaf lost gateway id{} — re-scanning", self.elected_owner);
-        }
+        // #3b: DON'T unlock+hop on mere owner-silence. The gateway TIME-SHARES — its ESP-NOW
+        // stays on ESP_NOW_FIXED_CHANNEL; only its WiFi rides the multi-channel roam SSID during
+        // a minutes-long OTA fetch (OTA_FETCH_BUDGET=300s). The old 6 s unlock made the leaf hop
+        // [1,6,11] and DRIFT off ch6 for the whole fetch → it never heard the relay OTAM and the
+        // gateway stopped hearing it (canary #3b: leaf H0, rx→0, bidirectional collapse). So HOLD
+        // the fixed channel and re-assert it (a live gateway will return here). A truly dead/moved
+        // gateway is still recovered by `maybe_leaf_reelect` (15 s, independent), and genuine
+        // owner/role CHANGES unlock explicitly at their own sites (post-reelect / gateway-demote).
         if self.scan_locked {
+            if now.saturating_sub(self.last_owner_heard_ms) > SCAN_SILENCE_MS {
+                let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
+            }
             return;
         }
         if now.saturating_sub(self.last_scan_hop_ms) >= DWELL_MS {

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2340,6 +2340,25 @@ impl RadioManager {
                 encrypt: false,
             });
         }
+        // #3b CHANNEL FIX (the real one — canary 7708b20 proved otam_tx=17/17 egress OK, yet leaf
+        // H0 with rx collapsed 10→2): the OTAM fires right after the WiFi FETCH. `switch(EspNow)`
+        // above issued an ASYNC `disconnect()` + `set_channel(ch6)`, but while the STA is still
+        // tearing down it HOLDS the AP's channel → the OTAM broadcast egresses on the AP channel,
+        // not ch6, so the ch6 leaf never hears it. SPIN until the STA truly releases the PHY, THEN
+        // pin ch6 (and re-pin right before each OTAM send below). `settle` (published) = how long
+        // the STA held on — settle>0 confirms this WAS the off-channel egress.
+        let mut settle: u16 = 0;
+        while settle < 40 {
+            if !matches!(self.controller.is_connected(), Ok(true)) {
+                break;
+            }
+            let _ = self.controller.disconnect();
+            settle = settle.saturating_add(1);
+            if tick() {
+                return LeafOtaOutcome::Aborted;
+            }
+        }
+        let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
         let gwbuf = unsafe { &mut *core::ptr::addr_of_mut!(GW_OTA_WINDOW) };
         let mut otam = [0u8; om::OTAM_FRAME_MAX];
         let Some(otam_len) =
@@ -2378,6 +2397,7 @@ impl RadioManager {
                     leaf_id, rx_any, otan_valid, last_wb: wb as u16, total: total as u16,
                     leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
                     otam_tx, otam_ok,
+                    settle,
                 });
                 let _ = self.switch(Mode::EspNow);
                 return LeafOtaOutcome::RelayFailed;
@@ -2402,7 +2422,10 @@ impl RadioManager {
                 // the image (OTAD) stays unicast — "no broadcast image push" preserved. The
                 // `target` id in the frame keeps canary-one-leaf semantics (only leaf_id arms).
                 if wb == 0 {
-                    // #3b: capture the send Result (send_to swallows it) to prove egress.
+                    // #3b: re-pin ch6 right before the announce (self-healing if the post-fetch
+                    // STA teardown released the channel late), then capture the send Result
+                    // (send_to swallows it) to prove egress.
+                    let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
                     otam_tx = otam_tx.saturating_add(1);
                     if let Ok(waiter) = self.esp_now.send(&BROADCAST_ADDRESS, &otam[..otam_len]) {
                         if waiter.wait().is_ok() {
@@ -2471,6 +2494,7 @@ impl RadioManager {
                     leaf_id, rx_any, otan_valid, last_wb: wb as u16, total: total as u16,
                     leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
                     otam_tx, otam_ok,
+                    settle,
                 });
                     return LeafOtaOutcome::RelayFailed;
                 }
@@ -2482,7 +2506,7 @@ impl RadioManager {
         self.leaf_relay_rx = Some(crate::net::wifi::RelayDiag {
             leaf_id, rx_any, otan_valid, last_wb: total as u16, total: total as u16,
             leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
-            otam_tx, otam_ok,
+            otam_tx, otam_ok, settle,
         });
 
         // --- CONFIRMING (Tier-2, build-matched): sample the leaf's SETTLED build over the

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2296,20 +2296,32 @@ impl RadioManager {
             }
         }
 
-        // --- CONFIRMING (Tier-2, build-matched): sample the leaf's SETTLED build after its
-        // self-test window elapses. The leaf runs the NEW image immediately post-activate,
-        // so it would STAT the new build even mid-self-test; a FAILED self-test then rolls
-        // it back to an OLDER build. So: an older-build sighting is a DEFINITIVE rollback
-        // (early-out); a new-build sighting only CONFIRMS if no rollback lands before the
-        // window closes (> the leaf self-test window + a STAT cadence). No STAT at all → a
-        // possible brick (USB recovery). This is the progression gate, not the safety gate
-        // (the leaf's local Tier-1 is what actually protects it).
+        // --- CONFIRMING (Tier-2, build-matched): sample the leaf's SETTLED build over the
+        // full confirm window. The leaf runs the NEW image immediately post-activate, so it
+        // STATs the new build even mid-self-test; a FAILED self-test then rolls it back to an
+        // OLDER build (and STATs that). We must NOT early-out:
+        //   • an early-out on a NEW-build sighting would miss a later rollback;
+        //   • an early-out on an OLD-build sighting would false-fail on a STALE STAT the leaf
+        //     broadcast at its old build DURING the (minutes-long) relay, still buffered in
+        //     the 10-deep ESP-NOW RX queue.
+        // So: DRAIN the stale queue first, then track the LAST-seen build across the whole
+        // window (> the leaf self-test window + a STAT cadence) → the settled verdict.
+        // A stale old-build STAT is overwritten by the post-reboot new-build STAT; a genuine
+        // rollback's old-build STAT is the last one seen. No STAT at all → possible brick.
+        // This is the PROGRESSION gate, not the safety gate (the leaf's local Tier-1 protects
+        // it); a wrong verdict at worst mis-labels the HA card, never bricks/compromises.
         log::info!(
             "smol #40: all {} chunks relayed — awaiting leaf id{} Tier-2 confirm at build {}",
             total, leaf_id, announce.build
         );
+        // Discard any frames buffered during the relay (incl. the leaf's stale old-build STAT).
+        for _ in 0..64 {
+            if self.esp_now.receive().is_none() {
+                break;
+            }
+        }
         let cdeadline = now_ms() + GW_CONFIRM_TIMEOUT_MS;
-        let mut saw_new = false;
+        let mut last_build: Option<u32> = None;
         while now_ms() < cdeadline {
             if tick() {
                 return LeafOtaOutcome::Aborted;
@@ -2318,28 +2330,31 @@ impl RadioManager {
                 if let Some(Frame::Stat { src, value }) = parse_frame(recv.data()) {
                     if src == leaf_id {
                         if let Some(b) = om::stat_build(value) {
-                            if b < announce.build {
-                                log::warn!(
-                                    "smol #40: leaf id{} reappeared at OLD build {} — self-test rolled it back",
-                                    leaf_id, b
-                                );
-                                return LeafOtaOutcome::RolledBack;
-                            }
-                            saw_new = true; // b >= pushed build → running the new image
+                            last_build = Some(b); // keep the latest — the settled state wins
                         }
                     }
                 }
             }
         }
-        if saw_new {
-            log::info!("smol #40: leaf id{} CONFIRMED at build {} — update stuck", leaf_id, announce.build);
-            LeafOtaOutcome::Confirmed
-        } else {
-            log::error!(
-                "smol #40: leaf id{} did not reappear at build {} within the confirm window — possible brick (USB recovery)",
-                leaf_id, announce.build
-            );
-            LeafOtaOutcome::Timeout
+        match last_build {
+            Some(b) if b >= announce.build => {
+                log::info!("smol #40: leaf id{} CONFIRMED at build {} — update stuck", leaf_id, b);
+                LeafOtaOutcome::Confirmed
+            }
+            Some(b) => {
+                log::warn!(
+                    "smol #40: leaf id{} settled at OLD build {} — self-test rolled it back (HA re-offers)",
+                    leaf_id, b
+                );
+                LeafOtaOutcome::RolledBack
+            }
+            None => {
+                log::error!(
+                    "smol #40: leaf id{} did not reappear at build {} within the confirm window — possible brick (USB recovery)",
+                    leaf_id, announce.build
+                );
+                LeafOtaOutcome::Timeout
+            }
         }
     }
 

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2325,6 +2325,21 @@ impl RadioManager {
                 encrypt: false,
             });
         }
+        // #3b: DEFENSIVE — (re)add the broadcast peer in the relay ESP-NOW context. Normal HELLOs
+        // egress without an explicit broadcast peer, but this send follows a WiFi fetch
+        // (WifiSta→switch(EspNow)) which may have perturbed the peer table / TX state; a missing
+        // broadcast peer makes `esp_now_send(ff:ff:…)` return NOT_FOUND → the OTAM never egresses
+        // (candidate cause of leaf H0 with the gateway on-channel). The `otam_tx/otam_ok` diag
+        // below proves whether the send now succeeds.
+        if !self.esp_now.peer_exists(&BROADCAST_ADDRESS) {
+            let _ = self.esp_now.add_peer(PeerInfo {
+                interface: EspNowWifiInterface::Sta,
+                peer_address: BROADCAST_ADDRESS,
+                lmk: None,
+                channel: None,
+                encrypt: false,
+            });
+        }
         let gwbuf = unsafe { &mut *core::ptr::addr_of_mut!(GW_OTA_WINDOW) };
         let mut otam = [0u8; om::OTAM_FRAME_MAX];
         let Some(otam_len) =
@@ -2343,6 +2358,9 @@ impl RadioManager {
         let mut ldbg_heard: u16 = 0;
         let mut ldbg_verdict: u8 = 255;
         let mut ldbg_sent: u16 = 0;
+        // #3b OTAM TX-diag: broadcast sends attempted vs returned-Ok (queued + TX-callback ok).
+        let mut otam_tx: u16 = 0;
+        let mut otam_ok: u16 = 0;
         let mut wb: u32 = 0;
         while wb < total {
             if tick() {
@@ -2359,6 +2377,7 @@ impl RadioManager {
                 self.leaf_relay_rx = Some(crate::net::wifi::RelayDiag {
                     leaf_id, rx_any, otan_valid, last_wb: wb as u16, total: total as u16,
                     leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
+                    otam_tx, otam_ok,
                 });
                 let _ = self.switch(Mode::EspNow);
                 return LeafOtaOutcome::RelayFailed;
@@ -2383,7 +2402,13 @@ impl RadioManager {
                 // the image (OTAD) stays unicast — "no broadcast image push" preserved. The
                 // `target` id in the frame keeps canary-one-leaf semantics (only leaf_id arms).
                 if wb == 0 {
-                    self.send_to(&BROADCAST_ADDRESS, &otam[..otam_len]);
+                    // #3b: capture the send Result (send_to swallows it) to prove egress.
+                    otam_tx = otam_tx.saturating_add(1);
+                    if let Ok(waiter) = self.esp_now.send(&BROADCAST_ADDRESS, &otam[..otam_len]) {
+                        if waiter.wait().is_ok() {
+                            otam_ok = otam_ok.saturating_add(1);
+                        }
+                    }
                 }
                 for i in 0..wlen_chunks as usize {
                     if (missing >> i) & 1 == 1 {
@@ -2445,6 +2470,7 @@ impl RadioManager {
                     self.leaf_relay_rx = Some(crate::net::wifi::RelayDiag {
                     leaf_id, rx_any, otan_valid, last_wb: wb as u16, total: total as u16,
                     leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
+                    otam_tx, otam_ok,
                 });
                     return LeafOtaOutcome::RelayFailed;
                 }
@@ -2456,6 +2482,7 @@ impl RadioManager {
         self.leaf_relay_rx = Some(crate::net::wifi::RelayDiag {
             leaf_id, rx_any, otan_valid, last_wb: total as u16, total: total as u16,
             leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
+            otam_tx, otam_ok,
         });
 
         // --- CONFIRMING (Tier-2, build-matched): sample the leaf's SETTLED build over the

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -536,6 +536,17 @@ impl Roster {
         Self { nodes: [Node::EMPTY; ROSTER_CAP] }
     }
 
+    /// #40: the MAC last heard for a KNOWN leaf `id` (learned from its HELLOs), for the
+    /// unicast OTA relay. `None` if that id hasn't been heard yet.
+    fn mac_for_id(&self, id: u8) -> Option<[u8; 6]> {
+        for n in &self.nodes {
+            if n.used && n.id_known && n.id == id {
+                return Some(n.mac);
+            }
+        }
+        None
+    }
+
     /// Find the slot for `mac`: existing match, else a free slot, else evict the
     /// oldest-heard (bounded — a new MAC past capacity drops the stalest).
     fn slot(&mut self, mac: [u8; 6]) -> usize {
@@ -1484,6 +1495,7 @@ impl RadioManager {
             &[], // #50: recovery burst publishes no live-screen status
                     None, // #21: a leaf's recovery burst is not a gateway relay
                     None, // #50b: recovery burst republishes no cached leaf status
+                    &mut None, // #40: a leaf's recovery burst never relays a leaf OTA
                     tick,
                 )
             }
@@ -2339,6 +2351,9 @@ impl RadioManager {
         status: &[u8],
         batt: &mut crate::batt::BattCache,
         grid: &mut crate::grid::GridCache,
+        // #40: filled with `(leaf_id, staged announce)` if this flush surfaced a leaf OTA
+        // install → `main` then calls `run_leaf_ota_relay` for that leaf. `None` otherwise.
+        leaf_ota: &mut Option<(u8, crate::ota::Announce)>,
         tick: &mut dyn FnMut() -> bool,
     ) -> bool {
         if !self.relay.is_gateway {
@@ -2415,6 +2430,7 @@ impl RadioManager {
                     status, // #50: gateway publishes its live screen as smol/<id>/status
                     Some(&mut self.cfg_cache), // #21: gateway caches leaf configs to relay
                     Some(&self.stat_cache), // #50b: gateway republishes cached leaf statuses
+                    leaf_ota, // #40: surface a pending leaf-OTA install for main to relay
                     tick,
                 )
             }
@@ -2893,16 +2909,17 @@ impl RadioManager {
         }
     }
 
-    /// #40: is a leaf mesh-OTA transfer in progress? (`main` shows a maintenance state.)
-    pub fn ota_leaf_active(&self) -> bool {
-        self.ota_leaf.is_active()
-    }
-
     /// #40 self-test (HOLE-1): has this node decoded ≥1 valid inbound `SMOLv1` frame since
     /// boot? This is the leaf's mesh-terms health proof (radio+parse+RX work on the new
     /// image) — the leaf analog of `reached_dhcp`, which a credential-less leaf never hits.
     pub fn heard_valid_frame(&self) -> bool {
         self.peers.last_hello_ms != 0
+    }
+
+    /// #40: look up a leaf's MAC (from the #27 roster, learned via its HELLOs) so the
+    /// gateway can unicast an OTA relay to it. `None` until the leaf has been heard.
+    pub fn mac_for_id(&self, id: u8) -> Option<[u8; 6]> {
+        self.roster.mac_for_id(id)
     }
 
     /// Current peer-link state as an [`LedState`], evaluated at `now_ms`.

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2407,7 +2407,12 @@ impl RadioManager {
         // ch6 windows. The first OTAM the leaf catches locks it to ch6 (`handle_ota_frame`) and
         // arms its session → it then holds ch6 (`leaf_scan_tick` is_active) for the transfer. Stop
         // early the instant the leaf NAKs (it's armed + ready for the windowed transfer).
-        const WAKE_MS: u64 = 20_000;
+        // #3b: 90s (was 20s) so the burst spans several of the leaf's re-election/hop cycles —
+        // after the off-ch6 fetch the leaf needs ~10-30s to stabilize + hop back onto ch6, and a
+        // longer flood raises the odds it catches one OTAM while there. Self-stops on first NAK,
+        // so a leaf that locks early doesn't pay the full window. (Band-aid for the coexist wall —
+        // the real cure is a ch6-locked fetch AP so the leaf never leaves ch6; flagged to JP.)
+        const WAKE_MS: u64 = 90_000;
         const WAKE_GAP_MS: u64 = 120;
         let wake_deadline = now_ms() + WAKE_MS;
         let mut last_wake_ms = 0u64;

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1543,6 +1543,7 @@ impl RadioManager {
         let mut ota_offer: Option<crate::ota::Announce> = None;
         let mut config_offer: Option<crate::app::DefaultScreen> = None;
         let mut install_requested = false;
+        let mut _leaf_install_seen = false; // #40 #1: a leaf's recovery burst is not a gateway relay
         let reached = match self.sta.as_mut() {
             None => false,
             Some(sta) => {
@@ -1559,6 +1560,7 @@ impl RadioManager {
                     &mut ota_offer,
                     &mut config_offer,
                     &mut install_requested,
+                    &mut _leaf_install_seen, // #40 #1: leaf recovery burst — never a gateway relay
                     &[], // #27: election-only recovery burst publishes no peers (leaf/v1)
             &[], // #50: recovery burst publishes no live-screen status
                     None, // #21: a leaf's recovery burst is not a gateway relay
@@ -2800,6 +2802,8 @@ impl RadioManager {
         let mut config_offer: Option<crate::app::DefaultScreen> = None;
         // #33: capture any OTA install command this flush surfaces.
         let mut install_requested = false;
+        // #40 #1: set iff this flush SEES a retained leaf install (pre-arm) → latch pending below.
+        let mut leaf_install_seen = false;
         let sta = self.sta.as_mut();
         let ok = match sta {
             None => false,
@@ -2835,6 +2839,7 @@ impl RadioManager {
                     &mut ota_offer,
                     &mut config_offer,
                     &mut install_requested,
+                    &mut leaf_install_seen, // #40 #1: latch pending on install-SEEN (below)
                     peers, // #27: gateway publishes its roster as retained smol/<id>/peers
                     status, // #50: gateway publishes its live screen as smol/<id>/status
                     Some(&mut self.cfg_cache), // #21: gateway caches leaf configs to relay
@@ -2858,6 +2863,15 @@ impl RadioManager {
         // #33: OR-in an install command (one-shot; `main`'s take clears it).
         if install_requested {
             self.install_requested = true;
+        }
+        // #40 #1 (self-OTA-first fix): if this flush SAW a retained leaf install, latch
+        // `leaf_ota_pending` NOW — on install-SEEN, before the arm (which needs the cached staged
+        // image). Otherwise the gateway's own `do_install` (gated on !leaf_ota_pending) could fire
+        // in the window between seeing its own install and the leaf arming → self-OTA first,
+        // inverting the demo order + rebooting the gateway early. Cleared on the terminal
+        // `record_leaf_ota` (retained install goes away → not seen next flush).
+        if leaf_install_seen {
+            self.leaf_ota_pending = true;
         }
         // #23 fix (oracle #2): APPLY the re-election result to the LIVE role. On a
         // connected flush, persist the refreshed staleness observation; if a LIVE

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2371,8 +2371,19 @@ impl RadioManager {
                     return LeafOtaOutcome::Aborted;
                 }
                 // (Re)send OTAM during window 0 so a leaf that missed it can still arm.
+                // #3b: BROADCAST the announce (not unicast to leaf_mac). Root cause of the
+                // a949574 canary's `leaf=H0V0N0` (leaf hears ZERO OTAMs while rx=10 proves the
+                // reverse path works): ESP-NOW unicast RX requires the SENDER be a registered
+                // peer on the receiver, but the leaf only adds the gateway as a peer WHEN it
+                // receives an OTA frame (handle_ota_frame) or a gateway HELLO — and the gateway
+                // is HELLO-silent during the mesh-deaf relay → bootstrap deadlock. A BROADCAST
+                // needs no peer (that's why HELLOs land), so the leaf receives it, arms, and
+                // adds the gateway peer → the subsequent UNICAST OTAD/OTAN then flow to the
+                // (correct, roster-learned) MACs. Design §B: only the small ANNOUNCE broadcasts;
+                // the image (OTAD) stays unicast — "no broadcast image push" preserved. The
+                // `target` id in the frame keeps canary-one-leaf semantics (only leaf_id arms).
                 if wb == 0 {
-                    self.send_to(&leaf_mac, &otam[..otam_len]);
+                    self.send_to(&BROADCAST_ADDRESS, &otam[..otam_len]);
                 }
                 for i in 0..wlen_chunks as usize {
                     if (missing >> i) & 1 == 1 {

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1246,6 +1246,10 @@ pub struct RadioManager {
     /// `cfg_cache` but UPLINK-sourced. Unused on a leaf (never flushes/publishes). REUSES
     /// `CfgCache` verbatim — a generic id→value upsert map (`Batt:3` fits `CFG_VALUE_MAX`).
     stat_cache: crate::net::wifi::CfgCache,
+    /// #40 leaf-mesh-OTA: the LEAF receive state machine (verify-sig → signed-bounds →
+    /// window reassembly → readback verify → activate). Idle except during a transfer.
+    /// Unused on a gateway (which drives the RELAY side via `run_leaf_ota_relay`).
+    ota_leaf: crate::ota_mesh::OtaLeafSession,
     /// #25 WLED: monotonic WiZmote sequence, ++ per emitted button. Wraps safely
     /// (reboot-to-0 is panic-safe; WLED's per-remote dedup may drop the first few
     /// post-reboot presses until it re-exceeds the pre-reboot value — accepted MVP).
@@ -1337,6 +1341,7 @@ impl RadioManager {
             cfg: CfgTracker::new(),
             cfg_cache: crate::net::wifi::CfgCache::new(),
             stat_cache: crate::net::wifi::CfgCache::new(),
+            ota_leaf: crate::ota_mesh::OtaLeafSession::new(),
             #[cfg(feature = "wled")]
             wled_seq: 0,
             elected_owner: id,
@@ -2349,6 +2354,15 @@ impl RadioManager {
             let rssi = recv.info.rx_control.rssi;
             let now = now_ms();
 
+            // #40 leaf-mesh-OTA transport (OTAM/OTAD/OTAN). Dispatched BEFORE the generic
+            // Frame parse — the 64-B signed manifest / raw image chunk don't fit the Frame
+            // enum. A LEAF drives its receive session here; a GATEWAY's relay is the
+            // dedicated blocking `run_leaf_ota_relay`, so it no-ops these in this drain.
+            if let Some(otaf) = crate::ota_mesh::parse_ota_frame(recv.data()) {
+                self.handle_ota_frame(otaf, src, rssi, now);
+                continue;
+            }
+
             match parse_frame(recv.data()) {
                 Some(Frame::Snk(f)) => {
                     // An MMO-snake frame proves the peer is audible → counts
@@ -2607,7 +2621,71 @@ impl RadioManager {
                 }
             }
         }
+        // #40: nudge the leaf OTA session once per service pass (idle-NAK a stalled
+        // window; abort on a progress/hard-cap timeout). No-op unless a transfer is live.
+        {
+            let mut out = [0u8; crate::ota_mesh::OTAN_FRAME_MAX];
+            if let crate::ota_mesh::LeafAction::Nak(n) = self.ota_leaf.tick(self.id, now_ms(), &mut out) {
+                let gw = self.ota_leaf.gateway_mac();
+                self.send_to(&gw, &out[..n]);
+            }
+        }
         label
+    }
+
+    /// #40: dispatch one decoded leaf-mesh-OTA frame. Updates peer liveness (an OTA frame
+    /// proves the gateway is audible — it also satisfies the leaf self-test's "heard a
+    /// valid SMOLv1 frame"), registers the sender for the unicast NAK back-channel, then
+    /// drives the receive session. On `Complete` [`crate::ota::activate`] reboots into the
+    /// new slot; on `Nak` we unicast the OTAN to the gateway; `Abort`/`None` do nothing.
+    fn handle_ota_frame(&mut self, f: crate::ota_mesh::OtaFrame<'_>, src: [u8; 6], rssi: i32, now: u64) {
+        use crate::ota_mesh::{LeafAction, OtaFrame};
+        self.peers.last_hello_ms = now;
+        self.roster.heard(src, None, rssi, now);
+        if !self.esp_now.peer_exists(&src) {
+            let _ = self.esp_now.add_peer(PeerInfo {
+                interface: EspNowWifiInterface::Sta,
+                peer_address: src,
+                lmk: None,
+                channel: None,
+                encrypt: false,
+            });
+        }
+        let mut out = [0u8; crate::ota_mesh::OTAN_FRAME_MAX];
+        let id = self.id;
+        let action = match f {
+            OtaFrame::Meta { target, session, m, sig } => {
+                self.ota_leaf.on_meta(target, session, m, sig, src, id, now)
+            }
+            OtaFrame::Data { target, session, seq, payload } => {
+                self.ota_leaf.on_data(target, session, seq, payload, src, id, now, &mut out)
+            }
+            // A NAK is leaf→gateway; the gateway consumes it inside its blocking relay
+            // loop, never here. A leaf ignores it.
+            OtaFrame::Nak { .. } => LeafAction::None,
+        };
+        match action {
+            LeafAction::Nak(n) => {
+                let gw = self.ota_leaf.gateway_mac();
+                self.send_to(&gw, &out[..n]);
+            }
+            LeafAction::Complete(slot) => {
+                crate::ota::activate(slot); // reboots on success; returns only on otadata-write fail
+            }
+            LeafAction::None | LeafAction::Abort => {}
+        }
+    }
+
+    /// #40: is a leaf mesh-OTA transfer in progress? (`main` shows a maintenance state.)
+    pub fn ota_leaf_active(&self) -> bool {
+        self.ota_leaf.is_active()
+    }
+
+    /// #40 self-test (HOLE-1): has this node decoded ≥1 valid inbound `SMOLv1` frame since
+    /// boot? This is the leaf's mesh-terms health proof (radio+parse+RX work on the new
+    /// image) — the leaf analog of `reached_dhcp`, which a credential-less leaf never hits.
+    pub fn heard_valid_frame(&self) -> bool {
+        self.peers.last_hello_ms != 0
     }
 
     /// Current peer-link state as an [`LedState`], evaluated at `now_ms`.

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1303,6 +1303,13 @@ pub struct RadioManager {
     /// #6 OTA: a gated retained announce surfaced by a burst (boot or gateway flush),
     /// pending `main`'s `take_ota_offer` → fetch. `None` when nothing is pending.
     ota_offer: Option<crate::ota::Announce>,
+    /// #40: the LAST raw (ungated) `smol/ota/staged` announce this gateway drained,
+    /// PERSISTED across flushes. A leaf-OTA install pairs with THIS (not a session-local
+    /// capture), so the pair is independent of whether the staged retained was re-drained
+    /// in the SAME flush that consumed the install — closing the "install consumed but
+    /// relay never armed" race (the staged and install are separate retained topics with
+    /// independent drain timing). Persists the current staged image for every leaf relay.
+    staged_raw: Option<crate::ota::Announce>,
     /// #21 node-manager: the parsed default-screen command surfaced by a burst,
     /// pending `main`'s `take_config_offer` → apply. `None` when nothing is pending.
     config_offer: Option<crate::app::DefaultScreen>,
@@ -1380,6 +1387,7 @@ impl RadioManager {
             mc_seen_ms: 0,
             last_reelect_ms: 0,
             ota_offer: None,
+            staged_raw: None,
             config_offer: None,
             install_requested: false,
             silent_until_relock: false,
@@ -1496,6 +1504,7 @@ impl RadioManager {
                     None, // #21: a leaf's recovery burst is not a gateway relay
                     None, // #50b: recovery burst republishes no cached leaf status
                     &mut None, // #40: a leaf's recovery burst never relays a leaf OTA
+                    &mut None, // #40: recovery burst carries no persistent staged
                     tick,
                 )
             }
@@ -2446,6 +2455,7 @@ impl RadioManager {
                     Some(&mut self.cfg_cache), // #21: gateway caches leaf configs to relay
                     Some(&self.stat_cache), // #50b: gateway republishes cached leaf statuses
                     leaf_ota, // #40: surface a pending leaf-OTA install for main to relay
+                    &mut self.staged_raw, // #40: persist the staged across flushes (pair-safe)
                     tick,
                 )
             }

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1321,6 +1321,11 @@ pub struct RadioManager {
     /// The phase is stored as the rendered `&'static str` (not the espnow-only enum) so the
     /// shared `wifi::mqtt_session` signature stays buildable in the wifi-only profile.
     leaf_ota_diag: Option<(u8, &'static str, bool)>,
+    /// #40 #1 DECOUPLE: true while a leaf-OTA relay is pending/in-flight (armed until its
+    /// outcome is terminal or the retry cap is hit). While set, the gateway SUPPRESSES its own
+    /// self-OTA (`do_install`) so a relay is never interrupted by the gateway rebooting into a
+    /// fresh build mid-session (and the two OTAs never collide/thrash the fleet).
+    leaf_ota_pending: bool,
     /// #40: consecutive non-terminal (transient) relay attempts for the current install —
     /// caps the auto-retry so a persistently-failing leaf can't loop the mesh-deaf relay.
     leaf_ota_retries: u8,
@@ -1404,6 +1409,7 @@ impl RadioManager {
             staged_raw: None,
             leaf_ota_diag: None,
             leaf_ota_retries: 0,
+            leaf_ota_pending: false,
             config_offer: None,
             install_requested: false,
             silent_until_relock: false,
@@ -2193,6 +2199,24 @@ impl RadioManager {
             leaf_id, outcome.as_str(), clear, self.leaf_ota_retries
         );
         self.leaf_ota_diag = Some((leaf_id, outcome.as_str(), clear));
+        // #1 DECOUPLE: the relay session is done for this install iff we're clearing it
+        // (terminal outcome or retry cap). While NOT cleared (transient retry) it stays
+        // pending so the gateway keeps suppressing its own self-OTA until the leaf resolves.
+        if clear {
+            self.leaf_ota_pending = false;
+        }
+    }
+
+    /// #40 #1: mark that a leaf-OTA relay has been armed (called by `main` when it takes an
+    /// armed `leaf_ota`). Suppresses the gateway's own self-OTA until the relay resolves.
+    pub fn note_leaf_ota_armed(&mut self) {
+        self.leaf_ota_pending = true;
+    }
+
+    /// #40 #1: is a leaf-OTA relay pending/in-flight? `main` gates the gateway's self-OTA
+    /// (`do_install`) on `!leaf_ota_pending()` so a relay is never interrupted.
+    pub fn leaf_ota_pending(&self) -> bool {
+        self.leaf_ota_pending
     }
 
     /// #40 GATEWAY leaf-mesh-OTA orchestration (§B4). Fetch the staged image (WiFi) into
@@ -2990,7 +3014,8 @@ impl RadioManager {
                 self.send_to(&gw, &out[..n]);
             }
             LeafAction::Complete(slot, build) => {
-                crate::ota::activate(slot, build); // reboots on success; returns only on otadata-write fail
+                // Leaf mesh-OTA → is_leaf_ota=true → confirm via hear-a-frame on next boot.
+                crate::ota::activate(slot, build, true); // reboots on success
             }
             LeafAction::None | LeafAction::Abort => {}
         }

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1507,6 +1507,13 @@ impl RadioManager {
         if self.relay.is_gateway {
             return false; // a gateway re-decides on its own flush; only leaves recover here
         }
+        // #3b: a leaf with a LIVE mesh-OTA session must NOT re-elect — re-election re-associates
+        // to WiFi (off-ch6) and took id8 OFFLINE mid-relay. While armed, the gateway is merely
+        // fetching (off-ch6, transiently silent), NOT dead; the leaf holds ch6 and waits for the
+        // OTAD. The session's own deadline/stall (ota_mesh) bounds a genuinely-abandoned relay.
+        if self.ota_leaf.is_active() {
+            return false;
+        }
         let silent = now.saturating_sub(self.last_owner_heard_ms) >= REELECT_SILENCE_MS;
         let retry_ok = now.saturating_sub(self.last_reelect_ms) >= REELECT_RETRY_MS;
         if !(silent && retry_ok) {
@@ -2300,6 +2307,77 @@ impl RadioManager {
             leaf_id, announce.build, size, total
         );
 
+        // --- #3b PRE-FETCH ARM (the AP-independent fix) ---------------------------------------
+        // Broadcast the OTAM to the leaf WHILE IT'S STILL RECEPTIVE ON ch6 — BEFORE the WiFi fetch
+        // takes the radio off-channel for minutes. At this point the leaf has only been
+        // gateway-silent for the just-finished flush (~seconds), so it's hopping [1,6,11] but
+        // still ONLINE (not yet the prolonged-re-election OFFLINE we saw post-fetch). The instant
+        // it catches an OTAM on a ch6 dwell it (a) locks ch6 via `handle_ota_frame` and (b) arms
+        // its session → `ota_leaf.is_active()` then PINS it on ch6 through the whole fetch (no
+        // scan, no re-election — see leaf_scan_tick + maybe_leaf_reelect gates). Post-fetch OTAD
+        // lands on the still-locked leaf. (The post-fetch wake-burst failed because it chased an
+        // ALREADY-scanning/offline leaf — canary leaf_ch=0. Arming pre-fetch stops the scan before
+        // it starts.) Bounded; breaks early once the leaf's LDBG shows armed (verdict=1) or it NAKs.
+        {
+            let _ = self.switch(Mode::EspNow); // ch6 (the flush left us in WifiSta)
+            let mut s = 0u16;
+            while s < 40 {
+                if !matches!(self.controller.is_connected(), Ok(true)) {
+                    break;
+                }
+                let _ = self.controller.disconnect();
+                s = s.saturating_add(1);
+                if tick() {
+                    return LeafOtaOutcome::Aborted;
+                }
+            }
+            let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
+            if !self.esp_now.peer_exists(&BROADCAST_ADDRESS) {
+                let _ = self.esp_now.add_peer(PeerInfo {
+                    interface: EspNowWifiInterface::Sta,
+                    peer_address: BROADCAST_ADDRESS,
+                    lmk: None,
+                    channel: None,
+                    encrypt: false,
+                });
+            }
+            let mut otam_pre = [0u8; om::OTAM_FRAME_MAX];
+            if let Some(pre_len) = om::encode_otam(
+                leaf_id, session, announce.signed_msg(), announce.sig(), &mut otam_pre,
+            ) {
+                const PREARM_MS: u64 = 15_000;
+                const PREARM_GAP_MS: u64 = 120;
+                let deadline = now_ms() + PREARM_MS;
+                let mut last = 0u64;
+                while now_ms() < deadline {
+                    if tick() {
+                        return LeafOtaOutcome::Aborted;
+                    }
+                    let t = now_ms();
+                    if t.saturating_sub(last) >= PREARM_GAP_MS {
+                        let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
+                        let _ = self.esp_now.send(&BROADCAST_ADDRESS, &otam_pre[..pre_len]);
+                        last = t;
+                    }
+                    if let Some(recv) = self.esp_now.receive() {
+                        if recv.info.src_address == leaf_mac {
+                            let armed = matches!(
+                                om::parse_ldbg(recv.data(), leaf_id),
+                                Some((_, 1, _, _))
+                            ) || matches!(
+                                om::parse_ota_frame(recv.data()),
+                                Some(om::OtaFrame::Nak { .. })
+                            );
+                            if armed {
+                                break; // leaf armed pre-fetch → its is_active hold now carries ch6
+                            }
+                        }
+                    }
+                }
+                log::info!("smol #3b: pre-fetch arm burst done (leaf id{})", leaf_id);
+            }
+        }
+
         // --- FETCH (WiFi) → stage+verify into THIS gateway's inactive slot (no activate).
         // CRITICAL: `run_leaf_ota_relay` is called IMMEDIATELY after `flush_telemetry`, which
         // leaves the radio in WifiSta. `switch()` is a NO-OP when already in-mode → it would
@@ -2407,12 +2485,13 @@ impl RadioManager {
         // ch6 windows. The first OTAM the leaf catches locks it to ch6 (`handle_ota_frame`) and
         // arms its session → it then holds ch6 (`leaf_scan_tick` is_active) for the transfer. Stop
         // early the instant the leaf NAKs (it's armed + ready for the windowed transfer).
-        // #3b: 90s (was 20s) so the burst spans several of the leaf's re-election/hop cycles —
-        // after the off-ch6 fetch the leaf needs ~10-30s to stabilize + hop back onto ch6, and a
-        // longer flood raises the odds it catches one OTAM while there. Self-stops on first NAK,
-        // so a leaf that locks early doesn't pay the full window. (Band-aid for the coexist wall —
-        // the real cure is a ch6-locked fetch AP so the leaf never leaves ch6; flagged to JP.)
-        const WAKE_MS: u64 = 90_000;
+        // #3b: this post-fetch burst is now a short FALLBACK + diag capture — the PRIMARY arming
+        // happens PRE-fetch (above), so a leaf that pre-armed is already locked+active here and
+        // this just backstops the case where pre-arm missed. Kept short (was 90s) since a leaf
+        // that didn't pre-arm has drifted off-ch6 for the whole fetch and a long post-fetch flood
+        // was proven dead (canary leaf_ch=0). Self-stops on first NAK. Also captures the leaf's
+        // LDBG (leaf_ch/verdict) for relaydiag. Real coexist cure stays infra (ch6 fetch AP, JP).
+        const WAKE_MS: u64 = 15_000;
         const WAKE_GAP_MS: u64 = 120;
         let wake_deadline = now_ms() + WAKE_MS;
         let mut last_wake_ms = 0u64;

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1338,7 +1338,8 @@ pub struct RadioManager {
     /// (last_wb/total): rx=0 → gateway heard nothing from the leaf (leaf offline / OTAD not
     /// landing); rx>0,otan=0 → leaf alive but never NAK'd this session; otan>0,last_wb<total →
     /// chunk-loss stall. `last_wb` is in chunk units (matches `total = om::total_chunks`).
-    leaf_relay_rx: Option<(u8, u16, u16, u16, u16)>,
+    /// Carries the leaf's `LDBG` self-report too (captured during the relay) — see `RelayDiag`.
+    leaf_relay_rx: Option<crate::net::wifi::RelayDiag>,
     /// #40: consecutive non-terminal (transient) relay attempts for the current install —
     /// caps the auto-retry so a persistently-failing leaf can't loop the mesh-deaf relay.
     leaf_ota_retries: u8,
@@ -1872,6 +1873,20 @@ impl RadioManager {
         self.send_to(&BROADCAST_ADDRESS, &msg[..base + 3 + n]);
     }
 
+    /// #40 #3: broadcast this LEAF's OTA RX-diag beacon (`LDBG` = id + heard/verdict/sent) so a
+    /// relaying gateway captures `on_meta`'s verdict LIVE (folded into `…/ota/relaydiag`). `main`
+    /// gates the call on `!is_gateway` + the ~2 s HELLO cadence. Payload is fixed-width binary.
+    /// `espnow`-scoped: the `LDBG` frame + `ota_leaf` self-report only exist in the mesh build.
+    #[cfg(feature = "espnow")]
+    pub fn broadcast_ldbg(&mut self, heard: u16, verdict: u8, sent: u16) {
+        let mut msg = [0u8; crate::ota_mesh::LDBG_FRAME_LEN];
+        let base = encode_id_frame(crate::ota_mesh::LDBG_PREFIX, self.id, &mut msg);
+        msg[base..base + 2].copy_from_slice(&heard.to_le_bytes());
+        msg[base + 2] = verdict;
+        msg[base + 3..base + 5].copy_from_slice(&sent.to_le_bytes());
+        self.send_to(&BROADCAST_ADDRESS, &msg[..base + 5]);
+    }
+
     /// #21 leaf-relay: GATEWAY-only. Broadcast one `SMOLv1 CFG` per CACHED leaf
     /// config (skipping the gateway's OWN id — it self-applies via the credentialed
     /// MQTT path). Single-hop (leaves never re-broadcast → no flood/loop). No-op on a
@@ -2320,10 +2335,14 @@ impl RadioManager {
         let mut otad = [0u8; om::OTAD_FRAME_MAX];
 
         // #3 RX-DIAG counters: rx_any = frames heard FROM this leaf during the relay windows;
-        // otan_valid = valid advancing/NAK OTANs for the live session. Stored into
-        // `leaf_relay_rx` at each terminal exit → published next flush to `…/ota/relaydiag`.
+        // otan_valid = valid advancing/NAK OTANs for the live session. Plus the leaf's own LDBG
+        // self-report (heard/verdict/sent), captured live from its beacon; verdict 255 = none seen.
+        // All stored into `leaf_relay_rx` at each terminal exit → published next flush (relaydiag).
         let mut rx_any: u16 = 0;
         let mut otan_valid: u16 = 0;
+        let mut ldbg_heard: u16 = 0;
+        let mut ldbg_verdict: u8 = 255;
+        let mut ldbg_sent: u16 = 0;
         let mut wb: u32 = 0;
         while wb < total {
             if tick() {
@@ -2337,7 +2356,10 @@ impl RadioManager {
             let read_len = ((window_bytes as u32).div_ceil(4) * 4) as usize;
             if !reader.read(window_off, &mut gwbuf[..read_len]) {
                 log::error!("smol #40: slot readback failed at window {} — aborting", wb);
-                self.leaf_relay_rx = Some((leaf_id, rx_any, otan_valid, wb as u16, total as u16));
+                self.leaf_relay_rx = Some(crate::net::wifi::RelayDiag {
+                    leaf_id, rx_any, otan_valid, last_wb: wb as u16, total: total as u16,
+                    leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
+                });
                 let _ = self.switch(Mode::EspNow);
                 return LeafOtaOutcome::RelayFailed;
             }
@@ -2371,6 +2393,13 @@ impl RadioManager {
                     if let Some(recv) = self.esp_now.receive() {
                         if recv.info.src_address == leaf_mac {
                             rx_any = rx_any.saturating_add(1); // #3: heard SOMETHING from the leaf
+                            // #3: capture the leaf's LDBG self-report (latest wins) — names WHY
+                            // otan=0 without needing the leaf back online post-relay.
+                            if let Some((h, v, n)) = om::parse_ldbg(recv.data(), leaf_id) {
+                                ldbg_heard = h;
+                                ldbg_verdict = v;
+                                ldbg_sent = n;
+                            }
                             if let Some(om::OtaFrame::Nak { origin, session: s, window_base, bitmap }) =
                                 om::parse_ota_frame(recv.data())
                             {
@@ -2402,7 +2431,10 @@ impl RadioManager {
                         "smol #40: window {} exceeded {} retransmit rounds (rx_any={} otan={}) — aborting (R2 bound)",
                         wb, GW_WINDOW_ROUNDS_MAX, rx_any, otan_valid
                     );
-                    self.leaf_relay_rx = Some((leaf_id, rx_any, otan_valid, wb as u16, total as u16));
+                    self.leaf_relay_rx = Some(crate::net::wifi::RelayDiag {
+                    leaf_id, rx_any, otan_valid, last_wb: wb as u16, total: total as u16,
+                    leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
+                });
                     return LeafOtaOutcome::RelayFailed;
                 }
             }
@@ -2410,7 +2442,10 @@ impl RadioManager {
         // #3 RX-DIAG: relay TX phase COMPLETE — all chunks delivered + acked (wb==total). Record
         // the full-progress RX evidence for the relaydiag; the confirm outcome (below) is the
         // separate Tier-2 verdict published to `…/ota/diag`.
-        self.leaf_relay_rx = Some((leaf_id, rx_any, otan_valid, total as u16, total as u16));
+        self.leaf_relay_rx = Some(crate::net::wifi::RelayDiag {
+            leaf_id, rx_any, otan_valid, last_wb: total as u16, total: total as u16,
+            leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
+        });
 
         // --- CONFIRMING (Tier-2, build-matched): sample the leaf's SETTLED build over the
         // full confirm window. The leaf runs the NEW image immediately post-activate, so it
@@ -3082,6 +3117,14 @@ impl RadioManager {
             Some((cid, mac)) if cid == id => Some(mac), // roster evicted it → use the cache
             _ => None,
         }
+    }
+
+    /// #40 #3: the leaf's OTA RX-diag `(otam_heard, on_meta_verdict, otan_sent)` — `main`
+    /// beacons it via `broadcast_ldbg` so a headless canary names (a)/(b)/(c) for a `relay-failed`.
+    /// `espnow`-scoped: `ota_leaf` (the receive session) only exists in the mesh build.
+    #[cfg(feature = "espnow")]
+    pub fn ota_leaf_dbg(&self) -> (u16, u8, u16) {
+        self.ota_leaf.dbg()
     }
 
     /// Current peer-link state as an [`LedState`], evaluated at `now_ms`.

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1340,8 +1340,11 @@ pub struct RadioManager {
     /// chunk-loss stall. `last_wb` is in chunk units (matches `total = om::total_chunks`).
     /// Carries the leaf's `LDBG` self-report too (captured during the relay) — see `RelayDiag`.
     leaf_relay_rx: Option<crate::net::wifi::RelayDiag>,
-    /// #40: consecutive non-terminal (transient) relay attempts for the current install —
-    /// caps the auto-retry so a persistently-failing leaf can't loop the mesh-deaf relay.
+    /// #40: consecutive non-terminal (transient) relay attempts — caps the auto-retry so a
+    /// persistently-failing leaf can't loop the mesh-deaf relay. SHARED across leaves: with
+    /// the #4 round-robin surfacing (wifi.rs), concurrent installs ALTERNATE, so this bounds
+    /// TOTAL wasted attempts (a per-leaf counter that reset on each rotation would never hit
+    /// the cap → an unbounded mesh-deaf loop; the shared cap is the safe choice).
     leaf_ota_retries: u8,
     /// #21 node-manager: the parsed default-screen command surfaced by a burst,
     /// pending `main`'s `take_config_offer` → apply. `None` when nothing is pending.
@@ -2704,6 +2707,10 @@ impl RadioManager {
         }
         let cdeadline = now_ms() + GW_CONFIRM_TIMEOUT_MS;
         let mut last_build: Option<u32> = None;
+        // #40 IDENTITY GUARD: a logical id STATed by the TARGET MAC that isn't `leaf_id`.
+        // With the runtime-NVS identity fix this stays None; if it fires, the image booted
+        // with a stolen/wrong id → an explicit `id-mismatch` beats a silent leaf-timeout.
+        let mut mac_seen_id: Option<u8> = None;
         let mut last_hello_ms = 0u64;
         while now_ms() < cdeadline {
             if tick() {
@@ -2723,11 +2730,17 @@ impl RadioManager {
                 last_hello_ms = t;
             }
             if let Some(recv) = self.esp_now.receive() {
+                // Copy the source MAC out FIRST (Copy) so the `recv.data()` borrow in the
+                // parse below doesn't collide with the identity-guard MAC compare.
+                let src_mac = recv.info.src_address;
                 if let Some(Frame::Stat { src, value }) = parse_frame(recv.data()) {
                     if src == leaf_id {
                         if let Some(b) = om::stat_build(value) {
                             last_build = Some(b); // keep the latest — the settled state wins
                         }
+                    } else if src_mac == leaf_mac {
+                        // Our target board (matched by sticky MAC) is STATing a DIFFERENT id.
+                        mac_seen_id = Some(src);
                     }
                 }
             }
@@ -2745,11 +2758,22 @@ impl RadioManager {
                 LeafOtaOutcome::RolledBack
             }
             None => {
-                log::error!(
-                    "smol #40: leaf id{} did not reappear at build {} within the confirm window — possible brick (USB recovery)",
-                    leaf_id, announce.build
-                );
-                LeafOtaOutcome::Timeout
+                if let Some(wrong) = mac_seen_id {
+                    // The physical board booted + STATs, but under the WRONG id — a stolen
+                    // baked-default identity (NVS not seeded / shared image on a fresh board).
+                    // Explicit `id-mismatch` (terminal) instead of a mystery leaf-timeout.
+                    log::error!(
+                        "smol #40: leaf id{} target MAC now STATs as id{} — IDENTITY MISMATCH (stolen baked id / NVS unseeded), not a brick",
+                        leaf_id, wrong
+                    );
+                    LeafOtaOutcome::IdMismatch
+                } else {
+                    log::error!(
+                        "smol #40: leaf id{} did not reappear at build {} within the confirm window — possible brick (USB recovery)",
+                        leaf_id, announce.build
+                    );
+                    LeafOtaOutcome::Timeout
+                }
             }
         }
     }

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2913,15 +2913,25 @@ impl RadioManager {
                     // SENDER leaf id; the MQTT flush republishes it as retained
                     // `smol/<leaf_id>/status`. Opaque bytes (mirror CFG) — a stray/foreign
                     // frame can at worst set a bad screen string, self-corrected next
-                    // cadence; never a brick. NOTE: `src` stays the frame's SOURCE MAC for
-                    // the roster liveness update (mirrors the BATT/GRID/CFG arms); the
-                    // leaf's id↔MAC mapping is already learned from its 2 s HELLOs, so the
-                    // `None` id here is correct + side-effect-free.
+                    // cadence; never a brick.
+                    //
+                    // #40 FIX (was `None`): LEARN the leaf's id↔MAC from its STAT. The STAT
+                    // frame CARRIES the sender's id (`leaf_id`), and the relay-eligible set is
+                    // exactly "leaves the gateway heard STAT from" (stat_cache / §B2). The old
+                    // `None` assumed the id↔MAC was already learned from the leaf's 2 s HELLOs
+                    // — but a leaf can be STAT-audible yet HELLO-silent to the gateway (e.g.
+                    // #51 silent-until-relock, or its HELLO simply not landing), leaving
+                    // `id_known=false` → `mac_for_id(leaf)` returned None → the relay armed but
+                    // bailed at the MAC lookup with no fetch (RUNTIME-confirmed via ota/diag=
+                    // mac-unknown). Recording `Some(leaf_id)` here makes the relay-set and the
+                    // MAC lookup consistent. Threat model unchanged: id↔MAC from an unauth STAT
+                    // is no weaker than from an unauth HELLO (both already trusted), and the
+                    // relayed image is ed25519-signed so a spoofed id→MAC only wastes a session.
                     if self.relay.is_gateway {
                         self.stat_cache.set(leaf_id, value);
                     }
                     self.peers.last_hello_ms = now;
-                    self.roster.heard(src, None, rssi, now);
+                    self.roster.heard(src, Some(leaf_id), rssi, now);
                     label = Some(alloc::string::String::from("stat"));
                 }
                 None => {

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -3030,11 +3030,18 @@ pub fn start(
     // #33: stash a boot-time install command (retained) so `main` fetches after boot.
     radio.install_requested = install_requested;
 
-    // OTA MF-1: confirm/rollback the running image on its first boot, NOW that the
-    // WiFi/DHCP result is known. self-test = reached DHCP (a broken-WiFi image can't;
-    // the just-run download proved the net is up, so a healthy image won't
-    // false-rollback). May `software_reset` (rollback) → never returns in that case.
-    crate::ota::boot_confirm(reached_dhcp);
+    // OTA MF-1 / #40 HOLE-1 — ROLE-AWARE first-boot self-test.
+    // A node that reached DHCP has a working uplink → confirm NOW (DHCP is the gateway's
+    // health proof; a broken-WiFi image can't reach it, so a healthy image won't
+    // false-rollback). A node that did NOT reach DHCP is a LEAF (it can never win the
+    // gateway election): confirming on `reached_dhcp=false` here would roll back EVERY
+    // mesh-OTA (the credential-less leaf never does DHCP). So a leaf DEFERS its self-test
+    // to the main loop, which confirms on the mesh predicate (heard ≥1 valid SMOLv1 frame
+    // within N s) instead. `boot_confirm(true)` may still reboot-on-nothing (no-op if the
+    // image is already Valid). See main.rs `leaf_selftest_pending`.
+    if reached_dhcp {
+        crate::ota::boot_confirm(true);
+    }
 
     // #23: GATEWAY iff we reached DHCP AND won the election (lowest-id owner). A board
     // that reached DHCP but LOST (a lower-id owner already holds it) demotes to leaf.

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -3298,7 +3298,10 @@ impl RadioManager {
                     // is no weaker than from an unauth HELLO (both already trusted), and the
                     // relayed image is ed25519-signed so a spoofed id→MAC only wastes a session.
                     if self.relay.is_gateway {
-                        self.stat_cache.set(leaf_id, value);
+                        // #68 F6/roster-robustness: stamp the STAT with the sender's MAC + time so
+                        // a stale leaf stops ghosting its status and stays mac-resolvable if the
+                        // LRU roster later evicts it.
+                        self.stat_cache.set(leaf_id, value, src, now);
                     }
                     self.peers.last_hello_ms = now;
                     self.roster.heard(src, Some(leaf_id), rssi, now);
@@ -3400,10 +3403,23 @@ impl RadioManager {
             self.leaf_ota_mac = Some((id, mac)); // freshest wins; refresh the session cache
             return Some(mac);
         }
-        match self.leaf_ota_mac {
-            Some((cid, mac)) if cid == id => Some(mac), // roster evicted it → use the cache
-            _ => None,
+        if let Some((cid, mac)) = self.leaf_ota_mac {
+            if cid == id {
+                return Some(mac); // roster evicted it mid-session → use the session cache
+            }
         }
+        // #68 roster-admission robustness: the roster (a 16-slot LRU with no staleness reaping)
+        // can EVICT a leaf that HELLOs sparsely while a chatty peer stays resident — so a leaf the
+        // gateway currently RELAYS/STATs (id8, live) can be absent from `mac_for_id`, silently
+        // no-arming its retained install. The stat_cache holds the id↔MAC of every recently-heard
+        // leaf (freshness-gated), so resolve from there as a last resort → any STAT-heard leaf
+        // stays armable. If it's genuinely off-air, the entry ages past STAT_FRESH_MS → None (no
+        // arm to a gone leaf; a stale ghost can't fake reachability).
+        let mac =
+            self.stat_cache
+                .mac_for(id, now_ms(), crate::net::wifi::STAT_FRESH_MS)?;
+        self.leaf_ota_mac = Some((id, mac));
+        Some(mac)
     }
 
     /// #40 #3: the leaf's OTA RX-diag `(otam_heard, on_meta_verdict, otan_sent)` — `main`

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1446,18 +1446,26 @@ impl RadioManager {
         if self.relay.is_gateway {
             return; // gateway owns its channel via association; never scans
         }
-        // #3b: DON'T unlock+hop on mere owner-silence. The gateway TIME-SHARES — its ESP-NOW
-        // stays on ESP_NOW_FIXED_CHANNEL; only its WiFi rides the multi-channel roam SSID during
-        // a minutes-long OTA fetch (OTA_FETCH_BUDGET=300s). The old 6 s unlock made the leaf hop
-        // [1,6,11] and DRIFT off ch6 for the whole fetch → it never heard the relay OTAM and the
-        // gateway stopped hearing it (canary #3b: leaf H0, rx→0, bidirectional collapse). So HOLD
-        // the fixed channel and re-assert it (a live gateway will return here). A truly dead/moved
-        // gateway is still recovered by `maybe_leaf_reelect` (15 s, independent), and genuine
-        // owner/role CHANGES unlock explicitly at their own sites (post-reelect / gateway-demote).
+        // #3b (regression fix): while ACTIVELY receiving a mesh-OTA, HOLD the channel — do NOT
+        // unlock/hop. The transfer runs on ESP_NOW_FIXED_CHANNEL and hopping mid-transfer drops
+        // chunks. NARROW + bounded: true only during a live session (`is_active`); with no OTA in
+        // flight this is a no-op and normal membership behaves EXACTLY as before. (60ff390 made
+        // the hold UNCONDITIONAL and broke basic mesh join — id8 couldn't re-acquire the gateway
+        // after routine beacon loss the way id9/pre-#40 does. This restores that path and scopes
+        // the hold to only when it's actually needed.)
+        if self.ota_leaf.is_active() {
+            let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
+            return;
+        }
+        // RESTORED old behavior: unlock + re-scan on owner-silence. A leaf MUST re-acquire the
+        // gateway after routine beacon loss to keep mesh membership. The fetch-drift is handled
+        // narrowly instead: (i) receiving an OTA frame locks the leaf to ch6 (`handle_ota_frame`),
+        // (ii) the gateway's OTAM wake-burst lets a hopping leaf catch the first announce.
+        if self.scan_locked && now.saturating_sub(self.last_owner_heard_ms) > SCAN_SILENCE_MS {
+            self.scan_locked = false;
+            log::info!("smol: leaf lost gateway id{} — re-scanning", self.elected_owner);
+        }
         if self.scan_locked {
-            if now.saturating_sub(self.last_owner_heard_ms) > SCAN_SILENCE_MS {
-                let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
-            }
             return;
         }
         if now.saturating_sub(self.last_scan_hop_ms) >= DWELL_MS {
@@ -2390,6 +2398,53 @@ impl RadioManager {
         // #3b OTAM TX-diag: broadcast sends attempted vs returned-Ok (queued + TX-callback ok).
         let mut otam_tx: u16 = 0;
         let mut otam_ok: u16 = 0;
+
+        // #3b WAKE-BURST: the leaf lost the gateway during the off-ch6 fetch and is now hopping
+        // [1,6,11] (on ch6 only ~⅓ of the time) and/or re-electing over WiFi — so a single OTAM
+        // per window-0 round (spaced by the 800 ms OTAN wait) rarely coincides with the leaf's
+        // brief ch6 dwell (canary: leaf H0). OPEN the relay with a DENSE OTAM flood: rebroadcast
+        // the announce every ~120 ms for up to WAKE_MS, maximizing overlap with the leaf's sparse
+        // ch6 windows. The first OTAM the leaf catches locks it to ch6 (`handle_ota_frame`) and
+        // arms its session → it then holds ch6 (`leaf_scan_tick` is_active) for the transfer. Stop
+        // early the instant the leaf NAKs (it's armed + ready for the windowed transfer).
+        const WAKE_MS: u64 = 20_000;
+        const WAKE_GAP_MS: u64 = 120;
+        let wake_deadline = now_ms() + WAKE_MS;
+        let mut last_wake_ms = 0u64;
+        while now_ms() < wake_deadline {
+            if tick() {
+                return LeafOtaOutcome::Aborted;
+            }
+            let t = now_ms();
+            if t.saturating_sub(last_wake_ms) >= WAKE_GAP_MS {
+                let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
+                otam_tx = otam_tx.saturating_add(1);
+                if let Ok(waiter) = self.esp_now.send(&BROADCAST_ADDRESS, &otam[..otam_len]) {
+                    if waiter.wait().is_ok() {
+                        otam_ok = otam_ok.saturating_add(1);
+                    }
+                }
+                last_wake_ms = t;
+            }
+            if let Some(recv) = self.esp_now.receive() {
+                if recv.info.src_address == leaf_mac {
+                    rx_any = rx_any.saturating_add(1);
+                    if let Some((h, v, n, c)) = om::parse_ldbg(recv.data(), leaf_id) {
+                        ldbg_heard = h;
+                        ldbg_verdict = v;
+                        ldbg_sent = n;
+                        ldbg_ch = c;
+                    }
+                    if matches!(
+                        om::parse_ota_frame(recv.data()),
+                        Some(om::OtaFrame::Nak { .. })
+                    ) {
+                        break; // leaf armed + NAKing → proceed to the windowed transfer
+                    }
+                }
+            }
+        }
+
         let mut wb: u32 = 0;
         while wb < total {
             if tick() {
@@ -3130,6 +3185,15 @@ impl RadioManager {
         use crate::ota_mesh::{LeafAction, OtaFrame};
         self.peers.last_hello_ms = now;
         self.roster.heard(src, None, rssi, now);
+        // #3b: an inbound OTA frame proves the gateway is audible on THIS channel (the relay
+        // runs on ESP_NOW_FIXED_CHANNEL). Treat it like the owner's HELLO — reset the
+        // owner-silence timer AND lock the channel — so the leaf STOPS the scan hop and STAYS on
+        // ch6 for the rest of the transfer. This is what lets the FIRST caught OTAM (caught while
+        // the leaf was mid-hop) pin the leaf so it hears the OTAD chunks + OTAM resends (#3b).
+        self.last_owner_heard_ms = now;
+        if !self.relay.is_gateway {
+            self.scan_locked = true;
+        }
         if !self.esp_now.peer_exists(&src) {
             let _ = self.esp_now.add_peer(PeerInfo {
                 interface: EspNowWifiInterface::Sta,

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1340,11 +1340,8 @@ pub struct RadioManager {
     /// chunk-loss stall. `last_wb` is in chunk units (matches `total = om::total_chunks`).
     /// Carries the leaf's `LDBG` self-report too (captured during the relay) — see `RelayDiag`.
     leaf_relay_rx: Option<crate::net::wifi::RelayDiag>,
-    /// #40: consecutive non-terminal (transient) relay attempts — caps the auto-retry so a
-    /// persistently-failing leaf can't loop the mesh-deaf relay. SHARED across leaves: with
-    /// the #4 round-robin surfacing (wifi.rs), concurrent installs ALTERNATE, so this bounds
-    /// TOTAL wasted attempts (a per-leaf counter that reset on each rotation would never hit
-    /// the cap → an unbounded mesh-deaf loop; the shared cap is the safe choice).
+    /// #40: consecutive non-terminal (transient) relay attempts for the current install —
+    /// caps the auto-retry so a persistently-failing leaf can't loop the mesh-deaf relay.
     leaf_ota_retries: u8,
     /// #21 node-manager: the parsed default-screen command surfaced by a burst,
     /// pending `main`'s `take_config_offer` → apply. `None` when nothing is pending.

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2989,8 +2989,8 @@ impl RadioManager {
                 let gw = self.ota_leaf.gateway_mac();
                 self.send_to(&gw, &out[..n]);
             }
-            LeafAction::Complete(slot) => {
-                crate::ota::activate(slot); // reboots on success; returns only on otadata-write fail
+            LeafAction::Complete(slot, build) => {
+                crate::ota::activate(slot, build); // reboots on success; returns only on otadata-write fail
             }
             LeafAction::None | LeafAction::Abort => {}
         }

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -176,7 +176,22 @@ const CFG_PREFIX: &[u8] = b"SMOLv1 CFG "; // + "NNN" + verbatim "<AppKind>:<page
 /// STAT → no flood/loop). Same unauthed, low-blast threat model as CFG: worst case a stray
 /// frame yields a bad screen STRING on a status topic — never code exec, self-corrected
 /// next cadence. Value bounded by `CFG_VALUE_MAX`.
-const STAT_PREFIX: &[u8] = b"SMOLv1 STAT "; // + "NNN" + verbatim "<AppKind>:<page>"
+const STAT_PREFIX: &[u8] = b"SMOLv1 STAT "; // + "NNN" + verbatim "<AppKind>:<page>|<build>"
+
+// #40 leaf-mesh-OTA GATEWAY relay tuning (blocking maintenance op; hardware-tunable — see
+// lucid-40-build-handoff.md). The relay monopolizes the radio for its duration by design.
+/// Wait for a leaf OTAN after (re)sending a window before resending it (ms).
+const GW_OTAN_WAIT_MS: u64 = 800;
+/// Max retransmit rounds per window before aborting the relay (R2 spoof/DoS bound).
+const GW_WINDOW_ROUNDS_MAX: u32 = 16;
+/// Tier-2 confirm window (ms) — MUST exceed the leaf self-test window (`LEAF_SELFTEST_
+/// WINDOW_MS` ≈ 60 s) + a STAT cadence (~10 s) so a late self-test rollback is observed
+/// before the gateway declares Confirmed.
+const GW_CONFIRM_TIMEOUT_MS: u64 = 120_000;
+/// One-window relay readback buffer (off the stack, in `.bss`). Alias-safe: a gateway
+/// relays to ONE leaf at a time (serial canary), and never runs a leaf receive session.
+static mut GW_OTA_WINDOW: [u8; crate::ota_mesh::WINDOW_BYTES] =
+    [0u8; crate::ota_mesh::WINDOW_BYTES];
 
 use crate::mesh_snake::snake_core::{self, SnkFrame};
 
@@ -2109,8 +2124,210 @@ impl RadioManager {
         match self.sta.as_mut() {
             None => false,
             Some(sta) => {
-                crate::net::wifi::run_ota_fetch(&mut self.controller, sta, rng, announce, tick)
+                // Self-OTA: activate-on-success (relay_mode = false; the slot out-param is
+                // unused since a successful self-fetch reboots inside `activate`).
+                crate::net::wifi::run_ota_fetch(
+                    &mut self.controller, sta, rng, announce, tick, false, &mut None,
+                )
             }
+        }
+    }
+
+    /// #40 GATEWAY leaf-mesh-OTA orchestration (§B4). Fetch the staged image (WiFi) into
+    /// THIS gateway's inactive slot → relay it over ESP-NOW to ONE leaf (windowed-NAK) →
+    /// watch for the leaf's Tier-2 STAT reappearance at the NEW build. CANARY-ONE-LEAF:
+    /// targets exactly `leaf_mac`; there is NO broadcast image push. Blocking + mesh-
+    /// degrading for its duration (WiFi fetch then ESP-NOW relay — never concurrent, §D#1);
+    /// the UI-alive `tick` runs throughout and latches a long-press ABORT. Returns the
+    /// outcome for the HA `smol/<leaf>/ota/state` publish. No-op on a non-gateway.
+    pub fn run_leaf_ota_relay(
+        &mut self,
+        leaf_id: u8,
+        leaf_mac: [u8; 6],
+        announce: &crate::ota::Announce,
+        tick: &mut dyn FnMut() -> bool,
+    ) -> crate::ota_mesh::LeafOtaOutcome {
+        use crate::ota_mesh::{
+            self as om, LeafOtaOutcome, CHUNK_PAYLOAD, WINDOW_BYTES, WINDOW_CHUNKS,
+        };
+        use esp_bootloader_esp_idf::ota::Slot;
+        if !self.relay.is_gateway {
+            return LeafOtaOutcome::RelayFailed;
+        }
+        let size = announce.size;
+        let total = om::total_chunks(size);
+        // Session discriminator (retry/concurrency): low 16 bits of the monotonic build.
+        let session: u16 = (announce.build & 0xFFFF) as u16;
+        log::info!(
+            "smol #40: RELAY start → leaf id{} build {} ({} B, {} chunks)",
+            leaf_id, announce.build, size, total
+        );
+
+        // --- FETCH (WiFi) → stage+verify into THIS gateway's inactive slot (no activate).
+        let _ = self.switch(Mode::WifiSta);
+        let rng = self.rng;
+        let mut staged: Option<Slot> = None;
+        let fetched = match self.sta.as_mut() {
+            Some(sta) => crate::net::wifi::run_ota_fetch(
+                &mut self.controller, sta, rng, announce, tick, true, &mut staged,
+            ),
+            None => false,
+        };
+        let staged = if fetched { staged } else { None };
+        let Some(slot) = staged else {
+            log::error!("smol #40: relay fetch/stage failed — aborting (leaf untouched)");
+            let _ = self.switch(Mode::EspNow);
+            return LeafOtaOutcome::RelayFailed;
+        };
+        let Some(reader) = crate::ota::SlotReader::open(slot) else {
+            let _ = self.switch(Mode::EspNow);
+            return LeafOtaOutcome::RelayFailed;
+        };
+
+        // --- RELAY (ESP-NOW) — windowed-NAK to the ONE leaf MAC. ---
+        let _ = self.switch(Mode::EspNow);
+        if !self.esp_now.peer_exists(&leaf_mac) {
+            let _ = self.esp_now.add_peer(PeerInfo {
+                interface: EspNowWifiInterface::Sta,
+                peer_address: leaf_mac,
+                lmk: None,
+                channel: None,
+                encrypt: false,
+            });
+        }
+        let gwbuf = unsafe { &mut *core::ptr::addr_of_mut!(GW_OTA_WINDOW) };
+        let mut otam = [0u8; om::OTAM_FRAME_MAX];
+        let Some(otam_len) =
+            om::encode_otam(leaf_id, session, announce.signed_msg(), announce.sig(), &mut otam)
+        else {
+            return LeafOtaOutcome::RelayFailed;
+        };
+        let mut otad = [0u8; om::OTAD_FRAME_MAX];
+
+        let mut wb: u32 = 0;
+        while wb < total {
+            if tick() {
+                return LeafOtaOutcome::Aborted;
+            }
+            let wlen_chunks = core::cmp::min(WINDOW_CHUNKS as u32, total - wb);
+            let window_off = wb * CHUNK_PAYLOAD as u32;
+            let window_bytes = core::cmp::min(WINDOW_BYTES as u32, size - window_off) as usize;
+            // Read this window from the staged slot (word-aligned length; extra padding
+            // bytes past `window_bytes` are read but never sent).
+            let read_len = ((window_bytes as u32).div_ceil(4) * 4) as usize;
+            if !reader.read(window_off, &mut gwbuf[..read_len]) {
+                log::error!("smol #40: slot readback failed at window {} — aborting", wb);
+                let _ = self.switch(Mode::EspNow);
+                return LeafOtaOutcome::RelayFailed;
+            }
+            let full = om::window_full_mask(wlen_chunks);
+            let mut missing = full; // first pass: send every chunk in the window
+            let mut rounds: u32 = 0;
+            loop {
+                if tick() {
+                    return LeafOtaOutcome::Aborted;
+                }
+                // (Re)send OTAM during window 0 so a leaf that missed it can still arm.
+                if wb == 0 {
+                    self.send_to(&leaf_mac, &otam[..otam_len]);
+                }
+                for i in 0..wlen_chunks as usize {
+                    if (missing >> i) & 1 == 1 {
+                        let seq = wb + i as u32;
+                        let coff = i * CHUNK_PAYLOAD;
+                        let clen = core::cmp::min(CHUNK_PAYLOAD, window_bytes - coff);
+                        let n = om::encode_otad(
+                            leaf_id, session, seq as u16, &gwbuf[coff..coff + clen], &mut otad,
+                        );
+                        self.send_to(&leaf_mac, &otad[..n]);
+                    }
+                }
+                // Wait for this window's OTAN (all-zero = advance; else the missing set).
+                let deadline = now_ms() + GW_OTAN_WAIT_MS;
+                let mut advanced = false;
+                let mut got_nak = false;
+                while now_ms() < deadline {
+                    if let Some(recv) = self.esp_now.receive() {
+                        if recv.info.src_address == leaf_mac {
+                            if let Some(om::OtaFrame::Nak { origin, session: s, window_base, bitmap }) =
+                                om::parse_ota_frame(recv.data())
+                            {
+                                if origin == leaf_id && s == session && window_base as u32 == wb {
+                                    let miss = om::bitmap_to_u64(bitmap) & full;
+                                    if miss == 0 {
+                                        advanced = true;
+                                    } else {
+                                        missing = miss;
+                                        got_nak = true;
+                                    }
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                if advanced {
+                    wb += WINDOW_CHUNKS as u32;
+                    break;
+                }
+                if !got_nak {
+                    missing = full; // no NAK in the wait → resend the whole window
+                }
+                rounds += 1;
+                if rounds > GW_WINDOW_ROUNDS_MAX {
+                    log::error!(
+                        "smol #40: window {} exceeded {} retransmit rounds — aborting (R2 bound)",
+                        wb, GW_WINDOW_ROUNDS_MAX
+                    );
+                    return LeafOtaOutcome::RelayFailed;
+                }
+            }
+        }
+
+        // --- CONFIRMING (Tier-2, build-matched): sample the leaf's SETTLED build after its
+        // self-test window elapses. The leaf runs the NEW image immediately post-activate,
+        // so it would STAT the new build even mid-self-test; a FAILED self-test then rolls
+        // it back to an OLDER build. So: an older-build sighting is a DEFINITIVE rollback
+        // (early-out); a new-build sighting only CONFIRMS if no rollback lands before the
+        // window closes (> the leaf self-test window + a STAT cadence). No STAT at all → a
+        // possible brick (USB recovery). This is the progression gate, not the safety gate
+        // (the leaf's local Tier-1 is what actually protects it).
+        log::info!(
+            "smol #40: all {} chunks relayed — awaiting leaf id{} Tier-2 confirm at build {}",
+            total, leaf_id, announce.build
+        );
+        let cdeadline = now_ms() + GW_CONFIRM_TIMEOUT_MS;
+        let mut saw_new = false;
+        while now_ms() < cdeadline {
+            if tick() {
+                return LeafOtaOutcome::Aborted;
+            }
+            if let Some(recv) = self.esp_now.receive() {
+                if let Some(Frame::Stat { src, value }) = parse_frame(recv.data()) {
+                    if src == leaf_id {
+                        if let Some(b) = om::stat_build(value) {
+                            if b < announce.build {
+                                log::warn!(
+                                    "smol #40: leaf id{} reappeared at OLD build {} — self-test rolled it back",
+                                    leaf_id, b
+                                );
+                                return LeafOtaOutcome::RolledBack;
+                            }
+                            saw_new = true; // b >= pushed build → running the new image
+                        }
+                    }
+                }
+            }
+        }
+        if saw_new {
+            log::info!("smol #40: leaf id{} CONFIRMED at build {} — update stuck", leaf_id, announce.build);
+            LeafOtaOutcome::Confirmed
+        } else {
+            log::error!(
+                "smol #40: leaf id{} did not reappear at build {} within the confirm window — possible brick (USB recovery)",
+                leaf_id, announce.build
+            );
+            LeafOtaOutcome::Timeout
         }
     }
 

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2702,9 +2702,23 @@ impl RadioManager {
         }
         let cdeadline = now_ms() + GW_CONFIRM_TIMEOUT_MS;
         let mut last_build: Option<u32> = None;
+        let mut last_hello_ms = 0u64;
         while now_ms() < cdeadline {
             if tick() {
                 return LeafOtaOutcome::Aborted;
+            }
+            // #3b REJOIN: HELLO on ch6 (~1 Hz) throughout the confirm window. The leaf just
+            // activated + REBOOTED into the new image and must HEAR A VALID FRAME to pass its
+            // hear-a-frame self-test (else it rolls back off the new build) AND lock onto us to
+            // STAT its new build (the confirm signal). The old confirm loop was SILENT — the
+            // rebooted leaf heard nothing → self-test never passed → it rolled back / never
+            // rejoined, so a SUCCESSFUL delivery (image activated + booted) looked like a failure
+            // (canary: leaf booted 126 from ota_1 but HA never saw a 126 STAT). Stay pinned ch6.
+            let t = now_ms();
+            if t.saturating_sub(last_hello_ms) >= 1000 {
+                let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
+                self.broadcast_hello();
+                last_hello_ms = t;
             }
             if let Some(recv) = self.esp_now.receive() {
                 if let Some(Frame::Stat { src, value }) = parse_frame(recv.data()) {

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -804,6 +804,10 @@ pub struct RelayDiag {
     /// (confirms the OTAM was egressing off-channel → the leaf H0 cause); `settle=0` ⇒ STA already
     /// down, so a persistent H0 is NOT the channel (→ leaf RX-filter, instrument the leaf next).
     pub settle: u16,
+    /// #3b LEAF-CHANNEL: the leaf's `current_channel()` from its captured LDBG (0=scanning/unlocked,
+    /// else the locked channel). Splits the settle=0 H0 fork: leaf_ch=6 ⇒ leaf on ch6 yet no OTAM
+    /// (RX issue); leaf_ch≠6 ⇒ leaf drifted off ch6 during the gateway's mesh-deaf fetch window.
+    pub leaf_ch: u8,
 }
 
 #[cfg(feature = "wifi")]
@@ -1500,7 +1504,7 @@ fn mqtt_session(
         if d.leaf_verdict == 255 {
             let _ = write!(rval, "none");
         } else {
-            let _ = write!(rval, "H{}V{}N{}", d.leaf_heard, d.leaf_verdict, d.leaf_sent);
+            let _ = write!(rval, "H{}V{}N{}ch{}", d.leaf_heard, d.leaf_verdict, d.leaf_sent, d.leaf_ch);
         }
         if let Some(n) =
             crate::net::mqtt::encode_publish(&mut pkt, rtopic.as_bytes(), rval.as_bytes(), true)

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -2237,7 +2237,7 @@ pub fn run_ota_fetch(
             return true;
         }
         log::info!("smol OTA: image VERIFIED (SHA-256 + ed25519) — activating the new slot");
-        crate::ota::activate(target, announce.build); // reboots on success
+        crate::ota::activate(target, announce.build, false); // self-OTA → confirm via DHCP
         false // reached only if the otadata write failed
     } else {
         log::error!("smol OTA: verify FAILED (size/SHA-256 or ed25519 signature) — discarded (good slot intact)");

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1326,8 +1326,16 @@ fn mqtt_session(
     // where an absent retained MC made the loop wait to `deadline` and drain them
     // incidentally. Bounded → an ABSENT announce/config costs only the settle window,
     // never the full session budget.
-    const DOWNLINK_SETTLE: Duration = Duration::from_millis(300);
-    let mut settle_deadline: Option<Instant> = None;
+    // #40 QUIET-PERIOD (settle-break truncation fix): the drain must not exit until the retained
+    // backlog is COMPLETE. The batt/grid/mc "downlink complete" flags key on three RETAINED
+    // topics the broker delivers instantly on SUBACK, so a FIXED window from "3 flags complete"
+    // broke BEFORE the rest of the retained burst (staged/install/cfg) arrived → truncated them
+    // (armdiag staged_raw/install-caught/cfg_cache all none; the arm only fired on the rare burst
+    // ordering that front-loaded the OTA topics → the ~30-min "slow arm"). Fix: break only after
+    // the 3 flags AND a QUIET GAP — no new packet for DOWNLINK_SETTLE — so the drain rides out the
+    // whole retained burst regardless of order. `last_msg` resets on every parsed packet below.
+    const DOWNLINK_SETTLE: Duration = Duration::from_millis(400);
+    let mut last_msg: Instant = Instant::now();
     // #40: the RAW (ungated) staged announce + a leaf id whose retained install cmd is
     // present. Paired AFTER the drain (both are retained → arrive in the same broker burst)
     // → `*leaf_ota`. The staged is the caller-PERSISTED `staged_raw` (updated below when a
@@ -1448,19 +1456,20 @@ fn mqtt_session(
                 }
                 Some((_, consumed)) => consumed,
             };
+            // #40 QUIET-PERIOD: a packet was parsed (the `None` arm broke above) → reset the
+            // quiet timer so an in-flight retained burst keeps the drain alive.
+            last_msg = Instant::now();
             acc.copy_within(consumed..acc_len, 0);
             acc_len -= consumed;
         }
-        // Primary downlinks in → drain the bounded settle window (catches the retained
-        // OTA announce + config that arrive just after mc), then finish. If batt/grid/mc
-        // never all arrive (e.g. absent MC at boot), fall through to the `deadline` break
-        // — which still drains ota/config during the wait (the original boot behaviour).
-        if got_batt && got_grid && got_mc {
-            match settle_deadline {
-                None => settle_deadline = Some(Instant::now() + DOWNLINK_SETTLE),
-                Some(sd) if Instant::now() > sd => break,
-                _ => {}
-            }
+        // #40 QUIET-PERIOD break: exit once the 3 downlink flags are in AND no new packet has
+        // arrived for DOWNLINK_SETTLE. The retained backlog (staged/install/cfg) arrives as a
+        // contiguous SUBACK burst, so a quiet gap means it's fully drained — order-independent,
+        // unlike the old fixed window that truncated a late-arriving OTA topic. If batt/grid/mc
+        // never all arrive (e.g. absent MC at boot), fall through to the `deadline` break — which
+        // still drains ota/config during the wait (the original boot behaviour).
+        if got_batt && got_grid && got_mc && Instant::now() >= last_msg + DOWNLINK_SETTLE {
+            break;
         }
         if Instant::now() > deadline {
             log::info!("smol: MQTT downlink(s) not all received in budget (keeping cache)");

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -583,6 +583,7 @@ pub fn run_ntp_burst(
         None, // #21: boot burst is not a gateway relay (no leaf-config cache)
         None, // #50b: boot burst republishes no cached leaf status
         &mut None, // #40: boot burst never relays a leaf OTA
+        &mut None, // #40: boot burst has no persistent staged to carry
         mqtt_deadline,
         tick,
     );
@@ -949,6 +950,12 @@ fn mqtt_session(
     // AND a staged image is available — the caller then relays it over ESP-NOW. The retained
     // cmd is CLEARED here (consumed) so an HA reload can't replay it. `&mut None` off-gateway.
     leaf_ota: &mut Option<(u8, crate::ota::Announce)>,
+    // #40: PERSISTENT (caller-owned, survives across flushes) last raw staged announce. The
+    // staged arm updates it when drained; the leaf-install pairing reads it — so a pair works
+    // even if the staged retained wasn't re-drained in the SAME flush that consumed the
+    // install (the race that left the install consumed but the relay never armed). `&mut None`
+    // on boot/leaf bursts (no persistence needed).
+    staged_raw: &mut Option<crate::ota::Announce>,
     deadline: Instant,
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
@@ -1270,10 +1277,11 @@ fn mqtt_session(
     let mut settle_deadline: Option<Instant> = None;
     // #40: the RAW (ungated) staged announce + a leaf id whose retained install cmd is
     // present. Paired AFTER the drain (both are retained → arrive in the same broker burst)
-    // → `*leaf_ota`. Raw (not the gate()d `ota_offer`) because the LEAF, not the gateway,
-    // owns the freshness gate (the OTAM handler rejects `build ≤ leaf.build`); the gateway
-    // may be NEWER than the leaf's target, so a gateway-build gate would wrongly drop it.
-    let mut raw_staged: Option<crate::ota::Announce> = None;
+    // → `*leaf_ota`. The staged is the caller-PERSISTED `staged_raw` (updated below when a
+    // staged retained is drained), so an install is paired with the last-known staged even
+    // if THIS flush didn't re-drain it. Raw (not the gate()d `ota_offer`) because the LEAF,
+    // not the gateway, owns the freshness gate (the OTAM handler rejects `build ≤ leaf.build`);
+    // the gateway may be NEWER than the leaf's target, so a gateway-build gate would drop it.
     let mut pending_leaf: Option<u8> = None;
     loop {
         if tick() {
@@ -1306,10 +1314,10 @@ fn mqtt_session(
                         // Stale/foreign/oversize → ignored (up-to-date; no offer).
                         match crate::ota::parse_announce(payload) {
                             Some(a) => {
-                                // #40: keep the RAW announce (pre-gate) for a possible leaf
+                                // #40: PERSIST the RAW announce (pre-gate) for a possible leaf
                                 // relay — the leaf owns its own freshness gate, so a
                                 // gateway-build gate must NOT drop it here.
-                                raw_staged = Some(a);
+                                *staged_raw = Some(a);
                                 match crate::ota::gate(&a) {
                                     Ok(()) => {
                                         log::info!(
@@ -1408,7 +1416,7 @@ fn mqtt_session(
     // replay it, twin of the self-OTA close) — an install with NO staged image is LEFT
     // retained so the NEXT flush (once staged is drained) can still arm it, instead of
     // silently consuming+losing it. The pairing result is logged either way (diagnostic).
-    match (pending_leaf, raw_staged) {
+    match (pending_leaf, *staged_raw) {
         (Some(leaf_id), Some(ann)) => {
             *leaf_ota = Some((leaf_id, ann));
             log::info!(
@@ -1631,7 +1639,7 @@ fn mqtt_session(
     // (stat_cache = Some). Idempotent retained publishes, bounded to the heard-leaf set.
     #[cfg(feature = "espnow")]
     if let Some(sc) = stat_cache {
-        let latest_staged = raw_staged.as_ref().map(|a| a.build);
+        let latest_staged = staged_raw.as_ref().map(|a| a.build);
         for i in 0..sc.count() {
             let (lid, val) = match sc.entry(i) {
                 Some(x) => x,
@@ -1732,6 +1740,9 @@ pub fn run_mqtt_burst(
     // #40: on a gateway flush, filled with `(leaf_id, staged announce)` when a leaf install
     // is pending → the caller relays it over ESP-NOW. `&mut None` on boot/leaf bursts.
     leaf_ota: &mut Option<(u8, crate::ota::Announce)>,
+    // #40: caller-persisted last raw staged announce (see `mqtt_session`). `&mut None` on
+    // boot/leaf bursts.
+    staged_raw: &mut Option<crate::ota::Announce>,
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
     let mut iface = create_interface(device);
@@ -1881,6 +1892,7 @@ pub fn run_mqtt_burst(
         cfg_cache, // #21: forward the gateway's leaf-config cache (or None)
         stat_cache, // #50b: forward the gateway's cached leaf statuses (or None)
         leaf_ota, // #40: forward the leaf-OTA install pairing (or &mut None)
+        staged_raw, // #40: forward the persistent staged announce (or &mut None)
         deadline,
         tick,
     )

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1336,18 +1336,6 @@ fn mqtt_session(
     // not the gateway, owns the freshness gate (the OTAM handler rejects `build ≤ leaf.build`);
     // the gateway may be NEWER than the leaf's target, so a gateway-build gate would drop it.
     let mut pending_leaf: Option<u8> = None;
-    // #40 #4 ROUND-ROBIN: the leaf we serviced on the PRIOR attempt — read from `leaf_diag`
-    // (set by the prior `record_leaf_ota`, still present here; it's consumed further below).
-    // With >1 retained install we prefer a DIFFERENT leaf this burst so one leaf's retry
-    // cycle can't monopolize the (minutes-long, mesh-deaf) relay and starve the other.
-    let last_leaf_serviced: Option<u8> = leaf_diag.as_ref().map(|t| t.0);
-    // #40 REGRESSION DIAG (491b7e9 canary): count the RETAINED gateway-OTA topics this drain
-    // actually SEES, BEFORE any catch gate — to split "topics never delivered/drained this
-    // session" (delivery/settle-timing) from "delivered but the catch logic dropped them".
-    // inst_seen = how many `smol/<id>/ota/install` topics reached the parse (raw delivery);
-    // stg_seen = whether the retained staged line was drained. Published in armdiag below.
-    let mut inst_seen: u8 = 0;
-    let mut stg_seen: bool = false;
     loop {
         if tick() {
             break; // #20 abort during downlink wait → fall through to clean DISCONNECT
@@ -1372,7 +1360,6 @@ fn mqtt_session(
                         mc = parse_mesh_channel(payload); // #23 election record
                         got_mc = true; // present (unparseable → treated as claimable below)
                     } else if topic == OTA_STAGED_TOPIC {
-                        stg_seen = true; // #40 REGRESSION DIAG: the staged line WAS drained this session
                         // #33 Model-A: parse + GATE the retained STAGED line (monotonicity +
                         // host allowlist + size). A gate-passing staged build becomes the
                         // latest_version + fetch TARGET (ota_offer) — but it does NOT fetch;
@@ -1440,9 +1427,6 @@ fn mqtt_session(
                             }
                         }
                     } else if let Some(leaf_id) = parse_leaf_install_topic(topic) {
-                        // #40 REGRESSION DIAG: an install topic REACHED the drain (raw delivery),
-                        // counted BEFORE the id/cfg/payload catch gate below.
-                        inst_seen = inst_seen.saturating_add(1);
                         // #40 (§B3): a wildcard-delivered leaf OTA install command. On a
                         // GATEWAY flush (cfg_cache = Some), an `INSTALL` for a leaf id ≠ self
                         // arms a mesh-OTA relay to that leaf (paired with `raw_staged` after
@@ -1451,15 +1435,11 @@ fn mqtt_session(
                         // here — else an install drained in a session with no staged image
                         // (a drain-timing miss) would be consumed+lost without ever arming.
                         if leaf_id != node_id && cfg_cache.is_some() && payload == b"INSTALL" {
-                            // #40 #4 ROUND-ROBIN: take the first candidate that DIFFERS from the
-                            // last-serviced leaf; keep an already-fair pick; if the only candidate
-                            // IS the last-serviced one, service it (it's alone → no starvation).
-                            let differs = |id: u8| Some(id) != last_leaf_serviced;
-                            pending_leaf = match pending_leaf {
-                                None => Some(leaf_id),
-                                Some(cur) if !differs(cur) && differs(leaf_id) => Some(leaf_id),
-                                Some(cur) => Some(cur),
-                            };
+                            // Surface this leaf's install (last-wins among concurrent retained
+                            // installs). Round-robin fairness across >1 leaf was REVERTED out of
+                            // this critical path (it rotated the surfaced leaf each burst, halving
+                            // the audible leaf's service rate → slow-arm); it rides the #68 pass.
+                            pending_leaf = Some(leaf_id);
                             *leaf_install_seen = true; // #40 #1: install-SEEN (pre-arm) → gateway suppresses its own self-OTA
                             log::info!("smol #40: leaf id{} OTA install command received", leaf_id);
                         }
@@ -1596,11 +1576,6 @@ fn mqtt_session(
             None => { let _ = write!(adval, "none"); }
         }
         let _ = write!(adval, " leaf_ota={}", if leaf_ota.is_some() { 1 } else { 0 });
-        // #40 REGRESSION DIAG: raw delivery counts. inst_seen=0 & stg_seen=0 ⇒ the retained
-        // OTA topics never reached the drain this session (delivery / settle-break timing, NOT
-        // the catch logic). inst_seen>0 with install-caught=none ⇒ the id/cfg/payload gate dropped
-        // them (a real catch bug). stg_seen=1 with staged_raw=none ⇒ the persist path.
-        let _ = write!(adval, " inst_seen={} stg_seen={}", inst_seen, if stg_seen { 1 } else { 0 });
         if let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, adtopic.as_bytes(), adval.as_bytes(), true) {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -564,6 +564,7 @@ pub fn run_ntp_burst(
     // costs nothing the mesh cares about; a miss still leaves the cache untouched.
     let mqtt_deadline = Instant::now() + MQTT_SESSION_BUDGET;
     let mqtt_port = 49152 + (rng.random() % 16384) as u16;
+    let mut _leaf_seen_boot = false; // #40 #1: boot burst is not a gateway relay → never set
     let _ = mqtt_session(
         &mut iface,
         device,
@@ -578,6 +579,7 @@ pub fn run_ntp_burst(
         ota_offer,
         config_offer,
         install_requested,
+        &mut _leaf_seen_boot, // #40 #1: boot burst sees no leaf installs
         &[], // #27: boot NTP+downlink burst publishes no peers (no roster yet)
         &[], // #50: boot burst publishes no live-screen status
         None, // #21: boot burst is not a gateway relay (no leaf-config cache)
@@ -967,6 +969,11 @@ fn mqtt_session(
     // #33 HA Update entity: set true iff a retained `install` command is present for this
     // board (the native Install button) — the caller AND-gates the fetch on it.
     install_requested: &mut bool,
+    // #40 #1: set true iff a retained `smol/<leaf>/ota/install` for ANOTHER node is SEEN this
+    // burst (install-seen, independent of whether it armed — arming needs the cached staged
+    // image). The gateway flush latches `leaf_ota_pending` on this so its OWN self-OTA is
+    // suppressed the moment a leaf install exists, closing the self-OTA-first race.
+    leaf_install_seen: &mut bool,
     // #27: this node's serialized roster (`PEERS|…`); published retained to
     // `smol/<node_id>/peers` after the telemetry loop iff non-empty.
     peers: &[u8],
@@ -1429,6 +1436,7 @@ fn mqtt_session(
                         // (a drain-timing miss) would be consumed+lost without ever arming.
                         if leaf_id != node_id && cfg_cache.is_some() && payload == b"INSTALL" {
                             pending_leaf = Some(leaf_id);
+                            *leaf_install_seen = true; // #40 #1: install-SEEN (pre-arm) → gateway suppresses its own self-OTA
                             log::info!("smol #40: leaf id{} OTA install command received", leaf_id);
                         }
                     }
@@ -1857,6 +1865,8 @@ pub fn run_mqtt_burst(
     config_offer: &mut Option<crate::app::DefaultScreen>,
     // #33: set true iff a retained OTA `install` command is present for this board.
     install_requested: &mut bool,
+    // #40 #1: set true iff a retained leaf `install` (for another node) is seen this burst.
+    leaf_install_seen: &mut bool,
     // #27: this node's serialized roster (`PEERS|…`) to publish retained as
     // `smol/<id>/peers`. Empty ⇒ nothing published (leaf / election-only burst).
     peers: &[u8],
@@ -2024,6 +2034,7 @@ pub fn run_mqtt_burst(
         ota_offer,
         config_offer,
         install_requested,
+        leaf_install_seen, // #40 #1: forward the leaf-install-seen latch
         peers, // #27: forward the caller's serialized roster to publish retained
         status, // #50: forward the live STAT|screen:page for smol/<id>/status
         cfg_cache, // #21: forward the gateway's leaf-config cache (or None)

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1341,6 +1341,13 @@ fn mqtt_session(
     // With >1 retained install we prefer a DIFFERENT leaf this burst so one leaf's retry
     // cycle can't monopolize the (minutes-long, mesh-deaf) relay and starve the other.
     let last_leaf_serviced: Option<u8> = leaf_diag.as_ref().map(|t| t.0);
+    // #40 REGRESSION DIAG (491b7e9 canary): count the RETAINED gateway-OTA topics this drain
+    // actually SEES, BEFORE any catch gate — to split "topics never delivered/drained this
+    // session" (delivery/settle-timing) from "delivered but the catch logic dropped them".
+    // inst_seen = how many `smol/<id>/ota/install` topics reached the parse (raw delivery);
+    // stg_seen = whether the retained staged line was drained. Published in armdiag below.
+    let mut inst_seen: u8 = 0;
+    let mut stg_seen: bool = false;
     loop {
         if tick() {
             break; // #20 abort during downlink wait → fall through to clean DISCONNECT
@@ -1365,6 +1372,7 @@ fn mqtt_session(
                         mc = parse_mesh_channel(payload); // #23 election record
                         got_mc = true; // present (unparseable → treated as claimable below)
                     } else if topic == OTA_STAGED_TOPIC {
+                        stg_seen = true; // #40 REGRESSION DIAG: the staged line WAS drained this session
                         // #33 Model-A: parse + GATE the retained STAGED line (monotonicity +
                         // host allowlist + size). A gate-passing staged build becomes the
                         // latest_version + fetch TARGET (ota_offer) — but it does NOT fetch;
@@ -1432,6 +1440,9 @@ fn mqtt_session(
                             }
                         }
                     } else if let Some(leaf_id) = parse_leaf_install_topic(topic) {
+                        // #40 REGRESSION DIAG: an install topic REACHED the drain (raw delivery),
+                        // counted BEFORE the id/cfg/payload catch gate below.
+                        inst_seen = inst_seen.saturating_add(1);
                         // #40 (§B3): a wildcard-delivered leaf OTA install command. On a
                         // GATEWAY flush (cfg_cache = Some), an `INSTALL` for a leaf id ≠ self
                         // arms a mesh-OTA relay to that leaf (paired with `raw_staged` after
@@ -1585,6 +1596,11 @@ fn mqtt_session(
             None => { let _ = write!(adval, "none"); }
         }
         let _ = write!(adval, " leaf_ota={}", if leaf_ota.is_some() { 1 } else { 0 });
+        // #40 REGRESSION DIAG: raw delivery counts. inst_seen=0 & stg_seen=0 ⇒ the retained
+        // OTA topics never reached the drain this session (delivery / settle-break timing, NOT
+        // the catch logic). inst_seen>0 with install-caught=none ⇒ the id/cfg/payload gate dropped
+        // them (a real catch bug). stg_seen=1 with staged_raw=none ⇒ the persist path.
+        let _ = write!(adval, " inst_seen={} stg_seen={}", inst_seen, if stg_seen { 1 } else { 0 });
         if let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, adtopic.as_bytes(), adval.as_bytes(), true) {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -260,6 +260,32 @@ fn parse_leaf_config_topic(topic: &[u8]) -> Option<u8> {
     (val <= 255).then_some(val as u8)
 }
 
+/// #40: parse a leaf id out of the wildcard-delivered `smol/<id>/ota/install` topic
+/// (the shape `smol/+/ota/install` delivers). Twin of [`parse_leaf_config_topic`] —
+/// same defensive parse (broker-supplied topic; 1–3 ASCII digits clamped to u8).
+/// `cfg(wifi)`: it is called from the shared `mqtt_session` (a gateway is `espnow`, but
+/// the function must still compile in the `wifi`-only build, where it is simply never hit).
+#[cfg(feature = "wifi")]
+fn parse_leaf_install_topic(topic: &[u8]) -> Option<u8> {
+    let rest = topic.strip_prefix(b"smol/")?;
+    let slash = rest.iter().position(|&b| b == b'/')?;
+    let (idb, tail) = rest.split_at(slash);
+    if tail != b"/ota/install" {
+        return None;
+    }
+    if idb.is_empty() || idb.len() > 3 {
+        return None;
+    }
+    let mut val: u16 = 0;
+    for &b in idb {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        val = val * 10 + (b - b'0') as u16;
+    }
+    (val <= 255).then_some(val as u8)
+}
+
 /// Budget for one full MQTT session (TCP connect → CONNECT/CONNACK → publishes →
 /// SUBSCRIBE → retained downlink → DISCONNECT). Sub-bound of the enclosing burst
 /// so MQTT can't eat the whole flush/NTP window; a miss just leaves the cache be.
@@ -556,6 +582,7 @@ pub fn run_ntp_burst(
         &[], // #50: boot burst publishes no live-screen status
         None, // #21: boot burst is not a gateway relay (no leaf-config cache)
         None, // #50b: boot burst republishes no cached leaf status
+        &mut None, // #40: boot burst never relays a leaf OTA
         mqtt_deadline,
         tick,
     );
@@ -917,6 +944,11 @@ fn mqtt_session(
     // `None` on boot/leaf/election bursts (no republish duty). Read-only (the cache is
     // filled by the ESP-NOW `SMOLv1 STAT` service arm, not here).
     stat_cache: Option<&CfgCache>,
+    // #40 leaf-mesh-OTA: on a GATEWAY flush, filled with `(leaf_id, raw staged announce)`
+    // when a retained `smol/<leaf>/ota/install = INSTALL` is present for a leaf id ≠ self
+    // AND a staged image is available — the caller then relays it over ESP-NOW. The retained
+    // cmd is CLEARED here (consumed) so an HA reload can't replay it. `&mut None` off-gateway.
+    leaf_ota: &mut Option<(u8, crate::ota::Announce)>,
     deadline: Instant,
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
@@ -1052,6 +1084,14 @@ fn mqtt_session(
         if let Some(n) =
             crate::net::mqtt::encode_subscribe(&mut pkt, 8, b"smol/+/config/default_screen")
         {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
+        // #40 leaf-mesh-OTA (§B3): a GATEWAY also wildcard-subscribes the leaf OTA install
+        // command (pid 9), twin of the config wildcard above → it acts on a leaf's native
+        // HA Update Install button (`smol/<leaf>/ota/install = INSTALL`) by relaying the
+        // staged image over ESP-NOW. The board's OWN install still arrives via `cmd_topic`
+        // (pid 7) → self-OTA; the wildcard feeds ONLY other leaf ids.
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 9, b"smol/+/ota/install") {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
     }
@@ -1228,6 +1268,13 @@ fn mqtt_session(
     // never the full session budget.
     const DOWNLINK_SETTLE: Duration = Duration::from_millis(300);
     let mut settle_deadline: Option<Instant> = None;
+    // #40: the RAW (ungated) staged announce + a leaf id whose retained install cmd is
+    // present. Paired AFTER the drain (both are retained → arrive in the same broker burst)
+    // → `*leaf_ota`. Raw (not the gate()d `ota_offer`) because the LEAF, not the gateway,
+    // owns the freshness gate (the OTAM handler rejects `build ≤ leaf.build`); the gateway
+    // may be NEWER than the leaf's target, so a gateway-build gate would wrongly drop it.
+    let mut raw_staged: Option<crate::ota::Announce> = None;
+    let mut pending_leaf: Option<u8> = None;
     loop {
         if tick() {
             break; // #20 abort during downlink wait → fall through to clean DISCONNECT
@@ -1258,21 +1305,27 @@ fn mqtt_session(
                         // the fetch is AND-gated on this board's own `install` command below.
                         // Stale/foreign/oversize → ignored (up-to-date; no offer).
                         match crate::ota::parse_announce(payload) {
-                            Some(a) => match crate::ota::gate(&a) {
-                                Ok(()) => {
-                                    log::info!(
-                                        "smol OTA: staged build {} available (running {})",
+                            Some(a) => {
+                                // #40: keep the RAW announce (pre-gate) for a possible leaf
+                                // relay — the leaf owns its own freshness gate, so a
+                                // gateway-build gate must NOT drop it here.
+                                raw_staged = Some(a);
+                                match crate::ota::gate(&a) {
+                                    Ok(()) => {
+                                        log::info!(
+                                            "smol OTA: staged build {} available (running {})",
+                                            a.build,
+                                            crate::ota::BUILD_NUMBER
+                                        );
+                                        *ota_offer = Some(a);
+                                    }
+                                    Err(why) => log::info!(
+                                        "smol OTA: staged build {} not newer/ineligible ({:?})",
                                         a.build,
-                                        crate::ota::BUILD_NUMBER
-                                    );
-                                    *ota_offer = Some(a);
+                                        why
+                                    ),
                                 }
-                                Err(why) => log::info!(
-                                    "smol OTA: staged build {} not newer/ineligible ({:?})",
-                                    a.build,
-                                    why
-                                ),
-                            },
+                            }
                             None => log::warn!("smol OTA: malformed staged line ignored"),
                         }
                     } else if topic == cfg_topic.as_bytes() {
@@ -1312,6 +1365,24 @@ fn mqtt_session(
                                 );
                             }
                         }
+                    } else if let Some(leaf_id) = parse_leaf_install_topic(topic) {
+                        // #40 (§B3): a wildcard-delivered leaf OTA install command. On a
+                        // GATEWAY flush (cfg_cache = Some), an `INSTALL` for a leaf id ≠ self
+                        // arms a mesh-OTA relay to that leaf (paired with `raw_staged` after
+                        // the drain). PANIC-FREE exact byte compare (untrusted retained). The
+                        // retained cmd is CLEARED (empty retained publish) so an HA reload
+                        // can't replay it — the exact closure as the self-OTA `cmd_topic`.
+                        if leaf_id != node_id && cfg_cache.is_some() && payload == b"INSTALL" {
+                            pending_leaf = Some(leaf_id);
+                            log::info!("smol #40: leaf id{} OTA install command received", leaf_id);
+                            let mut itopic = MqttScratch::new();
+                            let _ = write!(itopic, "smol/{}/ota/install", leaf_id);
+                            if let Some(n) =
+                                crate::net::mqtt::encode_publish(&mut pkt, itopic.as_bytes(), b"", true)
+                            {
+                                let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+                            }
+                        }
                     }
                     consumed
                 }
@@ -1335,6 +1406,13 @@ fn mqtt_session(
             log::info!("smol: MQTT downlink(s) not all received in budget (keeping cache)");
             break;
         }
+    }
+
+    // #40: pair a pending leaf install with the staged image (both retained → both drained
+    // above). The caller relays it over ESP-NOW. A leaf install with NO staged image → no-op
+    // (nothing to relay). `Announce` is `Copy`, so the pair moves out cleanly.
+    if let (Some(leaf_id), Some(ann)) = (pending_leaf, raw_staged) {
+        *leaf_ota = Some((leaf_id, ann));
     }
 
     // --- #23 single-gateway ELECTION with RUNTIME re-decision + stale-owner takeover ---
@@ -1584,6 +1662,9 @@ pub fn run_mqtt_burst(
     // #50b: `Some` on a gateway flush → republish cached leaf statuses (see `mqtt_session`);
     // `None` otherwise.
     stat_cache: Option<&CfgCache>,
+    // #40: on a gateway flush, filled with `(leaf_id, staged announce)` when a leaf install
+    // is pending → the caller relays it over ESP-NOW. `&mut None` on boot/leaf bursts.
+    leaf_ota: &mut Option<(u8, crate::ota::Announce)>,
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
     let mut iface = create_interface(device);
@@ -1732,6 +1813,7 @@ pub fn run_mqtt_burst(
         status, // #50: forward the live STAT|screen:page for smol/<id>/status
         cfg_cache, // #21: forward the gateway's leaf-config cache (or None)
         stat_cache, // #50b: forward the gateway's cached leaf statuses (or None)
+        leaf_ota, // #40: forward the leaf-OTA install pairing (or &mut None)
         deadline,
         tick,
     )

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -585,6 +585,7 @@ pub fn run_ntp_burst(
         &mut None, // #40: boot burst never relays a leaf OTA
         &mut None, // #40: boot burst has no persistent staged to carry
         &mut None, // #40: boot burst has no relay diag to publish
+        &mut None, // #3: boot burst has no relay RX-diag to publish
         mqtt_deadline,
         tick,
     );
@@ -962,6 +963,9 @@ fn mqtt_session(
     // terminal/exhausted phase) vs retry (transient). Consumed (set None) after publish.
     // `&mut None` off-gateway.
     leaf_diag: &mut Option<(u8, &'static str, bool)>,
+    // #3 RELAY RX-DIAG: the last relay's `(leaf_id, rx_any, otan_valid, last_wb, total)`.
+    // PUBLISHED to retained `smol/<leaf>/ota/relaydiag` here, consumed after. `&mut None` off-gw.
+    leaf_relay_rx: &mut Option<(u8, u16, u16, u16, u16)>,
     deadline: Instant,
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
@@ -1449,6 +1453,27 @@ fn mqtt_session(
         *leaf_diag = None; // consumed — published once
     }
 
+    // #3 RELAY RX-DIAG: publish the last relay attempt's RX evidence to retained
+    // `smol/<leaf>/ota/relaydiag` (headless #3 disambiguation). rx=0 → gateway heard NOTHING
+    // from the leaf (leaf offline / OTAD not landing); rx>0 & otan=0 → leaf alive but never
+    // NAK'd this session; otan>0 & last_wb<total → chunk-loss stall. Consumed after publish.
+    if let Some((lid, rx_any, otan_valid, last_wb, total)) = *leaf_relay_rx {
+        let mut rtopic = MqttScratch::new();
+        let _ = write!(rtopic, "smol/{}/ota/relaydiag", lid);
+        let mut rval = MqttScratch::new();
+        let _ = write!(rval, "rx={} otan={} last_wb={}/{}", rx_any, otan_valid, last_wb, total);
+        if let Some(n) =
+            crate::net::mqtt::encode_publish(&mut pkt, rtopic.as_bytes(), rval.as_bytes(), true)
+        {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
+        log::info!(
+            "smol #3: published smol/{}/ota/relaydiag = rx={} otan={} last_wb={}/{}",
+            lid, rx_any, otan_valid, last_wb, total
+        );
+        *leaf_relay_rx = None; // consumed — published once
+    }
+
     // #40: ARM a pending leaf install by pairing it with the (persisted) staged image. Does
     // NOT clear the install here — the clear is OUTCOME-driven (the diag block above, once
     // `main` reports the relay result), so a mac-unknown / fetch-fail / relay-fail LEAVES the
@@ -1808,6 +1833,9 @@ pub fn run_mqtt_burst(
     // #40: last relay attempt's `(leaf_id, phase, clear)` → published to `smol/<leaf>/ota/diag`
     // (see `mqtt_session`). `&mut None` on boot/leaf bursts.
     leaf_diag: &mut Option<(u8, &'static str, bool)>,
+    // #3: last relay attempt's RX evidence → published to `smol/<leaf>/ota/relaydiag` (see
+    // `mqtt_session`). `&mut None` on boot/leaf bursts.
+    leaf_relay_rx: &mut Option<(u8, u16, u16, u16, u16)>,
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
     let mut iface = create_interface(device);
@@ -1959,6 +1987,7 @@ pub fn run_mqtt_burst(
         leaf_ota, // #40: forward the leaf-OTA install pairing (or &mut None)
         staged_raw, // #40: forward the persistent staged announce (or &mut None)
         leaf_diag, // #40: forward the diag/clear state (or &mut None)
+        leaf_relay_rx, // #3: forward the relay RX-diag (or &mut None)
         deadline,
         tick,
     )

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1416,6 +1416,11 @@ fn mqtt_session(
         }
     }
 
+    // #40 ARMDIAG: snapshot whether THIS flush caught an install (before the diag block below
+    // may null `pending_leaf`) — dumped to `smol/<gw>/ota/armdiag` after the arm, so one
+    // reflash shows EXACTLY which arm-chain link is null (headless arm trace).
+    let install_caught = pending_leaf;
+
     // #40 DIAG + clear/retry (from the PRIOR attempt, recorded by `main` after the relay):
     // publish the phase to retained `smol/<leaf>/ota/diag` (headless observability — the
     // mesh-only leaf has no serial), then either CLEAR the retained install (terminal phase
@@ -1461,6 +1466,38 @@ fn mqtt_session(
             );
         }
         _ => {}
+    }
+
+    // #40 ARMDIAG — dump the arm-chain state EVERY gateway flush to retained
+    // `smol/<gw>/ota/armdiag`, so ONE reflash shows exactly which link is null (the C3 gives
+    // no serial). `install-caught` = an INSTALL for a leaf hit this flush; `staged_raw` = the
+    // persisted staged build; `leaf_ota` = the pair armed. If install-caught=<id> +
+    // staged_raw=<b> + leaf_ota=1 → armed (issue is downstream, in the relay). If
+    // staged_raw=none → the persist path never wrote it. If install-caught=none → the wildcard
+    // sub / arm never fired. Gateway-only (cfg_cache = Some).
+    if cfg_cache.is_some() {
+        let mut adtopic = MqttScratch::new();
+        let _ = write!(adtopic, "smol/{}/ota/armdiag", node_id);
+        let mut adval = MqttScratch::new();
+        let _ = write!(adval, "install-caught=");
+        match install_caught {
+            Some(x) => { let _ = write!(adval, "{}", x); }
+            None => { let _ = write!(adval, "none"); }
+        }
+        let _ = write!(adval, " pending=");
+        match pending_leaf {
+            Some(x) => { let _ = write!(adval, "{}", x); }
+            None => { let _ = write!(adval, "none"); }
+        }
+        let _ = write!(adval, " staged_raw=");
+        match staged_raw.as_ref() {
+            Some(a) => { let _ = write!(adval, "{}", a.build); }
+            None => { let _ = write!(adval, "none"); }
+        }
+        let _ = write!(adval, " leaf_ota={}", if leaf_ota.is_some() { 1 } else { 0 });
+        if let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, adtopic.as_bytes(), adval.as_bytes(), true) {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
     }
 
     // --- #23 single-gateway ELECTION with RUNTIME re-decision + stale-owner takeover ---

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -584,6 +584,7 @@ pub fn run_ntp_burst(
         None, // #50b: boot burst republishes no cached leaf status
         &mut None, // #40: boot burst never relays a leaf OTA
         &mut None, // #40: boot burst has no persistent staged to carry
+        &mut None, // #40: boot burst has no relay diag to publish
         mqtt_deadline,
         tick,
     );
@@ -956,6 +957,11 @@ fn mqtt_session(
     // install (the race that left the install consumed but the relay never armed). `&mut None`
     // on boot/leaf bursts (no persistence needed).
     staged_raw: &mut Option<crate::ota::Announce>,
+    // #40 headless diag + clear/retry: the last relay attempt's `(leaf_id, phase, clear)`.
+    // PUBLISHED to `smol/<leaf>/ota/diag` here, and drives the retained-install clear (on a
+    // terminal/exhausted phase) vs retry (transient). Consumed (set None) after publish.
+    // `&mut None` off-gateway.
+    leaf_diag: &mut Option<(u8, &'static str, bool)>,
     deadline: Instant,
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
@@ -1410,28 +1416,47 @@ fn mqtt_session(
         }
     }
 
-    // #40: pair a pending leaf install with the staged image (both retained → both drained
-    // above). The caller relays it over ESP-NOW. `Announce` is `Copy`, so the pair moves out.
-    // The retained install is CLEARED only on a SUCCESSFUL pair (so an HA reload can't
-    // replay it, twin of the self-OTA close) — an install with NO staged image is LEFT
-    // retained so the NEXT flush (once staged is drained) can still arm it, instead of
-    // silently consuming+losing it. The pairing result is logged either way (diagnostic).
-    match (pending_leaf, *staged_raw) {
-        (Some(leaf_id), Some(ann)) => {
-            *leaf_ota = Some((leaf_id, ann));
-            log::info!(
-                "smol #40: ARMED relay for leaf id{} (staged build {}) — clearing install cmd",
-                leaf_id, ann.build
-            );
+    // #40 DIAG + clear/retry (from the PRIOR attempt, recorded by `main` after the relay):
+    // publish the phase to retained `smol/<leaf>/ota/diag` (headless observability — the
+    // mesh-only leaf has no serial), then either CLEAR the retained install (terminal phase
+    // = the leaf installed/rolled-back, or the transient-retry cap was hit) or LEAVE it
+    // retained to retry. On a clear, also null `pending_leaf` for THIS flush so we don't
+    // re-arm a just-finished leaf. Runs BEFORE the arm below. Consumed after publish.
+    if let Some((lid, phase, clear)) = *leaf_diag {
+        let mut dtopic = MqttScratch::new();
+        let _ = write!(dtopic, "smol/{}/ota/diag", lid);
+        if let Some(n) =
+            crate::net::mqtt::encode_publish(&mut pkt, dtopic.as_bytes(), phase.as_bytes(), true)
+        {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
+        log::info!("smol #40: published smol/{}/ota/diag = {} (clear={})", lid, phase, clear);
+        if clear {
             let mut itopic = MqttScratch::new();
-            let _ = write!(itopic, "smol/{}/ota/install", leaf_id);
+            let _ = write!(itopic, "smol/{}/ota/install", lid);
             if let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, itopic.as_bytes(), b"", true) {
                 let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
             }
+            if pending_leaf == Some(lid) {
+                pending_leaf = None; // don't re-arm a leaf we just consumed
+            }
+        }
+        *leaf_diag = None; // consumed — published once
+    }
+
+    // #40: ARM a pending leaf install by pairing it with the (persisted) staged image. Does
+    // NOT clear the install here — the clear is OUTCOME-driven (the diag block above, once
+    // `main` reports the relay result), so a mac-unknown / fetch-fail / relay-fail LEAVES the
+    // install retained → the next flush retries (bounded by LEAF_OTA_MAX_RETRIES). `Announce`
+    // is `Copy`, so the pair moves out cleanly.
+    match (pending_leaf, *staged_raw) {
+        (Some(leaf_id), Some(ann)) => {
+            *leaf_ota = Some((leaf_id, ann));
+            log::info!("smol #40: ARMED relay for leaf id{} (staged build {})", leaf_id, ann.build);
         }
         (Some(leaf_id), None) => {
             log::warn!(
-                "smol #40: leaf id{} install pending but NO staged image drained this session — leaving retained for the next flush to arm",
+                "smol #40: leaf id{} install pending but NO staged image known yet — leaving retained for the next flush to arm",
                 leaf_id
             );
         }
@@ -1743,6 +1768,9 @@ pub fn run_mqtt_burst(
     // #40: caller-persisted last raw staged announce (see `mqtt_session`). `&mut None` on
     // boot/leaf bursts.
     staged_raw: &mut Option<crate::ota::Announce>,
+    // #40: last relay attempt's `(leaf_id, phase, clear)` → published to `smol/<leaf>/ota/diag`
+    // (see `mqtt_session`). `&mut None` on boot/leaf bursts.
+    leaf_diag: &mut Option<(u8, &'static str, bool)>,
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
     let mut iface = create_interface(device);
@@ -1893,6 +1921,7 @@ pub fn run_mqtt_burst(
         stat_cache, // #50b: forward the gateway's cached leaf statuses (or None)
         leaf_ota, // #40: forward the leaf-OTA install pairing (or &mut None)
         staged_raw, // #40: forward the persistent staged announce (or &mut None)
+        leaf_diag, // #40: forward the diag/clear state (or &mut None)
         deadline,
         tick,
     )

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1778,6 +1778,12 @@ pub fn run_ota_fetch(
     mut rng: Rng,
     announce: &crate::ota::Announce,
     tick: &mut dyn FnMut() -> bool,
+    // #40 relay-mode: when true, stage+verify the image to the inactive slot but do NOT
+    // activate — hand the staged slot back via `staged_slot` so a GATEWAY can relay FROM
+    // it to a leaf (no gateway reboot). Self-OTA passes `false` + `&mut None` → the fetch
+    // body is byte-identical, only the terminal action differs (activate-reboot vs return).
+    relay_mode: bool,
+    staged_slot: &mut Option<esp_bootloader_esp_idf::ota::Slot>,
 ) -> bool {
     let Some((host, port, path)) = crate::ota::split_url(announce.url()) else {
         log::error!("smol OTA: malformed announce URL — aborting fetch");
@@ -1995,6 +2001,14 @@ pub fn run_ota_fetch(
     if writer.finalize(announce.size, &announce.sha256)
         && crate::ota::verify_signature(announce.signed_msg(), announce.sig())
     {
+        if relay_mode {
+            // #40: the gateway staged+verified a leaf's image into ITS inactive slot; do
+            // NOT activate (this board isn't the one being updated). Hand back the slot so
+            // the relay reads it back chunk-by-chunk over ESP-NOW.
+            log::info!("smol #40: relay image staged+VERIFIED in the inactive slot (not activated)");
+            *staged_slot = Some(target);
+            return true;
+        }
         log::info!("smol OTA: image VERIFIED (SHA-256 + ed25519) — activating the new slot");
         crate::ota::activate(target); // reboots on success
         false // reached only if the otadata write failed

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -372,7 +372,7 @@ pub fn try_time_sync(
     // wifi-only build has no relay/gateway role, so the reached-DHCP flag is unused.
     let mut reached_dhcp = false;
     // wifi-only build has no mesh election; pass a throwaway result.
-    let mut elect = MeshElect::new(crate::NODE_ID);
+    let mut elect = MeshElect::new(crate::node_id());
     // wifi-only build has no main-loop OTA/config consume; capture (unused) offers.
     let mut _ota_offer: Option<crate::ota::Announce> = None;
     let mut _config_offer: Option<crate::app::DefaultScreen> = None;
@@ -383,7 +383,7 @@ pub fn try_time_sync(
         rng,
         &mut || false,
         &mut reached_dhcp,
-        crate::NODE_ID,
+        crate::node_id(),
         batt,
         grid,
         &mut elect,
@@ -1336,6 +1336,11 @@ fn mqtt_session(
     // not the gateway, owns the freshness gate (the OTAM handler rejects `build ≤ leaf.build`);
     // the gateway may be NEWER than the leaf's target, so a gateway-build gate would drop it.
     let mut pending_leaf: Option<u8> = None;
+    // #40 #4 ROUND-ROBIN: the leaf we serviced on the PRIOR attempt — read from `leaf_diag`
+    // (set by the prior `record_leaf_ota`, still present here; it's consumed further below).
+    // With >1 retained install we prefer a DIFFERENT leaf this burst so one leaf's retry
+    // cycle can't monopolize the (minutes-long, mesh-deaf) relay and starve the other.
+    let last_leaf_serviced: Option<u8> = leaf_diag.as_ref().map(|t| t.0);
     loop {
         if tick() {
             break; // #20 abort during downlink wait → fall through to clean DISCONNECT
@@ -1435,7 +1440,15 @@ fn mqtt_session(
                         // here — else an install drained in a session with no staged image
                         // (a drain-timing miss) would be consumed+lost without ever arming.
                         if leaf_id != node_id && cfg_cache.is_some() && payload == b"INSTALL" {
-                            pending_leaf = Some(leaf_id);
+                            // #40 #4 ROUND-ROBIN: take the first candidate that DIFFERS from the
+                            // last-serviced leaf; keep an already-fair pick; if the only candidate
+                            // IS the last-serviced one, service it (it's alone → no starvation).
+                            let differs = |id: u8| Some(id) != last_leaf_serviced;
+                            pending_leaf = match pending_leaf {
+                                None => Some(leaf_id),
+                                Some(cur) if !differs(cur) && differs(leaf_id) => Some(leaf_id),
+                                Some(cur) => Some(cur),
+                            };
                             *leaf_install_seen = true; // #40 #1: install-SEEN (pre-arm) → gateway suppresses its own self-OTA
                             log::info!("smol #40: leaf id{} OTA install command received", leaf_id);
                         }

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1606,6 +1606,58 @@ fn mqtt_session(
         }
     }
 
+    // --- #40 §B2: publish each RELAYED LEAF's Update discovery + ota/state ON ITS BEHALF ---
+    // A credential-less leaf never opens MQTT, so the gateway is its proxy (the same role it
+    // plays for the leaf's telemetry/status relay). SAME `smol<leaf>_update` unique_id +
+    // topics as self-OTA → ONE entity, device-merged onto the leaf's existing card; the
+    // gateway keeps `installed_version` fresh from the RELAYED STAT build, so a leaf-mesh-OTA
+    // result — the new build, or a self-test rollback to the old — shows in HA HEADLESS
+    // (the whole point: the C3 USB-JTAG boards give no reliable headless serial). Gateway-only
+    // (stat_cache = Some). Idempotent retained publishes, bounded to the heard-leaf set.
+    #[cfg(feature = "espnow")]
+    if let Some(sc) = stat_cache {
+        let latest_staged = raw_staged.as_ref().map(|a| a.build);
+        for i in 0..sc.count() {
+            let (lid, val) = match sc.entry(i) {
+                Some(x) => x,
+                None => continue,
+            };
+            if lid == node_id {
+                continue; // the gateway's own Update is self-published above
+            }
+            let noun = crate::net::names::name_for_id(lid).1;
+            // Discovery (retained) — the self-OTA template, for <leaf>. `cmd_t=~/install`
+            // = `smol/<leaf>/ota/install`, which the gateway wildcard-subs → relay (§B3).
+            let mut dtopic = MqttScratch::new();
+            let _ = write!(dtopic, "homeassistant/update/smol{}/config", lid);
+            let mut djson = MqttScratch::new();
+            let _ = write!(
+                djson,
+                "{{\"~\":\"smol/{}/ota\",\"stat_t\":\"~/state\",\"cmd_t\":\"~/install\",\"pl_inst\":\"INSTALL\",\"dev_cla\":\"firmware\",\"name\":\"Update\",\"has_entity_name\":true,\"uniq_id\":\"smol{}_update\",\"object_id\":\"smol_{}_update\",\"dev\":{{\"ids\":[\"smol{}\"],\"name\":\"smol {} {}\"}}}}",
+                lid, lid, lid, lid, lid, noun
+            );
+            if let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, dtopic.as_bytes(), djson.as_bytes(), true) {
+                let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+            }
+            // State (retained) ONLY if the leaf reported a build (STAT `|<build>` field) —
+            // don't clobber a self-published value with "unknown" for a leaf on old firmware.
+            if let Some(installed) = crate::ota_mesh::stat_build(val) {
+                let latest = latest_staged.unwrap_or(installed);
+                let mut sjson = MqttScratch::new();
+                let _ = write!(
+                    sjson,
+                    "{{\"installed_version\":\"{}\",\"latest_version\":\"{}\",\"in_progress\":false,\"title\":\"smol v{}\"}}",
+                    installed, latest, latest
+                );
+                let mut stopic = MqttScratch::new();
+                let _ = write!(stopic, "smol/{}/ota/state", lid);
+                if let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, stopic.as_bytes(), sjson.as_bytes(), true) {
+                    let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+                }
+            }
+        }
+    }
+
     // --- DISCONNECT (clean goodbye) + close the socket ---
     if let Some(n) = crate::net::mqtt::encode_disconnect(&mut pkt) {
         let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -815,6 +815,12 @@ pub struct RelayDiag {
 #[cfg(feature = "wifi")]
 const CFG_CACHE_CAP: usize = 16;
 
+/// #68 F6: a cached leaf STAT older than this (ms since last heard) is treated as STALE — its
+/// `smol/<id>/status` republish is skipped (no ghost) and its MAC no longer resolves a relay arm.
+/// ~4.5× the 10 s STAT cadence: a leaf that missed several STATs is genuinely gone, not just laggy.
+#[cfg(feature = "wifi")]
+pub const STAT_FRESH_MS: u64 = 45_000;
+
 /// #21 leaf-relay: the GATEWAY's per-leaf default-screen cache. Filled from the
 /// retained wildcard `smol/+/config/default_screen` during a flush; re-broadcast as
 /// `SMOLv1 CFG` frames on the ~10 s cadence (mode.rs `broadcast_cached_configs`) so
@@ -825,6 +831,16 @@ pub struct CfgCache {
     ids: [u8; CFG_CACHE_CAP],
     vals: [[u8; CFG_VALUE_MAX]; CFG_CACHE_CAP],
     lens: [u8; CFG_CACHE_CAP],
+    /// #68 F6: last-heard timestamp (now_ms) per entry. Gates the stat republish on freshness
+    /// (a leaf that goes off-air STOPS refreshing its retained smol/<id>/status → HA sees it go
+    /// stale instead of a perpetually-fresh GHOST — the ghost that masked id9's floor-wipe + faked
+    /// id8-alive all demo). Also bounds the `mac_for` fallback to recently-heard leaves.
+    last_ms: [u64; CFG_CACHE_CAP],
+    /// #68: the src MAC the entry was last heard from. Lets the relay arm resolve a STAT-heard
+    /// leaf's MAC even after the volatile 16-slot LRU roster evicts it (roster-admission robustness
+    /// — "any STAT-heard leaf stays mac_for_id-resolvable"). Only meaningful for stat_cache (uplink);
+    /// cfg_cache (downlink configs) passes a zero MAC + is never mac-queried.
+    macs: [[u8; 6]; CFG_CACHE_CAP],
     count: usize,
 }
 
@@ -839,6 +855,8 @@ impl CfgCache {
             ids: [0; CFG_CACHE_CAP],
             vals: [[0; CFG_VALUE_MAX]; CFG_CACHE_CAP],
             lens: [0; CFG_CACHE_CAP],
+            last_ms: [0; CFG_CACHE_CAP],
+            macs: [[0; 6]; CFG_CACHE_CAP],
             count: 0,
         }
     }
@@ -846,12 +864,14 @@ impl CfgCache {
     /// Upsert a leaf's config value (truncated to `CFG_VALUE_MAX`). A full cache drops
     /// the entry and logs it (no silent cap). Value bytes are opaque here — the gateway
     /// RELAYS them verbatim; the leaf's `parse_default_screen` is the strict validator.
-    pub fn set(&mut self, id: u8, value: &[u8]) {
+    pub fn set(&mut self, id: u8, value: &[u8], mac: [u8; 6], now: u64) {
         let n = value.len().min(CFG_VALUE_MAX);
         for i in 0..self.count {
             if self.ids[i] == id {
                 self.vals[i][..n].copy_from_slice(&value[..n]);
                 self.lens[i] = n as u8;
+                self.last_ms[i] = now; // #68 F6: freshen
+                self.macs[i] = mac;
                 return;
             }
         }
@@ -860,6 +880,8 @@ impl CfgCache {
             self.ids[i] = id;
             self.vals[i][..n].copy_from_slice(&value[..n]);
             self.lens[i] = n as u8;
+            self.last_ms[i] = now;
+            self.macs[i] = mac;
             self.count += 1;
         } else {
             log::warn!("smol #21: cfg cache full ({}) — dropping config for id{}", CFG_CACHE_CAP, id);
@@ -881,6 +903,32 @@ impl CfgCache {
         } else {
             None
         }
+    }
+
+    /// #68 F6: the `i`-th entry, but ONLY if it was heard within `ttl` ms of `now`. The stat
+    /// republish uses this so a leaf that stopped transmitting stops refreshing its retained
+    /// status → HA sees it go stale instead of a perpetually-fresh ghost.
+    #[allow(dead_code)]
+    pub fn entry_fresh(&self, i: usize, now: u64, ttl: u64) -> Option<(u8, &[u8])> {
+        if i < self.count && now.saturating_sub(self.last_ms[i]) <= ttl {
+            let n = self.lens[i] as usize;
+            Some((self.ids[i], &self.vals[i][..n]))
+        } else {
+            None
+        }
+    }
+
+    /// #68: the MAC last heard for `id`, IFF the entry is fresh (within `ttl`). Lets the relay
+    /// arm resolve a recently-STAT-heard leaf's MAC even after the LRU roster evicts it — so a
+    /// STAT-audible-but-roster-dropped leaf is still armable (vs the silent mac-unknown no-arm).
+    #[allow(dead_code)]
+    pub fn mac_for(&self, id: u8, now: u64, ttl: u64) -> Option<[u8; 6]> {
+        for i in 0..self.count {
+            if self.ids[i] == id && now.saturating_sub(self.last_ms[i]) <= ttl {
+                return Some(self.macs[i]);
+            }
+        }
+        None
     }
 }
 
@@ -1287,8 +1335,12 @@ fn mqtt_session(
     // published just above via #50a) and empty values. Prepend `STAT|` so EVERY status
     // topic is uniform (`STAT|<screen>:<page>`), self + leaves, for the one HA template.
     if let Some(sc) = stat_cache {
+        // #68 F6: freshness-gate the status republish. An off-air leaf's entry goes stale →
+        // its retained smol/<id>/status STOPS refreshing → HA sees it age out instead of a
+        // perpetually-fresh ghost (the ghost that faked id8-alive + masked id9's floor-wipe).
+        let now_ms = Instant::now().duration_since_epoch().as_millis();
         for i in 0..sc.count() {
-            if let Some((lid, val)) = sc.entry(i) {
+            if let Some((lid, val)) = sc.entry_fresh(i, now_ms, STAT_FRESH_MS) {
                 if lid == node_id || val.is_empty() {
                     continue;
                 }
@@ -1426,7 +1478,10 @@ fn mqtt_session(
                         // anyway. Only present when cfg_cache = Some (gateway flush).
                         if leaf_id != node_id {
                             if let Some(cache) = cfg_cache.as_deref_mut() {
-                                cache.set(leaf_id, payload);
+                                // #68: cfg_cache is DOWNLINK (never mac-queried) → zero MAC; the
+                                // timestamp is set for API uniformity (cfg_cache isn't freshness-gated).
+                                let now = Instant::now().duration_since_epoch().as_millis();
+                                cache.set(leaf_id, payload, [0u8; 6], now);
                                 log::info!(
                                     "smol #21: cached leaf id{} config for relay ({} B)",
                                     leaf_id,

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -793,6 +793,12 @@ pub struct RelayDiag {
     pub leaf_heard: u16,
     pub leaf_verdict: u8,
     pub leaf_sent: u16,
+    /// #3b TX-diag: OTAM broadcast sends ATTEMPTED / that returned Ok (queued + TX-callback ok).
+    /// `otam_ok=0` while `otam_tx>0` ⇒ the send itself fails (peer-table / post-fetch ESP-NOW TX
+    /// state) → the announce never egresses (explains leaf H0 with the gateway on-channel).
+    /// `otam_ok>0` while leaf stays H0 ⇒ frame egresses but the leaf's RX drops it (deeper).
+    pub otam_tx: u16,
+    pub otam_ok: u16,
 }
 
 #[cfg(feature = "wifi")]
@@ -1484,7 +1490,8 @@ fn mqtt_session(
         let mut rval = MqttScratch::new();
         // Gateway RX evidence + the leaf's own LDBG self-report. `leaf=none` ⇒ no LDBG captured
         // (old leaf fw / leaf off-air during the relay); else `H<heard>V<verdict>N<sent>`.
-        let _ = write!(rval, "rx={} otan={} last_wb={}/{} leaf=", d.rx_any, d.otan_valid, d.last_wb, d.total);
+        let _ = write!(rval, "rx={} otan={} last_wb={}/{} otam_tx={}/{} leaf=",
+            d.rx_any, d.otan_valid, d.last_wb, d.total, d.otam_tx, d.otam_ok);
         if d.leaf_verdict == 255 {
             let _ = write!(rval, "none");
         } else {

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -2237,7 +2237,7 @@ pub fn run_ota_fetch(
             return true;
         }
         log::info!("smol OTA: image VERIFIED (SHA-256 + ed25519) — activating the new slot");
-        crate::ota::activate(target); // reboots on success
+        crate::ota::activate(target, announce.build); // reboots on success
         false // reached only if the otadata write failed
     } else {
         log::error!("smol OTA: verify FAILED (size/SHA-256 or ed25519 signature) — discarded (good slot intact)");

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1369,19 +1369,13 @@ fn mqtt_session(
                         // #40 (§B3): a wildcard-delivered leaf OTA install command. On a
                         // GATEWAY flush (cfg_cache = Some), an `INSTALL` for a leaf id ≠ self
                         // arms a mesh-OTA relay to that leaf (paired with `raw_staged` after
-                        // the drain). PANIC-FREE exact byte compare (untrusted retained). The
-                        // retained cmd is CLEARED (empty retained publish) so an HA reload
-                        // can't replay it — the exact closure as the self-OTA `cmd_topic`.
+                        // the drain). PANIC-FREE exact byte compare (untrusted retained). NOTE:
+                        // the retained cmd is CLEARED only AFTER a successful pair (below), NOT
+                        // here — else an install drained in a session with no staged image
+                        // (a drain-timing miss) would be consumed+lost without ever arming.
                         if leaf_id != node_id && cfg_cache.is_some() && payload == b"INSTALL" {
                             pending_leaf = Some(leaf_id);
                             log::info!("smol #40: leaf id{} OTA install command received", leaf_id);
-                            let mut itopic = MqttScratch::new();
-                            let _ = write!(itopic, "smol/{}/ota/install", leaf_id);
-                            if let Some(n) =
-                                crate::net::mqtt::encode_publish(&mut pkt, itopic.as_bytes(), b"", true)
-                            {
-                                let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
-                            }
                         }
                     }
                     consumed
@@ -1409,10 +1403,31 @@ fn mqtt_session(
     }
 
     // #40: pair a pending leaf install with the staged image (both retained → both drained
-    // above). The caller relays it over ESP-NOW. A leaf install with NO staged image → no-op
-    // (nothing to relay). `Announce` is `Copy`, so the pair moves out cleanly.
-    if let (Some(leaf_id), Some(ann)) = (pending_leaf, raw_staged) {
-        *leaf_ota = Some((leaf_id, ann));
+    // above). The caller relays it over ESP-NOW. `Announce` is `Copy`, so the pair moves out.
+    // The retained install is CLEARED only on a SUCCESSFUL pair (so an HA reload can't
+    // replay it, twin of the self-OTA close) — an install with NO staged image is LEFT
+    // retained so the NEXT flush (once staged is drained) can still arm it, instead of
+    // silently consuming+losing it. The pairing result is logged either way (diagnostic).
+    match (pending_leaf, raw_staged) {
+        (Some(leaf_id), Some(ann)) => {
+            *leaf_ota = Some((leaf_id, ann));
+            log::info!(
+                "smol #40: ARMED relay for leaf id{} (staged build {}) — clearing install cmd",
+                leaf_id, ann.build
+            );
+            let mut itopic = MqttScratch::new();
+            let _ = write!(itopic, "smol/{}/ota/install", leaf_id);
+            if let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, itopic.as_bytes(), b"", true) {
+                let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+            }
+        }
+        (Some(leaf_id), None) => {
+            log::warn!(
+                "smol #40: leaf id{} install pending but NO staged image drained this session — leaving retained for the next flush to arm",
+                leaf_id
+            );
+        }
+        _ => {}
     }
 
     // --- #23 single-gateway ELECTION with RUNTIME re-decision + stale-owner takeover ---

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -774,6 +774,27 @@ static mut MQTT_ACC: [u8; 512] = [0; 512];
 #[cfg(feature = "wifi")]
 pub const CFG_VALUE_MAX: usize = 16;
 
+/// #40 #3: one relay attempt's diagnostic snapshot — gateway-side RX evidence PLUS the leaf's
+/// self-reported OTA state (captured from its `LDBG` beacon during the relay). Published to
+/// retained `smol/<leaf>/ota/relaydiag`. Defined at the `wifi` level (not `ota_mesh`/`mode`,
+/// both espnow-only) so this `run_mqtt_burst` publish path names it in the wifi-only profile too.
+/// `leaf_verdict == 255` ⇒ no `LDBG` captured (old leaf fw / leaf off-air during the relay).
+/// Together they name a `rx>0 otan=0` relay-failed: leaf_heard=0 → OTAM TX not landing on the
+/// leaf; verdict 2-6 → `on_meta` rejected (which gate); verdict=1 & leaf_sent=0 → armed but never
+/// NAK'd (servicing); leaf_sent>0 & otan_valid=0 → leaf NAK'd but the gateway never heard it.
+#[cfg(feature = "wifi")]
+#[derive(Clone, Copy)]
+pub struct RelayDiag {
+    pub leaf_id: u8,
+    pub rx_any: u16,
+    pub otan_valid: u16,
+    pub last_wb: u16,
+    pub total: u16,
+    pub leaf_heard: u16,
+    pub leaf_verdict: u8,
+    pub leaf_sent: u16,
+}
+
 #[cfg(feature = "wifi")]
 const CFG_CACHE_CAP: usize = 16;
 
@@ -965,7 +986,7 @@ fn mqtt_session(
     leaf_diag: &mut Option<(u8, &'static str, bool)>,
     // #3 RELAY RX-DIAG: the last relay's `(leaf_id, rx_any, otan_valid, last_wb, total)`.
     // PUBLISHED to retained `smol/<leaf>/ota/relaydiag` here, consumed after. `&mut None` off-gw.
-    leaf_relay_rx: &mut Option<(u8, u16, u16, u16, u16)>,
+    leaf_relay_rx: &mut Option<RelayDiag>,
     deadline: Instant,
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
@@ -1457,19 +1478,26 @@ fn mqtt_session(
     // `smol/<leaf>/ota/relaydiag` (headless #3 disambiguation). rx=0 → gateway heard NOTHING
     // from the leaf (leaf offline / OTAD not landing); rx>0 & otan=0 → leaf alive but never
     // NAK'd this session; otan>0 & last_wb<total → chunk-loss stall. Consumed after publish.
-    if let Some((lid, rx_any, otan_valid, last_wb, total)) = *leaf_relay_rx {
+    if let Some(d) = *leaf_relay_rx {
         let mut rtopic = MqttScratch::new();
-        let _ = write!(rtopic, "smol/{}/ota/relaydiag", lid);
+        let _ = write!(rtopic, "smol/{}/ota/relaydiag", d.leaf_id);
         let mut rval = MqttScratch::new();
-        let _ = write!(rval, "rx={} otan={} last_wb={}/{}", rx_any, otan_valid, last_wb, total);
+        // Gateway RX evidence + the leaf's own LDBG self-report. `leaf=none` ⇒ no LDBG captured
+        // (old leaf fw / leaf off-air during the relay); else `H<heard>V<verdict>N<sent>`.
+        let _ = write!(rval, "rx={} otan={} last_wb={}/{} leaf=", d.rx_any, d.otan_valid, d.last_wb, d.total);
+        if d.leaf_verdict == 255 {
+            let _ = write!(rval, "none");
+        } else {
+            let _ = write!(rval, "H{}V{}N{}", d.leaf_heard, d.leaf_verdict, d.leaf_sent);
+        }
         if let Some(n) =
             crate::net::mqtt::encode_publish(&mut pkt, rtopic.as_bytes(), rval.as_bytes(), true)
         {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
         log::info!(
-            "smol #3: published smol/{}/ota/relaydiag = rx={} otan={} last_wb={}/{}",
-            lid, rx_any, otan_valid, last_wb, total
+            "smol #3: relaydiag id{} rx={} otan={} last_wb={}/{} leafV={}",
+            d.leaf_id, d.rx_any, d.otan_valid, d.last_wb, d.total, d.leaf_verdict
         );
         *leaf_relay_rx = None; // consumed — published once
     }
@@ -1835,7 +1863,7 @@ pub fn run_mqtt_burst(
     leaf_diag: &mut Option<(u8, &'static str, bool)>,
     // #3: last relay attempt's RX evidence → published to `smol/<leaf>/ota/relaydiag` (see
     // `mqtt_session`). `&mut None` on boot/leaf bursts.
-    leaf_relay_rx: &mut Option<(u8, u16, u16, u16, u16)>,
+    leaf_relay_rx: &mut Option<RelayDiag>,
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
     let mut iface = create_interface(device);

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -799,6 +799,11 @@ pub struct RelayDiag {
     /// `otam_ok>0` while leaf stays H0 ⇒ frame egresses but the leaf's RX drops it (deeper).
     pub otam_tx: u16,
     pub otam_ok: u16,
+    /// #3b CHANNEL-diag: iterations spent waiting for the WiFi STA to release the PHY after the
+    /// fetch, before pinning ch6. `settle>0` ⇒ the STA WAS still holding the AP channel post-fetch
+    /// (confirms the OTAM was egressing off-channel → the leaf H0 cause); `settle=0` ⇒ STA already
+    /// down, so a persistent H0 is NOT the channel (→ leaf RX-filter, instrument the leaf next).
+    pub settle: u16,
 }
 
 #[cfg(feature = "wifi")]
@@ -1490,8 +1495,8 @@ fn mqtt_session(
         let mut rval = MqttScratch::new();
         // Gateway RX evidence + the leaf's own LDBG self-report. `leaf=none` ⇒ no LDBG captured
         // (old leaf fw / leaf off-air during the relay); else `H<heard>V<verdict>N<sent>`.
-        let _ = write!(rval, "rx={} otan={} last_wb={}/{} otam_tx={}/{} leaf=",
-            d.rx_any, d.otan_valid, d.last_wb, d.total, d.otam_tx, d.otam_ok);
+        let _ = write!(rval, "rx={} otan={} last_wb={}/{} otam_tx={}/{} settle={} leaf=",
+            d.rx_any, d.otan_valid, d.last_wb, d.total, d.otam_tx, d.otam_ok, d.settle);
         if d.leaf_verdict == 255 {
             let _ = write!(rval, "none");
         } else {

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -678,11 +678,6 @@ impl LeafImageWriter {
         self.target
     }
 
-    /// Real image bytes accepted so far (for the OLED progress line).
-    pub fn written(&self) -> u32 {
-        self.written
-    }
-
     /// Append one COMPLETED WINDOW's bytes (in strict image order) to the inactive
     /// slot. The write offset is `self.written` (word-aligned by construction — every
     /// non-final window is exactly 64·231 bytes). Erases sector-ahead, then writes the

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -511,6 +511,9 @@ fn inactive_slot() -> Option<Slot> {
 #[cfg(feature = "espnow")]
 pub fn activate(target: Slot) {
     if set_slot_new(target).is_some() {
+        // #40: mark this boot-chain as a genuine OTA activate so the next boot's `boot_confirm`
+        // runs the self-test (a USB flash, which power-cycles, clears this → no self-test).
+        mark_ota_activated();
         log::info!("smol OTA: image verified — activating new slot, rebooting");
         esp_hal::system::software_reset();
     } else {
@@ -603,6 +606,15 @@ pub fn boot_confirm(self_test_passed: bool) {
     if !matches!(state, OtaImageState::New | OtaImageState::PendingVerify) {
         return; // Valid/Undefined/etc — a normal, already-confirmed boot
     }
+    // #40 USB-flash EXEMPTION: a `New` image that did NOT come from our `activate()` this
+    // power-cycle (a USB flash, or a power-cycled OTA) must NOT self-test — else a freshly
+    // USB-flashed image gets reverted/rolled back for hearing no mesh frame. It's operator-
+    // intended (USB) or already ed25519+sha verified (OTA), so ACCEPT it as-is.
+    if !ota_was_activated() {
+        let _ = ota.set_current_ota_state(OtaImageState::Valid);
+        log::info!("smol OTA: unconfirmed image but not a fresh OTA activate (USB flash / power-cycle) — accepting, no self-test");
+        return;
+    }
     let bl_auto_revert = matches!(state, OtaImageState::PendingVerify);
     log::info!(
         "smol OTA: unconfirmed image on boot — running self-test (bootloader auto-revert {})",
@@ -610,6 +622,7 @@ pub fn boot_confirm(self_test_passed: bool) {
     );
     if self_test_passed {
         let _ = ota.set_current_ota_state(OtaImageState::Valid);
+        clear_ota_activated(); // fate decided — don't re-self-test on a later crash-reset
         log::info!("smol OTA: self-test PASS — image CONFIRMED (Valid)");
     } else {
         // #40 BRICK-SAFETY (was a hard brick): roll back ONLY if the target slot holds a
@@ -621,6 +634,7 @@ pub fn boot_confirm(self_test_passed: bool) {
         // safe; bricking is not.
         let target = ota.current_slot().ok().map(|c| c.next());
         let can_rollback = target.map(slot_has_valid_image).unwrap_or(false);
+        clear_ota_activated(); // fate decided either way
         if can_rollback {
             if let Some(t) = target {
                 let _ = ota.set_current_slot(t);
@@ -1018,6 +1032,60 @@ static mut OTA_BOOT_GUARD: [u32; 2] = [0u32; 2];
 
 #[cfg(feature = "espnow")]
 const BOOT_GUARD_MAGIC: u32 = 0x736D_6C4B; // "smlK"
+
+// ---------------------------------------------------------------------------
+// #40 USB-flash EXEMPTION — only a genuine OTA-`activate()` boot should self-test.
+//
+// A USB-flashed image boots as `New` (unconfirmed) just like an OTA image, so `boot_confirm`
+// couldn't tell them apart → EVERY USB flash ran the self-test → false rollback (or, before
+// the brick-safe fix, a brick). Distinguish them with an RTC-fast marker set ONLY inside
+// `activate()`: a genuine OTA does `activate()` → `software_reset()` (marker persists across
+// the reset). A USB flash / power-cycle CLEARS RTC RAM → marker absent → `boot_confirm`
+// ACCEPTS the image without self-testing (it's operator-intended; an OTA image was already
+// ed25519+sha verified before activate). `wifi`-scoped so `boot_confirm` can read it.
+// ---------------------------------------------------------------------------
+
+/// `[magic, activated_flag]` in persistent RTC-fast RAM (survives `software_reset`, cleared
+/// on power-loss). `activated_flag == 1` ⇔ this boot descends from a genuine `activate()`.
+#[cfg(feature = "wifi")]
+#[esp_hal::ram(rtc_fast, persistent)]
+static mut OTA_ACTIVATE_GUARD: [u32; 2] = [0u32; 2];
+
+#[cfg(feature = "wifi")]
+const ACTIVATE_GUARD_MAGIC: u32 = 0x736D_6C41; // "smlA"
+
+/// Mark the current boot-chain as a genuine OTA activate (call inside `activate()` right
+/// before the reset). Survives the `software_reset`; cleared by power-loss. `espnow`-scoped
+/// (only `activate()` — itself espnow — sets it; the wifi-only build never OTAs).
+#[cfg(feature = "espnow")]
+pub fn mark_ota_activated() {
+    unsafe {
+        let g = &mut *core::ptr::addr_of_mut!(OTA_ACTIVATE_GUARD);
+        g[0] = ACTIVATE_GUARD_MAGIC;
+        g[1] = 1;
+    }
+}
+
+/// True iff the running image was activated by our `activate()` this power-cycle (i.e. a
+/// genuine OTA, not a USB flash). Uninitialized RTC RAM (bad magic) ⇒ false (not activated).
+#[cfg(feature = "wifi")]
+pub fn ota_was_activated() -> bool {
+    unsafe {
+        let g = &*core::ptr::addr_of!(OTA_ACTIVATE_GUARD);
+        g[0] == ACTIVATE_GUARD_MAGIC && g[1] == 1
+    }
+}
+
+/// Clear the activate marker (call once the image's fate is decided — confirmed / rolled
+/// back / accepted — so a later crash-reset doesn't re-run the self-test on the same chain).
+#[cfg(feature = "wifi")]
+fn clear_ota_activated() {
+    unsafe {
+        let g = &mut *core::ptr::addr_of_mut!(OTA_ACTIVATE_GUARD);
+        g[0] = ACTIVATE_GUARD_MAGIC;
+        g[1] = 0;
+    }
+}
 
 /// Bump the unconfirmed-boot counter and return the new value. Call at the absolute
 /// earliest boot point when `otadata` is `New`/`PendingVerify`, BEFORE anything that

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -495,11 +495,14 @@ impl ImageWriter {
 // default id (7) → a stolen identity → a duplicate-id roster → the gateway's confirm
 // waits for a STAT from an id that no longer exists → a structural leaf-timeout.
 //
-// Fix: the TRUE id lives in NVS. OTA writes ONLY the inactive app slot + `otadata`
-// (never the `nvs` partition at 0x9000), so identity survives ANY image. A USB flash
-// (`espflash erase-flash` + flash) wipes NVS to 0xFF; the first boot then SEEDS NVS
-// from the baked const — which the USB flow sets correctly via `SMOL_NODE_ID=<n>`.
-// Steady state after that: NVS is the single source of truth.
+// Fix: the TRUE id lives in NVS, in `nvs` SECTOR 0 (offset 0, 16 B). The OTA image
+// transfer writes ONLY the inactive app slot + `otadata` — never `nvs` — so identity
+// survives ANY image. The freshness-floor bump (below) DOES write `nvs`, but only sectors
+// 1-2 (offsets ≥ 4096); it never touches sector 0 (oracle F1 — a floor bump erases a whole
+// sector, so identity and the floor cells MUST live in different sectors, or the bump wipes
+// the id → fleet reverts to the baked default 7). A USB flash (`espflash erase-flash` +
+// flash) wipes NVS to 0xFF; the first boot then SEEDS sector 0 from the baked const — which
+// the USB flow sets correctly via `SMOL_NODE_ID=<n>`. Steady state: NVS is the id's truth.
 //
 // BRICK-SAFE: any flash/partition/parse error → fall back to the baked const and do
 // NOT write. The seed is best-effort (a failed seed just retries next boot). The
@@ -1036,21 +1039,34 @@ impl SlotReader {
 // over the unauth mesh). FLOOR-ONLY, #40-local: NO epoch, zero change to #32's signed M.
 //
 // ⚠️ #40 CLAIMS THE `nvs` PARTITION as a raw persistent store (smol uses no ESP-IDF NVS
-// today — verified). This is NOT the ESP-IDF NVS key/value format; if a future feature
-// ever needs real NVS, give it a different partition or coordinate this offset. All
-// access is through a partition-scoped `FlashRegion` (OOB-safe, like the slot writer),
-// so a bug here can only corrupt the floor cell — never the app slots or otadata, and
-// never a brick (the sig + monotonicity gates still hold; the floor is defense-in-depth).
+// today — verified). It is shared by TWO #40 users, SEGREGATED BY SECTOR: the IDENTITY
+// record owns sector 0 (offset 0); the freshness-floor cells own sectors 1-2 (offsets
+// 4096/8192). This is NOT the ESP-IDF NVS key/value format; a future feature needing real
+// NVS must get a different partition or coordinate these offsets. All access is through a
+// partition-scoped `FlashRegion` (OOB-safe, like the slot writer), so a bug here can only
+// corrupt a floor cell — never the app slots, otadata, OR the identity sector — and never a
+// brick (the sig + monotonicity gates still hold; the floor is defense-in-depth).
 //
-// Layout: two ping-pong cells at nvs relative offsets 0 and 4096, each a 12-byte record
-// `[MAGIC(4 LE) | build(4 LE) | crc32(4 LE)]`. Read = max valid build across both cells.
-// Write = erase the cell holding the SMALLER/invalid build, write the new record there;
-// the other cell always retains ≥ the erased one, so a torn write never regresses the
-// floor (power-loss-safe). One erase+write per OTA → negligible wear.
+// Layout: two ping-pong cells at nvs relative offsets 4096 and 8192 (sectors 1 and 2),
+// each a 12-byte record `[MAGIC(4 LE) | build(4 LE) | crc32(4 LE)]`. Read = max valid
+// build across both cells. Write = erase the cell holding the SMALLER/invalid build, write
+// the new record there; the other cell always retains ≥ the erased one, so a torn write
+// never regresses the floor (power-loss-safe). One erase+write per OTA → negligible wear.
+//
+// ⚠️ SECTOR SEGREGATION (brick-class, oracle F1): the floor cells MUST NOT share a 4 KB
+// sector with the #40 IDENTITY record (nvs offset 0, sector 0). The floor bump ERASES a
+// full sector (`erase(target_rel, target_rel + 4096)`); if a cell sat at offset 0 that
+// erase would DESTROY the identity record → the leaf falls back to the baked default id →
+// with the fleet-shared image, the whole fleet becomes id 7 on the next reboot. So the
+// cells live at sectors 1 & 2 (base 4096), leaving sector 0 exclusively for identity.
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "espnow")]
 const FLOOR_MAGIC: u32 = 0x736D_6C46; // "smlF"
+/// First floor cell's nvs offset — SECTOR 1, NOT sector 0 (sector 0 is the identity record;
+/// a floor bump erases its whole target sector and would wipe identity if it sat at 0).
+#[cfg(feature = "espnow")]
+const FLOOR_CELL_BASE: u32 = 4096;
 #[cfg(feature = "espnow")]
 const FLOOR_CELL_STRIDE: u32 = 4096; // one sector apart (erase granularity)
 #[cfg(feature = "espnow")]
@@ -1098,8 +1114,8 @@ fn floor_cell_read(rel: u32) -> Option<u32> {
 /// The current freshness floor = max valid build across both cells (0 if none written).
 #[cfg(feature = "espnow")]
 pub fn fresh_floor_get() -> u32 {
-    let a = floor_cell_read(0).unwrap_or(0);
-    let b = floor_cell_read(FLOOR_CELL_STRIDE).unwrap_or(0);
+    let a = floor_cell_read(FLOOR_CELL_BASE).unwrap_or(0);
+    let b = floor_cell_read(FLOOR_CELL_BASE + FLOOR_CELL_STRIDE).unwrap_or(0);
     a.max(b)
 }
 
@@ -1110,14 +1126,19 @@ pub fn fresh_floor_get() -> u32 {
 #[cfg(feature = "espnow")]
 pub fn fresh_floor_bump(build: u32) {
     use embedded_storage::nor_flash::NorFlash;
-    let a = floor_cell_read(0);
-    let b = floor_cell_read(FLOOR_CELL_STRIDE);
+    let a = floor_cell_read(FLOOR_CELL_BASE);
+    let b = floor_cell_read(FLOOR_CELL_BASE + FLOOR_CELL_STRIDE);
     let cur = a.unwrap_or(0).max(b.unwrap_or(0));
     if build <= cur {
         return; // already covered — no write, no wear
     }
     // Target the cell with the smaller (or invalid) build; the other keeps the prior max.
-    let target_rel = if a.unwrap_or(0) <= b.unwrap_or(0) { 0 } else { FLOOR_CELL_STRIDE };
+    // Both offsets are in sectors 1/2 — NEVER sector 0, so this erase can't wipe identity.
+    let target_rel = if a.unwrap_or(0) <= b.unwrap_or(0) {
+        FLOOR_CELL_BASE
+    } else {
+        FLOOR_CELL_BASE + FLOOR_CELL_STRIDE
+    };
     let mut rec = [0u8; FLOOR_RECORD_LEN];
     rec[0..4].copy_from_slice(&FLOOR_MAGIC.to_le_bytes());
     rec[4..8].copy_from_slice(&build.to_le_bytes());

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -487,6 +487,128 @@ impl ImageWriter {
 }
 
 // ---------------------------------------------------------------------------
+// #40 IDENTITY: runtime node-id persisted in the `nvs` data partition
+// ---------------------------------------------------------------------------
+// The compile-time `crate::NODE_ID` is only a FACTORY SEED. A single OTA image is
+// shared by the whole fleet — `ota_publish.sh` builds ONE image with no per-node
+// `SMOL_NODE_ID`, so a leaf that installs it would otherwise boot with the baked
+// default id (7) → a stolen identity → a duplicate-id roster → the gateway's confirm
+// waits for a STAT from an id that no longer exists → a structural leaf-timeout.
+//
+// Fix: the TRUE id lives in NVS. OTA writes ONLY the inactive app slot + `otadata`
+// (never the `nvs` partition at 0x9000), so identity survives ANY image. A USB flash
+// (`espflash erase-flash` + flash) wipes NVS to 0xFF; the first boot then SEEDS NVS
+// from the baked const — which the USB flow sets correctly via `SMOL_NODE_ID=<n>`.
+// Steady state after that: NVS is the single source of truth.
+//
+// BRICK-SAFE: any flash/partition/parse error → fall back to the baked const and do
+// NOT write. The seed is best-effort (a failed seed just retries next boot). The
+// record is self-validating (magic + version + id + ~id + checksum) so an erased or
+// corrupt sector is REJECTED (→ reseed), never misread as an id.
+
+/// Identity record magic ("smol identity, format v1").
+#[cfg(feature = "wifi")]
+const IDENT_MAGIC: [u8; 4] = *b"SMi1";
+#[cfg(feature = "wifi")]
+const IDENT_VERSION: u8 = 1;
+/// Record length — WRITE_SIZE(4)-aligned; the payload is 8 B, the rest reserved (0).
+#[cfg(feature = "wifi")]
+const IDENT_REC_LEN: usize = 16;
+
+/// Decode a stored identity record. `Some(id)` iff magic + version + both redundancy
+/// guards check out. Erased flash (all 0xFF) and any corruption fail every check.
+#[cfg(feature = "wifi")]
+fn parse_identity(rec: &[u8]) -> Option<u8> {
+    if rec.len() < 8 || rec[0..4] != IDENT_MAGIC || rec[4] != IDENT_VERSION {
+        return None;
+    }
+    let id = rec[5];
+    if rec[6] != id ^ 0xFF || rec[7] != id.wrapping_add(0x5A) {
+        return None; // complement + checksum guards
+    }
+    Some(id)
+}
+
+/// Encode the 16-byte identity record for `id`.
+#[cfg(feature = "wifi")]
+fn encode_identity(id: u8) -> [u8; IDENT_REC_LEN] {
+    let mut r = [0u8; IDENT_REC_LEN];
+    r[0..4].copy_from_slice(&IDENT_MAGIC);
+    r[4] = IDENT_VERSION;
+    r[5] = id;
+    r[6] = id ^ 0xFF;
+    r[7] = id.wrapping_add(0x5A);
+    r
+}
+
+/// Read the node id from the `nvs` partition. `None` on any flash/partition error OR
+/// when no valid record is present (erased/corrupt) — the caller then falls back to
+/// (and seeds from) the baked const.
+#[cfg(feature = "wifi")]
+fn read_identity_nvs() -> Option<u8> {
+    use embedded_storage::nor_flash::ReadNorFlash;
+    let mut flash = FlashStorage::new();
+    let mut buf = [0u8; PT_SCRATCH];
+    let pt = read_partition_table(&mut flash, &mut buf).ok()?;
+    let nvs = pt
+        .find_partition(PartitionType::Data(DataPartitionSubType::Nvs))
+        .ok()??;
+    let mut region = nvs.as_embedded_storage(&mut flash);
+    let mut rec = [0u8; IDENT_REC_LEN];
+    region.read(0, &mut rec).ok()?;
+    parse_identity(&rec)
+}
+
+/// Seed the `nvs` identity record from `id` — ONLY when the first sector is fully
+/// erased (0xFF), so we NEVER clobber foreign data. Best-effort: any error is swallowed
+/// (identity still works this boot from the baked const; the next boot retries the seed).
+#[cfg(feature = "wifi")]
+fn seed_identity_nvs(id: u8) {
+    use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
+    let mut flash = FlashStorage::new();
+    let mut buf = [0u8; PT_SCRATCH];
+    let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
+        return;
+    };
+    let Ok(Some(nvs)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Nvs)) else {
+        return;
+    };
+    let mut region = nvs.as_embedded_storage(&mut flash);
+    // Refuse to write unless the WHOLE first sector is erased (all 0xFF) — guards any
+    // (unexpected) real NVS content from being erased. An erase-flashed board's nvs is
+    // uniformly 0xFF, so a genuinely-fresh board always seeds.
+    let sector = <FlashStorage as NorFlash>::ERASE_SIZE as u32;
+    let mut chunk = [0u8; 64];
+    let mut off = 0u32;
+    while off < sector {
+        if region.read(off, &mut chunk).is_err() {
+            return;
+        }
+        if chunk.iter().any(|&b| b != 0xFF) {
+            return; // not erased → someone else owns this sector; don't touch it
+        }
+        off += chunk.len() as u32;
+    }
+    if region.erase(0, sector).is_err() {
+        return;
+    }
+    let _ = region.write(0, &encode_identity(id));
+}
+
+/// The node's RUNTIME identity: the NVS record if valid, else the baked `crate::NODE_ID`
+/// (which is ALSO seeded into NVS so it persists across every future OTA). Called once at
+/// boot and cached by `crate::node_id()`. BRICK-SAFE — never panics.
+#[cfg(feature = "wifi")]
+pub fn resolve_node_id() -> u8 {
+    if let Some(id) = read_identity_nvs() {
+        return id;
+    }
+    let baked = crate::NODE_ID;
+    seed_identity_nvs(baked);
+    baked
+}
+
+// ---------------------------------------------------------------------------
 // otadata operations: inactive-slot lookup, activation, first-boot confirm
 // ---------------------------------------------------------------------------
 

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -509,13 +509,18 @@ fn inactive_slot() -> Option<Slot> {
 /// (`New`), then REBOOT into it. Call ONLY after [`ImageWriter::finalize`] returned
 /// true. If the otadata write fails, we do NOT reboot — the good slot stays active.
 #[cfg(feature = "espnow")]
-pub fn activate(target: Slot, new_build: u32) {
+pub fn activate(target: Slot, new_build: u32, is_leaf_ota: bool) {
     if set_slot_new(target).is_some() {
-        // #40: tag the marker with the NEW image's build# so the next boot's `boot_confirm`
-        // self-tests IFF the running build matches (i.e. this exact OTA image booted). A USB
-        // flash of a different build won't match a stale RTC marker → accepted (bug #5 fix).
-        mark_ota_activated(new_build);
-        log::info!("smol OTA: image verified — activating new slot (build {}), rebooting", new_build);
+        // #40: tag the marker with the NEW image's build# + OTA type. `boot_confirm` self-tests
+        // IFF the running build matches (bug #5 — a USB flash of a different build won't match a
+        // stale marker), and the deferred LEAF self-test runs only for `is_leaf_ota` (so a
+        // self-OTA'd gateway confirms via DHCP, never the hear-a-frame path → no 113↔114 loop).
+        mark_ota_activated(new_build, is_leaf_ota);
+        log::info!(
+            "smol OTA: image verified — activating new slot (build {}, {}), rebooting",
+            new_build,
+            if is_leaf_ota { "leaf-mesh-OTA" } else { "self-OTA" }
+        );
         esp_hal::system::software_reset();
     } else {
         log::error!("smol OTA: activation (otadata write) failed — staying on current image");
@@ -1054,26 +1059,32 @@ const BOOT_GUARD_MAGIC: u32 = 0x736D_6C4B; // "smlK"
 // edge — it'd self-test, but brick-safely.) `wifi`-scoped so `boot_confirm` can read it.
 // ---------------------------------------------------------------------------
 
-/// `[magic, activated_build]` in persistent RTC-fast RAM (survives `software_reset` AND a
-/// USB-JTAG reflash; only a power cycle clears it). `activated_build` = the build# passed to
-/// the `activate()` that produced this boot chain; matched against the running `BUILD_NUMBER`.
+/// `[magic, activated_build, is_leaf_ota]` in persistent RTC-fast RAM (survives
+/// `software_reset` AND a USB-JTAG reflash; only a power cycle clears it). `activated_build`
+/// = the build# passed to the `activate()` that produced this boot chain (matched against the
+/// running `BUILD_NUMBER`); `is_leaf_ota` = 1 for a mesh-OTA (confirm via hear-a-frame), 0 for
+/// a self-OTA (confirm via reached-DHCP). The OTA TYPE, not the runtime role, decides the
+/// confirm path — a self-OTA'd gateway that transiently misses DHCP at one boot must NOT be
+/// rolled back by the leaf hear-a-frame path (the 113↔114 oscillation), and its role is
+/// ambiguous at that boot anyway.
 #[cfg(feature = "wifi")]
 #[esp_hal::ram(rtc_fast, persistent)]
-static mut OTA_ACTIVATE_GUARD: [u32; 2] = [0u32; 2];
+static mut OTA_ACTIVATE_GUARD: [u32; 3] = [0u32; 3];
 
 #[cfg(feature = "wifi")]
 const ACTIVATE_GUARD_MAGIC: u32 = 0x736D_6C41; // "smlA"
 
-/// Tag the marker with the build# of the image being activated (call inside `activate()`,
-/// passing the NEW image's build# — from the signed manifest for a mesh-OTA, or the announce
-/// for a self-OTA). Survives the reset AND a USB reflash; only a power cycle clears it.
-/// `espnow`-scoped (only `activate()` — itself espnow — sets it; wifi-only never OTAs).
+/// Tag the marker with the build# + OTA type of the image being activated (call inside
+/// `activate()`, passing the NEW image's build# and whether this is a LEAF mesh-OTA). Survives
+/// the reset AND a USB reflash; only a power cycle clears it. `espnow`-scoped (only `activate()`
+/// — itself espnow — sets it; wifi-only never OTAs).
 #[cfg(feature = "espnow")]
-pub fn mark_ota_activated(build: u32) {
+pub fn mark_ota_activated(build: u32, is_leaf_ota: bool) {
     unsafe {
         let g = &mut *core::ptr::addr_of_mut!(OTA_ACTIVATE_GUARD);
         g[0] = ACTIVATE_GUARD_MAGIC;
         g[1] = build;
+        g[2] = is_leaf_ota as u32;
     }
 }
 
@@ -1088,6 +1099,19 @@ pub fn ota_was_activated_for(running_build: u32) -> bool {
     }
 }
 
+/// True iff the current OTA-activate boot chain is a LEAF mesh-OTA (confirm via hear-a-frame).
+/// A self-OTA (is_leaf_ota=0) confirms via reached-DHCP only and NEVER runs the deferred leaf
+/// self-test — so a transient DHCP miss can't roll a self-OTA'd gateway back on a quiet mesh.
+/// `cfg(espnow)`, not `wifi`: the ONLY caller is the `#[cfg(espnow)]` deferred-leaf-selftest gate
+/// in `main`; a wifi-only (gateway) build confirms via DHCP and never reads this (would warn-unused).
+#[cfg(feature = "espnow")]
+pub fn ota_activated_is_leaf() -> bool {
+    unsafe {
+        let g = &*core::ptr::addr_of!(OTA_ACTIVATE_GUARD);
+        g[0] == ACTIVATE_GUARD_MAGIC && g[2] == 1
+    }
+}
+
 /// Clear the activate marker (call once the image's fate is decided — confirmed / rolled
 /// back / accepted — so a later crash-reset doesn't re-run the self-test on the same chain).
 #[cfg(feature = "wifi")]
@@ -1096,6 +1120,7 @@ fn clear_ota_activated() {
         let g = &mut *core::ptr::addr_of_mut!(OTA_ACTIVATE_GUARD);
         g[0] = ACTIVATE_GUARD_MAGIC;
         g[1] = 0;
+        g[2] = 0;
     }
 }
 

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -533,6 +533,39 @@ fn set_slot_new(target: Slot) -> Option<()> {
     Some(())
 }
 
+/// #40 BRICK-SAFETY: does `slot` hold a bootable app image? Reads the slot's first word
+/// through a partition-scoped region and checks the ESP-IDF app-image magic byte `0xE9`.
+/// An erased/empty slot reads `0xFF` → `false`. Used to REFUSE a rollback that would flip
+/// otadata to a slot with no image (e.g. a USB-flashed board whose other slot was never
+/// written → both-slots-unbootable BRICK). Conservative: any read/partition error → `false`
+/// (don't roll back into the unknown). `wifi`-scoped so `boot_confirm` (also `wifi`) can call
+/// it; the types resolve from the `esp-bootloader-esp-idf` dep present in every radio build.
+#[cfg(feature = "wifi")]
+fn slot_has_valid_image(slot: esp_bootloader_esp_idf::ota::Slot) -> bool {
+    use embedded_storage::nor_flash::ReadNorFlash;
+    use esp_bootloader_esp_idf::ota::Slot;
+    use esp_bootloader_esp_idf::partitions::AppPartitionSubType;
+    let sub = match slot {
+        Slot::Slot0 => AppPartitionSubType::Ota0,
+        Slot::Slot1 => AppPartitionSubType::Ota1,
+        _ => return false, // >2-slot table we don't use — refuse (brick-safe)
+    };
+    let mut flash = FlashStorage::new();
+    let mut buf = [0u8; PT_SCRATCH];
+    let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
+        return false;
+    };
+    let Ok(Some(app)) = pt.find_partition(PartitionType::App(sub)) else {
+        return false;
+    };
+    let mut region = app.as_embedded_storage(&mut flash);
+    let mut hdr = [0u8; 4]; // word-aligned read of the image header start
+    if region.read(0, &mut hdr).is_err() {
+        return false;
+    }
+    hdr[0] == 0xE9 // ESP-IDF app-image magic; erased flash is 0xFF
+}
+
 /// MF-1 (spec §4, LOAD-BEARING): first-boot self-test + APP-SIDE rollback. Call VERY
 /// EARLY, once per boot, after the WiFi/DHCP result is known (`self_test_passed` =
 /// "reached DHCP" — a broken-WiFi image can't, and the just-finished download proves
@@ -579,12 +612,28 @@ pub fn boot_confirm(self_test_passed: bool) {
         let _ = ota.set_current_ota_state(OtaImageState::Valid);
         log::info!("smol OTA: self-test PASS — image CONFIRMED (Valid)");
     } else {
-        if let Ok(cur) = ota.current_slot() {
-            let _ = ota.set_current_slot(cur.next());
+        // #40 BRICK-SAFETY (was a hard brick): roll back ONLY if the target slot holds a
+        // valid bootable image. Flipping otadata to an EMPTY/invalid slot (a USB-flashed
+        // board's never-written other slot) marks BOTH slots unbootable → "No bootable app
+        // partitions" crash-loop. If the other slot has no image, DO NOT flip — ACCEPT the
+        // current image (mark Valid, keep running). A USB-flashed image is operator-intended
+        // and a mesh-OTA image was ed25519+sha verified before activate, so accepting it is
+        // safe; bricking is not.
+        let target = ota.current_slot().ok().map(|c| c.next());
+        let can_rollback = target.map(slot_has_valid_image).unwrap_or(false);
+        if can_rollback {
+            if let Some(t) = target {
+                let _ = ota.set_current_slot(t);
+            }
+            let _ = ota.set_current_ota_state(OtaImageState::Valid);
+            log::warn!("smol OTA: self-test FAIL — ROLLING BACK to the previous (valid) slot");
+            esp_hal::system::software_reset();
+        } else {
+            let _ = ota.set_current_ota_state(OtaImageState::Valid);
+            log::warn!(
+                "smol OTA: self-test FAIL, but the rollback target has NO valid image — ACCEPTING the current image (brick-safe: no flip, no reset)"
+            );
         }
-        let _ = ota.set_current_ota_state(OtaImageState::Valid);
-        log::warn!("smol OTA: self-test FAIL — ROLLING BACK to the previous slot");
-        esp_hal::system::software_reset();
     }
 }
 

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -509,12 +509,13 @@ fn inactive_slot() -> Option<Slot> {
 /// (`New`), then REBOOT into it. Call ONLY after [`ImageWriter::finalize`] returned
 /// true. If the otadata write fails, we do NOT reboot — the good slot stays active.
 #[cfg(feature = "espnow")]
-pub fn activate(target: Slot) {
+pub fn activate(target: Slot, new_build: u32) {
     if set_slot_new(target).is_some() {
-        // #40: mark this boot-chain as a genuine OTA activate so the next boot's `boot_confirm`
-        // runs the self-test (a USB flash, which power-cycles, clears this → no self-test).
-        mark_ota_activated();
-        log::info!("smol OTA: image verified — activating new slot, rebooting");
+        // #40: tag the marker with the NEW image's build# so the next boot's `boot_confirm`
+        // self-tests IFF the running build matches (i.e. this exact OTA image booted). A USB
+        // flash of a different build won't match a stale RTC marker → accepted (bug #5 fix).
+        mark_ota_activated(new_build);
+        log::info!("smol OTA: image verified — activating new slot (build {}), rebooting", new_build);
         esp_hal::system::software_reset();
     } else {
         log::error!("smol OTA: activation (otadata write) failed — staying on current image");
@@ -606,13 +607,15 @@ pub fn boot_confirm(self_test_passed: bool) {
     if !matches!(state, OtaImageState::New | OtaImageState::PendingVerify) {
         return; // Valid/Undefined/etc — a normal, already-confirmed boot
     }
-    // #40 USB-flash EXEMPTION: a `New` image that did NOT come from our `activate()` this
-    // power-cycle (a USB flash, or a power-cycled OTA) must NOT self-test — else a freshly
-    // USB-flashed image gets reverted/rolled back for hearing no mesh frame. It's operator-
-    // intended (USB) or already ed25519+sha verified (OTA), so ACCEPT it as-is.
-    if !ota_was_activated() {
+    // #40 USB-flash EXEMPTION (build#-tagged, bug #5): self-test ONLY if the RUNNING build# is
+    // the one our `activate()` tagged — i.e. this exact OTA image booted. A `New` image whose
+    // build# doesn't match the marker (a USB flash, incl. a STALE marker that survived the
+    // USB-JTAG reflash, or a power-cycled OTA) must NOT self-test — else a freshly USB-flashed
+    // image gets reverted for hearing no mesh frame. It's operator-intended (USB) or already
+    // ed25519+sha verified (OTA), so ACCEPT it as-is.
+    if !ota_was_activated_for(BUILD_NUMBER) {
         let _ = ota.set_current_ota_state(OtaImageState::Valid);
-        log::info!("smol OTA: unconfirmed image but not a fresh OTA activate (USB flash / power-cycle) — accepting, no self-test");
+        log::info!("smol OTA: unconfirmed image but build# doesn't match a fresh OTA activate (USB flash / stale marker) — accepting, no self-test");
         return;
     }
     let bl_auto_revert = matches!(state, OtaImageState::PendingVerify);
@@ -1034,19 +1037,26 @@ static mut OTA_BOOT_GUARD: [u32; 2] = [0u32; 2];
 const BOOT_GUARD_MAGIC: u32 = 0x736D_6C4B; // "smlK"
 
 // ---------------------------------------------------------------------------
-// #40 USB-flash EXEMPTION — only a genuine OTA-`activate()` boot should self-test.
+// #40 USB-flash EXEMPTION — only a genuine OTA-`activate()` of THIS EXACT image self-tests.
 //
 // A USB-flashed image boots as `New` (unconfirmed) just like an OTA image, so `boot_confirm`
 // couldn't tell them apart → EVERY USB flash ran the self-test → false rollback (or, before
-// the brick-safe fix, a brick). Distinguish them with an RTC-fast marker set ONLY inside
-// `activate()`: a genuine OTA does `activate()` → `software_reset()` (marker persists across
-// the reset). A USB flash / power-cycle CLEARS RTC RAM → marker absent → `boot_confirm`
-// ACCEPTS the image without self-testing (it's operator-intended; an OTA image was already
-// ed25519+sha verified before activate). `wifi`-scoped so `boot_confirm` can read it.
+// the brick-safe fix, a brick). We tag an RTC-fast marker with the ACTIVATED image's build#
+// inside `activate()`; `boot_confirm` self-tests ONLY when the RUNNING `BUILD_NUMBER` matches
+// the marker's build#.
+//
+// ⚠️ CRITICAL (bug #5): a bare "an OTA happened" flag is NOT enough — RTC-fast RAM SURVIVES a
+// USB-JTAG reflash (`rst:0x15` is a peripheral reset, NOT power-off; only a true power cycle
+// clears it). A board that self-OTA'd earlier and stayed powered would carry a STALE marker
+// into a USB flash → false self-test → rollback (exactly what bricked/reverted id7). Tagging
+// the SPECIFIC build# fixes it: a USB flash of a DIFFERENT build won't match the stale marker
+// → accepted as operator-confirmed. (Re-flashing the byte-identical build# is a harmless
+// edge — it'd self-test, but brick-safely.) `wifi`-scoped so `boot_confirm` can read it.
 // ---------------------------------------------------------------------------
 
-/// `[magic, activated_flag]` in persistent RTC-fast RAM (survives `software_reset`, cleared
-/// on power-loss). `activated_flag == 1` ⇔ this boot descends from a genuine `activate()`.
+/// `[magic, activated_build]` in persistent RTC-fast RAM (survives `software_reset` AND a
+/// USB-JTAG reflash; only a power cycle clears it). `activated_build` = the build# passed to
+/// the `activate()` that produced this boot chain; matched against the running `BUILD_NUMBER`.
 #[cfg(feature = "wifi")]
 #[esp_hal::ram(rtc_fast, persistent)]
 static mut OTA_ACTIVATE_GUARD: [u32; 2] = [0u32; 2];
@@ -1054,25 +1064,27 @@ static mut OTA_ACTIVATE_GUARD: [u32; 2] = [0u32; 2];
 #[cfg(feature = "wifi")]
 const ACTIVATE_GUARD_MAGIC: u32 = 0x736D_6C41; // "smlA"
 
-/// Mark the current boot-chain as a genuine OTA activate (call inside `activate()` right
-/// before the reset). Survives the `software_reset`; cleared by power-loss. `espnow`-scoped
-/// (only `activate()` — itself espnow — sets it; the wifi-only build never OTAs).
+/// Tag the marker with the build# of the image being activated (call inside `activate()`,
+/// passing the NEW image's build# — from the signed manifest for a mesh-OTA, or the announce
+/// for a self-OTA). Survives the reset AND a USB reflash; only a power cycle clears it.
+/// `espnow`-scoped (only `activate()` — itself espnow — sets it; wifi-only never OTAs).
 #[cfg(feature = "espnow")]
-pub fn mark_ota_activated() {
+pub fn mark_ota_activated(build: u32) {
     unsafe {
         let g = &mut *core::ptr::addr_of_mut!(OTA_ACTIVATE_GUARD);
         g[0] = ACTIVATE_GUARD_MAGIC;
-        g[1] = 1;
+        g[1] = build;
     }
 }
 
-/// True iff the running image was activated by our `activate()` this power-cycle (i.e. a
-/// genuine OTA, not a USB flash). Uninitialized RTC RAM (bad magic) ⇒ false (not activated).
+/// True iff the RUNNING image (`running_build`) is the exact image our `activate()` produced —
+/// i.e. a genuine OTA of THIS build, not a USB flash (whose build# won't match a stale marker)
+/// nor uninitialized RTC RAM (bad magic ⇒ false).
 #[cfg(feature = "wifi")]
-pub fn ota_was_activated() -> bool {
+pub fn ota_was_activated_for(running_build: u32) -> bool {
     unsafe {
         let g = &*core::ptr::addr_of!(OTA_ACTIVATE_GUARD);
-        g[0] == ACTIVATE_GUARD_MAGIC && g[1] == 1
+        g[0] == ACTIVATE_GUARD_MAGIC && g[1] == running_build && running_build != 0
     }
 }
 

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -587,3 +587,385 @@ pub fn boot_confirm(self_test_passed: bool) {
         esp_hal::system::software_reset();
     }
 }
+
+// ===========================================================================
+// #40 leaf-mesh-OTA additions (espnow-only). See `crate::ota_mesh` for the
+// transport; this module owns the flash/otadata/NVS engine the leaf path reuses.
+// ===========================================================================
+
+/// #40: parse a bare signed manifest `M = "build|size|sha256hex"` (the exact bytes the
+/// gateway relays inside an `OTAM`, byte-identical to fields 1–3 of `smol/ota/staged`).
+/// Returns `(build, size, sha256)`. Panic-free — `None` on ANY malformed field. The
+/// caller MUST have already verified the ed25519 signature over these bytes (§3, the
+/// verify-BEFORE-trust order) before acting on the result.
+#[cfg(feature = "espnow")]
+pub fn parse_manifest(m: &[u8]) -> Option<(u32, u32, [u8; 32])> {
+    let s = core::str::from_utf8(m).ok()?;
+    let mut it = s.splitn(3, '|');
+    let build: u32 = it.next()?.parse().ok()?;
+    let size: u32 = it.next()?.parse().ok()?;
+    let sha256 = parse_hex_n::<32>(it.next()?)?;
+    // The final field must be EXACTLY the 64-hex sha with nothing trailing (splitn(3)
+    // would otherwise fold a `build|size|sha|junk` tail into field 3 — parse_hex_n's
+    // strict length check rejects that, so a trailing field fails closed).
+    Some((build, size, sha256))
+}
+
+// ---------------------------------------------------------------------------
+// #40 HOLE-3b — the partition-scoped leaf image writer.
+//
+// The shipped `ImageWriter` writes to ABSOLUTE flash offsets on the whole-flash
+// `FlashStorage` (fine for its SEQUENTIAL append). The leaf reassembles from a lossy
+// mesh, so a hostile/buggy chunk seq must NEVER be able to write past the inactive
+// slot into the running slot / otadata (HOLE-3 = a mid-transfer BRICK, before the
+// end-of-transfer verify ever runs). `LeafImageWriter` writes ONLY through a
+// `FlashRegion` (`as_embedded_storage`) on the inactive app partition, which
+// bounds-checks every erase/write against `[offset, offset+len)` and returns
+// `OutOfBounds` otherwise — so a write physically cannot escape the slot regardless
+// of any missed logical bound. (a)=the session's signed-bounds check, (b)=this. Both.
+//
+// It is fed COMPLETED WINDOWS in strict image order (the session releases a window
+// only when all its chunks are present), so the flash write stays sequential +
+// sector-erase-ahead (identical discipline to `ImageWriter`), and every write offset
+// is word-aligned (window offset = k·(64·231) = k·14784, a word multiple). Integrity
+// is proven by a READBACK hash of `slot[..size]` at `finalize` (row H / TOCTOU: hash
+// the exact bytes that will boot, not an in-RAM copy).
+// ---------------------------------------------------------------------------
+
+/// One-window readback scratch for [`LeafImageWriter::finalize`] (off the stack, in
+/// `.bss`). Alias-safe: one leaf OTA at a time (canary), single-caller, one-shot.
+#[cfg(feature = "espnow")]
+static mut OTA_READBACK: [u8; 4096] = [0u8; 4096];
+
+#[cfg(feature = "espnow")]
+pub struct LeafImageWriter {
+    /// The inactive slot's app-partition subtype (re-found each flush so the
+    /// `FlashRegion` borrow — which needs the parsed table + flash together — is
+    /// re-derived from locals; identical pattern to `inactive_slot`/`set_slot_new`).
+    sub: AppPartitionSubType,
+    /// Inactive slot capacity (write bound; a defense-in-depth mirror of the region check).
+    part_len: u32,
+    /// Real image bytes accepted so far == the next (word-aligned) write offset.
+    written: u32,
+    /// Partition-relative address erased through (sector granularity, monotonic).
+    erased_upto: u32,
+    /// The slot [`activate`] targets after a good finalize.
+    target: Slot,
+}
+
+#[cfg(feature = "espnow")]
+impl LeafImageWriter {
+    /// Open a writer for the inactive slot. `None` on any partition/flash error.
+    pub fn begin() -> Option<LeafImageWriter> {
+        let target = inactive_slot()?;
+        let sub = if target == Slot::Slot1 {
+            AppPartitionSubType::Ota1
+        } else {
+            AppPartitionSubType::Ota0
+        };
+        let mut flash = FlashStorage::new();
+        let mut buf = [0u8; PT_SCRATCH];
+        let part_len = {
+            let pt = read_partition_table(&mut flash, &mut buf).ok()?;
+            let app = pt.find_partition(PartitionType::App(sub)).ok()??;
+            app.len()
+        };
+        Some(LeafImageWriter { sub, part_len, written: 0, erased_upto: 0, target })
+    }
+
+    /// The slot this writer targets (passed to [`activate`] after a good finalize).
+    pub fn target(&self) -> Slot {
+        self.target
+    }
+
+    /// Real image bytes accepted so far (for the OLED progress line).
+    pub fn written(&self) -> u32 {
+        self.written
+    }
+
+    /// Append one COMPLETED WINDOW's bytes (in strict image order) to the inactive
+    /// slot. The write offset is `self.written` (word-aligned by construction — every
+    /// non-final window is exactly 64·231 bytes). Erases sector-ahead, then writes the
+    /// word-aligned prefix + a 0xFF-padded ≤3-byte tail (the tail only ever occurs on
+    /// the FINAL window, so it never misaligns a following write). Returns `false` on
+    /// any bound/flash error → the caller ABORTS (otadata untouched, good slot boots).
+    pub fn feed_window(&mut self, data: &[u8]) -> bool {
+        use embedded_storage::nor_flash::NorFlash;
+        let real = data.len() as u32;
+        if real == 0 {
+            return true;
+        }
+        // Defense-in-depth spatial bound (the region also enforces this physically).
+        if self.written.saturating_add(real) > self.part_len {
+            return false;
+        }
+        // Re-derive the partition-scoped region from locals (table + flash borrowed
+        // together for the region's lifetime; dropped at end of this call).
+        let mut flash = FlashStorage::new();
+        let mut ptbuf = [0u8; PT_SCRATCH];
+        let pt = match read_partition_table(&mut flash, &mut ptbuf) {
+            Ok(pt) => pt,
+            Err(_) => return false,
+        };
+        let app = match pt.find_partition(PartitionType::App(self.sub)) {
+            Ok(Some(p)) => p,
+            _ => return false,
+        };
+        let mut region = app.as_embedded_storage(&mut flash);
+
+        let word = <FlashStorage as NorFlash>::WRITE_SIZE as u32; // 4
+        let sector = <FlashStorage as NorFlash>::ERASE_SIZE as u32; // 4096
+        let padded = real.div_ceil(word) * word;
+        let write_end = self.written + padded;
+        // Erase-ahead (sector granularity). Monotonic — never re-erases written bytes.
+        while self.erased_upto < write_end {
+            let s = self.erased_upto;
+            if region.erase(s, s + sector).is_err() {
+                return false;
+            }
+            self.erased_upto = self.erased_upto.saturating_add(sector);
+        }
+        // Word-aligned prefix, straight from `data` (no copy).
+        let prefix = (real & !(word - 1)) as usize;
+        if prefix > 0 && region.write(self.written, &data[..prefix]).is_err() {
+            return false;
+        }
+        // Sub-word tail (final window only) — 0xFF-pad to a word (inert; the image
+        // header carries the true length). Written at a word-aligned offset.
+        let tail = real as usize - prefix;
+        if tail > 0 {
+            let mut w = [0xFFu8; 4];
+            w[..tail].copy_from_slice(&data[prefix..real as usize]);
+            if region.write(self.written + prefix as u32, &w).is_err() {
+                return false;
+            }
+        }
+        self.written += real;
+        true
+    }
+
+    /// The INTEGRITY GATE: exact size match AND a READBACK SHA-256 of `slot[..size]`
+    /// (the exact bytes that will boot) == the signed sha. `true` ⇒ [`activate`] is
+    /// safe. otadata is still untouched here — a failure discards with the good slot
+    /// active. The caller has ALREADY verified the ed25519 sig over the manifest.
+    pub fn finalize(self, expected_size: u32, expected_sha: &[u8; 32]) -> bool {
+        use embedded_storage::nor_flash::ReadNorFlash;
+        use sha2::Digest;
+        if self.written != expected_size {
+            return false;
+        }
+        let mut flash = FlashStorage::new();
+        let mut ptbuf = [0u8; PT_SCRATCH];
+        let pt = match read_partition_table(&mut flash, &mut ptbuf) {
+            Ok(pt) => pt,
+            Err(_) => return false,
+        };
+        let app = match pt.find_partition(PartitionType::App(self.sub)) {
+            Ok(Some(p)) => p,
+            _ => return false,
+        };
+        let mut region = app.as_embedded_storage(&mut flash);
+        let buf = unsafe { &mut *core::ptr::addr_of_mut!(OTA_READBACK) };
+        let mut hasher = sha2::Sha256::new();
+        let mut off = 0u32;
+        while off < expected_size {
+            let want = core::cmp::min(buf.len() as u32, expected_size - off);
+            // Read word-aligned (offset is a multiple of 4096; round the length up so a
+            // non-word-aligned tail still reads legally — extra bytes are not hashed).
+            let read_len = (want.div_ceil(4) * 4) as usize;
+            if region.read(off, &mut buf[..read_len]).is_err() {
+                return false;
+            }
+            hasher.update(&buf[..want as usize]);
+            off += want;
+        }
+        hasher.finalize().as_slice() == &expected_sha[..]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #40 §3C — the persistent signed-freshness FLOOR (NVS-backed).
+//
+// `fresh_floor` = the highest build ever booted-as-`New`. The leaf accepts a mesh OTA
+// iff `sig ok ∧ build > running ∧ build > fresh_floor ∧ size/sha ok`, closing the
+// signed-INTERMEDIATE / rolled-back-build replay (a genuinely-signed old build re-pushed
+// over the unauth mesh). FLOOR-ONLY, #40-local: NO epoch, zero change to #32's signed M.
+//
+// ⚠️ #40 CLAIMS THE `nvs` PARTITION as a raw persistent store (smol uses no ESP-IDF NVS
+// today — verified). This is NOT the ESP-IDF NVS key/value format; if a future feature
+// ever needs real NVS, give it a different partition or coordinate this offset. All
+// access is through a partition-scoped `FlashRegion` (OOB-safe, like the slot writer),
+// so a bug here can only corrupt the floor cell — never the app slots or otadata, and
+// never a brick (the sig + monotonicity gates still hold; the floor is defense-in-depth).
+//
+// Layout: two ping-pong cells at nvs relative offsets 0 and 4096, each a 12-byte record
+// `[MAGIC(4 LE) | build(4 LE) | crc32(4 LE)]`. Read = max valid build across both cells.
+// Write = erase the cell holding the SMALLER/invalid build, write the new record there;
+// the other cell always retains ≥ the erased one, so a torn write never regresses the
+// floor (power-loss-safe). One erase+write per OTA → negligible wear.
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "espnow")]
+const FLOOR_MAGIC: u32 = 0x736D_6C46; // "smlF"
+#[cfg(feature = "espnow")]
+const FLOOR_CELL_STRIDE: u32 = 4096; // one sector apart (erase granularity)
+#[cfg(feature = "espnow")]
+const FLOOR_RECORD_LEN: usize = 12;
+
+/// CRC-32 (IEEE, reflected poly 0xEDB88320) over `data` — torn-write detector for the
+/// floor cell. Pure, panic-free, no table (small input, speed irrelevant).
+#[cfg(feature = "espnow")]
+fn crc32(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &b in data {
+        crc ^= b as u32;
+        let mut i = 0;
+        while i < 8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+            i += 1;
+        }
+    }
+    !crc
+}
+
+/// Read one floor cell at `rel` (nvs-relative). `None` on flash error / bad magic / bad crc.
+#[cfg(feature = "espnow")]
+fn floor_cell_read(rel: u32) -> Option<u32> {
+    use embedded_storage::nor_flash::ReadNorFlash;
+    let mut flash = FlashStorage::new();
+    let mut ptbuf = [0u8; PT_SCRATCH];
+    let pt = read_partition_table(&mut flash, &mut ptbuf).ok()?;
+    let nvs = pt
+        .find_partition(PartitionType::Data(DataPartitionSubType::Nvs))
+        .ok()??;
+    let mut region = nvs.as_embedded_storage(&mut flash);
+    let mut rec = [0u8; FLOOR_RECORD_LEN];
+    region.read(rel, &mut rec).ok()?;
+    let magic = u32::from_le_bytes([rec[0], rec[1], rec[2], rec[3]]);
+    if magic != FLOOR_MAGIC {
+        return None; // erased (0xFFFFFFFF) or never written
+    }
+    let build = u32::from_le_bytes([rec[4], rec[5], rec[6], rec[7]]);
+    let crc = u32::from_le_bytes([rec[8], rec[9], rec[10], rec[11]]);
+    (crc == crc32(&rec[0..8])).then_some(build)
+}
+
+/// The current freshness floor = max valid build across both cells (0 if none written).
+#[cfg(feature = "espnow")]
+pub fn fresh_floor_get() -> u32 {
+    let a = floor_cell_read(0).unwrap_or(0);
+    let b = floor_cell_read(FLOOR_CELL_STRIDE).unwrap_or(0);
+    a.max(b)
+}
+
+/// Raise the floor to `max(floor, build)`, persisting it. Idempotent (a no-op if the
+/// floor already covers `build`). Writes to the cell holding the SMALLER/invalid build
+/// so the other cell always retains the prior floor → a torn write cannot regress it.
+/// Called once at first-boot-pre-self-test on `otadata == New` (before radio init).
+#[cfg(feature = "espnow")]
+pub fn fresh_floor_bump(build: u32) {
+    use embedded_storage::nor_flash::NorFlash;
+    let a = floor_cell_read(0);
+    let b = floor_cell_read(FLOOR_CELL_STRIDE);
+    let cur = a.unwrap_or(0).max(b.unwrap_or(0));
+    if build <= cur {
+        return; // already covered — no write, no wear
+    }
+    // Target the cell with the smaller (or invalid) build; the other keeps the prior max.
+    let target_rel = if a.unwrap_or(0) <= b.unwrap_or(0) { 0 } else { FLOOR_CELL_STRIDE };
+    let mut rec = [0u8; FLOOR_RECORD_LEN];
+    rec[0..4].copy_from_slice(&FLOOR_MAGIC.to_le_bytes());
+    rec[4..8].copy_from_slice(&build.to_le_bytes());
+    let crc = crc32(&rec[0..8]);
+    rec[8..12].copy_from_slice(&crc.to_le_bytes());
+
+    let mut flash = FlashStorage::new();
+    let mut ptbuf = [0u8; PT_SCRATCH];
+    let pt = match read_partition_table(&mut flash, &mut ptbuf) {
+        Ok(pt) => pt,
+        Err(_) => return,
+    };
+    let nvs = match pt.find_partition(PartitionType::Data(DataPartitionSubType::Nvs)) {
+        Ok(Some(p)) => p,
+        _ => return,
+    };
+    let mut region = nvs.as_embedded_storage(&mut flash);
+    if region.erase(target_rel, target_rel + FLOOR_CELL_STRIDE).is_err() {
+        return;
+    }
+    let _ = region.write(target_rel, &rec);
+}
+
+// ---------------------------------------------------------------------------
+// #40 §3/self-test §3 — the unconfirmed-boot (K) counter.
+//
+// A `New` image that PANICS before finishing the leaf self-test resets (MF-2
+// custom_halt→software_reset) STILL in `New` → it would re-run the self-test and could
+// boot-loop the bad slot forever (bootloader auto-revert is OFF). This bounds it: the
+// counter is bumped at the ABSOLUTE EARLIEST boot point (before any subsystem that can
+// panic); at K it forces the app-side flip to the good slot. Stored in RTC-fast RAM —
+// survives `software_reset`, cleared on power-loss (acceptable: a power-cycled leaf
+// re-runs the self-test cleanly, §5). Persistent RTC RAM is UNINITIALIZED at power-on,
+// so a magic word gates it: garbage magic ⇒ treat as a fresh (count 0) power-on.
+// ---------------------------------------------------------------------------
+
+/// `[magic, count]` in persistent RTC-fast RAM. `#[ram(rtc_fast, persistent)]` keeps it
+/// across a `software_reset`; it is uninitialized at power-on (magic detects that).
+#[cfg(feature = "espnow")]
+#[esp_hal::ram(rtc_fast, persistent)]
+static mut OTA_BOOT_GUARD: [u32; 2] = [0u32; 2];
+
+#[cfg(feature = "espnow")]
+const BOOT_GUARD_MAGIC: u32 = 0x736D_6C4B; // "smlK"
+
+/// Bump the unconfirmed-boot counter and return the new value. Call at the absolute
+/// earliest boot point when `otadata` is `New`/`PendingVerify`, BEFORE anything that
+/// can panic in init (so an early-init crash still trips the crash-loop bound).
+#[cfg(feature = "espnow")]
+pub fn unconfirmed_boot_bump() -> u32 {
+    unsafe {
+        let g = &mut *core::ptr::addr_of_mut!(OTA_BOOT_GUARD);
+        if g[0] != BOOT_GUARD_MAGIC {
+            g[0] = BOOT_GUARD_MAGIC;
+            g[1] = 0;
+        }
+        g[1] = g[1].saturating_add(1);
+        g[1]
+    }
+}
+
+/// Reset the counter (call on a successful self-test confirm).
+#[cfg(feature = "espnow")]
+pub fn unconfirmed_boot_reset() {
+    unsafe {
+        let g = &mut *core::ptr::addr_of_mut!(OTA_BOOT_GUARD);
+        g[0] = BOOT_GUARD_MAGIC;
+        g[1] = 0;
+    }
+}
+
+/// True iff `otadata`'s state is `New`/`PendingVerify` — i.e. a freshly-activated image
+/// on its FIRST boot, whose self-test has not yet confirmed. Drives the earliest-boot
+/// freshness-floor bump + K-counter (and the deferred leaf self-test in the main loop).
+/// Self-contained flash borrow; `false` on any flash/partition error (fail-safe: a board
+/// we can't read otadata on simply skips the OTA bookkeeping).
+#[cfg(feature = "espnow")]
+pub fn otadata_unconfirmed() -> bool {
+    let mut flash = FlashStorage::new();
+    let mut buf = [0u8; PT_SCRATCH];
+    let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
+        return false;
+    };
+    let Ok(Some(od)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Ota)) else {
+        return false;
+    };
+    let mut region = od.as_embedded_storage(&mut flash);
+    let Ok(mut ota) = Ota::new(&mut region) else {
+        return false;
+    };
+    matches!(
+        ota.current_ota_state(),
+        Ok(OtaImageState::New) | Ok(OtaImageState::PendingVerify)
+    )
+}

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -784,6 +784,62 @@ impl LeafImageWriter {
 }
 
 // ---------------------------------------------------------------------------
+// #40 gateway relay — read the staged image back from a slot to relay over ESP-NOW.
+//
+// After `run_ota_fetch(relay_mode=true)` stages+verifies a leaf's image into the gateway's
+// INACTIVE slot, the relay reads it back window-by-window (partition-scoped, word-aligned)
+// and sends the chunks. Read-only; never writes → cannot brick anything.
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "espnow")]
+pub struct SlotReader {
+    sub: AppPartitionSubType,
+    part_len: u32,
+}
+
+#[cfg(feature = "espnow")]
+impl SlotReader {
+    /// Open a reader for `slot` (the gateway's just-staged inactive slot). `None` on error.
+    pub fn open(slot: Slot) -> Option<SlotReader> {
+        let sub = if slot == Slot::Slot1 {
+            AppPartitionSubType::Ota1
+        } else {
+            AppPartitionSubType::Ota0
+        };
+        let mut flash = FlashStorage::new();
+        let mut buf = [0u8; PT_SCRATCH];
+        let part_len = {
+            let pt = read_partition_table(&mut flash, &mut buf).ok()?;
+            let app = pt.find_partition(PartitionType::App(sub)).ok()??;
+            app.len()
+        };
+        Some(SlotReader { sub, part_len })
+    }
+
+    /// Read `out.len()` bytes at partition-relative `off` (both word-aligned by the caller).
+    /// `false` on any bound/flash error. Partition-scoped → an out-of-slot `off` errors, it
+    /// never reads foreign flash.
+    pub fn read(&self, off: u32, out: &mut [u8]) -> bool {
+        use embedded_storage::nor_flash::ReadNorFlash;
+        if off.saturating_add(out.len() as u32) > self.part_len {
+            return false;
+        }
+        let mut flash = FlashStorage::new();
+        let mut ptbuf = [0u8; PT_SCRATCH];
+        let pt = match read_partition_table(&mut flash, &mut ptbuf) {
+            Ok(pt) => pt,
+            Err(_) => return false,
+        };
+        let app = match pt.find_partition(PartitionType::App(self.sub)) {
+            Ok(Some(p)) => p,
+            _ => return false,
+        };
+        let mut region = app.as_embedded_storage(&mut flash);
+        region.read(off, out).is_ok()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // #40 §3C — the persistent signed-freshness FLOOR (NVS-backed).
 //
 // `fresh_floor` = the highest build ever booted-as-`New`. The leaf accepts a mesh OTA

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -446,6 +446,12 @@ impl OtaLeafSession {
         (self.dbg_otam_heard, self.dbg_verdict, self.dbg_otan_sent)
     }
 
+    /// #3b: is a mesh-OTA transfer live? `leaf_scan_tick` holds ch6 (no hop) while true so the
+    /// windowed transfer isn't dropped by a channel hop. False in steady state → scan unaffected.
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
     /// The gateway MAC this session locked onto (unicast target for NAKs). Zero if idle.
     pub fn gateway_mac(&self) -> [u8; 6] {
         self.gateway_mac

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -300,19 +300,48 @@ const LEAF_PROGRESS_STALL_MS: u64 = 30_000;
 /// Hard total-session cap (ms) — a runaway transfer aborts → good slot boots (R1: USB).
 const LEAF_SESSION_MAX_MS: u64 = 600_000;
 
-/// Outcome of a GATEWAY → leaf relay+confirm session — drives `smol/<leaf>/ota/state`.
+/// Outcome/phase of a GATEWAY → leaf relay attempt — published to `smol/<leaf>/ota/diag`
+/// (headless observability: the mesh-only leaf gives no serial, so the gateway reports the
+/// terminal phase over MQTT on its next burst). Also drives the install clear/retry policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LeafOtaOutcome {
     /// Leaf reappeared at the NEW build (Tier-2 build-matched) — the update stuck.
     Confirmed,
     /// Leaf reappeared at an OLDER build — its self-test failed → app-side rollback (HA re-offers).
     RolledBack,
-    /// The gateway couldn't fetch/stage/relay (never reached the leaf's verify).
+    /// The gateway could not FETCH/stage the image (WiFi/HTTP/verify) — never relayed.
+    FetchFailed,
+    /// The ESP-NOW relay loop exhausted its retransmit rounds (leaf not NAKing) — never confirmed.
     RelayFailed,
     /// No STAT reappearance within the confirm window — possible brick (USB recovery).
     Timeout,
+    /// The armed install's target leaf MAC isn't in the roster yet (never heard its HELLO).
+    MacUnknown,
     /// Operator aborted (long-press) mid-session.
     Aborted,
+}
+
+impl LeafOtaOutcome {
+    /// Short retained-payload phase string for `smol/<leaf>/ota/diag`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LeafOtaOutcome::Confirmed => "confirmed",
+            LeafOtaOutcome::RolledBack => "rolled-back",
+            LeafOtaOutcome::FetchFailed => "fetch-failed",
+            LeafOtaOutcome::RelayFailed => "relay-failed",
+            LeafOtaOutcome::Timeout => "leaf-timeout",
+            LeafOtaOutcome::MacUnknown => "mac-unknown",
+            LeafOtaOutcome::Aborted => "aborted",
+        }
+    }
+
+    /// Terminal ⇒ the leaf DEFINITIVELY acted on the image (installed the new build, or
+    /// self-tested + rolled back) → clear the install, don't auto-retry. The rest are
+    /// transient (no fetch / no relay / MAC not yet learned) → leave the install retained to
+    /// retry, bounded by a cap.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, LeafOtaOutcome::Confirmed | LeafOtaOutcome::RolledBack)
+    }
 }
 
 /// What `service()` must do after handing a frame / a tick to the leaf session.

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -350,6 +350,11 @@ pub enum LeafOtaOutcome {
     Timeout,
     /// The armed install's target leaf MAC isn't in the roster yet (never heard its HELLO).
     MacUnknown,
+    /// #40 IDENTITY: the physical leaf we targeted (by sticky MAC) reappeared STATing a
+    /// DIFFERENT logical id than we relayed to — the image booted with a stolen/wrong id
+    /// (baked-default collision / NVS not seeded). Explicit diag instead of a silent
+    /// leaf-timeout; TERMINAL (a bad NVS won't heal by re-relaying the same image).
+    IdMismatch,
     /// Operator aborted (long-press) mid-session.
     Aborted,
 }
@@ -364,6 +369,7 @@ impl LeafOtaOutcome {
             LeafOtaOutcome::RelayFailed => "relay-failed",
             LeafOtaOutcome::Timeout => "leaf-timeout",
             LeafOtaOutcome::MacUnknown => "mac-unknown",
+            LeafOtaOutcome::IdMismatch => "id-mismatch",
             LeafOtaOutcome::Aborted => "aborted",
         }
     }
@@ -373,7 +379,13 @@ impl LeafOtaOutcome {
     /// transient (no fetch / no relay / MAC not yet learned) → leave the install retained to
     /// retry, bounded by a cap.
     pub fn is_terminal(&self) -> bool {
-        matches!(self, LeafOtaOutcome::Confirmed | LeafOtaOutcome::RolledBack)
+        // #40: IdMismatch is terminal — the image DID install (a board booted the new
+        // build), it just reports a wrong id; re-relaying can't fix a bad NVS, so clear
+        // the install + surface the diag rather than burn retries.
+        matches!(
+            self,
+            LeafOtaOutcome::Confirmed | LeafOtaOutcome::RolledBack | LeafOtaOutcome::IdMismatch
+        )
     }
 }
 

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -61,14 +61,17 @@ pub const OTAN_PREFIX: &[u8] = b"SMOLv1 OTAN "; // leaf→gateway (UNICAST): win
 /// sent[2 LE]. Broadcast on the HELLO cadence so the gateway's relay RX loop CAPTURES it while
 /// the leaf is provably online (rx>0), naming WHY a `relay-failed` had `otan=0` (see `RelayDiag`).
 pub const LDBG_PREFIX: &[u8] = b"SMOLv1 LDBG "; // leaf→broadcast: OTA receive-side self-report
-/// `LDBG` payload: id[3 ASCII] + otam_heard[2 LE] + verdict[1] + otan_sent[2 LE].
-pub const LDBG_FRAME_LEN: usize = 12 + 3 + 2 + 1 + 2;
+/// `LDBG` payload: id[3 ASCII] + otam_heard[2 LE] + verdict[1] + otan_sent[2 LE] + ch[1].
+/// #3b `ch` = the leaf's `current_channel()` at beacon time (0 = SCANNING/unlocked, else the
+/// locked channel 1/6/11). Decisive for the H0 fork: ch=6 means the leaf was ON ch6 yet still
+/// heard no OTAM (RX issue); ch≠6 means it drifted off ch6 during the gateway's fetch window.
+pub const LDBG_FRAME_LEN: usize = 12 + 3 + 2 + 1 + 2 + 1;
 
-/// Parse a leaf `LDBG` beacon → `(otam_heard, verdict, otan_sent)` iff it is well-formed AND
-/// addressed-from `want_id` (the 3-ASCII id field). `None` otherwise.
-pub fn parse_ldbg(data: &[u8], want_id: u8) -> Option<(u16, u8, u16)> {
+/// Parse a leaf `LDBG` beacon → `(otam_heard, verdict, otan_sent, leaf_ch)` iff it is well-formed
+/// AND addressed-from `want_id` (the 3-ASCII id field). `None` otherwise.
+pub fn parse_ldbg(data: &[u8], want_id: u8) -> Option<(u16, u8, u16, u8)> {
     let rest = data.strip_prefix(LDBG_PREFIX)?;
-    if rest.len() < 3 + 2 + 1 + 2 {
+    if rest.len() < 3 + 2 + 1 + 2 + 1 {
         return None;
     }
     if parse_id3(&rest[0..3])? != want_id {
@@ -77,7 +80,8 @@ pub fn parse_ldbg(data: &[u8], want_id: u8) -> Option<(u16, u8, u16)> {
     let heard = u16::from_le_bytes([rest[3], rest[4]]);
     let verdict = rest[5];
     let sent = u16::from_le_bytes([rest[6], rest[7]]);
-    Some((heard, verdict, sent))
+    let leaf_ch = rest[8];
+    Some((heard, verdict, sent, leaf_ch))
 }
 
 /// Max `OTAM` frame: 12 + 3 + 2 + 1 + `SIGNED_MSG_MAX` (M) + 64 (sig).

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -301,6 +301,7 @@ const LEAF_PROGRESS_STALL_MS: u64 = 30_000;
 const LEAF_SESSION_MAX_MS: u64 = 600_000;
 
 /// Outcome of a GATEWAY → leaf relay+confirm session — drives `smol/<leaf>/ota/state`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LeafOtaOutcome {
     /// Leaf reappeared at the NEW build (Tier-2 build-matched) — the update stuck.
     Confirmed,
@@ -366,11 +367,6 @@ impl OtaLeafSession {
             last_nak_ms: 0,
             writer: None,
         }
-    }
-
-    /// Is a transfer in progress? (Used by `main` to know the mesh is in a maintenance op.)
-    pub fn is_active(&self) -> bool {
-        self.active
     }
 
     /// The gateway MAC this session locked onto (unicast target for NAKs). Zero if idle.

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -323,6 +323,13 @@ use esp_bootloader_esp_idf::ota::Slot;
 const LEAF_IDLE_NAK_MS: u64 = 500;
 /// Abort the session if NO new chunk arrives for this long (a jam / dead gateway, ms).
 const LEAF_PROGRESS_STALL_MS: u64 = 30_000;
+/// #3b: grace for the ARMED-but-no-chunk-yet phase. Pre-fetch-arm arms the leaf via the OTAM
+/// BEFORE the gateway's WiFi fetch, so the FIRST OTAD arrives only after the fetch (up to
+/// `OTA_FETCH_BUDGET`=300s later). Without a longer grace the 30 s stall would abort the armed
+/// session mid-fetch (→ leaf drops the hold + scans → the bug we're fixing). Applies ONLY while
+/// window 0 has received nothing; once chunks flow, the tight 30 s stall resumes. Still bounded
+/// by `LEAF_SESSION_MAX_MS` (600s) → brick-safe (otadata untouched on abort).
+const LEAF_FIRST_CHUNK_GRACE_MS: u64 = 330_000;
 /// Hard total-session cap (ms) — a runaway transfer aborts → good slot boots (R1: USB).
 const LEAF_SESSION_MAX_MS: u64 = 600_000;
 
@@ -675,8 +682,16 @@ impl OtaLeafSession {
         if !self.active {
             return LeafAction::None;
         }
+        // #3b: while ARMED but still awaiting the very first chunk (window 0, nothing received),
+        // allow the fetch-spanning grace — the gateway is fetching off-ch6, not dead. Once any
+        // chunk lands, the tight progress stall resumes. The hard session cap still bounds it.
+        let stall_ms = if self.window_base == 0 && self.window_recv == 0 {
+            LEAF_FIRST_CHUNK_GRACE_MS
+        } else {
+            LEAF_PROGRESS_STALL_MS
+        };
         if now >= self.session_deadline_ms
-            || now.saturating_sub(self.last_new_chunk_ms) >= LEAF_PROGRESS_STALL_MS
+            || now.saturating_sub(self.last_new_chunk_ms) >= stall_ms
         {
             log::warn!("smol #40: mesh-OTA stalled — session discarded (good slot intact; USB recovery)");
             self.discard();

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -254,6 +254,24 @@ pub fn total_chunks(size: u32) -> u32 {
     (size / CHUNK_PAYLOAD as u32).saturating_add((size % CHUNK_PAYLOAD as u32 != 0) as u32)
 }
 
+/// "All chunks present" bitmap mask for a window of `len` chunks (`len` ≤ 64). Shared by
+/// the leaf (completeness check) and the gateway (retransmit set).
+pub fn window_full_mask(len: u32) -> u64 {
+    if len >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << len) - 1
+    }
+}
+
+/// Decode a ≤8-byte LE `OTAN` missing-bitmap into a `u64` (bit `i` ⇒ chunk `base+i` missing).
+pub fn bitmap_to_u64(b: &[u8]) -> u64 {
+    let mut a = [0u8; 8];
+    let n = b.len().min(8);
+    a[..n].copy_from_slice(&b[..n]);
+    u64::from_le_bytes(a)
+}
+
 /// #40 §C#3: parse the running build# from a `SMOLv1 STAT` value `"<screen>:<page>|<build>"`
 /// (the last `|`-field). Used by the gateway's Tier-2 confirm — "reappeared AT THE NEW
 /// BUILD", never bare presence (so a rolled-back leaf HELLOing at the OLD build doesn't
@@ -281,6 +299,20 @@ const LEAF_IDLE_NAK_MS: u64 = 500;
 const LEAF_PROGRESS_STALL_MS: u64 = 30_000;
 /// Hard total-session cap (ms) — a runaway transfer aborts → good slot boots (R1: USB).
 const LEAF_SESSION_MAX_MS: u64 = 600_000;
+
+/// Outcome of a GATEWAY → leaf relay+confirm session — drives `smol/<leaf>/ota/state`.
+pub enum LeafOtaOutcome {
+    /// Leaf reappeared at the NEW build (Tier-2 build-matched) — the update stuck.
+    Confirmed,
+    /// Leaf reappeared at an OLDER build — its self-test failed → app-side rollback (HA re-offers).
+    RolledBack,
+    /// The gateway couldn't fetch/stage/relay (never reached the leaf's verify).
+    RelayFailed,
+    /// No STAT reappearance within the confirm window — possible brick (USB recovery).
+    Timeout,
+    /// Operator aborted (long-press) mid-session.
+    Aborted,
+}
 
 /// What `service()` must do after handing a frame / a tick to the leaf session.
 pub enum LeafAction {
@@ -427,15 +459,6 @@ impl OtaLeafSession {
         core::cmp::min(wb + WINDOW_CHUNKS as u32, self.total_chunks) - wb
     }
 
-    /// The "all chunks present" bitmap mask for a window of `len` chunks (`len` ≤ 64).
-    fn full_mask(len: u32) -> u64 {
-        if len >= 64 {
-            u64::MAX
-        } else {
-            (1u64 << len) - 1
-        }
-    }
-
     /// Handle an `OTAD` image chunk. Enforces the HOLE-3 signed bounds BEFORE any buffer
     /// write, MAC-filters to the locked gateway, routes the chunk into the current window,
     /// and — on a completed window — flushes it to the (partition-scoped) inactive slot
@@ -508,7 +531,7 @@ impl OtaLeafSession {
 
         // Window complete?
         let wlen = self.window_len(wb);
-        let mask = Self::full_mask(wlen);
+        let mask = window_full_mask(wlen);
         if self.window_recv & mask != mask {
             return LeafAction::None; // still gaps — the idle timer will NAK them
         }
@@ -575,7 +598,7 @@ impl OtaLeafSession {
         // Current window incomplete → NAK its missing chunks.
         let wb = self.window_base;
         let wlen = self.window_len(wb);
-        let mask = Self::full_mask(wlen);
+        let mask = window_full_mask(wlen);
         let missing = mask & !self.window_recv;
         if missing == 0 {
             return LeafAction::None; // complete (an advance-ack is pending elsewhere)

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -351,8 +351,9 @@ pub enum LeafAction {
     /// Unicast `out[..len]` (an `OTAN`) back to the gateway's MAC.
     Nak(usize),
     /// The image is fully received AND verified (sig + size + readback sha). Activate
-    /// this slot — [`crate::ota::activate`] reboots into it (never returns on success).
-    Complete(Slot),
+    /// this slot with the manifest build# — [`crate::ota::activate`] reboots into it
+    /// (never returns on success); the build# tags the self-test exemption marker.
+    Complete(Slot, u32),
     /// The session aborted (bad frame class handled internally) — discard; nothing to send.
     Abort,
 }
@@ -366,6 +367,7 @@ static mut OTA_WINDOW_BUF: [u8; WINDOW_BYTES] = [0u8; WINDOW_BYTES];
 pub struct OtaLeafSession {
     active: bool,
     session_id: u16,
+    build: u32,
     size: u32,
     sha256: [u8; 32],
     total_chunks: u32,
@@ -385,6 +387,7 @@ impl OtaLeafSession {
         Self {
             active: false,
             session_id: 0,
+            build: 0,
             size: 0,
             sha256: [0u8; 32],
             total_chunks: 0,
@@ -462,6 +465,7 @@ impl OtaLeafSession {
         };
         self.active = true;
         self.session_id = session;
+        self.build = build;
         self.size = size;
         self.sha256 = sha256;
         self.total_chunks = total_chunks(size);
@@ -586,15 +590,15 @@ impl OtaLeafSession {
         }
 
         // ---- LAST window done → FINALIZE (readback verify) → activate. ------------
-        let (size, sha) = (self.size, self.sha256);
+        let (size, sha, build) = (self.size, self.sha256, self.build);
         let writer = self.writer.take();
         self.active = false;
         match writer {
             Some(w) => {
                 let target_slot = w.target();
                 if w.finalize(size, &sha) {
-                    log::info!("smol #40: image VERIFIED (readback SHA-256, ed25519 already ok) — activating");
-                    LeafAction::Complete(target_slot)
+                    log::info!("smol #40: image VERIFIED (readback SHA-256, ed25519 already ok) — activating build {}", build);
+                    LeafAction::Complete(target_slot, build)
                 } else {
                     log::error!("smol #40: readback verify FAILED — discarded (good slot intact)");
                     LeafAction::Abort

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -254,6 +254,15 @@ pub fn total_chunks(size: u32) -> u32 {
     (size / CHUNK_PAYLOAD as u32).saturating_add((size % CHUNK_PAYLOAD as u32 != 0) as u32)
 }
 
+/// #40 §C#3: parse the running build# from a `SMOLv1 STAT` value `"<screen>:<page>|<build>"`
+/// (the last `|`-field). Used by the gateway's Tier-2 confirm — "reappeared AT THE NEW
+/// BUILD", never bare presence (so a rolled-back leaf HELLOing at the OLD build doesn't
+/// false-confirm). `None` on an old screen-only value / non-numeric build (backward-safe).
+pub fn stat_build(value: &[u8]) -> Option<u32> {
+    let s = core::str::from_utf8(value).ok()?;
+    s.rsplit('|').next()?.parse().ok()
+}
+
 // ===========================================================================
 // Leaf receive session (the brick-critical path).
 //

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -57,6 +57,28 @@ pub const OTAN_BITMAP_BYTES: usize = WINDOW_CHUNKS / 8;
 pub const OTAM_PREFIX: &[u8] = b"SMOLv1 OTAM "; // gateway→leaf: signed manifest / announce
 pub const OTAD_PREFIX: &[u8] = b"SMOLv1 OTAD "; // gateway→leaf: one image chunk
 pub const OTAN_PREFIX: &[u8] = b"SMOLv1 OTAN "; // leaf→gateway (UNICAST): windowed NAK
+/// #40 #3: leaf→(broadcast) OTA RX-diag beacon: `LDBG ` + id[3] + heard[2 LE] + verdict[1] +
+/// sent[2 LE]. Broadcast on the HELLO cadence so the gateway's relay RX loop CAPTURES it while
+/// the leaf is provably online (rx>0), naming WHY a `relay-failed` had `otan=0` (see `RelayDiag`).
+pub const LDBG_PREFIX: &[u8] = b"SMOLv1 LDBG "; // leaf→broadcast: OTA receive-side self-report
+/// `LDBG` payload: id[3 ASCII] + otam_heard[2 LE] + verdict[1] + otan_sent[2 LE].
+pub const LDBG_FRAME_LEN: usize = 12 + 3 + 2 + 1 + 2;
+
+/// Parse a leaf `LDBG` beacon → `(otam_heard, verdict, otan_sent)` iff it is well-formed AND
+/// addressed-from `want_id` (the 3-ASCII id field). `None` otherwise.
+pub fn parse_ldbg(data: &[u8], want_id: u8) -> Option<(u16, u8, u16)> {
+    let rest = data.strip_prefix(LDBG_PREFIX)?;
+    if rest.len() < 3 + 2 + 1 + 2 {
+        return None;
+    }
+    if parse_id3(&rest[0..3])? != want_id {
+        return None;
+    }
+    let heard = u16::from_le_bytes([rest[3], rest[4]]);
+    let verdict = rest[5];
+    let sent = u16::from_le_bytes([rest[6], rest[7]]);
+    Some((heard, verdict, sent))
+}
 
 /// Max `OTAM` frame: 12 + 3 + 2 + 1 + `SIGNED_MSG_MAX` (M) + 64 (sig).
 pub const OTAM_FRAME_MAX: usize = 12 + 3 + 2 + 1 + ota::SIGNED_MSG_MAX + 64;
@@ -380,6 +402,15 @@ pub struct OtaLeafSession {
     last_new_chunk_ms: u64,
     last_nak_ms: u64,
     writer: Option<crate::ota::LeafImageWriter>,
+    /// #40 #3 LEAF RX-DIAG (instrumentation): lifetime counters surfaced via the leaf's `LDBG`
+    /// beacon (captured by a relaying gateway → `smol/<leaf>/ota/relaydiag`) so a headless
+    /// `relay-failed` (gateway `rx>0 otan=0`) names WHY the leaf never NAK'd:
+    /// `dbg_otam_heard` = OTAMs addressed to us that reached `on_meta`; `dbg_verdict` = the last
+    /// `on_meta` outcome (0 never-heard, 1 armed, 2 sig-fail, 3 build≤running, 4 ≤fresh_floor,
+    /// 5 size, 6 writer-open-fail, 7 dedup/live); `dbg_otan_sent` = OTANs this leaf emitted.
+    dbg_otam_heard: u16,
+    dbg_verdict: u8,
+    dbg_otan_sent: u16,
 }
 
 impl OtaLeafSession {
@@ -398,7 +429,17 @@ impl OtaLeafSession {
             last_new_chunk_ms: 0,
             last_nak_ms: 0,
             writer: None,
+            dbg_otam_heard: 0,
+            dbg_verdict: 0,
+            dbg_otan_sent: 0,
         }
+    }
+
+    /// #40 #3: lifetime leaf RX-diag `(otam_heard, last_on_meta_verdict, otan_sent)` — the leaf
+    /// beacons this via `LDBG` so a headless canary can name (a) never-heard-OTAM /
+    /// (b) on_meta-rejected / (c) armed-but-never-NAK'd, splitting the gateway's `rx>0 otan=0`.
+    pub fn dbg(&self) -> (u16, u8, u16) {
+        (self.dbg_otam_heard, self.dbg_verdict, self.dbg_otan_sent)
     }
 
     /// The gateway MAC this session locked onto (unicast target for NAKs). Zero if idle.
@@ -431,12 +472,15 @@ impl OtaLeafSession {
         if target != my_id {
             return LeafAction::None; // not for us
         }
+        self.dbg_otam_heard = self.dbg_otam_heard.saturating_add(1); // #3: an OTAM reached us
         if self.active && self.session_id == session {
+            self.dbg_verdict = 7; // #3: dedup — already armed & live for this session
             return LeafAction::None; // periodic OTAM re-send for the live session — dedupe
         }
         // (1) AUTHENTICITY — the SOLE root of trust on the unauth mesh. Fail-closed.
         if !crate::ota::verify_signature(m, sig) {
             log::warn!("smol #40: OTAM sig FAILED — ignored (no state, no flash)");
+            self.dbg_verdict = 2; // #3: signature verify failed
             return LeafAction::None;
         }
         // (2) Only now is M trustworthy → parse build/size/sha.
@@ -446,23 +490,28 @@ impl OtaLeafSession {
         // (3) FRESHNESS + size gate (design §3C). Monotonicity ∧ floor ∧ slot bound.
         if build <= crate::ota::BUILD_NUMBER {
             log::info!("smol #40: OTAM build {} <= running {} — rejected", build, crate::ota::BUILD_NUMBER);
+            self.dbg_verdict = 3; // #3: build not fresh (<= running)
             return LeafAction::None;
         }
         let floor = crate::ota::fresh_floor_get();
         if build <= floor {
             log::info!("smol #40: OTAM build {} <= fresh_floor {} — replay rejected", build, floor);
+            self.dbg_verdict = 4; // #3: build <= fresh_floor (replay)
             return LeafAction::None;
         }
         if size == 0 || size > crate::ota::MAX_IMAGE_SIZE {
             log::info!("smol #40: OTAM size {} out of range — rejected", size);
+            self.dbg_verdict = 5; // #3: size out of range
             return LeafAction::None;
         }
         // (4) Open the inactive-slot writer. If a prior session was live, its writer is
         // dropped here (otadata untouched — it was never activated).
         let Some(writer) = crate::ota::LeafImageWriter::begin() else {
             log::error!("smol #40: cannot open inactive slot — OTAM ignored");
+            self.dbg_verdict = 6; // #3: inactive-slot writer open failed
             return LeafAction::None;
         };
+        self.dbg_verdict = 1; // #3: ARMED — session accepted (confirm via hear-a-frame)
         self.active = true;
         self.session_id = session;
         self.build = build;
@@ -541,6 +590,7 @@ impl OtaLeafSession {
             let acked_base = (seq / WINDOW_CHUNKS as u32) * WINDOW_CHUNKS as u32;
             let zero = [0u8; OTAN_BITMAP_BYTES];
             let n = encode_otan(my_id, self.session_id, acked_base as u16, &zero, out);
+            self.dbg_otan_sent = self.dbg_otan_sent.saturating_add(1); // #3: OTAN emitted
             return LeafAction::Nak(n);
         }
         if seq >= wb + WINDOW_CHUNKS as u32 {
@@ -586,6 +636,7 @@ impl OtaLeafSession {
             // More windows: ack this one (all-zero NAK) so the gateway sends the next.
             let zero = [0u8; OTAN_BITMAP_BYTES];
             let n = encode_otan(my_id, self.session_id, wb as u16, &zero, out);
+            self.dbg_otan_sent = self.dbg_otan_sent.saturating_add(1); // #3: OTAN emitted
             return LeafAction::Nak(n);
         }
 
@@ -634,6 +685,7 @@ impl OtaLeafSession {
         }
         self.last_nak_ms = now;
         let n = encode_otan(my_id, self.session_id, wb as u16, &missing.to_le_bytes(), out);
+        self.dbg_otan_sent = self.dbg_otan_sent.saturating_add(1); // #3: OTAN emitted
         LeafAction::Nak(n)
     }
 }

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -1,0 +1,578 @@
+//! #40 leaf-mesh-OTA — signed firmware delivery to ESP-NOW-only leaves over the mesh.
+//!
+//! Compiled ONLY in `espnow` builds (`mod ota_mesh;` is `#[cfg(feature = "espnow")]`
+//! in `main.rs`). The DEFAULT build links NONE of this (proven by cfg-gating, not
+//! ELF byte-equality — `build.rs` embeds a per-commit git stamp).
+//!
+//! # What this is
+//! A **credential-less leaf** never opens WiFi/MQTT, so it cannot fetch an image.
+//! The GATEWAY is its MQTT proxy: it fetches the fleet-staged, ed25519-signed image
+//! (the SAME `smol/ota/staged` line the whole fleet uses) to its own inactive slot,
+//! then relays it chunk-by-chunk over ESP-NOW to ONE leaf (canary-one-leaf). The leaf
+//! verifies the signature BEFORE it flashes, reassembles into its inactive slot, and
+//! activates only on a full size+sha match. Design: `scratch/smol-ha-batt/issue-40-
+//! leaf-mesh-ota-design.md` (§E LOCKED wire format) + `leaf-mesh-ota-design.md` (§0–6).
+//!
+//! # The brick-critical invariants (this whole file exists to honor them)
+//! 1. **verify-sig-BEFORE-flash** — the mesh is unauthenticated; the ed25519 sig over
+//!    the manifest `M = "build|size|sha256hex"` (reused byte-identical from #32) is the
+//!    SOLE thing preventing any RF device from flashing a leaf. Verified at OTAM receipt,
+//!    before any slot erase/write (HOLE-2 closed by the real baked key).
+//! 2. **HOLE-3 — every chunk is bounds-checked against the SIGNED manifest** BEFORE any
+//!    write (`seq < total_chunks` ∧ `seq*231 + len ≤ size`), AND every write goes through
+//!    a partition-scoped writer that physically errors on an out-of-region address
+//!    ([`crate::ota::LeafImageWriter`], HOLE-3b). An OOB `seq` cannot reach the active
+//!    slot / otadata → no mid-transfer brick.
+//! 3. **signed-freshness floor** — accept iff `sig ok ∧ build > running ∧ build >
+//!    fresh_floor ∧ size/sha ok` (closes the signed-intermediate / rolled-back-build
+//!    replay; `fresh_floor` in NVS, see [`crate::ota`]).
+//! 4. **canary-one-leaf** — the gateway targets exactly ONE leaf id; there is NEVER a
+//!    broadcast-to-all image push in this file. Load-bearing safety.
+//!
+//! # Wire format (LOCKED §E — all multi-byte ints LE, SMOLv1 family, 12-byte tags)
+//! Every parser here is panic-free and bounded-copy (it runs on untrusted mesh bytes).
+
+use crate::ota;
+
+// ---------------------------------------------------------------------------
+// Constants (LOCKED §E)
+// ---------------------------------------------------------------------------
+
+/// Image bytes per `OTAD` chunk: 250 − 12 (tag) − 3 (target) − 2 (session) − 2 (seq).
+pub const CHUNK_PAYLOAD: usize = 231;
+
+/// Chunks per windowed-NAK window. 64 → an 8-byte missing-bitmap (`u64`). The leaf
+/// tracks a per-window received bitmap; the gateway retransmits only the set bits.
+pub const WINDOW_CHUNKS: usize = 64;
+
+/// Bytes in one full window buffer (`WINDOW_CHUNKS * CHUNK_PAYLOAD`). The reassembly
+/// buffer holds exactly ONE window (windows complete in order → the on-the-wire image
+/// is fed to flash sequentially; no whole-image RAM buffer). 64 * 231 = 14 784.
+pub const WINDOW_BYTES: usize = WINDOW_CHUNKS * CHUNK_PAYLOAD;
+
+/// Bytes of the missing-bitmap in an `OTAN` (one bit per chunk in the window).
+pub const OTAN_BITMAP_BYTES: usize = WINDOW_CHUNKS / 8;
+
+/// 12-byte frame tags (mirror the SMOLv1 family; full-prefix strip like CFG/STAT).
+pub const OTAM_PREFIX: &[u8] = b"SMOLv1 OTAM "; // gateway→leaf: signed manifest / announce
+pub const OTAD_PREFIX: &[u8] = b"SMOLv1 OTAD "; // gateway→leaf: one image chunk
+pub const OTAN_PREFIX: &[u8] = b"SMOLv1 OTAN "; // leaf→gateway (UNICAST): windowed NAK
+
+/// Max `OTAM` frame: 12 + 3 + 2 + 1 + `SIGNED_MSG_MAX` (M) + 64 (sig).
+pub const OTAM_FRAME_MAX: usize = 12 + 3 + 2 + 1 + ota::SIGNED_MSG_MAX + 64;
+/// Max `OTAD` frame: 12 + 3 + 2 + 2 + 231 = 250 (the full ESP-NOW MTU).
+pub const OTAD_FRAME_MAX: usize = 12 + 3 + 2 + 2 + CHUNK_PAYLOAD;
+/// Max `OTAN` frame: 12 + 3 + 2 + 2 + 8.
+pub const OTAN_FRAME_MAX: usize = 12 + 3 + 2 + 2 + OTAN_BITMAP_BYTES;
+
+// ---------------------------------------------------------------------------
+// Parsed frames (borrow the RX buffer; used immediately in `service()`)
+// ---------------------------------------------------------------------------
+
+/// A decoded #40 OTA frame. `Meta`/`Data` are gateway→leaf; `Nak` is leaf→gateway.
+pub enum OtaFrame<'a> {
+    /// Signed session announce: the manifest `M` bytes + the 64-byte ed25519 sig.
+    /// The leaf verifies `sig` over `m` BEFORE trusting any field parsed from `m`.
+    Meta {
+        target: u8,
+        session: u16,
+        m: &'a [u8],
+        sig: &'a [u8; 64],
+    },
+    /// One image chunk: `payload` are the image bytes at offset `seq * CHUNK_PAYLOAD`.
+    Data {
+        target: u8,
+        session: u16,
+        seq: u16,
+        payload: &'a [u8],
+    },
+    /// Windowed NAK: bit `i` set in `bitmap` ⇒ chunk `window_base + i` is still missing.
+    /// An all-zero bitmap = "window complete, advance" (the only positive ack).
+    Nak {
+        origin: u8,
+        session: u16,
+        window_base: u16,
+        bitmap: &'a [u8],
+    },
+}
+
+/// Parse one #40 OTA frame. Returns `None` on ANY malformed input (never panics,
+/// never indexes past the slice) — the caller treats `None` as "not an OTA frame".
+pub fn parse_ota_frame(data: &[u8]) -> Option<OtaFrame<'_>> {
+    if let Some(rest) = data.strip_prefix(OTAM_PREFIX) {
+        // target[3] session[2] M_len[1] M[M_len] sig[64]
+        if rest.len() < 3 + 2 + 1 {
+            return None;
+        }
+        let target = parse_id3(&rest[0..3])?;
+        let session = u16::from_le_bytes([rest[3], rest[4]]);
+        let m_len = rest[5] as usize;
+        // Bound M by the shared cap so a hostile M_len can't over-read or blow buffers.
+        if m_len == 0 || m_len > ota::SIGNED_MSG_MAX {
+            return None;
+        }
+        let m_start = 6;
+        let sig_start = m_start + m_len;
+        let end = sig_start + 64;
+        if rest.len() < end {
+            return None;
+        }
+        let m = &rest[m_start..sig_start];
+        let sig: &[u8; 64] = rest[sig_start..end].try_into().ok()?;
+        return Some(OtaFrame::Meta { target, session, m, sig });
+    }
+    if let Some(rest) = data.strip_prefix(OTAD_PREFIX) {
+        // target[3] session[2] seq[2] payload[..]
+        if rest.len() < 3 + 2 + 2 {
+            return None;
+        }
+        let target = parse_id3(&rest[0..3])?;
+        let session = u16::from_le_bytes([rest[3], rest[4]]);
+        let seq = u16::from_le_bytes([rest[5], rest[6]]);
+        let payload = &rest[7..];
+        // A chunk can never carry more than one payload's worth (defensive; the real
+        // spatial gate is the signed-bounds check in the session, HOLE-3).
+        if payload.len() > CHUNK_PAYLOAD {
+            return None;
+        }
+        return Some(OtaFrame::Data { target, session, seq, payload });
+    }
+    if let Some(rest) = data.strip_prefix(OTAN_PREFIX) {
+        // origin[3] session[2] window_base[2] bitmap[..OTAN_BITMAP_BYTES]
+        if rest.len() < 3 + 2 + 2 {
+            return None;
+        }
+        let origin = parse_id3(&rest[0..3])?;
+        let session = u16::from_le_bytes([rest[3], rest[4]]);
+        let window_base = u16::from_le_bytes([rest[5], rest[6]]);
+        let bitmap = &rest[7..];
+        if bitmap.len() > OTAN_BITMAP_BYTES {
+            return None;
+        }
+        return Some(OtaFrame::Nak { origin, session, window_base, bitmap });
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Encoders (fixed-width, bounded; return the byte length written into `out`)
+// ---------------------------------------------------------------------------
+
+/// Encode an `OTAM`. `None` if `m` exceeds [`ota::SIGNED_MSG_MAX`] or `out` is too small.
+pub fn encode_otam(
+    target_id: u8,
+    session: u16,
+    m: &[u8],
+    sig: &[u8; 64],
+    out: &mut [u8],
+) -> Option<usize> {
+    if m.is_empty() || m.len() > ota::SIGNED_MSG_MAX {
+        return None;
+    }
+    let total = OTAM_PREFIX.len() + 3 + 2 + 1 + m.len() + 64;
+    if out.len() < total {
+        return None;
+    }
+    let mut n = 0;
+    out[..OTAM_PREFIX.len()].copy_from_slice(OTAM_PREFIX);
+    n += OTAM_PREFIX.len();
+    write_id3(target_id, &mut out[n..n + 3]);
+    n += 3;
+    out[n..n + 2].copy_from_slice(&session.to_le_bytes());
+    n += 2;
+    out[n] = m.len() as u8;
+    n += 1;
+    out[n..n + m.len()].copy_from_slice(m);
+    n += m.len();
+    out[n..n + 64].copy_from_slice(sig);
+    n += 64;
+    Some(n)
+}
+
+/// Encode an `OTAD`. `payload` is truncated to [`CHUNK_PAYLOAD`]; returns the length.
+pub fn encode_otad(target_id: u8, session: u16, seq: u16, payload: &[u8], out: &mut [u8]) -> usize {
+    let plen = payload.len().min(CHUNK_PAYLOAD);
+    let mut n = 0;
+    out[..OTAD_PREFIX.len()].copy_from_slice(OTAD_PREFIX);
+    n += OTAD_PREFIX.len();
+    write_id3(target_id, &mut out[n..n + 3]);
+    n += 3;
+    out[n..n + 2].copy_from_slice(&session.to_le_bytes());
+    n += 2;
+    out[n..n + 2].copy_from_slice(&seq.to_le_bytes());
+    n += 2;
+    out[n..n + plen].copy_from_slice(&payload[..plen]);
+    n += plen;
+    n
+}
+
+/// Encode an `OTAN`. `bitmap` is truncated to [`OTAN_BITMAP_BYTES`]; returns the length.
+pub fn encode_otan(origin_id: u8, session: u16, window_base: u16, bitmap: &[u8], out: &mut [u8]) -> usize {
+    let blen = bitmap.len().min(OTAN_BITMAP_BYTES);
+    let mut n = 0;
+    out[..OTAN_PREFIX.len()].copy_from_slice(OTAN_PREFIX);
+    n += OTAN_PREFIX.len();
+    write_id3(origin_id, &mut out[n..n + 3]);
+    n += 3;
+    out[n..n + 2].copy_from_slice(&session.to_le_bytes());
+    n += 2;
+    out[n..n + 2].copy_from_slice(&window_base.to_le_bytes());
+    n += 2;
+    out[n..n + blen].copy_from_slice(&bitmap[..blen]);
+    n += blen;
+    n
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers (id ⇄ 3-ASCII, chunk-count math) — pure, panic-free
+// ---------------------------------------------------------------------------
+
+/// Parse a 3-digit ASCII id (`b"007"` → 7). `None` on short/non-digit/>255.
+fn parse_id3(b: &[u8]) -> Option<u8> {
+    if b.len() < 3 {
+        return None;
+    }
+    let mut v: u16 = 0;
+    for &c in &b[..3] {
+        if !c.is_ascii_digit() {
+            return None;
+        }
+        v = v * 10 + (c - b'0') as u16;
+    }
+    (v <= 255).then_some(v as u8)
+}
+
+/// Write a u8 id as 3 zero-padded ASCII digits into `out[..3]` (caller guarantees len ≥ 3).
+fn write_id3(id: u8, out: &mut [u8]) {
+    out[0] = b'0' + id / 100;
+    out[1] = b'0' + (id / 10) % 10;
+    out[2] = b'0' + id % 10;
+}
+
+/// `ceil(size / CHUNK_PAYLOAD)` — total chunks for an image of `size` bytes. Saturating.
+pub fn total_chunks(size: u32) -> u32 {
+    (size / CHUNK_PAYLOAD as u32).saturating_add((size % CHUNK_PAYLOAD as u32 != 0) as u32)
+}
+
+// ===========================================================================
+// Leaf receive session (the brick-critical path).
+//
+// One transfer at a time (canary). Driven ENTIRELY by inbound frames + a timer, from
+// `RadioManager::service()`. The order of gates is load-bearing and must not be
+// reordered: verify-sig → parse M → freshness gate → begin writer → per-chunk signed
+// bounds → partition-scoped write → readback verify → activate. ANY failure discards
+// with otadata untouched (the good slot boots; a hard brick ⇒ USB recovery, §4).
+// ===========================================================================
+
+use esp_bootloader_esp_idf::ota::Slot;
+
+/// Emit a gap-NAK if a window stays incomplete this long since the last NAK (ms).
+const LEAF_IDLE_NAK_MS: u64 = 500;
+/// Abort the session if NO new chunk arrives for this long (a jam / dead gateway, ms).
+const LEAF_PROGRESS_STALL_MS: u64 = 30_000;
+/// Hard total-session cap (ms) — a runaway transfer aborts → good slot boots (R1: USB).
+const LEAF_SESSION_MAX_MS: u64 = 600_000;
+
+/// What `service()` must do after handing a frame / a tick to the leaf session.
+pub enum LeafAction {
+    /// Nothing to send.
+    None,
+    /// Unicast `out[..len]` (an `OTAN`) back to the gateway's MAC.
+    Nak(usize),
+    /// The image is fully received AND verified (sig + size + readback sha). Activate
+    /// this slot — [`crate::ota::activate`] reboots into it (never returns on success).
+    Complete(Slot),
+    /// The session aborted (bad frame class handled internally) — discard; nothing to send.
+    Abort,
+}
+
+/// One-window reassembly buffer (off the stack, in `.bss`). Alias-safe: exactly one
+/// leaf OTA at a time (canary), single-threaded, single-caller.
+static mut OTA_WINDOW_BUF: [u8; WINDOW_BYTES] = [0u8; WINDOW_BYTES];
+
+/// The leaf's mesh-OTA receive state. Small + `!Copy` (owns the writer handle). Lives
+/// in `RadioManager`; `active` is false except during a transfer.
+pub struct OtaLeafSession {
+    active: bool,
+    session_id: u16,
+    size: u32,
+    sha256: [u8; 32],
+    total_chunks: u32,
+    /// First seq of the current window (always a multiple of `WINDOW_CHUNKS`).
+    window_base: u32,
+    /// Received bitmap for the current window: bit `i` ⇒ chunk `window_base + i` is in buf.
+    window_recv: u64,
+    gateway_mac: [u8; 6],
+    session_deadline_ms: u64,
+    last_new_chunk_ms: u64,
+    last_nak_ms: u64,
+    writer: Option<crate::ota::LeafImageWriter>,
+}
+
+impl OtaLeafSession {
+    pub const fn new() -> Self {
+        Self {
+            active: false,
+            session_id: 0,
+            size: 0,
+            sha256: [0u8; 32],
+            total_chunks: 0,
+            window_base: 0,
+            window_recv: 0,
+            gateway_mac: [0u8; 6],
+            session_deadline_ms: 0,
+            last_new_chunk_ms: 0,
+            last_nak_ms: 0,
+            writer: None,
+        }
+    }
+
+    /// Is a transfer in progress? (Used by `main` to know the mesh is in a maintenance op.)
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    /// The gateway MAC this session locked onto (unicast target for NAKs). Zero if idle.
+    pub fn gateway_mac(&self) -> [u8; 6] {
+        self.gateway_mac
+    }
+
+    /// Discard the session (drop the writer WITHOUT activating → otadata untouched).
+    fn discard(&mut self) {
+        self.active = false;
+        self.window_recv = 0;
+        self.writer = None;
+    }
+
+    /// Handle an `OTAM` (signed announce). VERIFY-SIG-FIRST is the whole point: a frame
+    /// that fails the ed25519 check over `m` changes NO state and costs one verify (never
+    /// a flash op — the DoS/wear bound, attack row E). Then, and only then, parse M and
+    /// apply the freshness gate (`build > running ∧ build > fresh_floor ∧ size ok`).
+    /// `src` is the OTAM sender's MAC (the gateway); `my_id` is this leaf's id.
+    pub fn on_meta(
+        &mut self,
+        target: u8,
+        session: u16,
+        m: &[u8],
+        sig: &[u8; 64],
+        src: [u8; 6],
+        my_id: u8,
+        now: u64,
+    ) -> LeafAction {
+        if target != my_id {
+            return LeafAction::None; // not for us
+        }
+        if self.active && self.session_id == session {
+            return LeafAction::None; // periodic OTAM re-send for the live session — dedupe
+        }
+        // (1) AUTHENTICITY — the SOLE root of trust on the unauth mesh. Fail-closed.
+        if !crate::ota::verify_signature(m, sig) {
+            log::warn!("smol #40: OTAM sig FAILED — ignored (no state, no flash)");
+            return LeafAction::None;
+        }
+        // (2) Only now is M trustworthy → parse build/size/sha.
+        let Some((build, size, sha256)) = crate::ota::parse_manifest(m) else {
+            return LeafAction::None;
+        };
+        // (3) FRESHNESS + size gate (design §3C). Monotonicity ∧ floor ∧ slot bound.
+        if build <= crate::ota::BUILD_NUMBER {
+            log::info!("smol #40: OTAM build {} <= running {} — rejected", build, crate::ota::BUILD_NUMBER);
+            return LeafAction::None;
+        }
+        let floor = crate::ota::fresh_floor_get();
+        if build <= floor {
+            log::info!("smol #40: OTAM build {} <= fresh_floor {} — replay rejected", build, floor);
+            return LeafAction::None;
+        }
+        if size == 0 || size > crate::ota::MAX_IMAGE_SIZE {
+            log::info!("smol #40: OTAM size {} out of range — rejected", size);
+            return LeafAction::None;
+        }
+        // (4) Open the inactive-slot writer. If a prior session was live, its writer is
+        // dropped here (otadata untouched — it was never activated).
+        let Some(writer) = crate::ota::LeafImageWriter::begin() else {
+            log::error!("smol #40: cannot open inactive slot — OTAM ignored");
+            return LeafAction::None;
+        };
+        self.active = true;
+        self.session_id = session;
+        self.size = size;
+        self.sha256 = sha256;
+        self.total_chunks = total_chunks(size);
+        self.window_base = 0;
+        self.window_recv = 0;
+        self.gateway_mac = src;
+        self.session_deadline_ms = now.saturating_add(LEAF_SESSION_MAX_MS);
+        self.last_new_chunk_ms = now;
+        self.last_nak_ms = 0;
+        self.writer = Some(writer);
+        log::info!(
+            "smol #40: mesh-OTA session {} armed — build {} ({} B, {} chunks) from the gateway",
+            session, build, size, self.total_chunks
+        );
+        LeafAction::None
+    }
+
+    /// Number of valid chunks in the window starting at `wb` (the last window is short).
+    fn window_len(&self, wb: u32) -> u32 {
+        core::cmp::min(wb + WINDOW_CHUNKS as u32, self.total_chunks) - wb
+    }
+
+    /// The "all chunks present" bitmap mask for a window of `len` chunks (`len` ≤ 64).
+    fn full_mask(len: u32) -> u64 {
+        if len >= 64 {
+            u64::MAX
+        } else {
+            (1u64 << len) - 1
+        }
+    }
+
+    /// Handle an `OTAD` image chunk. Enforces the HOLE-3 signed bounds BEFORE any buffer
+    /// write, MAC-filters to the locked gateway, routes the chunk into the current window,
+    /// and — on a completed window — flushes it to the (partition-scoped) inactive slot
+    /// and advances (acking with an all-zero NAK). On the final window it finalizes
+    /// (readback verify) and returns `Complete`. `out` receives an OTAN when one is due.
+    pub fn on_data(
+        &mut self,
+        target: u8,
+        session: u16,
+        seq: u16,
+        payload: &[u8],
+        src: [u8; 6],
+        my_id: u8,
+        now: u64,
+        out: &mut [u8],
+    ) -> LeafAction {
+        if target != my_id || !self.active || session != self.session_id {
+            return LeafAction::None;
+        }
+        // R2/R3 defense-in-depth: only accept chunks from the MAC that sent the (signed) OTAM.
+        if src != self.gateway_mac {
+            return LeafAction::None;
+        }
+        let seq = seq as u32;
+        // ---- HOLE-3: signed-bounds every chunk, BEFORE any write. -----------------
+        // Bounds come from the SIGNED manifest (total_chunks/size) → un-tamperable.
+        if seq >= self.total_chunks {
+            return LeafAction::None;
+        }
+        let off = seq * CHUNK_PAYLOAD as u32;
+        // Exact expected length for this seq (full chunk, or the short final chunk). A
+        // wrong-length chunk is refused outright (never buffered) so reassembly can't be
+        // corrupted by a truncated/padded in-range chunk.
+        let expected = if seq == self.total_chunks - 1 {
+            self.size - off
+        } else {
+            CHUNK_PAYLOAD as u32
+        };
+        if payload.len() as u32 != expected {
+            return LeafAction::None;
+        }
+        // (redundant with `expected`, but keep the explicit §E spatial invariant visible)
+        if off + payload.len() as u32 > self.size {
+            return LeafAction::None;
+        }
+
+        let wb = self.window_base;
+        if seq < wb {
+            // A chunk for an ALREADY-COMPLETED window → the gateway didn't get our
+            // advance-ack. Re-send an all-zero NAK for that window (idempotent advance).
+            let acked_base = (seq / WINDOW_CHUNKS as u32) * WINDOW_CHUNKS as u32;
+            let zero = [0u8; OTAN_BITMAP_BYTES];
+            let n = encode_otan(my_id, self.session_id, acked_base as u16, &zero, out);
+            return LeafAction::Nak(n);
+        }
+        if seq >= wb + WINDOW_CHUNKS as u32 {
+            return LeafAction::None; // future window — gateway advances in order; ignore
+        }
+
+        // In the current window: buffer the payload at its window-relative offset.
+        let i = (seq - wb) as usize;
+        let bit = 1u64 << i;
+        let buf = unsafe { &mut *core::ptr::addr_of_mut!(OTA_WINDOW_BUF) };
+        let base = i * CHUNK_PAYLOAD;
+        buf[base..base + payload.len()].copy_from_slice(payload);
+        if self.window_recv & bit == 0 {
+            self.window_recv |= bit;
+            self.last_new_chunk_ms = now; // genuine progress (the hard-cap deadline is fixed)
+        }
+
+        // Window complete?
+        let wlen = self.window_len(wb);
+        let mask = Self::full_mask(wlen);
+        if self.window_recv & mask != mask {
+            return LeafAction::None; // still gaps — the idle timer will NAK them
+        }
+
+        // ---- Window complete → flush to the inactive slot (partition-scoped). -----
+        let window_bytes = core::cmp::min(WINDOW_BYTES as u32, self.size - wb * CHUNK_PAYLOAD as u32) as usize;
+        let ok = match self.writer.as_mut() {
+            Some(w) => w.feed_window(&buf[..window_bytes]),
+            None => false,
+        };
+        if !ok {
+            log::error!("smol #40: flash write failed at window {} — session discarded", wb);
+            self.discard();
+            return LeafAction::Abort;
+        }
+        // Advance.
+        self.window_base = wb + WINDOW_CHUNKS as u32;
+        self.window_recv = 0;
+        self.last_new_chunk_ms = now;
+        self.last_nak_ms = now;
+
+        if self.window_base < self.total_chunks {
+            // More windows: ack this one (all-zero NAK) so the gateway sends the next.
+            let zero = [0u8; OTAN_BITMAP_BYTES];
+            let n = encode_otan(my_id, self.session_id, wb as u16, &zero, out);
+            return LeafAction::Nak(n);
+        }
+
+        // ---- LAST window done → FINALIZE (readback verify) → activate. ------------
+        let (size, sha) = (self.size, self.sha256);
+        let writer = self.writer.take();
+        self.active = false;
+        match writer {
+            Some(w) => {
+                let target_slot = w.target();
+                if w.finalize(size, &sha) {
+                    log::info!("smol #40: image VERIFIED (readback SHA-256, ed25519 already ok) — activating");
+                    LeafAction::Complete(target_slot)
+                } else {
+                    log::error!("smol #40: readback verify FAILED — discarded (good slot intact)");
+                    LeafAction::Abort
+                }
+            }
+            None => LeafAction::Abort,
+        }
+    }
+
+    /// Timer nudge (call each `service()` pass). Emits a gap-NAK for the current window if
+    /// it has stalled, and aborts the session on a progress stall / hard-cap timeout.
+    pub fn tick(&mut self, my_id: u8, now: u64, out: &mut [u8]) -> LeafAction {
+        if !self.active {
+            return LeafAction::None;
+        }
+        if now >= self.session_deadline_ms
+            || now.saturating_sub(self.last_new_chunk_ms) >= LEAF_PROGRESS_STALL_MS
+        {
+            log::warn!("smol #40: mesh-OTA stalled — session discarded (good slot intact; USB recovery)");
+            self.discard();
+            return LeafAction::Abort;
+        }
+        if now.saturating_sub(self.last_nak_ms) < LEAF_IDLE_NAK_MS {
+            return LeafAction::None; // throttle
+        }
+        // Current window incomplete → NAK its missing chunks.
+        let wb = self.window_base;
+        let wlen = self.window_len(wb);
+        let mask = Self::full_mask(wlen);
+        let missing = mask & !self.window_recv;
+        if missing == 0 {
+            return LeafAction::None; // complete (an advance-ack is pending elsewhere)
+        }
+        self.last_nak_ms = now;
+        let n = encode_otan(my_id, self.session_id, wb as u16, &missing.to_le_bytes(), out);
+        LeafAction::Nak(n)
+    }
+}

--- a/tools/ota_publish.sh
+++ b/tools/ota_publish.sh
@@ -106,6 +106,14 @@ if [ -n "$BUILD_OVERRIDE" ]; then
 fi
 
 # ---- build (or take a prebuilt .bin) ----------------------------------------
+# #40 IDENTITY — the staged image is FLEET-SHARED BY DESIGN: it is built with NO
+# SMOL_NODE_ID, so it bakes the board.rs default id (7). That default is ONLY a factory
+# seed — every radio node reads its TRUE id from the `nvs` partition at runtime
+# (ota.rs::resolve_node_id, seeded on the first USB boot after an erase-flash). OTA never
+# touches `nvs`, so a single image installs onto id7/id8/id9/... and each KEEPS its own
+# identity. DO NOT add SMOL_NODE_ID here (that would re-fragment one image per node); and
+# do NOT USB-flash this staged .bin as a factory image without SMOL_NODE_ID=<n>, or a
+# fresh (erased) board would seed NVS to the default id 7.
 if [ -z "$BIN" ]; then
   echo "building espnow release @ $HASH (build $BUILD) ..."
   ( cd "$CLOCK" && SMOL_GIT_HASH="$HASH" SMOL_BUILD_NUMBER="$BUILD" \


### PR DESCRIPTION
Delivers **#40 leaf-mesh-OTA** to the LOCKED design (`issue-40-leaf-mesh-ota-design.md` §E + §A–D; `leaf-mesh-ota-design.md` §0–6; `leaf-boot-selftest-spec.md`). Single-hop, **canary-one-leaf**. **BRICK-CLASS** — a bug can brick a mesh-only leaf (USB-recovery only), so the leaf path is the focus.

## Data path
Gateway fetches the fleet-staged, ed25519-signed image into its **own inactive slot** (§D#1, no activate) → relays it chunk-by-chunk over ESP-NOW to ONE leaf (windowed-NAK) → the leaf **verifies the signature BEFORE it flashes**, reassembles into its inactive slot (partition-scoped), and activates only on a full size + readback-sha match → role-aware self-test confirms or app-side rolls back.

## Brick-critical invariants (all honored — see handoff §2)
- **verify-sig BEFORE any flash op** (leaf `on_meta`); a bad sig changes no state.
- **HOLE-3** signed-bounds every chunk before any write; **HOLE-3b** partition-scoped writer (`as_embedded_storage`→`FlashRegion`, errors `OutOfBounds`) — an OOB `seq` physically can't reach the active slot/otadata.
- **readback-sha** of `slot[..size]` before activate; otadata untouched on any failure.
- **signed-freshness floor** (NVS, torn-write-safe) + **K-counter** (RTC-fast) + **HOLE-1 role-aware self-test** (leaf = heard-a-mesh-frame, not DHCP).
- **canary-one-leaf** — targets exactly one MAC; no broadcast image push anywhere.

## Compile
`default` / `wifi` / `espnow` / `wled` all build; **espnow 0 warnings**. Default byte-behavior-unchanged (all #40 code cfg-gated). **NOT flashed** — team-lead owns the MAC-guarded canary.

## Adversarial audit
Found + fixed one real bug: the Tier-2 confirm loop could false-verdict on a STALE old-build STAT buffered during the relay — now drains the queue + samples the settled build (`155646f`).

## Scope note
Install trigger works end-to-end (`ota_publish.sh install <leaf>`). The HA Update-entity **discovery/state publish** (§B2, pure observability, deep untestable MQTT-burst threading) is specified precisely for a hardware-validated follow-up — see handoff §4.

**Full handoff + canary test plan (happy path / rollback proof / K-counter / floor-replay):** `scratch/smol-ha-batt/lucid-40-build-handoff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)