### PR TITLE
fix(ha): #40 harden dashboard Update-entity match (nounless object_id drift)

### DIFF
--- a/ha/dashboard/build_control_room.py
+++ b/ha/dashboard/build_control_room.py
@@ -144,7 +144,10 @@ def node_card(nid, meta, present):
             {"entity":f"sensor.smol_{nid}_peers","name":"peers / roster","icon":"mdi:lan"}]}}
     # ---- ctrl_bottom: firmware + install (always last → rounded bottom) ----
     bot=[{"type":"section","label":"firmware"}]
-    fw=next((e for e in present if re.match(rf"update\.smol_{nid}_.*_update$",e)),None)
+    # #40 changed the Update discovery object_id noun-based → nounless (smol_<id>_update, wifi.rs 5efee40),
+    # so match BOTH the legacy noun form (update.smol_<id>_<noun>_update, kept by HA registry stickiness on
+    # id7/8/9) AND the new nounless form a fresh node (id10+) / a registry reset now creates.
+    fw=next((e for e in present if re.match(rf"update\.smol_{nid}(_.*)?_update$",e)),None)
     if fw: bot.append({"entity":fw,"name":"firmware (version + update)"})
     inst=f"input_button.smol_ota_install_{nid}"
     if inst in present: bot.append({"entity":inst,"name":"Install staged (gateway consumes)","icon":"mdi:rocket-launch"})


### PR DESCRIPTION
## What
Post-#40-merge validation of `ha/` surfaced one real **entity-name drift** #40 introduced, and fixes it.

## The drift
#40 (`5efee40`) changed the MQTT Update-entity discovery `object_id` from noun-based (`smol_<id>_<noun>`) to **nounless** (`smol_<id>_update`). Today id7/8/9 still resolve to the legacy `update.smol_<id>_<noun>_update` **only via HA entity-registry stickiness** — but a **fresh node (id10+) or any registry reset** now creates `update.smol_<id>_update`, which the node-box regex `update\.smol_<id>_.*_update$` **fails to match** → a missing firmware/install row for that node.

## The fix
Widen the match to `update\.smol_<id>(_.*)?_update$` — matches **both** the legacy noun form and the new nounless form, still excludes non-update entities (`_status`, etc.). One line in `build_control_room.py`.

## Verification
- Unit-tested the regex against both entity forms + a negative case.
- **Deployed** via WS `lovelace/config/save` and verified live: all 3 firmware Update rows resolve (`update.smol_{7_dominion,8_nexus,9_herald}_update`), OTA relay-progress UX intact (27 relaydiag refs, 3 MESH-OTA chips, 6 install buttons).

## Also validated (clean — no change needed)
- `ha/packages/smol_mesh.yaml` is **byte-identical to the live VM** (repo↔live converged); all 4 OTA sensor families present (build/diag/armdiag/relaydiag).
- `smol/<id>/ota/state` is the firmware-emitted Update-entity state topic (self-contained discovery), **not** a missing sensor.
- nebula's docs-truthup is entirely `docs/` + `README.md` (out of `ha/` scope); it confirms HA entity names are already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)