### PR TITLE
#44 reproducible fleet images — verify image↔commit by sha256

### DIFF
--- a/docs/ota.md
+++ b/docs/ota.md
@@ -113,6 +113,37 @@ example:   OTA|52|590304|6122578e…60ea|http://<image-host>:8080/ota/smol-52.bi
 - `sha256` — 64 lowercase hex over the exact `.bin`; the integrity gate.
 - `url` — HTTP (no TLS in `no_std`); it's the **last** field so it may contain no `|`.
 
+## Reproducible builds — verify image ↔ commit before/after a flash (#44)
+
+The release image is **byte-reproducible for a fixed commit**: build it on any machine and
+you get the same `.bin`, hence the same `sha256`. Three things make it deterministic — the
+version stamp is pinned from the commit (`SMOL_GIT_HASH`/`SMOL_BUILD_NUMBER`, the build.rs
+deploy contract); absolute build paths are canonicalised with `--remap-path-prefix`
+(dependency + `build-std` `file!()` strings would otherwise embed `$CARGO_HOME`/the rustc
+sysroot and differ per machine); and `SOURCE_DATE_EPOCH` is pinned to the commit's own time
+(esp-bootloader-esp-idf otherwise stamps the app descriptor from the wall clock). The
+mechanism lives in `tools/repro_build.sh`; a plain `cargo build` is untouched (all of it is
+applied only by the release/verify tooling).
+
+So the announced `sha256` is a stable **identity** you can check against what's actually on a
+board — which is exactly what would have caught the dup-`NODE_ID` outage (#42): the wrong
+image flashed to id8/id9 could not be detected by an image↔board hash check because the build
+wasn't reproducible.
+
+```
+tools/verify_image.sh <commit>                 # build → prints  build size sha256
+tools/verify_image.sh <commit> --expect <sha>  # exit 0 if the image is that commit, 3 if not
+tools/verify_image.sh <commit> --twice         # proof: two isolated builds → identical sha
+tools/verify_image.sh --bin <file>             # just hash an existing .bin (no build)
+```
+
+`ota_publish.sh stage` builds through the same reproducible path, so the sha it announces is
+the sha `verify_image.sh` reproduces. Since #40's runtime-NVS node-id, one image serves the
+whole fleet (the OTA image carries no `SMOL_NODE_ID`; each board reads its id from `nvs` at
+runtime) — so there's **one sha per commit**, no board dimension. `verify_image.sh <commit>`
+with no `--node-id` reproduces that fleet sha; `--node-id N` is only for a USB **factory**
+image built with `SMOL_NODE_ID=N`.
+
 ## How recovery works (why canary is enough)
 
 Three layers, in order of how bad the image is:

--- a/tools/ota_publish.sh
+++ b/tools/ota_publish.sh
@@ -29,6 +29,10 @@ set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLOCK="$REPO/rust/clock"
 ESPFLASH="${ESPFLASH:-$HOME/.cargo/bin/espflash}"
+# #44: reproducible-build helpers — the release build below goes through repro_build_bin so
+# the announced sha256 is a stable, verifiable (commit) identity (see tools/verify_image.sh).
+# shellcheck source=tools/repro_build.sh
+. "$(dirname "${BASH_SOURCE[0]}")/repro_build.sh"
 # ⚙️ INFRA CONFIG — the defaults below are non-real PLACEHOLDERS (this repo is public).
 # Put YOUR real infra in a git-ignored `tools/ota_publish.env` (copy the tracked
 # `tools/ota_publish.env.example` → `tools/ota_publish.env`, edit) — it's sourced here if
@@ -114,13 +118,15 @@ fi
 # identity. DO NOT add SMOL_NODE_ID here (that would re-fragment one image per node); and
 # do NOT USB-flash this staged .bin as a factory image without SMOL_NODE_ID=<n>, or a
 # fresh (erased) board would seed NVS to the default id 7.
+# #44 REPRODUCIBLE — repro_build_bin pins the version stamp (as before) AND remaps absolute
+# build paths + pins SOURCE_DATE_EPOCH, so the same commit built anywhere yields the same
+# bytes → the SHA below is a stable identity an operator can pre/post-flash verify with
+# `verify_image.sh <commit>`. No node-id here is consistent with the fleet-shared design
+# above: ONE reproducible image, one sha per commit for the whole fleet.
 if [ -z "$BIN" ]; then
-  echo "building espnow release @ $HASH (build $BUILD) ..."
-  ( cd "$CLOCK" && SMOL_GIT_HASH="$HASH" SMOL_BUILD_NUMBER="$BUILD" \
-      cargo build --release --features espnow )
-  ELF="$CLOCK/target/riscv32imc-unknown-none-elf/release/clock"
+  echo "building reproducible espnow release @ $HASH (build $BUILD) ..."
   BIN="/tmp/smol-${BUILD}.bin"
-  "$ESPFLASH" save-image --chip esp32c3 "$ELF" "$BIN" >/dev/null
+  repro_build_bin "$CLOCK" "$BIN" "$HASH" "$BUILD" || die "reproducible build failed"
 fi
 [ -f "$BIN" ] || die "no image at $BIN"
 

--- a/tools/repro_build.sh
+++ b/tools/repro_build.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# repro_build.sh — reproducible fleet-image build helpers (issue #44). SOURCE this file;
+# it defines shell functions, runs nothing on its own.
+#
+# ── WHY ──────────────────────────────────────────────────────────────────────
+# The smol release ELF was not hash-reproducible: rustc embeds ABSOLUTE build paths
+# (panic `file!()` location strings) for every dependency and every build-std crate —
+#     ~$CARGO_HOME/registry/src/…/<dep>/src/lib.rs      (deps; ~62 strings)
+#     <rustc-sysroot>/lib/rustlib/src/rust/library/…    (core/alloc; ~3 strings)
+# Those roots differ per build host / working-dir / user, so the SAME (commit, node-id)
+# built on two machines produced different bytes → different sha256. That's why an OTA
+# image couldn't be hash-verified against its source commit/board, which compounded the
+# dup-NODE_ID outage (#42): the wrong image flashed to id8/id9 couldn't be caught by an
+# image↔board hash check. (The git version stamp is NOT the cause — the release pipeline
+# already pins it via SMOL_GIT_HASH/SMOL_BUILD_NUMBER, so it is deterministic per commit.)
+#
+# A SECOND source: esp-bootloader-esp-idf's build.rs stamps the esp_app_desc time/date from
+# `Timestamp::now()` (wall clock) unless SOURCE_DATE_EPOCH is set, so two builds of the same
+# commit differ by minutes even with paths remapped.
+#
+# ── FIX ──────────────────────────────────────────────────────────────────────
+# (1) Canonicalise the two path roots with `--remap-path-prefix` so the embedded strings are
+# identical on every machine (`/registry`, `/rust`). The SOURCE prefixes are machine-relative
+# (computed here from $CARGO_HOME + `rustc --print sysroot`); the TARGET tokens are fixed.
+# (2) Pin SOURCE_DATE_EPOCH to the COMMIT's Unix time so the app-descriptor timestamp is
+# deterministic per commit. Result: byte-reproducible image for a fixed (commit, node-id) → a
+# stable, verifiable sha256. Bonus: no `$HOME` path leaks into the public repo's binaries.
+#
+# ── DEFAULT-BUILD INVARIANT ───────────────────────────────────────────────────
+# These flags are applied ONLY when a caller opts in (ota_publish.sh / verify_image.sh
+# source this and splice REPRO_CARGO_ARGS into their `cargo build`). Nothing in
+# .cargo/config.toml or any source file changes, so a plain `cargo build` is byte-for-byte
+# whatever it was before — the default build is provably untouched (no cfg, no source edit).
+
+# The bare-metal target the fleet builds for (matches .cargo/config.toml `build.target`).
+REPRO_TARGET="riscv32imc-unknown-none-elf"
+
+# Resolve the rustc sysroot for the toolchain that will ACTUALLY build — rustup picks it from
+# the crate's rust-toolchain.toml, so this MUST be evaluated inside the crate dir (from home it
+# would return `stable`, not the pinned 1.96.1, and the remap prefix would miss the build-std
+# paths). Arg $1 = crate dir (default ".").
+repro_sysroot() {
+  local crate_dir="${1:-.}"
+  ( cd "$crate_dir" 2>/dev/null && "${RUSTC:-rustc}" --print sysroot 2>/dev/null ) || true
+}
+
+# Echo the machine-specific --remap-path-prefix flags (space-separated). Fixed targets
+# (/registry, /rust) ⇒ identical embedded strings on any host. Fails loudly if the rustc
+# sysroot can't be resolved (an un-remapped root would silently break reproducibility).
+# Arg $1 = crate dir to resolve the toolchain sysroot from (default ".").
+repro_remap_flags() {
+  local reg sysroot
+  reg="${CARGO_HOME:-$HOME/.cargo}/registry"
+  sysroot="$(repro_sysroot "${1:-.}")"
+  [ -n "$sysroot" ] || { echo "repro_build: could not resolve rustc sysroot — cannot remap build-std paths" >&2; return 1; }
+  printf -- '--remap-path-prefix=%s=/registry --remap-path-prefix=%s=/rust' "$reg" "$sysroot"
+}
+
+# Populate the global array REPRO_CARGO_ARGS with the `--config` override that JOINS the
+# remap flags onto the target's config-file rustflags (so the linker flags in
+# .cargo/config.toml are preserved — an env RUSTFLAGS would REPLACE, not extend, them).
+# Callers splice: `cargo build --release … "${REPRO_CARGO_ARGS[@]}"`.
+# Arg $1 = crate dir to resolve the toolchain sysroot from (default ".").
+repro_cargo_args() {
+  local reg sysroot
+  reg="${CARGO_HOME:-$HOME/.cargo}/registry"
+  sysroot="$(repro_sysroot "${1:-.}")"
+  [ -n "$sysroot" ] || { echo "repro_build: could not resolve rustc sysroot — cannot remap build-std paths" >&2; return 1; }
+  REPRO_CARGO_ARGS=(
+    --config "target.${REPRO_TARGET}.rustflags=[\"--remap-path-prefix=${reg}=/registry\",\"--remap-path-prefix=${sysroot}=/rust\"]"
+  )
+}
+
+# repro_build_bin <clock_dir> <out_bin> <hash> <build_number> [node_id]
+# Reproducibly build the espnow release image for (commit-identity, [node-id]) and write
+# the flashable .bin to <out_bin>. Pins the version stamp via the build.rs env contract,
+# applies the path remap, and extracts the image with `espflash save-image`. Echoes nothing
+# on success (the caller reads <out_bin>); returns non-zero on any step failure.
+repro_build_bin() {
+  local clock="$1" out="$2" hash="$3" number="$4" node_id="${5:-}"
+  local espflash="${ESPFLASH:-$HOME/.cargo/bin/espflash}"
+  repro_cargo_args "$clock" || return 1   # resolve the sysroot with the crate's pinned toolchain
+  # #44: pin the esp-bootloader-esp-idf app-descriptor build time. Its build.rs fills the
+  # esp_app_desc time/date from `Timestamp::now()` (wall clock) UNLESS SOURCE_DATE_EPOCH is
+  # set — so without this, two builds of the same commit differ (even with paths remapped).
+  # Pin it to the COMMIT's own Unix time ⇒ deterministic per commit. Precedence: a caller/CI
+  # SOURCE_DATE_EPOCH wins (archive builds with no .git); else the commit time; else a fixed
+  # constant so the build is deterministic even with neither.
+  local sde="${SOURCE_DATE_EPOCH:-}"
+  if [ -z "$sde" ]; then
+    sde="$(git -C "$clock" show -s --format=%ct "$hash" 2>/dev/null || true)"
+    [ -n "$sde" ] || sde=1000000000
+  fi
+  (
+    cd "$clock" || exit 1
+    # Pin identity (deterministic per commit); SMOL_NODE_ID only when a board is named
+    # (empty ⇒ build.rs omits it ⇒ board.rs NODE_ID fallback — the fleet-shared image).
+    export SMOL_GIT_HASH="$hash" SMOL_BUILD_NUMBER="$number" SOURCE_DATE_EPOCH="$sde"
+    [ -n "$node_id" ] && export SMOL_NODE_ID="$node_id"
+    cargo build --release --features espnow "${REPRO_CARGO_ARGS[@]}"
+  ) || return 1
+  # Honor CARGO_TARGET_DIR (verify_image.sh --twice points each build at an isolated dir);
+  # default to the in-tree target/ (ota_publish.sh's path) when unset.
+  local tdir="${CARGO_TARGET_DIR:-$clock/target}"
+  "$espflash" save-image --chip esp32c3 \
+    "$tdir/${REPRO_TARGET}/release/clock" "$out" >/dev/null || return 1
+}

--- a/tools/verify_image.sh
+++ b/tools/verify_image.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# verify_image.sh — reproducibly build a smol fleet image and print/verify its hash (#44).
+#
+# The release ELF is now byte-reproducible for a fixed (commit, node-id) — see
+# tools/repro_build.sh. This tool turns that into an image↔commit↔board CHECK you can run
+# before OR after a flash, so a wrong-image flash (the dup-NODE_ID outage, #42) is catchable:
+#
+#   verify_image.sh [<commit>] [--node-id N]        # build → print  build size sha256
+#   verify_image.sh [<commit>] [--node-id N] --expect <sha256>   # exit 0 match / 3 mismatch
+#   verify_image.sh --bin <file>                    # just hash an existing .bin (no build)
+#   verify_image.sh [<commit>] [--node-id N] --twice # PROVE determinism: 2 isolated builds,
+#                                                    # assert identical sha + no leaked paths
+#
+# <commit> defaults to HEAD. Read-only: NO flashing, NO MQTT, NO network — pure local build
+# + sha256. Mirrors the identity contract of ota_publish.sh (same SMOL_GIT_HASH/BUILD_NUMBER
+# pin, same espflash save-image), so a sha printed here equals the one that tool announces.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLOCK="$REPO/rust/clock"
+# shellcheck source=tools/repro_build.sh
+. "$(dirname "${BASH_SOURCE[0]}")/repro_build.sh"
+
+die(){ echo "ERROR: $*" >&2; exit 1; }
+
+COMMIT="HEAD"; NODE_ID=""; EXPECT=""; BIN=""; TWICE=0
+while [ $# -gt 0 ]; do case "$1" in
+  --node-id) NODE_ID="${2:?}"; shift 2;;
+  --expect)  EXPECT="${2:?}"; shift 2;;
+  --bin)     BIN="${2:?}"; shift 2;;
+  --twice)   TWICE=1; shift;;
+  -h|--help) sed -n '2,17p' "${BASH_SOURCE[0]}"; exit 0;;
+  *)         COMMIT="$1"; shift;;
+esac; done
+[ -z "$NODE_ID" ] || case "$NODE_ID" in *[!0-9]*|'') die "--node-id must be a positive integer";; esac
+
+# --bin: hash an existing image, no build (parity with ota_publish.sh --bin).
+if [ -n "$BIN" ]; then
+  [ -f "$BIN" ] || die "no image at $BIN"
+  printf 'bin=%s  size=%s  sha256=%s\n' "$BIN" "$(stat -c%s "$BIN")" "$(sha256sum "$BIN" | cut -d' ' -f1)"
+  exit 0
+fi
+
+cd "$REPO"
+HASH="$(git rev-parse --short=7 "$COMMIT")" || die "bad commit '$COMMIT'"
+BUILD="$(git rev-list --count "$COMMIT")"
+LABEL="build $BUILD ($HASH)${NODE_ID:+ node $NODE_ID}"
+
+# Build into an ISOLATED target dir so a repeat build is a true from-scratch rebuild (and so
+# --twice proves target-dir/path independence, not just a warm-cache no-op). Cleaned on exit.
+build_once() { # <target_dir> <out_bin>
+  local tdir="$1" out="$2"
+  CARGO_TARGET_DIR="$tdir" repro_build_bin "$CLOCK" "$out" "$HASH" "$BUILD" "$NODE_ID" \
+    || die "reproducible build failed ($LABEL)"
+}
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+echo "building reproducible espnow image — $LABEL ..." >&2
+build_once "$WORK/t1" "$WORK/a.bin"
+SIZE="$(stat -c%s "$WORK/a.bin")"; SHA="$(sha256sum "$WORK/a.bin" | cut -d' ' -f1)"
+
+# Reproducibility self-check: no absolute build path may survive in the shipped image.
+if strings "$WORK/a.bin" | grep -qE '/home/|/Users/|\.cargo/registry|/rustlib/'; then
+  echo "WARN: absolute build paths still present in the image — remap incomplete:" >&2
+  strings "$WORK/a.bin" | grep -oE '(/home/|/Users/)[^ ]*|[^ ]*\.cargo/registry[^ ]*|[^ ]*/rustlib/[^ ]*' | sort -u | head -5 >&2
+fi
+
+if [ "$TWICE" = 1 ]; then
+  echo "second isolated build to prove determinism ..." >&2
+  build_once "$WORK/t2" "$WORK/b.bin"
+  SHA2="$(sha256sum "$WORK/b.bin" | cut -d' ' -f1)"
+  if [ "$SHA" = "$SHA2" ]; then
+    echo "REPRODUCIBLE ✓  two isolated builds → identical sha256  ($LABEL)"
+  else
+    echo "NOT REPRODUCIBLE ✗  $SHA != $SHA2  ($LABEL)" >&2
+    exit 4
+  fi
+fi
+
+printf 'build=%s hash=%s%s size=%s sha256=%s\n' \
+  "$BUILD" "$HASH" "${NODE_ID:+ node=$NODE_ID}" "$SIZE" "$SHA"
+
+if [ -n "$EXPECT" ]; then
+  if [ "$SHA" = "$EXPECT" ]; then
+    echo "MATCH ✓  image is $LABEL"
+  else
+    echo "MISMATCH ✗  expected $EXPECT  got $SHA  — flashed image is NOT $LABEL" >&2
+    exit 3
+  fi
+fi


### PR DESCRIPTION
Closes #44.

## Problem
The release ELF wasn't hash-reproducible, so a flashed/OTA'd image couldn't be verified against its source commit by hash — which compounded the dup-`NODE_ID` outage (#42): the wrong image on id8/id9 was uncatchable by an image↔board hash check.

## Root cause (two sources, both proven)
1. **Absolute build paths** — deps (`$CARGO_HOME/registry`) + `build-std` (rustc sysroot) `file!()` strings embed per-machine paths (65× `/home/jp` in the release ELF).
2. **App-descriptor timestamp** — `esp-bootloader-esp-idf` stamps `esp_app_desc` time/date from `Timestamp::now()` unless `SOURCE_DATE_EPOCH` is set.

(The git version stamp was never the cause — `ota_publish.sh` already pins `SMOL_GIT_HASH`/`SMOL_BUILD_NUMBER`.)

## Fix (invocation-scoped — default `cargo build` provably untouched; no cfg, no source edit)
- `--remap-path-prefix` registry + sysroot → fixed `/registry`,`/rust` tokens (sources computed per-machine, targets fixed).
- `SOURCE_DATE_EPOCH` pinned to the commit's own Unix time (deterministic per commit; env-override + fixed fallback).

## Files
- `tools/repro_build.sh` (new) — sourceable helper: pinned + remapped release build → `espflash save-image`.
- `tools/verify_image.sh` (new) — `verify_image.sh <commit> [--node-id N] [--expect <sha>] [--twice] [--bin f]`; read-only, no MQTT/network.
- `tools/ota_publish.sh` — routes its build through `repro_build_bin` so the **announced sha** is the reproducible identity. (Rebase note: kept #40's fleet-shared-identity block + this routing — complementary.)
- `docs/ota.md` — reproducible-builds + verification section (present-tense re #40's runtime-NVS: one sha per commit for the whole fleet).

## Proof
Two isolated cold builds of HEAD (`6bbaff3`, on d7f3ec9) → **identical sha256** `7cf753d8799cf9fc44c97e44ca076d874cd5c6eac7806d5b1f2c602db5cfa9ba` (size 1003584); zero absolute paths in the `.bin`. Bonus: no `$HOME` path leaks into the public repo's shipped binaries.

## Review notes
- Touches the **release/signing pipeline** (`ota_publish.sh`) — worth an oracle diff pass.
- **Changes shipped-binary contents** (path remap + pinned timestamp) — worth a hygiene lens.
- `shellcheck -x` clean on the new scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)