### PR TITLE
[HOLD-FOR-MORNING-CANARY] #56 generalize the CFG mesh-relay to a keyed channel <NNN><KEY><value>

### DIFF
--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -128,6 +128,25 @@ input_boolean:
     icon: "mdi:pencil"
 
 # =====================================================================
+# KEYED CFG RELAY (issue #56) — the ONE wire that carries ALL per-node config
+# to the credential-less, ESP-NOW-only leaves.
+# ---------------------------------------------------------------------
+# A gateway subscribes each retained config topic below and re-broadcasts it to
+# its leaves as a SINGLE keyed ESP-NOW frame — `SMOLv1 CFG <NNN><KEY><value>` —
+# on the ~10 s cadence (NNN = 3-digit target leaf id; KEY = 1 ASCII channel byte;
+# value = the verbatim retained payload). The leaf DISPATCHES on KEY and ignores
+# any key its firmware predates (forward-compat). Topic → KEY contract:
+#     smol/<id>/config/default_screen  → S   (screen, issue #21)   ← the ONLY key #56 ships
+#     smol/<id>/config/led             → L   (blue-LED mode, #48)
+#     smol/config/units                → U   (display units, GLOBAL/#43)
+#     smol/<id>/config/plugins         → P   (plugin-enable mask, #55; topic TBD)
+# #56 is FOUNDATION ONLY: the firmware relays the S channel (default_screen) exactly
+# as before — this file's default_screen PUBLISH half is UNCHANGED, and a leaf keeps
+# converging on its dashboard-set screen. The L/U/(P) topics + GUI below already exist
+# HA-side; their gateway relay + leaf apply land with #48/#43/#55 (each adds one fill
+# site + one dispatch arm on top of this keyed channel — no new wire frame). HA never
+# emits a KEY: it publishes to the topic, the gateway maps topic → KEY on relay.
+# =====================================================================
 # NODE MANAGER (issue #21) — remotely set each node's DEFAULT SCREEN + page
 # via retained  smol/<id>/config/default_screen = <AppKind>:<page>.
 # Protocol LOCKED per nodemgr-design.md §2. This is the HA PUBLISH/GUI half;

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -992,7 +992,10 @@ fn main() -> ! {
             if let Some(c) = r.take_config_offer() {
                 Some(c)
             } else {
-                r.take_cfg_offer()
+                // #56: pull the SCREEN config channel (`S`) of the keyed CFG relay. Future
+                // channels (#48 led / #43 units / #55 plugins) each add their own
+                // `take_cfg_offer(key)` + apply beside this one — the S path is unchanged.
+                r.take_cfg_offer(crate::net::CFG_KEY_SCREEN)
                     .and_then(|o| app::parse_default_screen(&o.buf[..o.len]))
             }
         });

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -33,6 +33,14 @@ pub mod names;
 #[cfg(feature = "wifi")]
 pub use wifi::WifiPeripherals;
 
+// #56 keyed CFG: re-export the screen config-channel key so `main` (crate root, outside
+// this module) can name it when pulling the screen offer from the keyed relay. `wifi` is
+// private to `net`; `mode`/`wifi` reach the const directly, but `main` needs this bridge.
+// espnow-gated: `main` consumes it ONLY on the leaf-apply path (`take_cfg_offer`), which is
+// espnow-only — a wifi-only build reaches the const in-module (no re-export → no unused-import).
+#[cfg(feature = "espnow")]
+pub use wifi::CFG_KEY_SCREEN;
+
 // `try_time_sync` is the Phase-2 entry point; under `espnow`, `main` calls
 // `mode::start` instead, so only re-export it when espnow is NOT enabled.
 #[cfg(all(feature = "wifi", not(feature = "espnow")))]

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -156,17 +156,31 @@ const GRID_PREFIX: &[u8] = b"SMOLv1 GRID "; // + verbatim "GRID|l1|l2|l3"
 /// Max GRID payload retained/echoed — matches `GridCache` (LOCKED ≤ 96 B).
 const GRID_PAYLOAD_MAX: usize = 96;
 
-/// #21 leaf-relay config-downlink tag: `"SMOLv1 CFG "` (11 B, trailing space) then
-/// `"NNN"` (3-ASCII zero-padded TARGET leaf id) then the VERBATIM default-screen
-/// value (`<AppKind>:<page>`, empty = clear). Diverges from HELLO/BATT/GRID/TIME/OTA
-/// at byte 7 (`'C'`), so `strip_prefix` never confuses them. Single-hop gateway →
-/// leaf (leaves never re-broadcast). **HARD BOUNDARY (oracle R-P3, §0 of the #21
-/// design):** this frame carries SCREEN CONFIG ONLY — never OTA/url/install. It's a
-/// low-blast, reversible, escapable command (long-press → Menu is universal), so a
-/// forged frame's worst case is a valid screen or an ignore — never code exec, never
-/// a brick. The value length is bounded by `CFG_VALUE_MAX`; the leaf validates it
-/// with the strict/panic-free `parse_default_screen`.
-const CFG_PREFIX: &[u8] = b"SMOLv1 CFG "; // + "NNN" + verbatim "<AppKind>:<page>"
+/// #21/#56 leaf-relay config-downlink tag: `"SMOLv1 CFG "` (11 B, trailing space) then
+/// `"NNN"` (3-ASCII zero-padded TARGET leaf id), then a 1-byte config `KEY` (#56), then
+/// the VERBATIM value for that channel (empty = clear). Diverges from HELLO/BATT/GRID/
+/// TIME/OTA at byte 7 (`'C'`), so `strip_prefix` never confuses them. Single-hop gateway
+/// → leaf (leaves never re-broadcast).
+///
+/// **#56 keyed channel:** ONE relay carries N per-node config types — the KEY dispatches:
+/// `S` = default screen (#21; the ONLY channel #56 ships) · `L` = blue-LED mode (#48) ·
+/// `U` = display units (#43) · `P` = plugin-enable mask (#55). A leaf applies only the keys
+/// in [`CFG_APPLY_KEYS`]; a key its firmware predates is DROPPED (forward-compat, the #46
+/// clamp discipline — never mis-applied). Back-compat: a key-less frame (id only, empty
+/// tail) is read as an empty-value clear on the SCREEN key, matching the pre-#56 wire.
+///
+/// **HARD BOUNDARY (oracle R-P3, §0 of the #21 design):** the SCREEN key carries screen
+/// config ONLY — never OTA/url/install. It's a low-blast, reversible, escapable command
+/// (long-press → Menu is universal), so a forged frame's worst case is a valid screen or an
+/// ignore — never code exec, never a brick. Each key's value is bounded by `CFG_VALUE_MAX`;
+/// the leaf validates the screen value with the strict/panic-free `parse_default_screen`.
+const CFG_PREFIX: &[u8] = b"SMOLv1 CFG "; // + "NNN" + KEY + verbatim "<value>"
+/// #56 keyed CFG: the config keys THIS build knows how to APPLY on a leaf. #56 ships only
+/// the screen key; #48/#43/#55 each add their letter here alongside a `main` dispatch arm
+/// (a `take_cfg_offer(key)` + apply) and a gateway fill site in `mqtt_session`. Sized `[_; N]`
+/// (not `&[u8]`) so [`CfgTracker`] can allocate exactly one `.bss` buffer slot per key.
+/// An inbound key not listed is dropped at [`CfgTracker::set`] (never buffered/applied).
+const CFG_APPLY_KEYS: [u8; 1] = [crate::net::wifi::CFG_KEY_SCREEN];
 /// #50b leaf-status UPLINK tag: `"SMOLv1 STAT "` (12 B, trailing space) then `"NNN"`
 /// (3-ASCII zero-padded SENDER leaf id) then the verbatim live `<AppKind>:<page>` value
 /// (empty = none). Mirror of `CFG` but UPLINK (leaf → gateway): a leaf with no MQTT
@@ -285,10 +299,11 @@ enum Frame<'a> {
     /// A grid-downlink payload from a gateway (issue #16): the verbatim `GRID|…`
     /// bytes (twin of `Batt`; copied into `GridTracker` in `service`).
     Grid(&'a [u8]),
-    /// #21 leaf-relay: a gateway's CONFIG downlink — `target` leaf id + the verbatim
-    /// default-screen `value` bytes (`value` borrows the RX buffer; the leaf buffers
-    /// it in `CfgTracker` in `service` IFF `target == self.id`). Screen config ONLY.
-    Cfg { target: u8, value: &'a [u8] },
+    /// #21/#56 leaf-relay: a gateway's keyed CONFIG downlink — `target` leaf id, the config
+    /// channel `key` (`S`=screen/…), + the verbatim `value` bytes (`value` borrows the RX
+    /// buffer; the leaf buffers it per-key in `CfgTracker` in `service` IFF `target ==
+    /// self.id` AND the key is one it applies). Screen config ONLY on the `S` key.
+    Cfg { target: u8, key: u8, value: &'a [u8] },
     /// #50b leaf-status uplink: a leaf's live screen readback — `src` sender leaf id +
     /// the verbatim `<AppKind>:<page>` `value` bytes (`value` borrows the RX buffer; the
     /// GATEWAY caches it in `stat_cache` in `service`, keyed by `src`). Twin of `Cfg` but
@@ -447,34 +462,67 @@ pub struct GridOffer {
     pub len: usize,
 }
 
-/// #21 leaf-relay: buffers the most-recent inbound `SMOLv1 CFG` VALUE that targeted
-/// THIS leaf (the `service()` arm target-filters on `self.id` before buffering, so a
-/// config for another leaf never lands here). `main` takes it via
-/// [`RadioManager::take_cfg_offer`] and runs the bytes through the strict
-/// `parse_default_screen`. Fixed `.bss` buffer, no heap. Twin of [`BattTracker`].
+/// #21/#56 leaf-relay: buffers the most-recent inbound `SMOLv1 CFG` value that targeted
+/// THIS leaf, held in ONE `.bss` slot PER config key (#56) so keyed frames arriving in the
+/// same relay burst (the gateway broadcasts every cached key back-to-back) don't clobber
+/// each other. The `service()` arm target-filters on `self.id` before buffering (a config
+/// for another leaf never lands here) and `set` key-filters on [`CFG_APPLY_KEYS`] (an
+/// unapplied key is dropped). `main` takes a channel via [`RadioManager::take_cfg_offer`]
+/// and runs the bytes through that channel's validator (screen → `parse_default_screen`).
+/// Fixed `.bss`, no heap. Twin of [`BattTracker`], generalised to N keyed slots.
 struct CfgTracker {
-    buf: [u8; crate::net::wifi::CFG_VALUE_MAX],
-    len: usize,
-    have: bool,
+    vals: [[u8; crate::net::wifi::CFG_VALUE_MAX]; CFG_APPLY_KEYS.len()],
+    lens: [u8; CFG_APPLY_KEYS.len()],
+    have: [bool; CFG_APPLY_KEYS.len()],
 }
 
 impl CfgTracker {
     const fn new() -> Self {
-        Self { buf: [0; crate::net::wifi::CFG_VALUE_MAX], len: 0, have: false }
+        Self {
+            vals: [[0; crate::net::wifi::CFG_VALUE_MAX]; CFG_APPLY_KEYS.len()],
+            lens: [0; CFG_APPLY_KEYS.len()],
+            have: [false; CFG_APPLY_KEYS.len()],
+        }
     }
 
-    /// Buffer a freshly-received value (truncated to capacity).
-    fn set(&mut self, value: &[u8]) {
-        let n = value.len().min(crate::net::wifi::CFG_VALUE_MAX);
-        self.buf[..n].copy_from_slice(&value[..n]);
-        self.len = n;
-        self.have = true;
+    /// The `.bss` slot for `key`, or `None` if this build doesn't apply that key.
+    fn slot(key: u8) -> Option<usize> {
+        CFG_APPLY_KEYS.iter().position(|&k| k == key)
+    }
+
+    /// Buffer a freshly-received value under its `key` (truncated to capacity); returns
+    /// `true` if buffered. A `key` not in [`CFG_APPLY_KEYS`] is DROPPED and returns `false`
+    /// (#56 forward-compat — a newer gateway may relay a config channel this firmware
+    /// predates; ignore it rather than mis-apply, per the #46 clamp discipline).
+    fn set(&mut self, key: u8, value: &[u8]) -> bool {
+        match Self::slot(key) {
+            Some(i) => {
+                let n = value.len().min(crate::net::wifi::CFG_VALUE_MAX);
+                self.vals[i][..n].copy_from_slice(&value[..n]);
+                self.lens[i] = n as u8;
+                self.have[i] = true;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Take (clear) the buffered value for `key`, or `None` if none pending / unapplied key.
+    fn take(&mut self, key: u8) -> Option<CfgOffer> {
+        let i = Self::slot(key)?;
+        if self.have[i] {
+            self.have[i] = false;
+            Some(CfgOffer { buf: self.vals[i], len: self.lens[i] as usize })
+        } else {
+            None
+        }
     }
 }
 
-/// A `Copy` snapshot of a buffered CFG value handed to `main` by
-/// [`RadioManager::take_cfg_offer`]. `buf[..len]` is the verbatim `<AppKind>:<page>`
-/// value (empty = clear → board default); `main` parses it via `parse_default_screen`.
+/// A `Copy` snapshot of one keyed CFG channel's buffered value, handed to `main` by
+/// [`RadioManager::take_cfg_offer`]. For the screen key, `buf[..len]` is the verbatim
+/// `<AppKind>:<page>` value (empty = clear → board default) that `main` parses via
+/// `parse_default_screen`; other keys (#48/#43/#55) interpret their own value grammar.
 #[derive(Clone, Copy)]
 pub struct CfgOffer {
     pub buf: [u8; crate::net::wifi::CFG_VALUE_MAX],
@@ -1262,19 +1310,20 @@ pub struct RadioManager {
     /// Twin of `batt` (issue #16): most-recent inbound SMOLv1 GRID payload, buffered
     /// for `main` to store into its `GridCache`.
     grid: GridTracker,
-    /// #21 leaf-relay (LEAF side): most-recent inbound `SMOLv1 CFG` value that
-    /// targeted THIS leaf, buffered for `main` to apply via `take_cfg_offer`.
+    /// #21/#56 leaf-relay (LEAF side): most-recent inbound `SMOLv1 CFG` value PER config
+    /// key that targeted THIS leaf, buffered for `main` to apply via `take_cfg_offer(key)`.
     cfg: CfgTracker,
-    /// #21 leaf-relay (GATEWAY side): per-leaf default-screen cache, filled from the
-    /// MQTT wildcard during a flush and re-broadcast as `SMOLv1 CFG` on the ~10 s
-    /// cadence. Lives here so it persists across bursts (a (re)joined leaf converges
-    /// without HA re-publishing). Unused on a leaf (never flushes).
+    /// #21/#56 leaf-relay (GATEWAY side): per-(leaf, key) config cache, filled from the
+    /// MQTT wildcard during a flush and re-broadcast as keyed `SMOLv1 CFG` frames on the
+    /// ~10 s cadence. Lives here so it persists across bursts (a (re)joined leaf converges
+    /// without HA re-publishing). #56 fills only the screen key. Unused on a leaf.
     cfg_cache: crate::net::wifi::CfgCache,
     /// #50b leaf-status uplink (GATEWAY side): per-leaf live `<screen>:<page>` cache,
     /// filled by the `SMOLv1 STAT` service arm from leaf uplinks (leaves have no MQTT) and
     /// republished as retained `smol/<leaf>/status` on each gateway flush. Twin of
     /// `cfg_cache` but UPLINK-sourced. Unused on a leaf (never flushes/publishes). REUSES
-    /// `CfgCache` verbatim — a generic id→value upsert map (`Batt:3` fits `CFG_VALUE_MAX`).
+    /// `CfgCache` as a single-channel map — pinned to one fixed key so its (id, key) upsert
+    /// behaves id-keyed (`Batt:3` fits `CFG_VALUE_MAX`); the key column is inert here.
     stat_cache: crate::net::wifi::CfgCache,
     /// #40 leaf-mesh-OTA: the LEAF receive state machine (verify-sig → signed-bounds →
     /// window reassembly → readback verify → activate). Idle except during a transfer.
@@ -1856,24 +1905,26 @@ impl RadioManager {
         }
     }
 
-    /// #21 leaf-relay: broadcast one targeted `SMOLv1 CFG` frame — tag + 3-ASCII
-    /// zero-padded `target_id` + the verbatim `value`. Mirror of [`broadcast_batt`]:
-    /// fixed frame → `send_to(&BROADCAST_ADDRESS, ..)` (fire-and-forget). Every leaf
-    /// hears it; only the `target` acts (leaf-side target-filter). Value truncated to
-    /// `CFG_VALUE_MAX`; empty value = clear.
+    /// #21/#56 leaf-relay: broadcast one targeted keyed `SMOLv1 CFG` frame — tag + 3-ASCII
+    /// zero-padded `target_id` + the 1-byte config `key` (#56) + the verbatim `value`.
+    /// Mirror of [`broadcast_batt`]: fixed frame → `send_to(&BROADCAST_ADDRESS, ..)`
+    /// (fire-and-forget). Every leaf hears it; only the `target` acts, and only if it
+    /// applies `key` (leaf-side target + key filter). Value truncated to `CFG_VALUE_MAX`;
+    /// empty value = clear that key.
     ///
     /// [`broadcast_batt`]: RadioManager::broadcast_batt
-    pub fn broadcast_config(&mut self, target_id: u8, value: &[u8]) {
+    pub fn broadcast_config(&mut self, target_id: u8, key: u8, value: &[u8]) {
         let base = CFG_PREFIX.len();
-        let mut msg = [0u8; CFG_PREFIX.len() + 3 + crate::net::wifi::CFG_VALUE_MAX];
+        let mut msg = [0u8; CFG_PREFIX.len() + 3 + 1 + crate::net::wifi::CFG_VALUE_MAX];
         msg[..base].copy_from_slice(CFG_PREFIX);
         // 3-ASCII zero-padded target id (matches `parse_id`; u8 ⇒ each digit 0–9).
         msg[base] = b'0' + target_id / 100;
         msg[base + 1] = b'0' + (target_id / 10) % 10;
         msg[base + 2] = b'0' + target_id % 10;
+        msg[base + 3] = key; // #56: config channel key (S=screen / L=led / U=units / P=plugins)
         let n = value.len().min(crate::net::wifi::CFG_VALUE_MAX);
-        msg[base + 3..base + 3 + n].copy_from_slice(&value[..n]);
-        self.send_to(&BROADCAST_ADDRESS, &msg[..base + 3 + n]);
+        msg[base + 4..base + 4 + n].copy_from_slice(&value[..n]);
+        self.send_to(&BROADCAST_ADDRESS, &msg[..base + 4 + n]);
     }
 
     /// #50b leaf-status uplink: a LEAF broadcasts its OWN live `<screen>:<page>` as a
@@ -1929,33 +1980,29 @@ impl RadioManager {
             // Copy the entry out to release the `cfg_cache` borrow before the
             // `&mut self` broadcast_config call (disjoint-borrow discipline).
             let mut vbuf = [0u8; crate::net::wifi::CFG_VALUE_MAX];
-            let (id, vlen) = match self.cfg_cache.entry(i) {
-                Some((id, v)) => {
+            let (id, key, vlen) = match self.cfg_cache.entry(i) {
+                Some((id, key, v)) => {
                     let l = v.len();
                     vbuf[..l].copy_from_slice(v);
-                    (id, l)
+                    (id, key, l)
                 }
                 None => continue,
             };
             if id == own {
                 continue;
             }
-            self.broadcast_config(id, &vbuf[..vlen]);
+            self.broadcast_config(id, key, &vbuf[..vlen]);
         }
     }
 
-    /// #21 leaf-relay: take the buffered inbound CFG value that targeted us (if any),
-    /// clearing it. Twin of [`take_batt_offer`]; `main` runs the bytes through
-    /// `parse_default_screen` and edge-trigger-applies the result.
+    /// #21/#56 leaf-relay: take the buffered inbound value for config channel `key` that
+    /// targeted us (if any), clearing it. `None` if nothing pending or this build doesn't
+    /// apply `key`. Twin of [`take_batt_offer`]; for the screen key `main` runs the bytes
+    /// through `parse_default_screen` and edge-trigger-applies the result.
     ///
     /// [`take_batt_offer`]: RadioManager::take_batt_offer
-    pub fn take_cfg_offer(&mut self) -> Option<CfgOffer> {
-        if self.cfg.have {
-            self.cfg.have = false;
-            Some(CfgOffer { buf: self.cfg.buf, len: self.cfg.len })
-        } else {
-            None
-        }
+    pub fn take_cfg_offer(&mut self, key: u8) -> Option<CfgOffer> {
+        self.cfg.take(key)
     }
 
     /// #25 WLED: broadcast one WiZmote button over ESP-NOW on the CURRENT channel.
@@ -3260,17 +3307,28 @@ impl RadioManager {
                     self.roster.heard(src, None, rssi, now);
                     label = Some(alloc::string::String::from("grid"));
                 }
-                Some(Frame::Cfg { target, value }) => {
-                    // #21 leaf-relay: a gateway's CONFIG downlink. Target-filter FIRST
-                    // (per-leaf) — only buffer if it's addressed to US; a config for any
-                    // other leaf is ignored here. The value is the #21 default-screen
-                    // grammar; `main` validates it via the strict/panic-free
-                    // `parse_default_screen` (unknown/wrong-tier/bad-page → keep current;
-                    // empty → clear). HARD BOUNDARY: screen config ONLY — never OTA.
+                Some(Frame::Cfg { target, key, value }) => {
+                    // #21/#56 leaf-relay: a gateway's keyed CONFIG downlink. Target-filter
+                    // FIRST (per-leaf) — only buffer if addressed to US; a config for any
+                    // other leaf is ignored here. `CfgTracker::set` then per-KEY-filters:
+                    // a key this build doesn't apply (a future channel from a newer gateway)
+                    // is DROPPED (#56 forward-compat, #46 clamp). The value is opaque here;
+                    // the matching `main` dispatch validates it (screen → strict/panic-free
+                    // `parse_default_screen`: unknown/wrong-tier/bad-page → keep current;
+                    // empty → clear). HARD BOUNDARY: screen config ONLY on `S` — never OTA.
                     // Buffering the raw bytes (not parsing here) keeps this arm total.
                     if target == self.id {
-                        self.cfg.set(value);
-                        log::info!("smol #21: CFG frame for us ({} B value) — buffered", value.len());
+                        if self.cfg.set(key, value) {
+                            log::info!(
+                                "smol #56: CFG frame for us (key '{}', {} B value) — buffered",
+                                key as char,
+                                value.len()
+                            );
+                        } else {
+                            // Forward-compat: a key this firmware predates (newer gateway
+                            // mid rolling-OTA). Dropped, not mis-applied (#46 clamp).
+                            log::info!("smol #56: CFG frame for us (unknown key '{}') — ignored", key as char);
+                        }
                     }
                     self.peers.last_hello_ms = now;
                     self.roster.heard(src, None, rssi, now);
@@ -3300,8 +3358,9 @@ impl RadioManager {
                     if self.relay.is_gateway {
                         // #68 F6/roster-robustness: stamp the STAT with the sender's MAC + time so
                         // a stale leaf stops ghosting its status and stays mac-resolvable if the
-                        // LRU roster later evicts it.
-                        self.stat_cache.set(leaf_id, value, src, now);
+                        // LRU roster later evicts it. #56: pin the single-channel stat cache to one
+                        // fixed key (screen key) so its (id, key) upsert behaves id-keyed.
+                        self.stat_cache.set(leaf_id, crate::net::wifi::CFG_KEY_SCREEN, value, src, now);
                     }
                     self.peers.last_hello_ms = now;
                     self.roster.heard(src, Some(leaf_id), rssi, now);
@@ -3564,11 +3623,19 @@ fn parse_frame(data: &[u8]) -> Option<Frame<'_>> {
         return Some(Frame::Grid(rest));
     }
     if let Some(rest) = data.strip_prefix(CFG_PREFIX) {
-        // #21 leaf-relay: "NNN<value>" — 3-ASCII target id then the verbatim value
-        // (to end-of-frame; empty = clear). `parse_id` rejects short/non-digit and
-        // guarantees `rest.len() >= 3`, so `&rest[3..]` never panics.
+        // #21/#56 leaf-relay: "NNN<KEY><value>" — 3-ASCII target id, a 1-byte config KEY,
+        // then the verbatim value (to end-of-frame; empty = clear that key). `parse_id`
+        // rejects short/non-digit and guarantees `rest.len() >= 3`. The byte after the id
+        // is the KEY; `&rest[4..]` is its value (an empty slice for a keyed clear like
+        // "007S"). A key-less frame (id only, `rest.len() == 3`) is read as an empty-value
+        // clear on the SCREEN key — #56 back-compat with the pre-key `default_screen` wire.
+        // Unknown keys parse fine here and are dropped at the leaf's per-key dispatch.
         let target = parse_id(rest)?;
-        return Some(Frame::Cfg { target, value: &rest[3..] });
+        let (key, value): (u8, &[u8]) = match rest.get(3) {
+            Some(&k) => (k, &rest[4..]),
+            None => (crate::net::wifi::CFG_KEY_SCREEN, &rest[3..]),
+        };
+        return Some(Frame::Cfg { target, key, value });
     }
     if let Some(rest) = data.strip_prefix(STAT_PREFIX) {
         // #50b leaf-status uplink: "NNN<value>" — 3-ASCII SENDER id then the verbatim

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -776,6 +776,15 @@ static mut MQTT_ACC: [u8; 512] = [0; 512];
 #[cfg(feature = "wifi")]
 pub const CFG_VALUE_MAX: usize = 16;
 
+/// #56 keyed CFG: the single-ASCII config KEY that follows the 3-digit target id in a
+/// `SMOLv1 CFG` frame (`<NNN><KEY><value>`). ONE relay now carries N per-node config
+/// channels — `S` = default screen (#21, the only channel #56 ships); #48/#43/#55 add
+/// `L` (led) / `U` (units) / `P` (plugins). Defined at the `wifi` tier (like
+/// `CFG_VALUE_MAX`, §771) so the gateway FILL path (`mqtt_session`, wifi-only) and the
+/// ESP-NOW frame layer that RELAYS/parses it (espnow) both name it with no per-profile cfg.
+#[cfg(feature = "wifi")]
+pub const CFG_KEY_SCREEN: u8 = b'S';
+
 /// #40 #3: one relay attempt's diagnostic snapshot — gateway-side RX evidence PLUS the leaf's
 /// self-reported OTA state (captured from its `LDBG` beacon during the relay). Published to
 /// retained `smol/<leaf>/ota/relaydiag`. Defined at the `wifi` level (not `ota_mesh`/`mode`,
@@ -829,6 +838,12 @@ pub const STAT_FRESH_MS: u64 = 45_000;
 #[cfg(feature = "wifi")]
 pub struct CfgCache {
     ids: [u8; CFG_CACHE_CAP],
+    /// #56 keyed CFG: the config KEY (`S`/`L`/`U`/`P`) each entry belongs to. Upsert is
+    /// now on the COMPOSITE (id, key) so one leaf can hold N per-channel configs at once,
+    /// each relayed as its own `SMOLv1 CFG <NNN><KEY><value>` frame. #56 fills only `S`
+    /// (from `default_screen`); the column is inert for the single-channel `stat_cache`
+    /// reuse (it always upserts under one fixed key → identical id-keyed behaviour).
+    keys: [u8; CFG_CACHE_CAP],
     vals: [[u8; CFG_VALUE_MAX]; CFG_CACHE_CAP],
     lens: [u8; CFG_CACHE_CAP],
     /// #68 F6: last-heard timestamp (now_ms) per entry. Gates the stat republish on freshness
@@ -853,6 +868,7 @@ impl CfgCache {
     pub const fn new() -> Self {
         Self {
             ids: [0; CFG_CACHE_CAP],
+            keys: [0; CFG_CACHE_CAP],
             vals: [[0; CFG_VALUE_MAX]; CFG_CACHE_CAP],
             lens: [0; CFG_CACHE_CAP],
             last_ms: [0; CFG_CACHE_CAP],
@@ -861,13 +877,18 @@ impl CfgCache {
         }
     }
 
-    /// Upsert a leaf's config value (truncated to `CFG_VALUE_MAX`). A full cache drops
-    /// the entry and logs it (no silent cap). Value bytes are opaque here — the gateway
-    /// RELAYS them verbatim; the leaf's `parse_default_screen` is the strict validator.
-    pub fn set(&mut self, id: u8, value: &[u8], mac: [u8; 6], now: u64) {
+    /// #56: upsert a leaf's config value under its channel `key` (truncated to
+    /// `CFG_VALUE_MAX`). Match/insert is on the COMPOSITE (id, key) so one leaf holds N
+    /// keyed configs simultaneously — a `key` change never clobbers a different channel.
+    /// A full cache drops the entry and logs it (no silent cap). Value bytes are opaque
+    /// here — the gateway RELAYS them verbatim; the leaf's per-key dispatch validates
+    /// (screen → `parse_default_screen`). #68 F6: `mac`/`now` stamp the entry for the
+    /// stat-cache reuse (freshness gate + MAC-resolvable relay); the downlink cfg_cache
+    /// passes a zero MAC and is never mac-queried.
+    pub fn set(&mut self, id: u8, key: u8, value: &[u8], mac: [u8; 6], now: u64) {
         let n = value.len().min(CFG_VALUE_MAX);
         for i in 0..self.count {
-            if self.ids[i] == id {
+            if self.ids[i] == id && self.keys[i] == key {
                 self.vals[i][..n].copy_from_slice(&value[..n]);
                 self.lens[i] = n as u8;
                 self.last_ms[i] = now; // #68 F6: freshen
@@ -878,13 +899,19 @@ impl CfgCache {
         if self.count < CFG_CACHE_CAP {
             let i = self.count;
             self.ids[i] = id;
+            self.keys[i] = key;
             self.vals[i][..n].copy_from_slice(&value[..n]);
             self.lens[i] = n as u8;
             self.last_ms[i] = now;
             self.macs[i] = mac;
             self.count += 1;
         } else {
-            log::warn!("smol #21: cfg cache full ({}) — dropping config for id{}", CFG_CACHE_CAP, id);
+            log::warn!(
+                "smol #21/#56: cfg cache full ({}) — dropping id{} key '{}'",
+                CFG_CACHE_CAP,
+                id,
+                key as char
+            );
         }
     }
 
@@ -894,12 +921,13 @@ impl CfgCache {
         self.count
     }
 
-    /// The `i`-th cached entry as `(leaf_id, value_bytes)`, or `None` if out of range.
+    /// The `i`-th cached entry as `(leaf_id, key, value_bytes)`, or `None` if out of range.
+    /// #56: `key` is the config channel (`S`/…); the `stat_cache` reuse ignores it.
     #[allow(dead_code)]
-    pub fn entry(&self, i: usize) -> Option<(u8, &[u8])> {
+    pub fn entry(&self, i: usize) -> Option<(u8, u8, &[u8])> {
         if i < self.count {
             let n = self.lens[i] as usize;
-            Some((self.ids[i], &self.vals[i][..n]))
+            Some((self.ids[i], self.keys[i], &self.vals[i][..n]))
         } else {
             None
         }
@@ -1340,6 +1368,7 @@ fn mqtt_session(
         // perpetually-fresh ghost (the ghost that faked id8-alive + masked id9's floor-wipe).
         let now_ms = Instant::now().duration_since_epoch().as_millis();
         for i in 0..sc.count() {
+            // #68 F6 freshness gate; #56: the stat cache is single-channel, key column inert here.
             if let Some((lid, val)) = sc.entry_fresh(i, now_ms, STAT_FRESH_MS) {
                 if lid == node_id || val.is_empty() {
                     continue;
@@ -1478,12 +1507,15 @@ fn mqtt_session(
                         // anyway. Only present when cfg_cache = Some (gateway flush).
                         if leaf_id != node_id {
                             if let Some(cache) = cfg_cache.as_deref_mut() {
+                                // #56: `default_screen` is the SCREEN channel → cache under key
+                                // `S` (#48 led / #43 units / #55 plugins add their own topic + fill
+                                // site; the relay machinery is already key-generic).
                                 // #68: cfg_cache is DOWNLINK (never mac-queried) → zero MAC; the
                                 // timestamp is set for API uniformity (cfg_cache isn't freshness-gated).
                                 let now = Instant::now().duration_since_epoch().as_millis();
-                                cache.set(leaf_id, payload, [0u8; 6], now);
+                                cache.set(leaf_id, CFG_KEY_SCREEN, payload, [0u8; 6], now);
                                 log::info!(
-                                    "smol #21: cached leaf id{} config for relay ({} B)",
+                                    "smol #21/#56: cached leaf id{} screen config for relay ({} B)",
                                     leaf_id,
                                     payload.len()
                                 );
@@ -1848,7 +1880,8 @@ fn mqtt_session(
     if let Some(sc) = stat_cache {
         let latest_staged = staged_raw.as_ref().map(|a| a.build);
         for i in 0..sc.count() {
-            let (lid, val) = match sc.entry(i) {
+            // #56: the status cache is single-channel per leaf; its key column is inert here.
+            let (lid, _key, val) = match sc.entry(i) {
                 Some(x) => x,
                 None => continue,
             };


### PR DESCRIPTION
Closes #56.

> ⛔ **DO NOT MERGE TONIGHT — HOLD FOR MORNING CANARY.** This changes the ESP-NOW **CFG wire format** + the `default_screen` relay. It needs a JP-awake hardware canary smoke-test (gateway→leaf, dashboard-set screen converges) before merge. Fleet rests on merged #40 overnight.

## What
Generalizes the `SMOLv1 CFG` mesh-relay to a **keyed channel** — `SMOLv1 CFG <NNN><KEY><value>` — the foundation for #45/#48/#72/#75. One relay carries N per-node config channels, keyed by a 1-ASCII byte after the target id: `S`=screen (#21, the only channel shipped here); `L`/`U`/`P` reserved for #48/#43/#55.

- **Wire:** `broadcast_config` + `parse_frame` carry the KEY byte; `Frame::Cfg` gains `key`.
- **Leaf dispatch:** `CfgTracker` buffers per-key; a key the firmware predates is dropped (forward-compat, #46 clamp) — never mis-applied. `take_cfg_offer(key)`; `main` pulls the `S` channel through the unchanged `parse_default_screen` apply.
- **Gateway:** `CfgCache` upserts on composite `(id, key)` and relays each keyed config; `default_screen` fills under `S`.
- **Back-compat:** a key-less frame (id only) reads as an `S`-clear; `default_screen` end-to-end behavior unchanged.
- **HA** `smol_mesh.yaml`: documents the topic→KEY contract (comment-only, non-breaking).

## Rebase / merge note (#68 interaction)
Rebased onto d7f3ec9 (post-#40). #68 (F6 stat-cache staleness) independently extended `CfgCache::set`, adding `(mac, now)` for the freshness gate + MAC-resolvability. Unified to `set(id, key, value, mac, now)` — **both** features preserved (my composite `(id,key)` upsert + #68's stamping), and #68's `entry_fresh` freshness gate on the stat republish is kept intact (it's the ghost-fix — must not regress).

## Verification
All 4 profiles build (default / wifi / espnow / wled) — **espnow 0 warnings**. Clippy: only the known pre-existing `ota_mesh.rs` items (unrelated to this PR); zero findings in the changed files. Default-build invariant holds — all new code is `wifi`/`espnow` cfg-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)