### PR TITLE
fix(fw): #76 split-brain retained-peers ghost + #68 self-MAC filter (mesh-correctness tranche 1)

### DIFF
--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1278,6 +1278,10 @@ pub enum Mode {
 /// and, per esp-wifi's docs, must happen exactly once.
 pub struct RadioManager {
     controller: WifiController<'static>,
+    /// #68/#76 SELF-MAC: our own STA/ESP-NOW MAC, captured once at `new()`. `service()` drops
+    /// inbound frames whose `src` equals this — the esp-wifi RX path can loop our own broadcasts
+    /// back, which otherwise self-rosters us (roster anomaly #1) and pollutes PEERS.
+    self_mac: [u8; 6],
     esp_now: EspNow<'static>,
     /// The WiFi STA device, handed out once by esp-wifi's `Interfaces`. Held as
     /// an `Option` and BORROWED (never dropped) so it survives the boot NTP burst
@@ -1437,8 +1441,15 @@ impl RadioManager {
         controller.set_mode(WifiMode::Sta).ok()?;
         controller.start().ok()?;
 
+        // #68/#76 SELF-MAC: capture our STA MAC (ESP-NOW rides the STA interface) so service()
+        // can DROP frames from our own address. The esp-wifi RX queue can deliver our own
+        // broadcasts back to us; with no self-filter the gateway rosters ITSELF (constant-RSSI,
+        // age-0, flags-3 self-entry — roster anomaly #1) and wastes an eviction-immune slot.
+        let self_mac = interfaces.sta.mac_address();
+
         Some(Self {
             controller,
+            self_mac,
             esp_now: interfaces.esp_now,
             // Keep the STA device alive for the NTP burst; dropped afterward.
             sta: Some(interfaces.sta),
@@ -3076,6 +3087,14 @@ impl RadioManager {
                 break;
             };
             let src = recv.info.src_address;
+            // #68/#76 SELF-MAC FILTER: the esp-wifi RX path can deliver our OWN broadcasts back
+            // to us (HELLO/TIME/PEERS). With no guard the gateway rosters ITSELF (roster anomaly
+            // #1: a constant-RSSI, age-0, flags-3 self-entry that, being always freshest, is
+            // eviction-immune and permanently burns a 16-slot LRU slot — the #28 ceiling too).
+            // Drop our own frames before ANY handler (OTA dispatch + generic Frame parse below).
+            if src == self.self_mac {
+                continue;
+            }
             // RSSI of this frame (dBm) from the ESP-NOW RX control info; used by
             // BENCH. Captured up front so each arm can record it if relevant.
             let rssi = recv.info.rx_control.rssi;

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1823,6 +1823,24 @@ fn mqtt_session(
         elect.seen_seq
     );
 
+    // #76 RETAINED-PEERS GHOST FIX (also closes the #68 retained-peers-cleanup item): the peers
+    // publish above (retained `smol/<id>/peers`) only fires while this board is the OWNER. When it
+    // DEMOTES to leaf it stops flushing, so its last `PEERS|G|…` persists on the broker forever as
+    // a GHOST → observability shows a phantom extra gateway. This was the bulk of the #40-sweep
+    // "election split-brain" (#76): the all-three-PEERS|G was largely these stale retained records,
+    // not a live triple-claim (the election itself reconverged to a single owner post-bounce). So
+    // the moment the election says we are NOT the owner, CLEAR our retained peers with an empty
+    // payload (the board is still connected here — same free window the HA block below uses).
+    // Idempotent: a steady leaf just re-clears an already-empty topic. Same retained-hygiene class
+    // as F6 / stat_cache / armdiag — a demoted role must not leave a live-looking retained trace.
+    if !elect.i_am_owner {
+        let mut ptopic = MqttScratch::new();
+        let _ = write!(ptopic, "smol/{}/peers", node_id);
+        if let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, ptopic.as_bytes(), b"", true) {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
+    }
+
     // --- #33 HA Update entity: self-publish retained discovery + state, clear the cmd ---
     // The board is still connected here (free). `installed_version` = our BUILD_NUMBER;
     // `latest_version` = the gated announce's build if one is present (`ota_offer`), else


### PR DESCRIPTION
First tranche of the mesh-correctness wave — two small, proven-green fixes. Both are the recurring **retained/RX-hygiene** class the #40 campaign surfaced repeatedly.

## Changes
- **`bda9b48` — #76 election split-brain (retained-`PEERS|G` ghost).** The #40 sequential-OTA reboot cascade showed all three nodes publishing `PEERS|G` at once. Root cause: it was **largely a retained-topic ghost, not a live triple-claim** — a gateway publishes retained `smol/<id>/peers`, but on demote to leaf it stops flushing, so its last `PEERS|G` persists on the broker forever (phantom extra gateway). The election itself reconverged to a single owner post-bounce. Fix: clear the retained `smol/<id>/peers` (empty payload) the moment the election decides `!i_am_owner` — the board is still connected there. **Also closes the #68-continuation "retained-peers cleanup" item** (same root cause). The transient cross-AP-channel partition in the same sweep (id7 followed ch11) is scoped out to #29/coexist.
- **`b842604` — #68 self-MAC filter.** The esp-wifi RX path can loop our own broadcasts back to us; with no self-filter the gateway rosters itself (constant-RSSI/age-0/flags-3 self-entry), an eviction-immune slot that also lowers the #28 peer-table ceiling. Fix: capture the STA MAC at `RadioManager::new` and drop `src == self_mac` at the top of `service()`.

## Verification
- All 4 profiles compile; **espnow 0 warnings; 0 new warnings vs base b9cb493** (stash-verified — the wifi warnings are pre-existing `as_wire`/`live_screen`/`page` dead-code).
- **Hardware validation deferred to the morning consolidated canary** (nodes unplugged overnight; per tonight's no-canary policy, fw merges on oracle-green + compile-proof).

## Scope notes
- **#31 closed separately** (see #31) — already resolved by #51 A1 `silent_until_relock`; verified, no firmware change.
- **Remainder (#3 pending-gate · #28 peer eviction · #29 MC-channel fast-path · F2 pre-auth OTA mutation) → follow-up wave (lucid-mesh-wave2)**, root-caused + documented with file:line + fix plans in the session handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)