### PR TITLE
feat(fw): #70+#49 per-node retained DIAG record (observability wave)

### DIFF
--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -64,6 +64,11 @@ esp_bootloader_esp_idf::esp_app_desc!();
 #[cfg(feature = "wifi")]
 #[no_mangle]
 extern "Rust" fn custom_halt() -> ! {
+    // #70 observability: record that THIS reset was a PANIC before we reboot. A panic halts
+    // here → software_reset, which the SoC logs as a plain `CoreSw` (same as an intentional
+    // reboot / OTA activate) — so the DIAG record would show `rr=sw` and hide the crash. The
+    // RTC-fast panic marker (read+cleared next boot) recovers `rr=panic`. Set BEFORE the reset.
+    ota::mark_panic();
     esp_hal::system::software_reset()
 }
 
@@ -201,6 +206,15 @@ pub(crate) const TZ_OFFSET_SECONDS: i64 = -7 * 3600;
 /// advance/redraw on their own schedules so the I²C bus isn't hammered.
 pub(crate) const SUBTICK_MS: u32 = 20;
 
+/// #70/#49 observability: LEAF DIAG-record broadcast cadence (ms). Deliberately slow — the diag
+/// signals are slow-moving, so a 60 s beat keeps mesh airtime negligible.
+#[cfg(feature = "espnow")]
+const DIAG_CADENCE_MS: u64 = 60_000;
+/// #70/#49: minimum spacing between BUTTON-expedited diag broadcasts (ms) — bounds a press-mash
+/// so it can't flood the mesh with off-cadence diags.
+#[cfg(feature = "espnow")]
+const DIAG_EXPEDITE_MIN_MS: u64 = 3_000;
+
 /// Minimum time the boot splash (node name + firmware version) stays on screen,
 /// even when radio bring-up was instant (default build). The espnow/wifi NTP burst
 /// usually already exceeds this, so the splash naturally rides the burst window.
@@ -323,6 +337,13 @@ fn main() -> ! {
     } else {
         ota::unconfirmed_boot_reset();
     }
+
+    // #70 observability: capture the per-boot diagnostics ONCE (persisted boot-count bump +
+    // reset reason + boot slot + otadata state) for the retained DIAG record. Placed AFTER the
+    // OTA bookkeeping block so a K-counter forced rollback reboots BEFORE this runs — the
+    // rolled-back (good-slot) boot is the one that counts, not the aborted crash-loop boot.
+    #[cfg(feature = "espnow")]
+    ota::capture_boot_diag();
 
     // --- I2C bus to the OLED -------------------------------------------------
     let i2c = I2c::new(
@@ -587,6 +608,13 @@ fn main() -> ! {
     let mut last_input_ms: u64 = 0;
     #[cfg(feature = "espnow")]
     let mut flush_defer_since_ms: u64 = 0;
+    // #70/#49 observability: last time this LEAF broadcast its DIAG record, and a "expedite"
+    // flag set by a BOOT-button press (so a press shows up in HA within a few seconds instead
+    // of waiting the full slow diag cadence). Gateway publishes its own diag via the MQTT flush.
+    #[cfg(feature = "espnow")]
+    let mut last_diag_ms: u64 = 0;
+    #[cfg(feature = "espnow")]
+    let mut diag_dirty: bool = false;
 
     // FPS measurement for BENCH: count frames, recompute once per second.
     #[cfg(feature = "espnow")]
@@ -844,6 +872,26 @@ fn main() -> ! {
                 // #50 screen template is unaffected.
                 let val = alloc::format!("{}:{}|{}", live_kind.as_wire(), live_page, ota::BUILD_NUMBER);
                 r.broadcast_stat(val.as_bytes());
+            }
+            // #70/#49 observability: sample the free-heap watermark on the ~10 s tick (all roles,
+            // cheap) so `hmin` tracks leak/pressure at finer resolution than the diag publish.
+            if (now / 10_000) != ((now.saturating_sub(SUBTICK_MS as u64)) / 10_000) {
+                r.diag_sample_heap();
+            }
+            // #70/#49: a LEAF broadcasts its compact DIAG record on a SLOW ~60 s cadence (diag is
+            // slow-moving — keep mesh airtime low), expedited by a BOOT-button press (rate-limited
+            // to ≥ DIAG_EXPEDITE_MIN_MS so a mash can't spam the mesh). The gateway caches it and
+            // republishes retained smol/<leaf>/diag. Gateway publishes ITS OWN diag via the flush,
+            // so this is leaf-only — the exact inverse of the gateway BATT/GRID/CFG re-broadcasts.
+            if !r.is_gateway() {
+                let due = (now / DIAG_CADENCE_MS) != ((now.saturating_sub(SUBTICK_MS as u64)) / DIAG_CADENCE_MS);
+                let expedite = diag_dirty && now.saturating_sub(last_diag_ms) >= DIAG_EXPEDITE_MIN_MS;
+                if due || expedite {
+                    let rec = r.diag_record();
+                    r.broadcast_diag(rec.as_bytes());
+                    last_diag_ms = now;
+                    diag_dirty = false;
+                }
             }
 
             // NOTE: the MMO-snake SNK drain+broadcast used to live here. It MOVED
@@ -1205,6 +1253,13 @@ fn main() -> ! {
             #[cfg(feature = "espnow")]
             {
                 last_input_ms = now;
+                // #70: record the BOOT-button press for the DIAG record's press counters (HA
+                // fires a distinct press / long-press event on each increment) and flag the next
+                // diag broadcast to expedite so it reaches HA within a few seconds, not 60.
+                if let Some(radio) = ctx.radio.as_deref_mut() {
+                    radio.note_button(matches!(press, input::Press::Long));
+                }
+                diag_dirty = true;
             }
             if let Transition::Switch(kind) = app.on_button(press, &mut ctx) {
                 app = App::enter(kind, &ctx); // lazy-construct the entered screen

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2121,37 +2121,43 @@ impl RadioManager {
         }
     }
 
-    /// #70/#49: build this node's compact key=val DIAG record for retained `smol/<id>/diag`. ONE
-    /// record carrying the whole observability signal set — per the #70 HA contract, HA parses this
-    /// package-side (NO per-signal MQTT discovery). Space-separated `key=val` tokens (the relaydiag
-    /// idiom): `up`=uptime_s, `bt`=boot#, `rr`=reset reason, `slot`=running OTA slot (255=unknown),
-    /// `ota`=otadata state, `heap`=free bytes, `hmin`=min-free watermark, `fok`/`ffl`=flush ok/fail
-    /// (#9 proof), `vok`/`vfl`=OTA verify ok/fail (#32 proof, leaf mesh-OTA), `loss`=mesh loss %,
-    /// `btn`/`btnl`=BOOT short/long press counts. Samples heap first so `hmin <= heap` holds. Uses
-    /// the heap `String` (like the STAT/telemetry builders) — panic-free, bounded by the format.
+    /// #70/#49: build this node's compact DIAG record for retained `smol/<id>/diag`. Format matches
+    /// luna's DEPLOYED HA parser (PR #81): literal `DIAG` first field, then `key=value` pairs
+    /// PIPE-separated, order-independent, forward-compatible (HA picks by key, unknown keys ignored,
+    /// missing → safe default). ONE record carries the whole signal set — HA parses it package-side,
+    /// NO per-signal MQTT discovery (no entity doubling).
+    ///
+    /// Keys: `slot`=running OTA slot (0/1, 255=unknown), `rst`=reset reason (luna's enum + `panic`),
+    /// `boot`=boot count, `ota`=last OTA OUTCOME (confirmed/rolled-back/none — read LIVE, set by
+    /// `boot_confirm`; drives luna's rollback alert), `up`=uptime_s, `heap`=free bytes, `hmin`=min-
+    /// free watermark, `btn`/`btnl`=BOOT short/long press counts. #49 extras (folded in, ignored by
+    /// HA until it adds sensors): `fok`/`ffl`=flush ok/fail (#9 proof), `vok`/`vfl`=OTA verify ok/fail
+    /// (#32 proof), `loss`=mesh loss % (luna's #74-reserved `loss` key, same semantic). Samples heap
+    /// first so `hmin <= heap` holds. Heap `String` (like the STAT/telemetry builders) — panic-free.
     pub fn diag_record(&mut self) -> alloc::string::String {
         self.diag_sample_heap();
         let up_s = now_ms() / 1000;
         let d = crate::ota::boot_diag();
+        let ota = crate::ota::ota_outcome_token(); // live — boot_confirm sets it after capture
         let heap = esp_alloc::HEAP.free();
         let (vok, vfl) = self.ota_leaf.verify_counts();
         let loss = self.bench.loss_pct();
         alloc::format!(
-            "up={} bt={} rr={} slot={} ota={} heap={} hmin={} fok={} ffl={} vok={} vfl={} loss={} btn={} btnl={}",
-            up_s,
-            d.boot_count,
-            d.reset_reason,
+            "DIAG|slot={}|rst={}|boot={}|ota={}|up={}|heap={}|hmin={}|btn={}|btnl={}|fok={}|ffl={}|vok={}|vfl={}|loss={}",
             d.boot_slot,
-            d.ota_state,
+            d.reset_reason,
+            d.boot_count,
+            ota,
+            up_s,
             heap,
             self.diag.heap_min,
+            self.diag.btn,
+            self.diag.btnl,
             self.diag.flush_ok,
             self.diag.flush_fail,
             vok,
             vfl,
             loss,
-            self.diag.btn,
-            self.diag.btnl,
         )
     }
 

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -201,6 +201,15 @@ const CFG_APPLY_KEYS: [u8; 5] = [
 /// next cadence. Value bounded by `CFG_VALUE_MAX`.
 const STAT_PREFIX: &[u8] = b"SMOLv1 STAT "; // + "NNN" + verbatim "<AppKind>:<page>|<build>"
 
+/// #70/#49 observability UPLINK tag: `"SMOLv1 DIAG "` (12 B, trailing space) then `"NNN"`
+/// (3-ASCII zero-padded SENDER id) then the verbatim key=val DIAG record. Exact mirror of
+/// `STAT` but a SEPARATE frame (the DIAG value is ~130 B, far past STAT's 16 B `CFG_VALUE_MAX`)
+/// with its own gateway cache (`diag_cache`) → retained `smol/<id>/diag`. Diverges from STAT at
+/// byte 7 (`'D'` vs `'S'`), so `strip_prefix` never confuses them. Same unauthed, low-blast
+/// threat model: worst case a stray frame yields a bad diag string, self-corrected next cadence.
+/// Value bounded by `RELAY_VALUE_MAX`.
+const DIAG_PREFIX: &[u8] = b"SMOLv1 DIAG "; // + "NNN" + verbatim "up=.. bt=.. rr=.. …"
+
 // #40 leaf-mesh-OTA GATEWAY relay tuning (blocking maintenance op; hardware-tunable — see
 // lucid-40-build-handoff.md). The relay monopolizes the radio for its duration by design.
 /// Wait for a leaf OTAN after (re)sending a window before resending it (ms).
@@ -318,6 +327,41 @@ enum Frame<'a> {
     /// GATEWAY caches it in `stat_cache` in `service`, keyed by `src`). Twin of `Cfg` but
     /// UPLINK — republished as retained `smol/<src>/status`.
     Stat { src: u8, value: &'a [u8] },
+    /// #70/#49 observability uplink: a node's compact key=val DIAG record — `src` sender id +
+    /// the verbatim record bytes (borrow the RX buffer; the GATEWAY caches it in `diag_cache`,
+    /// keyed by `src`). Twin of `Stat` but a bigger value → retained `smol/<src>/diag`.
+    Diag { src: u8, value: &'a [u8] },
+}
+
+/// #70/#49 observability: a node's own live diag counters, folded into the retained DIAG record
+/// each cadence. `Copy` (lives inline in `RadioManager`). All monotonic-since-boot except the
+/// min-heap watermark. Cheap to maintain; no heap, no flash.
+#[derive(Clone, Copy)]
+struct DiagCounters {
+    /// Lowest free-heap reading observed since boot (leak/pressure watermark). `u32::MAX` until
+    /// the first sample so `min()` latches the true low-water on the first `diag_sample_heap`.
+    heap_min: u32,
+    /// BOOT-button SHORT-press count (monotonic, wraps). HA fires a `press` event on each change.
+    btn: u16,
+    /// BOOT-button LONG-press count (monotonic, wraps). HA fires a `long-press` event on change.
+    btnl: u16,
+    /// #49 flush ok/fail (GATEWAY): MQTT bursts that reached CONNACK vs failed/timed-out. Proves
+    /// the #9 flush-win on hardware (was UART0-only). Leaf-side these stay 0 (a leaf never flushes).
+    /// (OTA verify ok/fail is read live from `OtaLeafSession`, not mirrored here.)
+    flush_ok: u32,
+    flush_fail: u32,
+}
+
+impl DiagCounters {
+    const fn new() -> Self {
+        Self {
+            heap_min: u32::MAX,
+            btn: 0,
+            btnl: 0,
+            flush_ok: 0,
+            flush_fail: 0,
+        }
+    }
 }
 
 /// Tracks the two timestamps that define the peer link state. Monotonic ms
@@ -1364,6 +1408,13 @@ pub struct RadioManager {
     /// `CfgCache` as a single-channel map — pinned to one fixed key so its (id, key) upsert
     /// behaves id-keyed (`Batt:3` fits `CFG_VALUE_MAX`); the key column is inert here.
     stat_cache: crate::net::wifi::CfgCache,
+    /// #70/#49 observability (GATEWAY side): per-node relayed DIAG record cache, filled by the
+    /// `SMOLv1 DIAG` service arm from node uplinks and republished as retained `smol/<id>/diag`
+    /// on each flush (F6 freshness-gated). Twin of `stat_cache` but a bigger value. Unused leaf-side.
+    diag_cache: crate::net::wifi::RelayCache,
+    /// #70/#49 observability: this node's own live diag counters (min-heap watermark + BOOT-button
+    /// press counters; #49 adds flush/verify counters). Folded into the DIAG record each cadence.
+    diag: DiagCounters,
     /// #40 leaf-mesh-OTA: the LEAF receive state machine (verify-sig → signed-bounds →
     /// window reassembly → readback verify → activate). Idle except during a transfer.
     /// Unused on a gateway (which drives the RELAY side via `run_leaf_ota_relay`).
@@ -1517,6 +1568,8 @@ impl RadioManager {
             cfg: CfgTracker::new(),
             cfg_cache: crate::net::wifi::CfgCache::new(),
             stat_cache: crate::net::wifi::CfgCache::new(),
+            diag_cache: crate::net::wifi::RelayCache::new(),
+            diag: DiagCounters::new(),
             ota_leaf: crate::ota_mesh::OtaLeafSession::new(),
             #[cfg(feature = "wled")]
             wled_seq: 0,
@@ -1683,6 +1736,8 @@ impl RadioManager {
             &[], // #50: recovery burst publishes no live-screen status
                     None, // #21: a leaf's recovery burst is not a gateway relay
                     None, // #50b: recovery burst republishes no cached leaf status
+                    &[], // #70/#49: recovery burst publishes no own diag
+                    None, // #70/#49: recovery burst republishes no cached diag
                     &mut None, // #40: a leaf's recovery burst never relays a leaf OTA
                     &mut None, // #40: recovery burst carries no persistent staged
                     &mut None, // #40: recovery burst publishes no relay diag
@@ -2015,6 +2070,89 @@ impl RadioManager {
         let n = value.len().min(crate::net::wifi::CFG_VALUE_MAX);
         msg[base + 3..base + 3 + n].copy_from_slice(&value[..n]);
         self.send_to(&BROADCAST_ADDRESS, &msg[..base + 3 + n]);
+    }
+
+    /// #70/#49: broadcast this node's compact key=val DIAG record as a `SMOLv1 DIAG` frame —
+    /// mirror of [`broadcast_stat`] but a bigger value (`RELAY_VALUE_MAX`). Fire-and-forget; the
+    /// gateway caches it (`diag_cache`) and republishes retained `smol/<id>/diag`. `main` gates on
+    /// the ~60 s diag cadence (a BOOT-button press expedites one). Value truncated to the cap.
+    ///
+    /// [`broadcast_stat`]: RadioManager::broadcast_stat
+    pub fn broadcast_diag(&mut self, value: &[u8]) {
+        let base = DIAG_PREFIX.len();
+        let mut msg = [0u8; DIAG_PREFIX.len() + 3 + crate::net::wifi::RELAY_VALUE_MAX];
+        msg[..base].copy_from_slice(DIAG_PREFIX);
+        let own = self.id;
+        msg[base] = b'0' + own / 100;
+        msg[base + 1] = b'0' + (own / 10) % 10;
+        msg[base + 2] = b'0' + own % 10;
+        let n = value.len().min(crate::net::wifi::RELAY_VALUE_MAX);
+        msg[base + 3..base + 3 + n].copy_from_slice(&value[..n]);
+        self.send_to(&BROADCAST_ADDRESS, &msg[..base + 3 + n]);
+    }
+
+    /// #70: sample the live free-heap and lower the min-heap watermark. Cheap (one `HEAP.free()`);
+    /// `main` calls it on the ~10 s tick so the watermark tracks leak/pressure at finer resolution
+    /// than the slow diag publish cadence.
+    pub fn diag_sample_heap(&mut self) {
+        let free = esp_alloc::HEAP.free() as u32;
+        if free < self.diag.heap_min {
+            self.diag.heap_min = free;
+        }
+    }
+
+    /// #70: record a BOOT-button press (`long` = long-press). Bumps the monotonic press counter
+    /// that rides the DIAG record — HA fires a distinct press / long-press event on each increment.
+    pub fn note_button(&mut self, long: bool) {
+        if long {
+            self.diag.btnl = self.diag.btnl.wrapping_add(1);
+        } else {
+            self.diag.btn = self.diag.btn.wrapping_add(1);
+        }
+    }
+
+    /// #49: record an MQTT flush outcome (`ok` = reached CONNACK). The flush-success rate proves
+    /// the #9 flush-win on hardware (was UART0-only). Gateway-only in practice (leaves never flush).
+    pub fn note_flush(&mut self, ok: bool) {
+        if ok {
+            self.diag.flush_ok = self.diag.flush_ok.saturating_add(1);
+        } else {
+            self.diag.flush_fail = self.diag.flush_fail.saturating_add(1);
+        }
+    }
+
+    /// #70/#49: build this node's compact key=val DIAG record for retained `smol/<id>/diag`. ONE
+    /// record carrying the whole observability signal set — per the #70 HA contract, HA parses this
+    /// package-side (NO per-signal MQTT discovery). Space-separated `key=val` tokens (the relaydiag
+    /// idiom): `up`=uptime_s, `bt`=boot#, `rr`=reset reason, `slot`=running OTA slot (255=unknown),
+    /// `ota`=otadata state, `heap`=free bytes, `hmin`=min-free watermark, `fok`/`ffl`=flush ok/fail
+    /// (#9 proof), `vok`/`vfl`=OTA verify ok/fail (#32 proof, leaf mesh-OTA), `loss`=mesh loss %,
+    /// `btn`/`btnl`=BOOT short/long press counts. Samples heap first so `hmin <= heap` holds. Uses
+    /// the heap `String` (like the STAT/telemetry builders) — panic-free, bounded by the format.
+    pub fn diag_record(&mut self) -> alloc::string::String {
+        self.diag_sample_heap();
+        let up_s = now_ms() / 1000;
+        let d = crate::ota::boot_diag();
+        let heap = esp_alloc::HEAP.free();
+        let (vok, vfl) = self.ota_leaf.verify_counts();
+        let loss = self.bench.loss_pct();
+        alloc::format!(
+            "up={} bt={} rr={} slot={} ota={} heap={} hmin={} fok={} ffl={} vok={} vfl={} loss={} btn={} btnl={}",
+            up_s,
+            d.boot_count,
+            d.reset_reason,
+            d.boot_slot,
+            d.ota_state,
+            heap,
+            self.diag.heap_min,
+            self.diag.flush_ok,
+            self.diag.flush_fail,
+            vok,
+            vfl,
+            loss,
+            self.diag.btn,
+            self.diag.btnl,
+        )
     }
 
     /// #40 #3: broadcast this LEAF's OTA RX-diag beacon (`LDBG` = id + heard/verdict/sent) so a
@@ -2955,6 +3093,10 @@ impl RadioManager {
         let mut install_requested = false;
         // #40 #1: set iff this flush SEES a retained leaf install (pre-arm) → latch pending below.
         let mut leaf_install_seen = false;
+        // #70/#49: build the gateway's OWN DIAG record BEFORE the burst borrow (it takes `&mut self`
+        // — the run_mqtt_burst call below already holds disjoint field borrows). Published retained
+        // as `smol/<id>/diag`, and cached leaf diags are republished alongside via `diag_cache`.
+        let diag_rec = self.diag_record();
         let sta = self.sta.as_mut();
         let ok = match sta {
             None => false,
@@ -2997,6 +3139,8 @@ impl RadioManager {
                     status, // #50: gateway publishes its live screen as smol/<id>/status
                     Some(&mut self.cfg_cache), // #21: gateway caches leaf configs to relay
                     Some(&self.stat_cache), // #50b: gateway republishes cached leaf statuses
+                    diag_rec.as_bytes(), // #70/#49: gateway publishes its own smol/<id>/diag
+                    Some(&self.diag_cache), // #70/#49: republish cached relayed-node diags
                     leaf_ota, // #40: surface a pending leaf-OTA install for main to relay
                     &mut self.staged_raw, // #40: persist the staged across flushes (pair-safe)
                     &mut self.leaf_ota_diag, // #40: publish smol/<leaf>/ota/diag + clear/retry
@@ -3005,6 +3149,10 @@ impl RadioManager {
                 )
             }
         };
+        // #49: record the flush outcome (`ok` = reached CONNACK) into the diag counters — the
+        // flush-success rate is the on-device #9 flush-win proof (was UART0-only). Bumped here so
+        // it rides the NEXT diag record.
+        self.note_flush(ok);
         // #6 OTA: stash any announce this flush surfaced for `main` to act on.
         if ota_offer.is_some() {
             self.ota_offer = ota_offer;
@@ -3467,6 +3615,19 @@ impl RadioManager {
                     self.roster.heard(src, Some(leaf_id), rssi, now);
                     label = Some(alloc::string::String::from("stat"));
                 }
+                Some(Frame::Diag { src: node_id, value }) => {
+                    // #70/#49 observability uplink: a node's DIAG record. GATEWAY-only cache (a
+                    // leaf hearing another's DIAG ignores it — no MQTT). Buffer the raw record keyed
+                    // by SENDER id; the flush republishes it retained `smol/<id>/diag` (F6-gated).
+                    // Opaque bytes (mirror STAT) — a stray frame at worst yields a bad diag string,
+                    // self-corrected next cadence; never a brick.
+                    if self.relay.is_gateway {
+                        self.diag_cache.set(node_id, value, now);
+                    }
+                    self.peers.last_hello_ms = now;
+                    self.roster.heard(src, Some(node_id), rssi, now);
+                    label = Some(alloc::string::String::from("diag"));
+                }
                 None => {
                     // Unrecognised payload (other ESP-NOW traffic on-channel);
                     // surface it on the OLED but don't touch the handshake.
@@ -3822,6 +3983,12 @@ fn parse_frame(data: &[u8]) -> Option<Frame<'_>> {
         // short/non-digit and guarantees `rest.len() >= 3`, so `&rest[3..]` never panics.
         let src = parse_id(rest)?;
         return Some(Frame::Stat { src, value: &rest[3..] });
+    }
+    if let Some(rest) = data.strip_prefix(DIAG_PREFIX) {
+        // #70/#49 observability uplink: "NNN<record>" — 3-ASCII SENDER id then the verbatim
+        // key=val DIAG record (to end-of-frame; empty = none). Same `parse_id` guard as STAT.
+        let src = parse_id(rest)?;
+        return Some(Frame::Diag { src, value: &rest[3..] });
     }
     None
 }

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -596,6 +596,8 @@ pub fn run_ntp_burst(
         &[], // #50: boot burst publishes no live-screen status
         None, // #21: boot burst is not a gateway relay (no leaf-config cache)
         None, // #50b: boot burst republishes no cached leaf status
+        &[], // #70/#49: boot burst publishes no own diag
+        None, // #70/#49: boot burst republishes no cached diag
         &mut None, // #40: boot burst never relays a leaf OTA
         &mut None, // #40: boot burst has no persistent staged to carry
         &mut None, // #40: boot burst has no relay diag to publish
@@ -1098,6 +1100,96 @@ impl CfgCache {
     }
 }
 
+/// #70/#71 observability: max bytes of a relayed DIAG or SCAN record value. Larger than
+/// `CFG_VALUE_MAX` (16, sized for a screen string) because a diag/scan record is a multi-field
+/// line (~130 B) — but still well under the ~250 B ESP-NOW frame budget once the 12 B frame
+/// prefix + 3 B id are added.
+#[cfg(feature = "wifi")]
+pub const RELAY_VALUE_MAX: usize = 200;
+
+#[cfg(feature = "wifi")]
+const RELAY_CACHE_CAP: usize = 12;
+
+/// #70/#71: the GATEWAY's per-leaf cache of a relayed observability record (DIAG or SCAN). A
+/// leaf has no MQTT, so it broadcasts its record over ESP-NOW; the gateway caches the most
+/// recent per leaf id and republishes it RETAINED on each flush (`smol/<leaf>/diag`|`/scan`).
+/// Twin of [`CfgCache`] but id-keyed only (no config-key / MAC columns — MAC resolution stays
+/// with `stat_cache`) and a bigger value buffer. Bounded `.bss`, no heap; instantiated twice
+/// (diag + scan). #68 F6 freshness (`entry_fresh`) gates the republish so an off-air leaf's
+/// retained record ages out instead of ghosting.
+#[cfg(feature = "wifi")]
+pub struct RelayCache {
+    ids: [u8; RELAY_CACHE_CAP],
+    vals: [[u8; RELAY_VALUE_MAX]; RELAY_CACHE_CAP],
+    lens: [u16; RELAY_CACHE_CAP],
+    last_ms: [u64; RELAY_CACHE_CAP],
+    count: usize,
+}
+
+#[cfg(feature = "wifi")]
+impl RelayCache {
+    // Like `CfgCache`, these are called only by the espnow gateway (`RadioManager`); a
+    // wifi-only build (no `RadioManager`) leaves `new`/`set`/`count` unused → allow dead_code
+    // so the clippy gate stays clean in every profile.
+    #[allow(dead_code)]
+    pub const fn new() -> Self {
+        Self {
+            ids: [0; RELAY_CACHE_CAP],
+            vals: [[0; RELAY_VALUE_MAX]; RELAY_CACHE_CAP],
+            lens: [0; RELAY_CACHE_CAP],
+            last_ms: [0; RELAY_CACHE_CAP],
+            count: 0,
+        }
+    }
+
+    /// Upsert leaf `id`'s record (truncated to `RELAY_VALUE_MAX`), stamping `now` for the F6
+    /// freshness gate. A full cache drops the entry and logs it (no silent cap).
+    #[allow(dead_code)]
+    pub fn set(&mut self, id: u8, value: &[u8], now: u64) {
+        let n = value.len().min(RELAY_VALUE_MAX);
+        for i in 0..self.count {
+            if self.ids[i] == id {
+                self.vals[i][..n].copy_from_slice(&value[..n]);
+                self.lens[i] = n as u16;
+                self.last_ms[i] = now;
+                return;
+            }
+        }
+        if self.count < RELAY_CACHE_CAP {
+            let i = self.count;
+            self.ids[i] = id;
+            self.vals[i][..n].copy_from_slice(&value[..n]);
+            self.lens[i] = n as u16;
+            self.last_ms[i] = now;
+            self.count += 1;
+        } else {
+            log::warn!(
+                "smol #70/#71: relay cache full ({}) — dropping id{}",
+                RELAY_CACHE_CAP,
+                id
+            );
+        }
+    }
+
+    /// Number of cached leaf records.
+    #[allow(dead_code)]
+    pub fn count(&self) -> usize {
+        self.count
+    }
+
+    /// The `i`-th entry as `(leaf_id, value)`, but ONLY if heard within `ttl` ms of `now`
+    /// (#68 F6 freshness gate). Off-air leaves age out instead of ghosting a retained record.
+    #[allow(dead_code)]
+    pub fn entry_fresh(&self, i: usize, now: u64, ttl: u64) -> Option<(u8, &[u8])> {
+        if i < self.count && now.saturating_sub(self.last_ms[i]) <= ttl {
+            let n = self.lens[i] as usize;
+            Some((self.ids[i], &self.vals[i][..n]))
+        } else {
+            None
+        }
+    }
+}
+
 /// Push `data` out a connected TCP socket, polling the stack until it is all queued
 /// or `deadline` passes. Our MQTT packets are tiny (< tx buffer), so this normally
 /// completes in one `send_slice`; returns false on a socket error or timeout.
@@ -1211,6 +1303,14 @@ fn mqtt_session(
     // `None` on boot/leaf/election bursts (no republish duty). Read-only (the cache is
     // filled by the ESP-NOW `SMOLv1 STAT` service arm, not here).
     stat_cache: Option<&CfgCache>,
+    // #70/#49: this node's OWN compact DIAG record → retained `smol/<node_id>/diag`. Empty ⇒
+    // skipped (boot/election bursts). Built by `RadioManager::diag_record` (uptime, boot-count,
+    // reset reason, boot slot, otadata state, heap, flush/verify counters, button counts).
+    diag: &[u8],
+    // #70/#49: `Some` on a GATEWAY flush → after publishing THIS node's own diag, republish each
+    // CACHED relayed-node DIAG record as retained `smol/<id>/diag` (leaves have no MQTT). F6
+    // freshness-gated (an off-air node ages out, no ghost). `None` off-gateway. Read-only.
+    diag_cache: Option<&RelayCache>,
     // #40 leaf-mesh-OTA: on a GATEWAY flush, filled with `(leaf_id, raw staged announce)`
     // when a retained `smol/<leaf>/ota/install = INSTALL` is present for a leaf id ≠ self
     // AND a staged image is available — the caller then relays it over ESP-NOW. The retained
@@ -1564,6 +1664,37 @@ fn mqtt_session(
                 sbuf[5..5 + m].copy_from_slice(&val[..m]);
                 if let Some(n) =
                     crate::net::mqtt::encode_publish(&mut pkt, ltopic.as_bytes(), &sbuf[..5 + m], true)
+                {
+                    let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+                }
+            }
+        }
+    }
+
+    // #70/#49: publish this node's OWN compact DIAG record as RETAINED `smol/<id>/diag`, if any.
+    // ONE record — HA parses it package-side (no per-signal discovery, per the #70 contract).
+    if !diag.is_empty() {
+        let mut dtopic = MqttScratch::new();
+        let _ = write!(dtopic, "smol/{}/diag", node_id);
+        if let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, dtopic.as_bytes(), diag, true) {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
+    }
+
+    // #70/#49: republish each CACHED relayed-node DIAG record (filled by the ESP-NOW `SMOLv1 DIAG`
+    // service arm — leaves have no MQTT) as RETAINED `smol/<id>/diag`. Skip our OWN id (published
+    // just above) + empty values. Verbatim (the node already formatted the key=val record). #68 F6
+    // freshness-gated: an off-air node's entry ages out → its retained diag stops refreshing.
+    if let Some(dc) = diag_cache {
+        let now_ms = Instant::now().duration_since_epoch().as_millis();
+        for i in 0..dc.count() {
+            if let Some((nid, val)) = dc.entry_fresh(i, now_ms, STAT_FRESH_MS) {
+                if nid == node_id || val.is_empty() {
+                    continue;
+                }
+                let mut dtopic = MqttScratch::new();
+                let _ = write!(dtopic, "smol/{}/diag", nid);
+                if let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, dtopic.as_bytes(), val, true)
                 {
                     let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
                 }
@@ -2277,6 +2408,10 @@ pub fn run_mqtt_burst(
     // #50b: `Some` on a gateway flush → republish cached leaf statuses (see `mqtt_session`);
     // `None` otherwise.
     stat_cache: Option<&CfgCache>,
+    // #70/#49: this node's own DIAG record → retained `smol/<id>/diag` (empty ⇒ none; see `mqtt_session`).
+    diag: &[u8],
+    // #70/#49: `Some` on a gateway flush → republish cached relayed diags (see `mqtt_session`); `None` otherwise.
+    diag_cache: Option<&RelayCache>,
     // #40: on a gateway flush, filled with `(leaf_id, staged announce)` when a leaf install
     // is pending → the caller relays it over ESP-NOW. `&mut None` on boot/leaf bursts.
     leaf_ota: &mut Option<(u8, crate::ota::Announce)>,
@@ -2469,6 +2604,8 @@ pub fn run_mqtt_burst(
         status, // #50: forward the live STAT|screen:page for smol/<id>/status
         cfg_cache, // #21: forward the gateway's leaf-config cache (or None)
         stat_cache, // #50b: forward the gateway's cached leaf statuses (or None)
+        diag, // #70/#49: forward this node's own DIAG record (or empty)
+        diag_cache, // #70/#49: forward the gateway's cached relayed diags (or None)
         leaf_ota, // #40: forward the leaf-OTA install pairing (or &mut None)
         staged_raw, // #40: forward the persistent staged announce (or &mut None)
         leaf_diag, // #40: forward the diag/clear state (or &mut None)

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -970,6 +970,14 @@ const CFG_CACHE_CAP: usize = 16;
 #[cfg(feature = "wifi")]
 pub const STAT_FRESH_MS: u64 = 45_000;
 
+/// #70/#49 F6 (diag twin): a cached node DIAG older than this is STALE — its `smol/<id>/diag`
+/// republish is skipped so an off-air node ages out (no ghost). Sized off the SLOW ~60 s DIAG
+/// broadcast cadence (diag is slow-moving, kept low-airtime), NOT the 10 s STAT cadence: at ~2.5×
+/// the beat a node that missed 2 diags is gone. MUST exceed the diag cadence or a live node's
+/// record would flicker stale between broadcasts (the STAT gate's 45 s would wrongly drop it).
+#[cfg(feature = "wifi")]
+pub const DIAG_FRESH_MS: u64 = 150_000;
+
 /// #21 leaf-relay: the GATEWAY's per-leaf default-screen cache. Filled from the
 /// retained wildcard `smol/+/config/default_screen` during a flush; re-broadcast as
 /// `SMOLv1 CFG` frames on the ~10 s cadence (mode.rs `broadcast_cached_configs`) so
@@ -1688,7 +1696,9 @@ fn mqtt_session(
     if let Some(dc) = diag_cache {
         let now_ms = Instant::now().duration_since_epoch().as_millis();
         for i in 0..dc.count() {
-            if let Some((nid, val)) = dc.entry_fresh(i, now_ms, STAT_FRESH_MS) {
+            // #70 F6: DIAG's own (longer) freshness window — the ~60 s diag cadence would flicker
+            // stale under STAT's 45 s gate. A node that missed ~2 diags is genuinely gone.
+            if let Some((nid, val)) = dc.entry_fresh(i, now_ms, DIAG_FRESH_MS) {
                 if nid == node_id || val.is_empty() {
                     continue;
                 }

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -756,6 +756,7 @@ pub fn boot_confirm(self_test_passed: bool) {
     if self_test_passed {
         let _ = ota.set_current_ota_state(OtaImageState::Valid);
         clear_ota_activated(); // fate decided — don't re-self-test on a later crash-reset
+        mark_ota_outcome(false); // #70: DIAG ota=confirmed
         log::info!("smol OTA: self-test PASS — image CONFIRMED (Valid)");
     } else {
         // #40 BRICK-SAFETY (was a hard brick): roll back ONLY if the target slot holds a
@@ -773,10 +774,15 @@ pub fn boot_confirm(self_test_passed: bool) {
                 let _ = ota.set_current_slot(t);
             }
             let _ = ota.set_current_ota_state(OtaImageState::Valid);
+            mark_ota_outcome(true); // #70: DIAG ota=rolled-back — set BEFORE reset; the good-slot
+                                    // boot reports it (drives luna's rollback alert automation).
             log::warn!("smol OTA: self-test FAIL — ROLLING BACK to the previous (valid) slot");
             esp_hal::system::software_reset();
         } else {
             let _ = ota.set_current_ota_state(OtaImageState::Valid);
+            // #70: brick-safe accept (no valid rollback target) — the image IS running, so from
+            // HA's outcome view it's `confirmed` (no rollback occurred), not a silent failure.
+            mark_ota_outcome(false);
             log::warn!(
                 "smol OTA: self-test FAIL, but the rollback target has NO valid image — ACCEPTING the current image (brick-safe: no flip, no reset)"
             );
@@ -1456,12 +1462,14 @@ pub fn reset_reason_token() -> &'static str {
     if take_panic_mark() {
         return "panic";
     }
+    // Value strings match luna's DEPLOYED #70 HA parser (PR #81) exactly — the parser passes
+    // rst= through for display, so an out-of-enum value like "panic" still shows correctly.
     use esp_hal::rtc_cntl::SocResetReason as R;
     match esp_hal::system::reset_reason() {
-        Some(R::ChipPowerOn) => "por",
+        Some(R::ChipPowerOn) => "power-on",
         Some(R::CoreSw) | Some(R::Cpu0Sw) => "sw",
-        Some(R::CoreDeepSleep) => "dslp",
-        Some(R::SysBrownOut) => "bo",
+        Some(R::CoreDeepSleep) => "deep-sleep",
+        Some(R::SysBrownOut) => "brownout",
         Some(
             R::CoreMwdt0
             | R::CoreMwdt1
@@ -1472,7 +1480,8 @@ pub fn reset_reason_token() -> &'static str {
             | R::SysRtcWdt
             | R::SysSuperWdt,
         ) => "wdt",
-        Some(R::CoreUsbUart | R::CoreUsbJtag) => "usb",
+        Some(R::CoreUsbUart | R::CoreUsbJtag) => "usb-jtag",
+        Some(R::SysClkGlitch | R::CorePwrGlitch) => "glitch",
         Some(_) => "other",
         None => "unk",
     }
@@ -1501,42 +1510,58 @@ pub fn boot_slot() -> u8 {
     }
 }
 
-/// The otadata image-state as a short token. After a confirmed boot this is `valid`;
-/// `new`/`pend` means the first-boot self-test has not committed yet.
+/// #70 LAST OTA OUTCOME — the DIAG record's `ota=` field, matching luna's deployed parser
+/// (`confirmed` | `rolled-back` | `none`), which drives her rollback ALERT automation. This is
+/// an OUTCOME, not the raw otadata state: `boot_confirm` decides it (PASS → confirmed, self-test
+/// FAIL → rolled-back) AFTER `capture_boot_diag` runs, so it is read LIVE each diag cadence (not
+/// cached in `DiagBoot`). RTC-fast persistent (survives the rollback's `software_reset` so the
+/// good-slot boot reports `rolled-back`; a power cycle clears it → `none`, correct). Magic-gated
+/// so uninitialised RTC RAM reads as `none`, never a false outcome.
+#[cfg(feature = "wifi")]
+#[esp_hal::ram(rtc_fast, persistent)]
+static mut OTA_OUTCOME: [u32; 2] = [0u32; 2]; // [magic, 1=confirmed / 2=rolled-back]
+
+#[cfg(feature = "wifi")]
+const OTA_OUTCOME_MAGIC: u32 = 0x736D_6C4F; // "smlO"
+
+/// Record the last OTA outcome (call from `boot_confirm`): `rolled_back` true ⇒ `rolled-back`,
+/// else `confirmed`. Set before the rollback's `software_reset` so the next boot reports it.
+#[cfg(feature = "wifi")]
+pub fn mark_ota_outcome(rolled_back: bool) {
+    unsafe {
+        let m = &mut *core::ptr::addr_of_mut!(OTA_OUTCOME);
+        m[0] = OTA_OUTCOME_MAGIC;
+        m[1] = if rolled_back { 2 } else { 1 };
+    }
+}
+
+/// The last OTA outcome token for the DIAG `ota=` field. `none` until an OTA confirm/rollback
+/// happened this power-cycle (magic-gated: uninitialised RTC RAM ⇒ `none`).
 #[cfg(feature = "espnow")]
-pub fn ota_state_token() -> &'static str {
-    let mut flash = FlashStorage::new();
-    let mut buf = [0u8; PT_SCRATCH];
-    let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
-        return "err";
-    };
-    let Ok(Some(od)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Ota)) else {
-        return "n/a";
-    };
-    let mut region = od.as_embedded_storage(&mut flash);
-    let Ok(mut ota) = Ota::new(&mut region) else {
-        return "err";
-    };
-    match ota.current_ota_state() {
-        Ok(OtaImageState::Valid) => "valid",
-        Ok(OtaImageState::New) => "new",
-        Ok(OtaImageState::PendingVerify) => "pend",
-        Ok(OtaImageState::Invalid) => "inval",
-        Ok(OtaImageState::Aborted) => "abort",
-        Ok(OtaImageState::Undefined) => "undef",
-        Err(_) => "err",
+pub fn ota_outcome_token() -> &'static str {
+    unsafe {
+        let m = core::ptr::addr_of!(OTA_OUTCOME).read();
+        if m[0] != OTA_OUTCOME_MAGIC {
+            return "none";
+        }
+        match m[1] {
+            1 => "confirmed",
+            2 => "rolled-back",
+            _ => "none",
+        }
     }
 }
 
 /// The once-per-boot diagnostics, captured into a cache by `capture_boot_diag` and read every
-/// diag cadence by `boot_diag()`. `Copy` so it lives inline in the cache.
+/// diag cadence by `boot_diag()`. `Copy` so it lives inline in the cache. (The OTA outcome is
+/// NOT here — it's decided by `boot_confirm` after capture, so it's read live via
+/// `ota_outcome_token`.)
 #[cfg(feature = "espnow")]
 #[derive(Clone, Copy)]
 pub struct DiagBoot {
     pub boot_count: u32,
     pub reset_reason: &'static str,
     pub boot_slot: u8,
-    pub ota_state: &'static str,
 }
 
 #[cfg(feature = "espnow")]
@@ -1553,7 +1578,6 @@ pub fn capture_boot_diag() {
         boot_count: boot_count_bump(),
         reset_reason: reset_reason_token(),
         boot_slot: boot_slot(),
-        ota_state: ota_state_token(),
     };
     unsafe {
         *core::ptr::addr_of_mut!(BOOT_DIAG) = Some(d);
@@ -1569,7 +1593,6 @@ pub fn boot_diag() -> DiagBoot {
             boot_count: 0,
             reset_reason: "unk",
             boot_slot: 255,
-            ota_state: "n/a",
         })
     }
 }

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -1317,3 +1317,259 @@ pub fn otadata_unconfirmed() -> bool {
         Ok(OtaImageState::New) | Ok(OtaImageState::PendingVerify)
     )
 }
+
+// ===========================================================================
+// #70 observability — per-boot diagnostics for the retained DIAG record.
+//
+// Captured ONCE at boot (`capture_boot_diag`) into a `static mut` cache (rv32imc has
+// no atomics; single boot-path caller, no ISR — the same discipline as `NODE_ID_CACHE`
+// / the OTA scratch statics), then read every diag cadence by `boot_diag()`:
+//   • boot_count  — NVS-persisted, bumped once per boot (survives power-loss; the OTA
+//                   image write never touches nvs, so it survives every image too).
+//   • reset_reason— por / sw / panic / bo / wdt / usb / dslp / other / unk.
+//   • boot_slot   — the running app slot (0=ota_0 / 1=ota_1). A silent rollback FLIPS it.
+//   • ota_state   — otadata image state token (valid/new/pend/…).
+// All `espnow`-scoped: only the mesh DIAG record consumes them (a `wifi`-only build has
+// no `RadioManager` to build the frame). BRICK-SAFE: every read fails to a benign default
+// and never panics; the boot-count store is SECTOR-SEGREGATED from identity + the floor.
+// ---------------------------------------------------------------------------
+
+// #70 boot-count store: `[MAGIC(4 LE) | count(4 LE) | crc32(4 LE)]`, two ping-pong cells in
+// nvs SECTORS 3 & 4 (offsets 12288/16384). nvs is 0x6000 (6 sectors): sector 0 = identity,
+// sectors 1-2 = freshness floor, so 3/4 are free (5 left spare). Ping-pong = torn-write-safe
+// (a power-loss mid-bump keeps the other cell's prior count) AND halves per-sector flash wear
+// (each cell is erased only every OTHER boot). Same sector-segregation invariant as the floor:
+// a bump erases a whole 4 KB sector, so these MUST NOT share sector 0 (identity) or 1-2 (floor).
+#[cfg(feature = "espnow")]
+const BOOTCOUNT_MAGIC: u32 = 0x736D_6C42; // "smlB"
+#[cfg(feature = "espnow")]
+const BOOTCOUNT_CELL_BASE: u32 = 12288; // nvs sector 3 — NOT 0/1/2 (identity + floor)
+#[cfg(feature = "espnow")]
+const BOOTCOUNT_CELL_STRIDE: u32 = 4096; // one sector apart (erase granularity)
+#[cfg(feature = "espnow")]
+const BOOTCOUNT_RECORD_LEN: usize = 12;
+
+/// Read one boot-count cell at `rel` (nvs-relative). `None` on flash error / bad magic / crc.
+#[cfg(feature = "espnow")]
+fn bootcount_cell_read(rel: u32) -> Option<u32> {
+    use embedded_storage::nor_flash::ReadNorFlash;
+    let mut flash = FlashStorage::new();
+    let mut ptbuf = [0u8; PT_SCRATCH];
+    let pt = read_partition_table(&mut flash, &mut ptbuf).ok()?;
+    let nvs = pt
+        .find_partition(PartitionType::Data(DataPartitionSubType::Nvs))
+        .ok()??;
+    let mut region = nvs.as_embedded_storage(&mut flash);
+    let mut rec = [0u8; BOOTCOUNT_RECORD_LEN];
+    region.read(rel, &mut rec).ok()?;
+    let magic = u32::from_le_bytes([rec[0], rec[1], rec[2], rec[3]]);
+    if magic != BOOTCOUNT_MAGIC {
+        return None; // erased (0xFFFFFFFF) or never written
+    }
+    let count = u32::from_le_bytes([rec[4], rec[5], rec[6], rec[7]]);
+    let crc = u32::from_le_bytes([rec[8], rec[9], rec[10], rec[11]]);
+    (crc == crc32(&rec[0..8])).then_some(count)
+}
+
+/// Increment the NVS-persisted boot count and return the NEW value. Call ONCE per boot.
+/// Writes the incremented count to the cell holding the SMALLER/invalid count, so the other
+/// cell always retains the prior count → a torn write cannot lose it (power-loss safe).
+/// Best-effort: any flash error still returns the in-memory increment (the diag just isn't
+/// persisted this boot; the next boot re-reads the last good cell). Never panics, never
+/// touches identity (sector 0) or the floor (sectors 1-2).
+#[cfg(feature = "espnow")]
+pub fn boot_count_bump() -> u32 {
+    use embedded_storage::nor_flash::NorFlash;
+    let a = bootcount_cell_read(BOOTCOUNT_CELL_BASE);
+    let b = bootcount_cell_read(BOOTCOUNT_CELL_BASE + BOOTCOUNT_CELL_STRIDE);
+    let cur = a.unwrap_or(0).max(b.unwrap_or(0));
+    let next = cur.saturating_add(1);
+    // Target the cell with the smaller (or invalid) count; the other keeps the prior max.
+    // Both offsets are in sectors 3/4 — never sector 0/1/2, so this erase can't wipe identity
+    // or the freshness floor.
+    let target_rel = if a.unwrap_or(0) <= b.unwrap_or(0) {
+        BOOTCOUNT_CELL_BASE
+    } else {
+        BOOTCOUNT_CELL_BASE + BOOTCOUNT_CELL_STRIDE
+    };
+    let mut rec = [0u8; BOOTCOUNT_RECORD_LEN];
+    rec[0..4].copy_from_slice(&BOOTCOUNT_MAGIC.to_le_bytes());
+    rec[4..8].copy_from_slice(&next.to_le_bytes());
+    let crc = crc32(&rec[0..8]);
+    rec[8..12].copy_from_slice(&crc.to_le_bytes());
+    let mut flash = FlashStorage::new();
+    let mut ptbuf = [0u8; PT_SCRATCH];
+    let Ok(pt) = read_partition_table(&mut flash, &mut ptbuf) else {
+        return next;
+    };
+    let Ok(Some(nvs)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Nvs)) else {
+        return next;
+    };
+    let mut region = nvs.as_embedded_storage(&mut flash);
+    if region.erase(target_rel, target_rel + BOOTCOUNT_CELL_STRIDE).is_err() {
+        return next;
+    }
+    let _ = region.write(target_rel, &rec);
+    next
+}
+
+/// #70 panic marker: a panic on this fw halts via `custom_halt` → `software_reset`, which the
+/// SoC records as a plain software reset (`CoreSw`) — indistinguishable from an intentional
+/// reboot / OTA activate. `custom_halt` sets this RTC-fast persistent marker FIRST, so the
+/// next boot can tell a panic-reset (`rr=panic`) from a clean `rr=sw`. Survives the reset AND
+/// a USB reflash; a true power cycle clears it (a power-cycled board reports `por`, correct).
+#[cfg(feature = "wifi")]
+#[esp_hal::ram(rtc_fast, persistent)]
+static mut PANIC_MARK: [u32; 1] = [0u32; 1];
+
+#[cfg(feature = "wifi")]
+const PANIC_MARK_MAGIC: u32 = 0x736D_6C50; // "smlP"
+
+/// Set the panic marker (call from `custom_halt`, BEFORE `software_reset`).
+#[cfg(feature = "wifi")]
+pub fn mark_panic() {
+    unsafe {
+        let m = &mut *core::ptr::addr_of_mut!(PANIC_MARK);
+        m[0] = PANIC_MARK_MAGIC;
+    }
+}
+
+/// Read-and-clear the panic marker. `true` iff this boot chain began with a panic. Cleared on
+/// read so only the FIRST boot after the panic reports it. `espnow`-scoped: only the mesh diag
+/// path (`reset_reason_token`) reads it; a wifi-only build sets the marker (via `mark_panic`) but
+/// has no DIAG consumer, so it never takes it.
+#[cfg(feature = "espnow")]
+fn take_panic_mark() -> bool {
+    unsafe {
+        let m = &mut *core::ptr::addr_of_mut!(PANIC_MARK);
+        let hit = m[0] == PANIC_MARK_MAGIC;
+        m[0] = 0;
+        hit
+    }
+}
+
+/// The last reset reason as a short, stable token for the DIAG record. Reads (and clears) the
+/// panic marker first — a panic shows as `CoreSw` at the SoC level, so the marker recovers the
+/// `panic` distinction. Everything else maps the C3 `SocResetReason` set to a compact token.
+#[cfg(feature = "espnow")]
+pub fn reset_reason_token() -> &'static str {
+    if take_panic_mark() {
+        return "panic";
+    }
+    use esp_hal::rtc_cntl::SocResetReason as R;
+    match esp_hal::system::reset_reason() {
+        Some(R::ChipPowerOn) => "por",
+        Some(R::CoreSw) | Some(R::Cpu0Sw) => "sw",
+        Some(R::CoreDeepSleep) => "dslp",
+        Some(R::SysBrownOut) => "bo",
+        Some(
+            R::CoreMwdt0
+            | R::CoreMwdt1
+            | R::Cpu0Mwdt0
+            | R::Cpu0Mwdt1
+            | R::CoreRtcWdt
+            | R::Cpu0RtcWdt
+            | R::SysRtcWdt
+            | R::SysSuperWdt,
+        ) => "wdt",
+        Some(R::CoreUsbUart | R::CoreUsbJtag) => "usb",
+        Some(_) => "other",
+        None => "unk",
+    }
+}
+
+/// The running app slot as 0 (`ota_0`) / 1 (`ota_1`); 255 on a non-OTA board or any read
+/// error. A silent rollback flips this vs the pushed slot — the headline #70 signal.
+#[cfg(feature = "espnow")]
+pub fn boot_slot() -> u8 {
+    let mut flash = FlashStorage::new();
+    let mut buf = [0u8; PT_SCRATCH];
+    let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
+        return 255;
+    };
+    let Ok(Some(od)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Ota)) else {
+        return 255;
+    };
+    let mut region = od.as_embedded_storage(&mut flash);
+    let Ok(mut ota) = Ota::new(&mut region) else {
+        return 255;
+    };
+    match ota.current_slot() {
+        Ok(Slot::Slot0) => 0,
+        Ok(Slot::Slot1) => 1,
+        _ => 255,
+    }
+}
+
+/// The otadata image-state as a short token. After a confirmed boot this is `valid`;
+/// `new`/`pend` means the first-boot self-test has not committed yet.
+#[cfg(feature = "espnow")]
+pub fn ota_state_token() -> &'static str {
+    let mut flash = FlashStorage::new();
+    let mut buf = [0u8; PT_SCRATCH];
+    let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
+        return "err";
+    };
+    let Ok(Some(od)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Ota)) else {
+        return "n/a";
+    };
+    let mut region = od.as_embedded_storage(&mut flash);
+    let Ok(mut ota) = Ota::new(&mut region) else {
+        return "err";
+    };
+    match ota.current_ota_state() {
+        Ok(OtaImageState::Valid) => "valid",
+        Ok(OtaImageState::New) => "new",
+        Ok(OtaImageState::PendingVerify) => "pend",
+        Ok(OtaImageState::Invalid) => "inval",
+        Ok(OtaImageState::Aborted) => "abort",
+        Ok(OtaImageState::Undefined) => "undef",
+        Err(_) => "err",
+    }
+}
+
+/// The once-per-boot diagnostics, captured into a cache by `capture_boot_diag` and read every
+/// diag cadence by `boot_diag()`. `Copy` so it lives inline in the cache.
+#[cfg(feature = "espnow")]
+#[derive(Clone, Copy)]
+pub struct DiagBoot {
+    pub boot_count: u32,
+    pub reset_reason: &'static str,
+    pub boot_slot: u8,
+    pub ota_state: &'static str,
+}
+
+#[cfg(feature = "espnow")]
+static mut BOOT_DIAG: Option<DiagBoot> = None;
+
+/// Capture the per-boot diagnostics ONCE, very early in `main` (after the OTA bookkeeping, so a
+/// forced rollback reboots BEFORE the count bumps — the rolled-back boot counts, the aborted one
+/// does not). Bumps the persisted boot count, latches the reset reason (incl. the panic marker
+/// take), and reads the boot slot + otadata state. Single-threaded boot-path caller (no ISR).
+/// Call exactly once — a second call would double-bump the boot count.
+#[cfg(feature = "espnow")]
+pub fn capture_boot_diag() {
+    let d = DiagBoot {
+        boot_count: boot_count_bump(),
+        reset_reason: reset_reason_token(),
+        boot_slot: boot_slot(),
+        ota_state: ota_state_token(),
+    };
+    unsafe {
+        *core::ptr::addr_of_mut!(BOOT_DIAG) = Some(d);
+    }
+}
+
+/// The cached per-boot diagnostics (a benign all-unknown default if `capture_boot_diag` never
+/// ran). Read by the DIAG frame builder each cadence.
+#[cfg(feature = "espnow")]
+pub fn boot_diag() -> DiagBoot {
+    unsafe {
+        core::ptr::addr_of!(BOOT_DIAG).read().unwrap_or(DiagBoot {
+            boot_count: 0,
+            reset_reason: "unk",
+            boot_slot: 255,
+            ota_state: "n/a",
+        })
+    }
+}

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -434,6 +434,14 @@ pub struct OtaLeafSession {
     dbg_otam_heard: u16,
     dbg_verdict: u8,
     dbg_otan_sent: u16,
+    /// #49 observability: lifetime OTA integrity-verify outcomes on the leaf mesh-OTA receive
+    /// path, folded into the retained DIAG record (`vok`/`vfl`) — the on-device proof of the #32
+    /// signed-refuse that was previously UART0-only. `verify_fail` bumps on an ed25519-sig fail
+    /// (the #32 refuse line) OR a readback-SHA mismatch; `verify_ok` on a full readback-verified
+    /// image. Policy rejections (build≤running / ≤floor / size) are NOT counted here — they are
+    /// gating decisions over an already-valid signature, tracked by `dbg_verdict`/relaydiag.
+    verify_ok: u16,
+    verify_fail: u16,
 }
 
 impl OtaLeafSession {
@@ -455,7 +463,14 @@ impl OtaLeafSession {
             dbg_otam_heard: 0,
             dbg_verdict: 0,
             dbg_otan_sent: 0,
+            verify_ok: 0,
+            verify_fail: 0,
         }
+    }
+
+    /// #49: lifetime OTA integrity-verify counters `(ok, fail)` for the DIAG record (`vok`/`vfl`).
+    pub fn verify_counts(&self) -> (u16, u16) {
+        (self.verify_ok, self.verify_fail)
     }
 
     /// #40 #3: lifetime leaf RX-diag `(otam_heard, last_on_meta_verdict, otan_sent)` — the leaf
@@ -514,6 +529,7 @@ impl OtaLeafSession {
         if !crate::ota::verify_signature(m, sig) {
             log::warn!("smol #40: OTAM sig FAILED — ignored (no state, no flash)");
             self.dbg_verdict = 2; // #3: signature verify failed
+            self.verify_fail = self.verify_fail.saturating_add(1); // #49: the #32 refuse-line proof
             return LeafAction::None;
         }
         // (2) Only now is M trustworthy → parse build/size/sha.
@@ -686,9 +702,11 @@ impl OtaLeafSession {
                 let target_slot = w.target();
                 if w.finalize(size, &sha) {
                     log::info!("smol #40: image VERIFIED (readback SHA-256, ed25519 already ok) — activating build {}", build);
+                    self.verify_ok = self.verify_ok.saturating_add(1); // #49: full integrity-verified
                     LeafAction::Complete(target_slot, build)
                 } else {
                     log::error!("smol #40: readback verify FAILED — discarded (good slot intact)");
+                    self.verify_fail = self.verify_fail.saturating_add(1); // #49: readback SHA mismatch
                     LeafAction::Abort
                 }
             }


### PR DESCRIPTION
## Observability wave — MERGE LADDER slot 3 (quartet → mesh → observability → cast)
Rebased onto current main (7e3fefc) — includes #81 (luna's HA obs-wave) + #82 (mesh-correctness). Clean rebase, no conflicts.

> Hardware validation deferred to the morning consolidated canary (boards unplugged tonight). Merges on oracle-green + 4-profile compile proof per the no-canary overnight policy.

## What this delivers (#70 + #49)
ONE compact retained `smol/<id>/diag` record per node — the built-in observability the #40 debugging night lacked (a silent rollback was invisible until USB bootloader logs). Conforms exactly to luna's DEPLOYED HA parser (PR #81): `value.split('|')`, literal `DIAG` first field, then order-independent `key=value` pairs — HA parses package-side, NO per-signal MQTT discovery (no entity doubling).

Record: `DIAG|slot=|rst=|boot=|ota=|up=|heap=|hmin=|btn=|btnl=|fok=|ffl=|vok=|vfl=|loss=`

### #70 — silent-rollback trio + resources + buttons
- `ota=` last OTA OUTCOME (confirmed/rolled-back/none) — drives luna's rollback alert. Set by boot_confirm via a magic-gated RTC-fast marker written BEFORE the rollback reset, so the good-slot boot reports it; read live each cadence.
- `rst=` reset reason in luna's enum (power-on/sw/wdt/brownout/usb-jtag/deep-sleep/glitch) + `panic` (the C3 routes a panic through custom_halt→software_reset = plain `sw` at the SoC; recovered via an RTC-fast panic marker).
- `slot=` running OTA slot (a rollback flips it), `boot=` NVS-persisted boot-count (2-cell ping-pong at nvs sectors 3&4, segregated from identity@0 + floor@1-2 so a bump-erase can't wipe either; torn-write-safe + halves wear).
- `heap=` free + `hmin=` self-tracked min-free watermark (leak/pressure).
- `btn=`/`btnl=` BOOT short/long press counters (monotonic; HA fires press/long-press events on increment). A press expedites the next leaf diag broadcast (rate-limited).

### #49 — runtime counters folded into the SAME diag topic
- `fok`/`ffl` flush ok/fail (gateway CONNACK) — on-device #9 flush-win proof.
- `vok`/`vfl` OTA verify ok/fail (leaf mesh-OTA ed25519-sig refuse + readback-SHA) — on-device #32 signed-refuse proof. Both were UART0-only.
- `loss` mesh loss % (aligns with luna's #74-reserved `loss` key).

### Transport (mirrors STAT #50b)
New `SMOLv1 DIAG` frame (own value buffer — record ~130 B, past STAT's 16 B CFG_VALUE_MAX) + a shared bigger-value `RelayCache`, F6 freshness-gated with a diag-specific `DIAG_FRESH_MS`=150 s (the ~60 s diag cadence would flicker stale under STAT's 45 s gate — fixed). Node broadcasts DIAG ~60 s; gateway caches per-node + republishes retained `smol/<id>/diag` (off-air node ages out — no ghost). Gateway publishes its own diag during the flush.

## Verification
- All 4 profiles compile (default / wifi / espnow / wled); rebased tree re-verified.
- Default-build invariant holds via cfg-gating (not ELF equality).
- 0 new clippy warnings on espnow (3 pre-existing toolchain-1.96 lint-drift warnings in ota_mesh.rs are on origin/main, not from this diff).
- No hardware flashing (team-lead owns the fleet; validation → morning canary).

## Follow-up: #71 (WiFi scan)
Separate PR after the quartet merges — on-demand (W key, mirroring quartet's R cache-bypass), HW-canary-gated. Design + nebula's API/privacy grounding in scratch/smol-dreamteam/vesper-observability-design.md.

Refs #70 #49 #9 #32 #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)