### PR TITLE
feat(fw): #26 smol Cast — stream the OLED image to a WLED matrix (DNRGB UDP)

### DIFF
--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -150,6 +150,18 @@ espnow = ["wifi", "esp-wifi/esp-now", "dep:ed25519-compact"]
 # `#![cfg(feature = "wled")]` and every hook is `#[cfg(feature = "wled")]`).
 wled = ["espnow"]
 
+# #26 smol Cast: mirror the gateway's OLED image onto a network WLED matrix as
+# realtime UDP pixels (DNRGB, :21324) — NOT ESP-NOW (cleaner than #25's control path).
+# Builds on `espnow` (⊃ `wifi`): casting is a GATEWAY-role activity — it needs an
+# associated STA to reach the matrix AND the recurring gateway flush that carries the
+# stream, both of which only the espnow build has (a wifi-only board only associates
+# once at boot). Pure-additive: NO new crate links — a DrawTarget tee mirrors the
+# framebuffer, a pure packer encodes DNRGB, and the existing flush association carries
+# it. The default / wifi / espnow / wled builds are BYTE-FREE of it (`net::cast*` is
+# `#[cfg(feature = "cast")]` and every hook is cfg-gated; the `Oled` type only swaps to
+# the tee under this flag).
+cast = ["espnow"]
+
 # COEXIST SOAK (issue #23 PART 1 — the gating experiment, NOT for production).
 # The gateway stays WiFi-associated after boot (no switch to ESP-NOW time-share),
 # the mesh rides the AP channel (pinned to ch1 = north-bedroom), and mesh + MQTT

--- a/rust/clock/src/app.rs
+++ b/rust/clock/src/app.rs
@@ -13,9 +13,15 @@
 //! NOT a plugin) + a ~12-line dispatch core.
 
 use crate::input::Press;
+// Only the plain (non-cast) `Oled` alias below names these; under `feature = "cast"`
+// the alias is `CastOled` and these imports would be unused.
+#[cfg(not(feature = "cast"))]
 use ssd1306::mode::BufferedGraphicsMode;
+#[cfg(not(feature = "cast"))]
 use ssd1306::prelude::I2CInterface;
+#[cfg(not(feature = "cast"))]
 use ssd1306::size::DisplaySize72x40;
+#[cfg(not(feature = "cast"))]
 use ssd1306::Ssd1306;
 
 /// The one concrete OLED type in the firmware. `Ctx` holds this CONCRETELY (not a
@@ -23,11 +29,20 @@ use ssd1306::Ssd1306;
 /// and `flush` lives on `Ssd1306`, not the `DrawTarget` trait. The generic draw
 /// helpers (`draw_clock`, …) still take `&mut impl DrawTarget`; a plugin passes
 /// `ctx.display` (which coerces) and flushes it itself.
+#[cfg(not(feature = "cast"))]
 pub type Oled = Ssd1306<
     I2CInterface<esp_hal::i2c::master::I2c<'static, esp_hal::Blocking>>,
     DisplaySize72x40,
     BufferedGraphicsMode<DisplaySize72x40>,
 >;
+
+/// #26 cast: under `feature = "cast"` the one concrete OLED becomes the tee-wrapper
+/// [`crate::net::cast_oled::CastOled`], which mirrors every draw into a shadow
+/// framebuffer for the WLED pixel-stream. It is a drop-in for the plain `Ssd1306`
+/// (same `DrawTarget` + inherent `flush()`/`init()`), so every plugin + `main` draw
+/// site is unchanged; only the boot construction in `main` wraps the raw panel.
+#[cfg(feature = "cast")]
+pub type Oled = crate::net::cast_oled::CastOled;
 
 /// How this node's clock was last set — surfaced to plugins (Bench own-status,
 /// future Clock/HUD provenance) via [`Ctx::mesh`]. `main` owns the transition:

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -75,9 +75,12 @@ use esp_hal::{
     time::Instant,
     time::Rate,
 };
-use ssd1306::{
-    mode::DisplayConfig, prelude::*, size::DisplaySize72x40, I2CDisplayInterface, Ssd1306,
-};
+use ssd1306::{prelude::*, size::DisplaySize72x40, I2CDisplayInterface, Ssd1306};
+// `DisplayConfig::init` inits the PLAIN Ssd1306 (non-cast builds). Under `feature =
+// "cast"` the display is the `CastOled` tee, whose inherent `init()` forwards to the
+// inner panel (it imports `DisplayConfig` itself), so `main` no longer names the trait.
+#[cfg(not(feature = "cast"))]
+use ssd1306::mode::DisplayConfig;
 
 // App-plugin framework (issue #7): the `Oled` alias, `Ctx`, `Plugin` trait,
 // `AppKind`/`App` enum + centralized dispatch, and the `REGISTRY` that
@@ -320,8 +323,15 @@ fn main() -> ! {
     // --- SSD1306 display -----------------------------------------------------
     let interface = I2CDisplayInterface::new(i2c);
     // Rotated 180° (case hangs from the USB-C end) — see DISPLAY_ROTATION.
-    let mut display = Ssd1306::new(interface, DisplaySize72x40, DISPLAY_ROTATION)
+    let raw_display = Ssd1306::new(interface, DisplaySize72x40, DISPLAY_ROTATION)
         .into_buffered_graphics_mode();
+    // #26 cast: wrap the panel in the DrawTarget tee so every draw is mirrored into a
+    // shadow framebuffer for the WLED pixel-stream. Byte-identical `Oled` (plain
+    // Ssd1306) in every non-cast build — see `app::Oled`.
+    #[cfg(not(feature = "cast"))]
+    let mut display = raw_display;
+    #[cfg(feature = "cast")]
+    let mut display = crate::net::cast_oled::CastOled::new(raw_display);
     display.init().expect("display init");
 
     // (Text styles now live inside each plugin's render — CLOCK's big-digit
@@ -1088,6 +1098,12 @@ fn main() -> ! {
         // cadence + its framebuffer clear/flush — the old per-mode match arms,
         // relocated VERBATIM into each `Plugin::update` (the equivalence proof).
         app.update(&mut ctx);
+
+        // #26 cast: snapshot the just-rendered glass image into the shared cast frame
+        // (the `ctx` borrow of `display` has ended at the `update` call above), so the
+        // next gateway flush can stream it to the WLED matrix. No-op unless feature=cast.
+        #[cfg(feature = "cast")]
+        crate::net::cast::publish_frame(display.mirror());
 
         // The redraw latch is single-tick: this tick's `update` consumed it.
         redraw = false;

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -24,6 +24,16 @@ pub mod mode;
 #[cfg(feature = "wled")]
 pub mod wled;
 
+// #26 smol Cast: stream the gateway's OLED image to a network WLED matrix as
+// realtime UDP pixels. `cast = ["wifi"]`. `cast` is the PURE packer + shadow
+// framebuffer (host-testable, no HAL deps); `cast_oled` is the DrawTarget tee that
+// feeds it (needs ssd1306). Absent from every non-cast build → the default / wifi /
+// espnow / wled profiles are byte-free of it.
+#[cfg(feature = "cast")]
+pub mod cast;
+#[cfg(feature = "cast")]
+pub mod cast_oled;
+
 // Deterministic magical node names (realm-sigil port). Needs no radio — a node
 // derives its OWN name and any peer's name from the logical id alone — so it is
 // compiled in ALL builds (peer names are only *displayed* under espnow, but our

--- a/rust/clock/src/net/cast.rs
+++ b/rust/clock/src/net/cast.rs
@@ -1,0 +1,277 @@
+//! #26 smol Cast — stream the gateway's OLED image to a network WLED matrix as
+//! realtime UDP pixels.
+//!
+//! ## What this is
+//! The gateway mirrors the 72×40 1-bit image on its own glass onto a network LED
+//! matrix running WLED, over plain WiFi/UDP (NOT ESP-NOW — cleaner than #25's
+//! control path). WLED exposes a realtime pixel protocol on UDP :21324; we
+//! down-sample smol's mono framebuffer to the matrix's NxM grid, colour it (a
+//! mono→RGB choice, since the OLED can't do colour), and stream one frame every
+//! ~100 ms while the radio is associated. `feature = "cast"` (= `wifi`); the
+//! default / wifi-only-without-cast / espnow / wled builds are byte-free of it.
+//!
+//! ## This file is PURE (no esp-hal / ssd1306 / embedded-graphics deps)
+//! Everything here is plain integer/byte logic so it is host-unit-testable off the
+//! target (see the scratch harness). The DrawTarget tee-wrapper that FEEDS the
+//! [`Mirror`] from live draws lives in `net/cast_oled.rs` (it needs ssd1306), and
+//! the UDP send site lives in `net/wifi.rs` (it needs smoltcp). This module owns
+//! only: the shadow framebuffer, the down-sample, the serpentine LED mapping, and
+//! the DNRGB packet encoder.
+//!
+//! ## Wire protocol — WLED DNRGB (realtime UDP, port 21324)
+//! WLED realtime frame: `[proto][timeout][start_hi][start_lo][R,G,B]…`.
+//!   * `proto = 4` (DNRGB — start-indexed RGB; DRGB=2 has no index and caps a whole
+//!     frame at one packet, but a 16×16 = 256-LED DRGB frame is 770 B > the 512 B
+//!     smoltcp UDP TX buffer, so we always use DNRGB and CHUNK — see [`MAX_LEDS_PER_PKT`]).
+//!   * `timeout` = seconds WLED waits after the LAST packet before reverting to its
+//!     normal (non-realtime) mode. A small value ([`DEFAULT_TIMEOUT_S`]) means the
+//!     matrix self-releases a few seconds after cast stops — no explicit "off" frame
+//!     needed. 255 would pin realtime until reboot (we deliberately do NOT use it).
+//!   * `start` = 16-bit LED index the packet's first RGB triple applies to.
+//!
+//! WLED lays the linear LED stream onto its configured 2D grid; a **serpentine**
+//! matrix wires odd rows right→left, so we emit physical-index order with the
+//! odd-row reversal baked in (see [`cell_for_led`]) — "serpentine order matters".
+
+/// Source framebuffer geometry — the smol OLED (must match `DisplaySize72x40`).
+pub const SRC_W: usize = 72;
+pub const SRC_H: usize = 40;
+/// 72×40 = 2880 px, 1 bit each = 360 bytes. Row-major bit-packed.
+const SRC_BYTES: usize = SRC_W * SRC_H / 8;
+
+/// WLED realtime UDP port.
+pub const WLED_PORT: u16 = 21324;
+
+/// DNRGB protocol id (byte 0) + its 4-byte header `[id][timeout][hi][lo]`.
+const PROTO_DNRGB: u8 = 4;
+const DNRGB_HEADER: usize = 4;
+
+/// Max LEDs packed into ONE UDP packet. Bounds a packet to `4 + 3*128 = 388 B`,
+/// safely under the 512 B smoltcp UDP TX buffer smol already allocates (`net/wifi.rs`).
+/// A 16×16 = 256-LED matrix therefore streams as 2 packets/frame; 8×8 = 64 as 1.
+pub const MAX_LEDS_PER_PKT: usize = 128;
+
+/// Default WLED revert timeout (byte 1), seconds. Short so the matrix returns to its
+/// normal effect a couple seconds after casting stops, with no explicit off-frame.
+pub const DEFAULT_TIMEOUT_S: u8 = 2;
+
+/// A shadow copy of the gateway's 1-bit glass image, in logical (pre-rotation)
+/// embedded-graphics coordinates — the SAME (x, y) the app draw code plots at.
+/// Fed pixel-for-pixel by the [`crate::net::cast_oled::CastOled`] tee-wrapper as the
+/// active screen renders, so it always holds exactly what was last flushed to the
+/// OLED. Fixed 360 B, lives in the display owner's frame — no heap.
+#[derive(Clone)]
+pub struct Mirror {
+    bits: [u8; SRC_BYTES],
+}
+
+impl Mirror {
+    pub const fn new() -> Self {
+        Self { bits: [0; SRC_BYTES] }
+    }
+
+    /// Set/clear one logical pixel. Out-of-bounds is a silent no-op (mirrors the
+    /// ssd1306 `set_pixel` contract, so the tee never diverges from the panel).
+    #[inline]
+    pub fn plot(&mut self, x: usize, y: usize, on: bool) {
+        if x >= SRC_W || y >= SRC_H {
+            return;
+        }
+        let idx = y * SRC_W + x;
+        let byte = idx / 8;
+        let bit = idx % 8;
+        if on {
+            self.bits[byte] |= 1 << bit;
+        } else {
+            self.bits[byte] &= !(1 << bit);
+        }
+    }
+
+    /// Read one logical pixel (false when out of bounds).
+    #[inline]
+    pub fn get(&self, x: usize, y: usize) -> bool {
+        if x >= SRC_W || y >= SRC_H {
+            return false;
+        }
+        let idx = y * SRC_W + x;
+        (self.bits[idx / 8] >> (idx % 8)) & 1 != 0
+    }
+
+    /// Clear (or fill) the whole shadow — mirrors `display.clear()`.
+    #[inline]
+    pub fn fill(&mut self, on: bool) {
+        self.bits.fill(if on { 0xFF } else { 0 });
+    }
+}
+
+impl Default for Mirror {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Target-matrix description. Dimensions + wiring + colour come from the git-ignored
+/// `secrets.rs` (the WLED host is a LAN IP, so it must never be committed to this
+/// PUBLIC repo — same discipline as `WIFI_SSID` / `OTA_IMAGE_HOSTS`).
+#[derive(Clone, Copy)]
+pub struct MatrixCfg {
+    /// Matrix width / height in LEDs (e.g. 16 × 16).
+    pub w: usize,
+    pub h: usize,
+    /// True if the matrix is wired serpentine (odd rows run right→left).
+    pub serpentine: bool,
+    /// Rotate the source 180° before mapping — matches the OLED's `Rotate180`
+    /// mount so the matrix shows what a viewer reads off the glass. Tune on-glass.
+    pub flip180: bool,
+    /// A matrix cell lights when ≥ this percent of its source block is lit. Low
+    /// (~12) keeps sparse OLED text legible when down-sampled to a coarse grid.
+    pub thresh_pct: u32,
+    /// RGB for a lit / unlit cell (the mono→colour choice; OLED can't do colour).
+    pub on: [u8; 3],
+    pub off: [u8; 3],
+    /// WLED revert timeout (byte 1), seconds.
+    pub timeout_s: u8,
+}
+
+impl MatrixCfg {
+    /// Total LED count = w × h.
+    #[inline]
+    pub fn total(&self) -> usize {
+        self.w * self.h
+    }
+}
+
+/// Inverse serpentine mapping: which source-grid cell `(mx, my)` a given PHYSICAL
+/// LED index drives. DNRGB writes to CONSECUTIVE physical LEDs, so we walk physical
+/// index order and reverse odd rows for a serpentine matrix. Row-major, LED 0 =
+/// top-left, rows top→bottom.
+#[inline]
+pub fn cell_for_led(led: usize, cfg: &MatrixCfg) -> (usize, usize) {
+    let row = led.checked_div(cfg.w).unwrap_or(0);
+    let col_in_row = led.checked_rem(cfg.w).unwrap_or(0);
+    let mx = if cfg.serpentine && (row & 1 == 1) {
+        cfg.w.saturating_sub(1).saturating_sub(col_in_row)
+    } else {
+        col_in_row
+    };
+    (mx, row)
+}
+
+/// Down-sample one matrix cell to on/off: is the fraction of lit source pixels in
+/// the cell's source block ≥ `thresh_pct`? Box-maps the NxM grid over 72×40 and
+/// applies the optional 180° flip. Total-safe (empty block → off; div guards).
+#[inline]
+pub fn cell_on(m: &Mirror, mx: usize, my: usize, cfg: &MatrixCfg) -> bool {
+    if cfg.w == 0 || cfg.h == 0 {
+        return false;
+    }
+    let x0 = mx * SRC_W / cfg.w;
+    let x1 = (((mx + 1) * SRC_W / cfg.w).max(x0 + 1)).min(SRC_W);
+    let y0 = my * SRC_H / cfg.h;
+    let y1 = (((my + 1) * SRC_H / cfg.h).max(y0 + 1)).min(SRC_H);
+    let mut lit: u32 = 0;
+    let mut tot: u32 = 0;
+    let mut sy = y0;
+    while sy < y1 {
+        let mut sx = x0;
+        while sx < x1 {
+            let (rx, ry) = if cfg.flip180 {
+                (SRC_W - 1 - sx, SRC_H - 1 - sy)
+            } else {
+                (sx, sy)
+            };
+            if m.get(rx, ry) {
+                lit += 1;
+            }
+            tot += 1;
+            sx += 1;
+        }
+        sy += 1;
+    }
+    tot > 0 && lit * 100 >= cfg.thresh_pct * tot
+}
+
+/// Encode ONE DNRGB packet covering LEDs `[start, start+count)` into `out`, where
+/// `count` is bounded by both [`MAX_LEDS_PER_PKT`] and the room in `out`. Returns
+/// `Some((bytes_written, next_start))`: send `out[..bytes_written]`, then if
+/// `next_start < cfg.total()` call again with `next_start` to emit the rest of the
+/// frame. Returns `None` when `start` is past the end or `out` can't hold a header
+/// + one LED (never panics; total on every branch).
+pub fn pack_dnrgb(m: &Mirror, cfg: &MatrixCfg, start: usize, out: &mut [u8]) -> Option<(usize, usize)> {
+    let total = cfg.total();
+    if start >= total || out.len() < DNRGB_HEADER + 3 {
+        return None;
+    }
+    let room_leds = (out.len() - DNRGB_HEADER) / 3;
+    let count = room_leds.min(MAX_LEDS_PER_PKT).min(total - start);
+    out[0] = PROTO_DNRGB;
+    out[1] = cfg.timeout_s;
+    out[2] = ((start >> 8) & 0xFF) as u8;
+    out[3] = (start & 0xFF) as u8;
+    let mut i = 0;
+    while i < count {
+        let led = start + i;
+        let (mx, my) = cell_for_led(led, cfg);
+        let rgb = if cell_on(m, mx, my, cfg) { cfg.on } else { cfg.off };
+        let o = DNRGB_HEADER + i * 3;
+        out[o] = rgb[0];
+        out[o + 1] = rgb[1];
+        out[o + 2] = rgb[2];
+        i += 1;
+    }
+    Some((DNRGB_HEADER + count * 3, start + count))
+}
+
+// =========================================================================
+// Cross-module handoff (single-threaded, no ISR — the established smol pattern).
+// =========================================================================
+//
+// The frame SOURCE (the live glass image) is produced in `main`'s render loop
+// (via the [`crate::net::cast_oled::CastOled`] tee), but the UDP SEND happens deep
+// inside a gateway flush (`net::wifi::run_mqtt_burst`, reached through the
+// `RadioManager`). Rather than thread a `&Mirror` + flag through every layer, we
+// hand them off through two `static mut`s — exactly the discipline `main`'s
+// `NODE_ID_CACHE` and `net::mode`'s `GW_OTA_WINDOW` already use: written and read
+// ONLY from the single-threaded boot/main path (never an ISR), so the accesses are
+// race-free, and `addr_of[_mut]!` avoids ever forming a reference to the static
+// (keeps the `static_mut_refs` lint quiet).
+
+/// The most-recent glass image, published by `main` each render tick.
+static mut CAST_MIRROR: Mirror = Mirror::new();
+/// Whether HA has enabled casting (retained `smol/<id>/cast` = `ON`). Re-read from
+/// the broker each gateway flush, so absence / a cleared topic reads as OFF.
+static mut CAST_ENABLED: bool = false;
+
+/// `main`: copy the freshly-rendered glass into the shared cast frame (every tick).
+#[inline]
+pub fn publish_frame(m: &Mirror) {
+    // SAFETY: single-caller (main loop, never an ISR); no reference is formed.
+    unsafe {
+        core::ptr::addr_of_mut!(CAST_MIRROR).write(m.clone());
+    }
+}
+
+/// Gateway flush: read the shared cast frame under a closure (no `&'static mut`
+/// escapes → `static_mut_refs`-clean).
+#[inline]
+pub fn with_frame<R>(f: impl FnOnce(&Mirror) -> R) -> R {
+    // SAFETY: single-caller (flush runs on the main path, never an ISR); the shared
+    // ref does not outlive the closure.
+    unsafe { f(&*core::ptr::addr_of!(CAST_MIRROR)) }
+}
+
+/// mqtt_session: latch the HA cast-enable flag from the retained topic.
+#[inline]
+pub fn set_enabled(on: bool) {
+    // SAFETY: single-caller (flush/main path, never an ISR); no reference is formed.
+    unsafe {
+        core::ptr::addr_of_mut!(CAST_ENABLED).write(on);
+    }
+}
+
+/// Gateway flush: is casting currently enabled?
+#[inline]
+pub fn is_enabled() -> bool {
+    // SAFETY: single-caller (flush/main path, never an ISR); no reference is formed.
+    unsafe { core::ptr::addr_of!(CAST_ENABLED).read() }
+}

--- a/rust/clock/src/net/cast_oled.rs
+++ b/rust/clock/src/net/cast_oled.rs
@@ -1,0 +1,110 @@
+//! #26 smol Cast — the `DrawTarget` tee-wrapper that feeds the cast [`Mirror`].
+//!
+//! ## Why this exists
+//! ssd1306 0.10's `BufferedGraphicsMode` keeps its 1-bit panel buffer PRIVATE with
+//! no read accessor (only `set_pixel` write + `clear`), so there is no way to READ
+//! back what was flushed to the glass. To "mirror the gateway's screen" we instead
+//! TEE at draw time: [`CastOled`] wraps the real `Ssd1306` and, for every pixel an
+//! app draws, writes it to BOTH the panel (via the crate's public `set_pixel`) and a
+//! shadow [`Mirror`]. The shadow is then the exact image on the glass, ready to
+//! down-sample + stream to a WLED matrix (see `net/cast.rs`).
+//!
+//! ## Isolation
+//! `feature = "cast"` only. When cast is OFF, `app::Oled` stays the plain `Ssd1306`
+//! (this file isn't compiled) so the default / wifi / espnow / wled builds are
+//! byte-identical — the mirror machinery exists solely in a `--features cast` build.
+//!
+//! ## Fidelity
+//! `draw_iter` here is the SAME two steps the stock `Ssd1306` `DrawTarget` does
+//! (bounding-box filter → `set_pixel`), plus one extra `mirror.plot` — so the panel
+//! sees byte-identical draws; the mirror is a faithful copy in logical (pre-rotation)
+//! coordinates (the 180° mount is applied later, in the down-sampler's `flip180`).
+
+#![cfg(feature = "cast")]
+
+// `prelude::*` brings the traits (`DrawTarget`, `OriginDimensions`, `Dimensions`),
+// `Size`, `Point`, and `Pixel`; only `BinaryColor` is outside the prelude.
+use embedded_graphics::{pixelcolor::BinaryColor, prelude::*};
+use ssd1306::mode::{BufferedGraphicsMode, DisplayConfig};
+use ssd1306::prelude::I2CInterface;
+use ssd1306::size::DisplaySize72x40;
+use ssd1306::Ssd1306;
+
+use crate::net::cast::{Mirror, SRC_H, SRC_W};
+
+/// The concrete SSD1306 — byte-identical to the pre-cast `app::Oled` alias.
+type RawOled = Ssd1306<
+    I2CInterface<esp_hal::i2c::master::I2c<'static, esp_hal::Blocking>>,
+    DisplaySize72x40,
+    BufferedGraphicsMode<DisplaySize72x40>,
+>;
+
+/// The display's `DrawTarget`/flush error type (`display_interface::DisplayError`),
+/// named through the trait so this file needs no direct `display_interface` dep.
+type Err = <RawOled as DrawTarget>::Error;
+
+/// Tee display: forwards every draw to the real OLED and mirrors it into `mirror`.
+/// Drop-in for `RawOled` — `main` builds it around the freshly-constructed panel and
+/// the plugins keep using `clear()` / `draw()` / `flush()` unchanged.
+pub struct CastOled {
+    inner: RawOled,
+    mirror: Mirror,
+}
+
+impl CastOled {
+    /// Wrap a just-constructed (buffered-graphics) SSD1306.
+    pub fn new(inner: RawOled) -> Self {
+        Self {
+            inner,
+            mirror: Mirror::new(),
+        }
+    }
+
+    /// Initialise the panel (forwards `DisplayConfig::init`).
+    pub fn init(&mut self) -> Result<(), Err> {
+        self.inner.init()
+    }
+
+    /// Flush the dirty region to the panel (forwards the inherent `Ssd1306::flush`).
+    pub fn flush(&mut self) -> Result<(), Err> {
+        self.inner.flush()
+    }
+
+    /// The shadow copy of the current glass image (read by the cast send path).
+    pub fn mirror(&self) -> &Mirror {
+        &self.mirror
+    }
+}
+
+impl OriginDimensions for CastOled {
+    fn size(&self) -> Size {
+        Size::new(SRC_W as u32, SRC_H as u32)
+    }
+}
+
+impl DrawTarget for CastOled {
+    type Color = BinaryColor;
+    type Error = Err;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        let bb = self.bounding_box();
+        for Pixel(pos, color) in pixels {
+            if bb.contains(pos) {
+                let on = color.is_on();
+                // Same write the stock Ssd1306 DrawTarget does…
+                self.inner.set_pixel(pos.x as u32, pos.y as u32, on);
+                // …plus the shadow copy for casting.
+                self.mirror.plot(pos.x as usize, pos.y as usize, on);
+            }
+        }
+        Ok(())
+    }
+
+    fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
+        self.mirror.fill(color.is_on());
+        self.inner.clear(color)
+    }
+}

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1095,6 +1095,11 @@ fn mqtt_session(
     // #33 Model-A per-board OTA install command topic (native HA Update button → INSTALL).
     let mut cmd_topic = MqttScratch::new();
     let _ = write!(cmd_topic, "smol/{}/ota/install", node_id);
+    // #26 cast: this board's retained cast-enable topic (payload ON/OFF). feature=cast.
+    #[cfg(feature = "cast")]
+    let mut cast_topic = MqttScratch::new();
+    #[cfg(feature = "cast")]
+    let _ = write!(cast_topic, "smol/{}/cast", node_id);
 
     // --- TCP connect ---
     {
@@ -1210,6 +1215,16 @@ fn mqtt_session(
     // #33 HA Update entity: subscribe this board's OTA command topic (pid 7).
     if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 7, cmd_topic.as_bytes()) {
         let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+    }
+    // #26 cast: subscribe this board's retained cast-enable topic (pid 5). Reset the
+    // flag to OFF FIRST so an absent / cleared retained topic reads as disabled — the
+    // retained ON (if present) re-enables it during the drain below.
+    #[cfg(feature = "cast")]
+    {
+        crate::net::cast::set_enabled(false);
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 5, cast_topic.as_bytes()) {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
     }
     // #21 leaf-relay: a GATEWAY (cfg_cache = Some) also subscribes the WILDCARD leaf
     // config topic (pid 8) so it caches every leaf's default-screen to relay over
@@ -1435,6 +1450,13 @@ fn mqtt_session(
             let consumed = match crate::net::mqtt::parse_packet(&acc[..acc_len]) {
                 None => break,
                 Some((crate::net::mqtt::Incoming::Publish { topic, payload }, consumed)) => {
+                    // #26 cast: precompute the cast-topic match as a plain bool (avoids a
+                    // block-in-`if`-condition; `false` in non-cast builds, where `cast_topic`
+                    // does not exist, so the arm below is inert there).
+                    #[cfg(feature = "cast")]
+                    let is_cast_topic = topic == cast_topic.as_bytes();
+                    #[cfg(not(feature = "cast"))]
+                    let is_cast_topic = false;
                     if topic == BATT_TOPIC {
                         let now = Instant::now().duration_since_epoch().as_millis();
                         batt.store(payload, now); // memcpy out before we compact `acc`
@@ -1498,6 +1520,16 @@ fn mqtt_session(
                         if payload == b"INSTALL" {
                             *install_requested = true;
                             log::info!("smol #33: OTA install command received");
+                        }
+                    } else if is_cast_topic {
+                        // Untrusted RETAINED payload → exact byte compare only (same
+                        // discipline as the OTA install arm): ON/on/1 enables the WLED
+                        // pixel-stream for this gateway's flush; anything else disables.
+                        #[cfg(feature = "cast")]
+                        {
+                            let on = payload == b"ON" || payload == b"on" || payload == b"1";
+                            crate::net::cast::set_enabled(on);
+                            log::info!("smol #26: cast {}", if on { "ENABLED" } else { "disabled" });
                         }
                     } else if let Some(leaf_id) = parse_leaf_config_topic(topic) {
                         // #21 leaf-relay: a wildcard-delivered OTHER leaf's config. Cache
@@ -2012,7 +2044,11 @@ pub fn run_mqtt_burst(
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
     let mut iface = create_interface(device);
+    // #26 cast adds one UDP socket (the WLED pixel-stream) to the set.
+    #[cfg(not(feature = "cast"))]
     let mut sockets_storage: [SocketStorage; 3] = Default::default();
+    #[cfg(feature = "cast")]
+    let mut sockets_storage: [SocketStorage; 4] = Default::default();
     let mut sockets = SocketSet::new(&mut sockets_storage[..]);
 
     let mut dhcp_socket = dhcpv4::Socket::new();
@@ -2044,6 +2080,27 @@ pub fn run_mqtt_burst(
         udp::PacketBuffer::new(&mut warm_tx_meta[..], &mut warm_tx[..]),
     );
     let warm_handle = sockets.add(warm_socket);
+
+    // #26 cast: a real UDP socket for the WLED DNRGB pixel-stream (present only in a
+    // cast build). TX sized for one full DNRGB chunk (4 + 3*128 = 388 B ⇒ 512 with
+    // margin); RX tiny (WLED never replies to realtime frames). Streamed AFTER the
+    // MQTT session below, reusing this still-associated interface.
+    #[cfg(feature = "cast")]
+    let mut cast_rx_meta = [udp::PacketMetadata::EMPTY; 1];
+    #[cfg(feature = "cast")]
+    let mut cast_tx_meta = [udp::PacketMetadata::EMPTY; 4];
+    #[cfg(feature = "cast")]
+    let mut cast_rx = [0u8; 4];
+    #[cfg(feature = "cast")]
+    let mut cast_tx = [0u8; 512];
+    #[cfg(feature = "cast")]
+    let cast_handle = {
+        let s = udp::Socket::new(
+            udp::PacketBuffer::new(&mut cast_rx_meta[..], &mut cast_rx[..]),
+            udp::PacketBuffer::new(&mut cast_tx_meta[..], &mut cast_tx[..]),
+        );
+        sockets.add(s)
+    };
 
     // FINDING 1b (retained): bound the ENTIRE flush by the short RELAY_FLUSH_BUDGET,
     // not the 30 s NTP budget — a dead AP fails fast so the loop isn't frozen 30 s.
@@ -2139,7 +2196,11 @@ pub fn run_mqtt_burst(
     let src_port = 49152 + (rng.random() % 16384) as u16;
     // #23: refresh election/liveness each flush — the caller's `elect` carries the
     // persistent (owner,seq,seen_ms) observation IN and the re-decided role OUT.
-    mqtt_session(
+    // #26 cast: the result is bound (not tail-returned) so the cast stream can run
+    // BETWEEN the session and the return; in a non-cast build that stream is cfg'd
+    // away, leaving a `let … ; return` shape — a cfg-conditional `let_and_return`.
+    #[allow(clippy::let_and_return)]
+    let session_ok = mqtt_session(
         &mut iface,
         device,
         &mut sockets,
@@ -2164,7 +2225,130 @@ pub fn run_mqtt_burst(
         leaf_relay_rx, // #3: forward the relay RX-diag (or &mut None)
         deadline,
         tick,
-    )
+    );
+
+    // #26 cast: if HA enabled it (learned via the retained `smol/<id>/cast` topic during
+    // the session above), stream the mirrored glass image to the WLED matrix over the
+    // STILL-LIVE association — the MQTT DISCONNECT only closed the TCP socket, not the STA
+    // link (the caller re-pins ESP-NOW after we return). Bounded + long-press-abortable.
+    #[cfg(feature = "cast")]
+    if crate::net::cast::is_enabled() {
+        let cast_port = 49152 + (rng.random() % 16384) as u16;
+        cast_stream(
+            &mut iface,
+            device,
+            &mut sockets,
+            cast_handle,
+            cast_port,
+            deadline,
+            tick,
+        );
+    }
+
+    session_ok
+}
+
+/// #26 cast — hold the (already-associated) STA and stream the mirrored glass image to
+/// the WLED matrix as DNRGB realtime UDP frames at ~10 fps for a bounded window. The
+/// single radio is WiFi-committed (mesh-deaf) for the hold — the documented one-radio
+/// cost, same as any burst — so it is short and long-press-abortable (`tick`). WLED
+/// reverts to its normal render `DEFAULT_TIMEOUT_S` after the last frame, so simply
+/// ceasing to stream releases the matrix; no explicit off-frame is needed. NOTE: `main`
+/// is blocked in the flush while this runs, so the streamed image is the last-rendered
+/// glass (a per-flush snapshot); continuous live-motion mirroring is the coexist
+/// follow-on (it needs a persistent interleaved poll loop, which smol does not run).
+#[cfg(feature = "cast")]
+const CAST_HOLD: Duration = Duration::from_millis(3000);
+/// ~10 fps — modest so the single radio isn't monopolised harder than a normal flush.
+#[cfg(feature = "cast")]
+const CAST_FRAME_INTERVAL: Duration = Duration::from_millis(100);
+
+#[cfg(feature = "cast")]
+fn cast_stream(
+    iface: &mut Interface,
+    device: &mut esp_wifi::wifi::WifiDevice<'static>,
+    sockets: &mut SocketSet,
+    cast_handle: smoltcp::iface::SocketHandle,
+    src_port: u16,
+    burst_deadline: Instant,
+    tick: &mut dyn FnMut() -> bool,
+) {
+    use crate::net::cast;
+    let cfg = cast::MatrixCfg {
+        w: crate::secrets::WLED_CAST_W,
+        h: crate::secrets::WLED_CAST_H,
+        serpentine: crate::secrets::WLED_CAST_SERPENTINE,
+        flip180: crate::secrets::WLED_CAST_FLIP180,
+        thresh_pct: crate::secrets::WLED_CAST_THRESH_PCT,
+        on: crate::secrets::WLED_CAST_ON,
+        off: crate::secrets::WLED_CAST_OFF,
+        timeout_s: cast::DEFAULT_TIMEOUT_S,
+    };
+    let host = crate::secrets::WLED_CAST_HOST;
+    let dst = (
+        IpAddress::Ipv4(Ipv4Addr::new(host[0], host[1], host[2], host[3])),
+        cast::WLED_PORT,
+    );
+
+    // Bind the cast UDP socket once (ephemeral local port).
+    {
+        let s = sockets.get_mut::<udp::Socket>(cast_handle);
+        if !s.is_open() && s.bind(src_port).is_err() {
+            log::warn!("smol #26: cast socket bind failed");
+            return;
+        }
+    }
+
+    let hold_deadline = {
+        let cap = Instant::now() + CAST_HOLD;
+        if cap < burst_deadline {
+            cap
+        } else {
+            burst_deadline
+        }
+    };
+    let total = cfg.total();
+    let mut next_frame = Instant::now();
+    let mut frames = 0u32;
+    loop {
+        if tick() {
+            break; // long-press → free the radio
+        }
+        iface.poll(smoltcp_now(), device, sockets);
+        if Instant::now() >= next_frame {
+            // One frame = all DNRGB chunks covering LEDs 0..total.
+            let mut start = 0usize;
+            let mut pkt = [0u8; 4 + 3 * cast::MAX_LEDS_PER_PKT];
+            while start < total {
+                let Some((n, next)) =
+                    cast::with_frame(|m| cast::pack_dnrgb(m, &cfg, start, &mut pkt))
+                else {
+                    break;
+                };
+                {
+                    let s = sockets.get_mut::<udp::Socket>(cast_handle);
+                    let _ = s.send_slice(&pkt[..n], dst);
+                }
+                iface.poll(smoltcp_now(), device, sockets); // push the datagram out
+                start = next;
+            }
+            frames += 1;
+            next_frame = Instant::now() + CAST_FRAME_INTERVAL;
+        }
+        if Instant::now() >= hold_deadline {
+            break;
+        }
+    }
+    log::info!(
+        "smol #26: cast streamed {} frame(s) to WLED {}.{}.{}.{} ({}x{})",
+        frames,
+        host[0],
+        host[1],
+        host[2],
+        host[3],
+        cfg.w,
+        cfg.h
+    );
 }
 
 /// OTA download budget. Unlike a ~1 s telemetry flush, the OTA burst is mesh-DEAF for

--- a/rust/clock/src/secrets.rs.example
+++ b/rust/clock/src/secrets.rs.example
@@ -39,3 +39,43 @@ pub const MQTT_PASS: &str = "YOUR_MQTT_PASSWORD";
 /// URL hosts the OTA fetch will accept an image from (spec §4b-5). Real LAN IP(s)
 /// live only in the git-ignored `secrets.rs` — never commit them (repo is PUBLIC).
 pub const OTA_IMAGE_HOSTS: &[&str] = &["10.0.0.0"]; // your OTA image host(s)
+
+// --- #26 smol Cast → WLED matrix (realtime UDP pixel stream) ------------------
+// The gateway mirrors its OLED image onto a network LED matrix running WLED, over
+// UDP :21324 (DNRGB). The matrix's LAN IP lives ONLY here (git-ignored) — never
+// commit it (repo is PUBLIC), same discipline as WIFI_SSID / OTA_IMAGE_HOSTS. Only a
+// `--features cast` build reads these; each is `#[cfg(feature = "cast")]` so a
+// non-cast build never warns on the unused const.
+
+/// WLED matrix IPv4 as four octets. Find it in your router leases, the WLED web UI
+/// (Info → IP), or Home Assistant (the `light.wled` device's connection info).
+#[cfg(feature = "cast")]
+pub const WLED_CAST_HOST: [u8; 4] = [10, 0, 0, 0];
+
+/// Matrix dimensions in LEDs — MUST match the WLED 2D matrix config. Default 16×16.
+#[cfg(feature = "cast")]
+pub const WLED_CAST_W: usize = 16;
+#[cfg(feature = "cast")]
+pub const WLED_CAST_H: usize = 16;
+
+/// True if the matrix is wired SERPENTINE (odd rows run right→left — the common
+/// matrix wiring + WLED's default 2D "serpentine" option). MUST match WLED's config.
+#[cfg(feature = "cast")]
+pub const WLED_CAST_SERPENTINE: bool = true;
+
+/// Rotate the source 180° before mapping — matches smol's Rotate180 OLED mount so the
+/// matrix shows what a viewer reads off the glass. Flip if the image comes out upside
+/// down (this + serpentine are the two knobs to tune the orientation on-glass).
+#[cfg(feature = "cast")]
+pub const WLED_CAST_FLIP180: bool = true;
+
+/// A matrix cell lights when ≥ this percent of its 72×40 source block is lit. Low
+/// (~12) keeps sparse OLED text legible when down-sampled to a coarse grid.
+#[cfg(feature = "cast")]
+pub const WLED_CAST_THRESH_PCT: u32 = 12;
+
+/// RGB for a lit / unlit matrix cell (the mono→colour choice; the OLED is 1-bit).
+#[cfg(feature = "cast")]
+pub const WLED_CAST_ON: [u8; 3] = [0, 255, 120]; // smol green
+#[cfg(feature = "cast")]
+pub const WLED_CAST_OFF: [u8; 3] = [0, 0, 0];


### PR DESCRIPTION
## #26 — smol Cast: stream the display to a network WLED matrix (realtime UDP pixels)

Closes #26. **Merge-ladder position: LAST** (quartet → mesh → observability → cast); rebased onto current `main` (incl. #82 mesh-correctness + #81 obs-wave).

The gateway mirrors its own **72×40 1-bit OLED image** onto a network **WLED matrix** as realtime **DNRGB** UDP pixels (port 21324) over plain WiFi — **not** ESP-NOW (cleaner than #25's control path). **OFF by default**; enabled per-node via a retained MQTT topic.

### Design
- **`feature = "cast"` builds on `espnow`** — casting is a gateway-role activity: it needs an associated STA to reach the matrix *and* the recurring gateway flush that carries the stream (a wifi-only board only associates once at boot). The **default / wifi / espnow / wled** builds are **byte-free** of cast (every hook `#[cfg(feature="cast")]`; the `Oled` type only swaps to the tee under this flag).
- **Source = a DrawTarget tee, not a buffer read.** ssd1306 0.10's `BufferedGraphicsMode` buffer is private with no read accessor, so a literal panel read-back is impossible without forking the pinned crate. `net/cast_oled.rs::CastOled` wraps the real `Ssd1306` and mirrors every pixel (via the crate's public `set_pixel`) into a 360 B shadow `Mirror` as apps draw — `draw_iter` does the *same* two steps the stock impl does (bb-filter → `set_pixel`) plus one `mirror.plot`, so the panel sees byte-identical draws. Under `cast`, `app::Oled = CastOled` (drop-in: same `DrawTarget` + inherent `flush()`/`init()`), so every plugin + `main` draw site is unchanged.
- **Pure packer `net/cast.rs`** (no HAL/ssd/eg deps → host-unit-tested): box-downsample with `thresh_pct` + `flip180`, serpentine/progressive LED-index mapping, and a chunked DNRGB encoder (`[4][timeout][hi][lo][RGB…]`, ≤128 LEDs/pkt so a packet stays under the 512 B smoltcp UDP buffer: 16×16 → 2 pkts, 8×8 → 1).
- **Toggle:** retained `smol/<id>/cast` = `ON`/`1` enables, anything else (OFF/empty/absent) disables. `mqtt_session` subscribes it (pid 5), resets to OFF before the drain, latches the flag. Same untrusted-retained discipline as the OTA install arm (exact byte compare; worst case = a valid on/off).
- **Send:** after `mqtt_session` returns (only TCP/MQTT disconnected — the STA is *still associated* until the caller re-pins ESP-NOW), `run_mqtt_burst` streams the mirror as DNRGB at ~10 fps for a bounded **~3 s hold** via a dedicated cast UDP socket, long-press-abortable. WLED's `timeout` byte = 2 s → the matrix self-reverts a couple seconds after the stream stops, so ceasing to stream releases it (no off-frame needed).
- **Cross-module handoff via two `static mut`s** (the established `GW_OTA_WINDOW` / `NODE_ID_CACHE` pattern — single-threaded, no ISR, `addr_of!` so no `static_mut_refs`): `main` publishes the frame each render tick, the gateway flush reads it. This keeps **every function signature unchanged** (`mqtt_session` / `run_mqtt_burst` / the `mode.rs` callers).

### Config (git-ignored `secrets.rs` — repo is PUBLIC)
WLED host + matrix dims live only in the local `secrets.rs`; `secrets.rs.example` carries a cfg-gated template (generic 16×16 / placeholder IP). My local build targets JP's live **c3iffy** (8×8, WLED 0.16, VLAN11 = same subnet as the boards) with `serpentine = false` (its render uses `idx = y*8 + x`).

### Verification
- **All 5 profiles compile, 0 warnings** (default / wifi / espnow / wled / cast), release, `riscv32imc`, toolchain 1.96.1.
- **cast is clippy-clean** (`clippy -D warnings`) for the new code. *(Note: a full `clippy --features espnow` currently also surfaces pre-existing lints in `ota_mesh.rs` — `too_many_arguments`, `is_multiple_of` — introduced by clippy 1.96 on already-merged #40 code; **not touched by this PR**.)*
- **Host packer test:** 26/26 assertions (serpentine + progressive mapping, DNRGB header, chunking, start-index bytes, downsample threshold, flip180, OOB safety).

> **Hardware / live-WLED validation is DEFERRED to the morning consolidated canary** (JP unplugged the 3 nodes overnight). This PR merges on **oracle-green + the 5-profile compile proof** below; the on-glass WLED test (via team-lead, who owns flashing) runs in the morning.

### HW verification plan (team-lead flashes — I don't flash/publish; runs at the morning canary)
1. Flash a gateway image: `SMOL_NODE_ID=7 cargo build --release --features cast` (cast ⊃ espnow) → gateway board.
2. Enable: publish **retained** `smol/7/cast` = `ON`. Disable: publish `smol/7/cast` = `` (empty) or `OFF`.
3. On the next gateway flush, expect: HA `select.wled_live_override` flips to a live/realtime state, the matrix shows smol's current screen (green-on-black, downsampled) for ~3 s then reverts; serial logs `cast ENABLED` + `cast streamed N frame(s) to WLED …`.
4. Orientation knobs if needed: `WLED_CAST_FLIP180` (upside-down) / `WLED_CAST_SERPENTINE` (scrambled).

### Honest scope
`main` blocks during the flush, so the streamed image is the last-rendered glass (a per-flush snapshot), not continuous live motion — the WLED override + on-glass image both prove out. Continuous live-motion mirroring is a coexist follow-on (needs a persistent interleaved poll loop, which smol deliberately does not run — single-radio / mesh-deaf avoidance, #23).

**Mesh-deaf cost (opt-in):** while cast is ENABLED (retained `smol/<id>/cast = ON`; OFF by default), each gateway flush's mesh-deaf window extends by up to `CAST_HOLD` = 3 s (~30 frames @100 ms). Bounded, opt-in, and long-press-abortable — but on this #20/#23 mesh-deaf-conscious fleet it's a real, deliberate trade: enabling cast trades ≤3 s extra deaf-per-flush for the live matrix mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
