### PR TITLE
feat(fw): #48 #43 #55 #52 — CFG quartet (LED · units · plugins · reboot) + #39 install-retain

### DIFF
--- a/rust/clock/src/app.rs
+++ b/rust/clock/src/app.rs
@@ -96,6 +96,10 @@ pub struct Ctx<'a> {
     /// CLOCK render (universal). On espnow it tracks the relayed / gateway-own
     /// `smol/config/units`; on a non-espnow build it is always [`crate::units::Units::default`].
     pub units: crate::units::Units,
+    /// #55 per-node plugin-visibility mask (bit = shown; see [`plugin_bit`]), owned by `main`.
+    /// Read by the Home menu to filter rows. `0` = keep all (the #55 safety + the non-espnow
+    /// default — the relay/apply path is radio-only, so a non-espnow build never changes it).
+    pub plugin_mask: u16,
     /// HA battery-voltage cache (the Batt screen), borrowed read-only. Owned by
     /// `main` and filled by the WiFi burst's MQTT downlink (`net/wifi.rs`'s
     /// `mqtt_session`) or an inbound SMOLv1 BATT frame — either can happen while
@@ -458,3 +462,31 @@ pub const REGISTRY: &[AppDesc] = &[
     AppDesc { title: "WLED", kind: AppKind::WledRemote },
     AppDesc { title: "About", kind: AppKind::About },
 ];
+
+/// #55 plugin visibility: the STABLE mask bit for an app kind, INDEPENDENT of the (cfg-gated)
+/// REGISTRY index/order. Fixed per kind so HA sends ONE bit-map to the whole fleet and each node
+/// applies only the bits for the variants it compiles — a bit for an absent variant is simply
+/// never tested. `Menu` is never maskable (it isn't a REGISTRY row) → `None`.
+///
+/// Bit map (luna's HA contract): 0=Clock · 1=Snake · 2=Bench · 3=Batt · 4=Grid · 5=WledRemote
+/// · 6=About. The `SNAKE_KIND` alias (MeshSnake under espnow) shares the "Snake" bit (1), so a
+/// mask hides "Snake" whether the menu row launches solo Snake or MeshSnake. The cfg'd arms stay
+/// exhaustive in every profile: an absent variant's arm is removed exactly when the variant is.
+pub const fn plugin_bit(kind: AppKind) -> Option<u8> {
+    match kind {
+        AppKind::Clock => Some(0),
+        AppKind::Snake => Some(1),
+        #[cfg(feature = "espnow")]
+        AppKind::MeshSnake => Some(1), // SNAKE_KIND alias → same "Snake" bit
+        #[cfg(feature = "espnow")]
+        AppKind::Bench => Some(2),
+        #[cfg(feature = "wifi")]
+        AppKind::Batt => Some(3),
+        #[cfg(feature = "wifi")]
+        AppKind::Grid => Some(4),
+        #[cfg(feature = "wled")]
+        AppKind::WledRemote => Some(5),
+        AppKind::About => Some(6),
+        AppKind::Menu => None,
+    }
+}

--- a/rust/clock/src/app.rs
+++ b/rust/clock/src/app.rs
@@ -92,6 +92,10 @@ pub struct Ctx<'a> {
     /// Set by `main` after a mode switch; a plugin repaints when true OR when its
     /// own cadence (once/second, on-step, on-page-change, …) fires.
     pub redraw: bool,
+    /// #43 fleet-global display units (°F/°C · 12h/24h), owned by `main`. Read by the
+    /// CLOCK render (universal). On espnow it tracks the relayed / gateway-own
+    /// `smol/config/units`; on a non-espnow build it is always [`crate::units::Units::default`].
+    pub units: crate::units::Units,
     /// HA battery-voltage cache (the Batt screen), borrowed read-only. Owned by
     /// `main` and filled by the WiFi burst's MQTT downlink (`net/wifi.rs`'s
     /// `mqtt_session`) or an inbound SMOLv1 BATT frame — either can happen while

--- a/rust/clock/src/clock.rs
+++ b/rust/clock/src/clock.rs
@@ -57,6 +57,7 @@ impl Plugin for ClockState {
                 ctx.display,
                 sod,
                 ctx.sensors,
+                ctx.units,
                 #[cfg(feature = "espnow")]
                 ctx.label,
             );
@@ -74,6 +75,7 @@ fn draw_clock<D>(
     display: &mut D,
     sod: u32,
     sensors: &mut sensors::Sensors,
+    units: crate::units::Units,
     #[cfg(feature = "espnow")] label: &str,
 ) where
     D: DrawTarget<Color = BinaryColor>,
@@ -89,7 +91,8 @@ fn draw_clock<D>(
 
     // Refresh the sensor sample (chip °C + battery V).
     let reading = sensors.read();
-    let sensor_line = sensors::format_sensor_line(&reading);
+    // #43: temperature unit (°F/°C) per the fleet-global config.
+    let sensor_line = sensors::format_sensor_line(&reading, units.temp_f);
     log::debug!(
         "smol: chip {}C, batt {:.2}V (~{}%)",
         reading.chip_c as i32,
@@ -112,23 +115,28 @@ fn draw_clock<D>(
         label
     };
 
-    // 12-hour clock with AM/PM and a colon that blinks once per second.
+    // #43: 24-hour (`HH:MM`, no AM/PM — default) or 12-hour (`H:MM` + AM/PM, the pre-#43
+    // behavior), per the fleet-global units. A colon blinks once per second either way.
     let h24 = (sod / 3600) % 24;
     let mm = (sod / 60) % 60;
-    let pm = h24 >= 12;
-    let h12 = {
+    // Displayed hour + how to render it. 24h: 0..23, ALWAYS two digits (leading zero), no
+    // AM/PM. 12h: 1..12, NO leading zero (4 or 5 chars) + an AM/PM tag.
+    let (hh, two_digit, pm) = if units.clk_24h {
+        (h24, true, false)
+    } else {
         let h = h24 % 12;
-        if h == 0 { 12 } else { h }
+        let h12 = if h == 0 { 12 } else { h };
+        (h12, h12 >= 10, h24 >= 12)
     };
     let colon = if sod % 2 == 1 { b' ' } else { b':' };
-    // Build "H:MM" or "HH:MM" (no leading zero on the hour) — 4 or 5 chars.
+    // Build "HH:MM" (5 chars) or 12h single-digit "H:MM" (4 chars).
     let mut tb = [0u8; 5];
     let mut ti = 0usize;
-    if h12 >= 10 {
-        tb[ti] = b'1';
+    if two_digit {
+        tb[ti] = b'0' + (hh / 10) as u8;
         ti += 1;
     }
-    tb[ti] = b'0' + (h12 % 10) as u8;
+    tb[ti] = b'0' + (hh % 10) as u8;
     ti += 1;
     tb[ti] = colon;
     ti += 1;
@@ -138,14 +146,17 @@ fn draw_clock<D>(
     ti += 1;
     let hm = core::str::from_utf8(&tb[..ti]).unwrap_or("--:--");
     // Center: "12:34" (5ch/50px) -> x=11; "1:34" (4ch/40px) -> x=16.
-    let tx = if h12 >= 10 { 11 } else { 16 };
+    let tx = if two_digit { 11 } else { 16 };
 
-    // AM/PM small in the top-right (its own row above the big digits — no overlap).
-    let ampm = if pm { "PM" } else { "AM" };
-    Text::with_baseline(ampm, Point::new(59, 0), label_style, Baseline::Top)
-        .draw(display)
-        .ok();
-    // Big 12-hour time, 20px tall from y=8 (AM/PM row sits above it).
+    // AM/PM small in the top-right (its own row above the big digits — no overlap). 12h ONLY;
+    // a 24-hour clock has no AM/PM tag.
+    if !units.clk_24h {
+        let ampm = if pm { "PM" } else { "AM" };
+        Text::with_baseline(ampm, Point::new(59, 0), label_style, Baseline::Top)
+            .draw(display)
+            .ok();
+    }
+    // Big time, 20px tall from y=8 (the AM/PM row, if present, sits above it).
     Text::with_baseline(hm, Point::new(tx, 8), time_style, Baseline::Top)
         .draw(display)
         .ok();

--- a/rust/clock/src/led.rs
+++ b/rust/clock/src/led.rs
@@ -85,6 +85,35 @@ impl LedState {
     }
 }
 
+/// #48 dashboard LED control — the per-node MODE that gates the auto-driven [`LedState`]
+/// indicator. `Status` (default) keeps the ESP-NOW peer-state machine (backward-compatible);
+/// `On`/`Off` force the LED solid/dark regardless of link state. Relayed to leaves over the
+/// keyed CFG channel (key `L`); the gateway reads its own `smol/<id>/config/led`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum LedMode {
+    /// Auto-drive from the peer-state machine — the pre-#48 behavior. Default.
+    #[default]
+    Status,
+    /// Force the LED solid ON, ignoring link state.
+    On,
+    /// Force the LED dark, ignoring link state.
+    Off,
+}
+
+impl LedMode {
+    /// Parse a `smol/<id>/config/led` payload (`status`/`on`/`off`, case-sensitive to match
+    /// the HA input_select options). Unknown/garbage → `None` (caller keeps the current mode;
+    /// this is an untrusted retained/relayed value, so never panic — #46 clamp discipline).
+    pub fn from_wire(s: &str) -> Option<LedMode> {
+        match s.trim() {
+            "status" => Some(LedMode::Status),
+            "on" => Some(LedMode::On),
+            "off" => Some(LedMode::Off),
+            _ => None,
+        }
+    }
+}
+
 /// Square-wave phase: true for the first half-period, false for the second.
 #[inline]
 fn blink_phase(now_ms: u64, half_ms: u64) -> bool {
@@ -133,6 +162,18 @@ impl Led {
     /// sets the pin level. Idempotent for a given (state, now) pair.
     pub fn apply(&mut self, state: LedState, now_ms: u64) {
         let lit = state.is_lit(now_ms);
+        self.pin.set_level(Self::level_for(lit));
+    }
+
+    /// #48: drive the LED honoring the dashboard [`LedMode`]. `Status` defers to the auto
+    /// `state` (identical to [`Led::apply`]); `On`/`Off` force lit/dark. Same cheap
+    /// per-sub-tick contract as `apply`.
+    pub fn apply_mode(&mut self, mode: LedMode, state: LedState, now_ms: u64) {
+        let lit = match mode {
+            LedMode::Status => state.is_lit(now_ms),
+            LedMode::On => true,
+            LedMode::Off => false,
+        };
         self.pin.set_level(Self::level_for(lit));
     }
 }

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -225,6 +225,15 @@ const FLUSH_IDLE_MS: u64 = 3_000;
 #[cfg(feature = "espnow")]
 const FLUSH_DEFER_CAP_MS: u64 = 120_000;
 
+/// #52 remote-reboot boot-debounce: IGNORE (but consume) a reboot command (`take_cfg_offer(R)`)
+/// received within this window of boot. `millis()` is monotonic-since-boot, so the loop's `now`
+/// IS the uptime. Belt-and-suspenders against a reboot-loop soft-brick — the transient +
+/// cache-bypass design already prevents a cached reboot, but a one-shot R landing right as a leaf
+/// boots (e.g. a re-press racing the boot) would otherwise reset it before it stabilises. A
+/// genuinely-wanted reboot in the first ~10 s is just re-pressed once the node is up.
+#[cfg(feature = "espnow")]
+const REBOOT_DEBOUNCE_MS: u64 = 10_000;
+
 /// OLED panel rotation. The pocket-watch case hangs from the USB-C end, so the
 /// display is physically upside-down and must be rotated 180° to read upright.
 ///
@@ -1025,6 +1034,24 @@ fn main() -> ! {
                         log::info!("smol #55: plugin mask -> {:#06x}", m);
                     }
                     plugin_mask = m;
+                }
+            }
+
+            // #52: a remote reboot command (key `R`) — a COMMAND (cache-bypass, one-shot). Applied
+            // once (edge — `take` clears it); the value is empty (the key IS the command). Feeds
+            // BOTH a leaf (relayed `<id>R`) and the gateway's OWN reset (injected into `self.cfg`),
+            // so both self-reboot on this one debounced path. BOOT-DEBOUNCE: within
+            // REBOOT_DEBOUNCE_MS of boot, CONSUME but IGNORE it (never a reboot-loop soft-brick);
+            // `now` is millis()-since-boot = uptime. `software_reset()` never returns.
+            if r.take_cfg_offer(crate::net::CFG_KEY_REBOOT).is_some() {
+                if now >= REBOOT_DEBOUNCE_MS {
+                    log::warn!("smol #52: remote reboot commanded — software_reset()");
+                    esp_hal::system::software_reset();
+                } else {
+                    log::info!(
+                        "smol #52: reboot ignored — within {} ms of boot (debounce)",
+                        REBOOT_DEBOUNCE_MS
+                    );
                 }
             }
             let state = r.peer_led_state(now);

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -549,6 +549,10 @@ fn main() -> ! {
     // Phase 3: LED-state trace bookkeeping (LED stays a `main` concern).
     #[cfg(feature = "espnow")]
     let mut last_led_state: Option<led::LedState> = None;
+    // #48: dashboard LED mode (status/on/off). Held across the loop; updated from the relayed
+    // `smol/<id>/config/led` (key `L`). Default `Status` = the pre-#48 peer-state indicator.
+    #[cfg(feature = "espnow")]
+    let mut led_mode = led::LedMode::default();
 
     // #20 (1a): last BOOT-button activity + the current flush-deferral start, to
     // postpone a recurring flush while the user is interacting (capped).
@@ -963,12 +967,23 @@ fn main() -> ! {
                 flush_defer_since_ms = 0;
             }
 
+            // #48: pull the relayed LED-mode config (leaf) and update the held mode. Edge-safe:
+            // a garbage/unknown value parses to None → keep the current mode (never a bad LED).
+            // On the gateway, its OWN led config is applied via the gateway-own path (deferred).
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_LED) {
+                if let Some(m) = led::LedMode::from_wire(core::str::from_utf8(&o.buf[..o.len]).unwrap_or("")) {
+                    if m != led_mode {
+                        log::info!("smol #48: LED mode -> {:?}", m);
+                    }
+                    led_mode = m;
+                }
+            }
             let state = r.peer_led_state(now);
             if last_led_state != Some(state) {
                 log::info!("smol: LED -> {:?}", state);
                 last_led_state = Some(state);
             }
-            led.apply(state, now);
+            led.apply_mode(led_mode, state, now);
         }
 
         // === FPS accounting (espnow / BENCH): count every loop iteration.

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -111,6 +111,10 @@ mod snake;
 mod mesh_snake;
 // On-board sensors: chip die-temp (tsens) + battery ADC on GPIO4. Always on.
 mod sensors;
+// #43 display units (°F/°C · 12h/24h): the fleet-global `Units` config + wire parse.
+// Always compiled — the CLOCK screen (universal) renders through it; only espnow nodes
+// receive a config (the relay/apply path is radio-only, like the screen/LED channels).
+mod units;
 // HA battery-voltage screen (Batt): the display-only Plugin + its `BattCache`,
 // filled by the WiFi burst's MQTT downlink (SUBSCRIBE `smol/display/batt`; see
 // net/wifi.rs) — the fetch needs the radio (espnow ⊃ wifi); default build omits it.
@@ -554,6 +558,13 @@ fn main() -> ! {
     #[cfg(feature = "espnow")]
     let mut led_mode = led::LedMode::default();
 
+    // #43 display units (°F/°C · 12h/24h), fleet-global. Held across the loop; on espnow the
+    // relayed / gateway-own `smol/config/units` (key `U`, broadcast target 255) updates it.
+    // On a non-espnow build there's no relay path, so it stays the default — the render (CLOCK
+    // screen, universal) just reads it. `mut` is used only under espnow (the apply block below).
+    #[allow(unused_mut)]
+    let mut units = units::Units::default();
+
     // #20 (1a): last BOOT-button activity + the current flush-deferral start, to
     // postpone a recurring flush while the user is interacting (capped).
     #[cfg(feature = "espnow")]
@@ -832,7 +843,10 @@ fn main() -> ! {
                 let reading = sensors.read();
                 let tele = alloc::format!(
                     "{} {}",
-                    sensors::format_sensor_line(&reading).as_str(),
+                    // #43: telemetry/uplink keeps the CANONICAL °F wire format regardless of the
+                    // display units — HA parses this data channel; the units config is a
+                    // display-only (#43 scope) concern for the physical OLED.
+                    sensors::format_sensor_line(&reading, true).as_str(),
                     bottom_line.as_str()
                 );
                 r.relay_emit(tele.as_bytes(), now);
@@ -856,7 +870,9 @@ fn main() -> ! {
                     let reading = sensors.read();
                     let own = alloc::format!(
                         "{} {}",
-                        sensors::format_sensor_line(&reading).as_str(),
+                        // #43: uplink keeps the canonical °F wire format (see the relay_emit
+                        // site above) — display units never reshape a data channel.
+                        sensors::format_sensor_line(&reading, true).as_str(),
                         bottom_line.as_str()
                     );
                     // #50: the LIVE screen:page the render loop draws NOW — read from the
@@ -978,6 +994,19 @@ fn main() -> ! {
                     led_mode = m;
                 }
             }
+
+            // #43: pull the relayed/gateway-own display-units config (key `U`, fleet-global via
+            // broadcast target 255) and update the held `Units`. Edge-safe: a garbage/partial
+            // value parses to None → keep the current units (never a half-applied unit). Same
+            // unified path as LED: a leaf gets it relayed, the gateway injects its own (GwOwnCfg).
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_UNITS) {
+                if let Some(u) = units::Units::from_wire(core::str::from_utf8(&o.buf[..o.len]).unwrap_or("")) {
+                    if u != units {
+                        log::info!("smol #43: display units -> {:?}", u);
+                    }
+                    units = u;
+                }
+            }
             let state = r.peer_led_state(now);
             if last_led_state != Some(state) {
                 log::info!("smol: LED -> {:?}", state);
@@ -1031,6 +1060,8 @@ fn main() -> ! {
             unix_now,
             node_id: node_id(),
             redraw,
+            // #43 fleet-global display units (°F/°C · 12h/24h) — read by the CLOCK render.
+            units,
             #[cfg(feature = "wifi")]
             batt: &batt_cache,
             #[cfg(feature = "wifi")]

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -565,6 +565,13 @@ fn main() -> ! {
     #[allow(unused_mut)]
     let mut units = units::Units::default();
 
+    // #55 plugin-visibility mask (bit = shown; see `app::plugin_bit`). `0` = keep all — the
+    // default AND the non-espnow value (the relay/apply path is radio-only). Held across the
+    // loop; on espnow the relayed / gateway-own `smol/<id>/config/plugins` updates it. Read by
+    // the Home menu to filter rows; `mut` is used only under espnow (the apply block below).
+    #[allow(unused_mut)]
+    let mut plugin_mask: u16 = 0;
+
     // #20 (1a): last BOOT-button activity + the current flush-deferral start, to
     // postpone a recurring flush while the user is interacting (capped).
     #[cfg(feature = "espnow")]
@@ -1007,6 +1014,19 @@ fn main() -> ! {
                     units = u;
                 }
             }
+
+            // #55: pull the relayed/gateway-own plugin-visibility mask (key `P`) and update it.
+            // Edge-safe: garbage/partial hex parses to None → keep the current mask (never blanks
+            // the menu). The mask filters Home-menu rows; a masked-off LIVE screen is caught after
+            // `ctx` is built (below) and falls back to the board default.
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_PLUGINS) {
+                if let Some(m) = menu::parse_plugin_mask(core::str::from_utf8(&o.buf[..o.len]).unwrap_or("")) {
+                    if m != plugin_mask {
+                        log::info!("smol #55: plugin mask -> {:#06x}", m);
+                    }
+                    plugin_mask = m;
+                }
+            }
             let state = r.peer_led_state(now);
             if last_led_state != Some(state) {
                 log::info!("smol: LED -> {:?}", state);
@@ -1062,6 +1082,8 @@ fn main() -> ! {
             redraw,
             // #43 fleet-global display units (°F/°C · 12h/24h) — read by the CLOCK render.
             units,
+            // #55 per-node plugin-visibility mask — read by the Home menu to filter rows.
+            plugin_mask,
             #[cfg(feature = "wifi")]
             batt: &batt_cache,
             #[cfg(feature = "wifi")]
@@ -1120,6 +1142,22 @@ fn main() -> ! {
                 log::info!("smol #21: default screen cleared → board default");
             }
             _ => {}
+        }
+
+        // #55: if the LIVE screen is now masked-off (a plugin the user is currently viewing was
+        // just hidden), fall back to the board default so the mask can never strand them on a
+        // hidden screen. Loop-safe: SKIP if we're already on the default kind — so even a mask
+        // that hides the default itself doesn't thrash (you land there once and stay; the menu's
+        // `enabled_indices` still guarantees a non-empty list). Edge-driven by any mask change.
+        #[cfg(feature = "espnow")]
+        {
+            let (live_kind, _) = app.live_screen();
+            if live_kind != DEFAULT_APP && !menu::kind_enabled(live_kind, plugin_mask) {
+                app = App::enter(DEFAULT_APP, &ctx);
+                app.set_page(DEFAULT_PAGE);
+                ctx.redraw = true;
+                log::info!("smol #55: live screen masked off → board default");
+            }
         }
 
         // One debounced BOOT-button gesture → the active plugin. ANY press forces

--- a/rust/clock/src/menu.rs
+++ b/rust/clock/src/menu.rs
@@ -43,6 +43,60 @@ const VISIBLE: usize = 3;
 const FIRST_Y: i32 = 11;
 const ROW_H: i32 = 9;
 
+/// #55: parse a `smol/<id>/config/plugins` payload — up to 4 ASCII-hex chars → a `u16` bit mask
+/// (e.g. `"007F"`, `"7f"`, `"5"`). Case-insensitive, panic-free. Empty / too long / any non-hex
+/// char → `None`, so the caller KEEPS its current mask (untrusted retained/relayed value — the
+/// #46 clamp). Bit `i` (see [`crate::app::plugin_bit`]) set = that app is shown in the Home menu.
+///
+/// espnow-only: the config apply path (`take_cfg_offer(P)`) is radio-only (like the screen/LED/
+/// units channels) — a non-espnow build never receives a mask (stays `0` = all shown).
+#[cfg(feature = "espnow")]
+pub fn parse_plugin_mask(s: &str) -> Option<u16> {
+    let s = s.trim();
+    if s.is_empty() || s.len() > 4 {
+        return None;
+    }
+    let mut v: u16 = 0;
+    for b in s.bytes() {
+        let d = match b {
+            b'0'..=b'9' => b - b'0',
+            b'a'..=b'f' => b - b'a' + 10,
+            b'A'..=b'F' => b - b'A' + 10,
+            _ => return None,
+        };
+        v = (v << 4) | d as u16;
+    }
+    Some(v)
+}
+
+/// #55: is `kind` shown under `mask`? A ZERO mask = keep all (the #55 safety: never blank the
+/// menu — also the non-espnow default, where the mask is never set). A kind with no plugin bit
+/// (`Menu`) is always shown. `mask` bit `plugin_bit(kind)` set = shown.
+pub fn kind_enabled(kind: crate::app::AppKind, mask: u16) -> bool {
+    mask == 0 || crate::app::plugin_bit(kind).is_none_or(|b| mask & (1 << b) != 0)
+}
+
+/// #55: the REGISTRY indices the mask ENABLES, in registry order (a fixed `.bss` buffer — at most
+/// `REGISTRY.len()` entries). SAFETY: if the mask enables NOTHING compiled, fall back to the whole
+/// registry — the menu is never blank (#55 safety / #46 clamp). Returns `(indices, count)`.
+fn enabled_indices(mask: u16) -> ([usize; REGISTRY.len()], usize) {
+    let mut buf = [0usize; REGISTRY.len()];
+    let mut n = 0;
+    for (i, desc) in REGISTRY.iter().enumerate() {
+        if kind_enabled(desc.kind, mask) {
+            buf[n] = i;
+            n += 1;
+        }
+    }
+    if n == 0 {
+        for (i, slot) in buf.iter_mut().enumerate() {
+            *slot = i;
+        }
+        n = REGISTRY.len();
+    }
+    (buf, n)
+}
+
 /// Home-menu state: which item is highlighted, and the top of the scroll window.
 pub struct Menu {
     selected: usize,
@@ -59,7 +113,7 @@ impl Menu {
     /// Render the title (node noun) + the visible window of [`REGISTRY`] rows,
     /// the selection in inverse video, plus edge chevrons when items sit off the
     /// window. Heap-free; all labels are `'static`.
-    fn draw(&self, display: &mut crate::app::Oled) {
+    fn draw(&self, display: &mut crate::app::Oled, mask: u16) {
         let title: MonoTextStyle<BinaryColor> = MonoTextStyleBuilder::new()
             .font(&FONT_6X10)
             .text_color(BinaryColor::On)
@@ -83,12 +137,16 @@ impl Menu {
             .draw(display)
             .ok();
 
-        // The window of rows [win .. win+VISIBLE), clamped to the registry length.
-        let end = (self.win + VISIBLE).min(REGISTRY.len());
-        for (i, desc) in REGISTRY.iter().enumerate().skip(self.win).take(VISIBLE) {
-            let rel = (i - self.win) as i32;
+        // #55: `selected`/`win` index the ENABLED subset (the mask may hide rows). The window
+        // [win .. win+VISIBLE) walks that subset; each position maps to a REGISTRY row via `idx`.
+        // A zero mask → all rows enabled → identical to the pre-#55 behavior.
+        let (idx, n) = enabled_indices(mask);
+        let end = (self.win + VISIBLE).min(n);
+        for pos in self.win..end {
+            let desc = &REGISTRY[idx[pos]];
+            let rel = (pos - self.win) as i32;
             let y = FIRST_Y + rel * ROW_H;
-            if i == self.selected {
+            if pos == self.selected {
                 // Highlight bar spanning the 72 px width, then inverse text.
                 Rectangle::new(Point::new(0, y - 1), Size::new(72, ROW_H as u32))
                     .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
@@ -104,7 +162,7 @@ impl Menu {
             }
         }
 
-        // Edge chevrons: mark items above/below the window. Draw in inverse when
+        // Edge chevrons: mark enabled items above/below the window. Draw in inverse when
         // the marked row is the highlighted (white-bar) one so it stays visible.
         if self.win > 0 {
             let style = if self.selected == self.win { item_sel } else { item };
@@ -112,7 +170,7 @@ impl Menu {
                 .draw(display)
                 .ok();
         }
-        if end < REGISTRY.len() {
+        if end < n {
             let bottom = end - 1;
             let style = if self.selected == bottom { item_sel } else { item };
             let y = FIRST_Y + (VISIBLE as i32 - 1) * ROW_H;
@@ -125,10 +183,17 @@ impl Menu {
 
 impl Plugin for Menu {
     fn on_button(&mut self, press: Press, ctx: &mut Ctx) -> Transition {
+        // #55: `selected`/`win` index the ENABLED subset. Resolve it (a zero mask → the full
+        // list) and clamp first — the mask may have shrunk the subset since the last press.
+        // `n >= 1` always (enabled_indices falls back to the whole registry if nothing is on).
+        let (idx, n) = enabled_indices(ctx.plugin_mask);
+        if self.selected >= n {
+            self.selected = n - 1;
+        }
         match press {
-            // Short tap: advance the selection (wrapping) and follow the window.
+            // Short tap: advance the selection (wrapping over the enabled subset) + follow window.
             Press::Short => {
-                self.selected = (self.selected + 1) % REGISTRY.len();
+                self.selected = (self.selected + 1) % n;
                 if self.selected < self.win {
                     self.win = self.selected;
                 } else if self.selected >= self.win + VISIBLE {
@@ -137,9 +202,9 @@ impl Plugin for Menu {
                 ctx.redraw = true;
                 Transition::Stay
             }
-            // Long press: enter the highlighted app (the SNAKE_KIND merge means
-            // "Snake" launches MeshSnake under espnow — see the registry).
-            Press::Long => Transition::Switch(REGISTRY[self.selected].kind),
+            // Long press: enter the highlighted app (the SNAKE_KIND merge means "Snake" launches
+            // MeshSnake under espnow). `idx[selected]` maps the subset position to its REGISTRY row.
+            Press::Long => Transition::Switch(REGISTRY[idx[self.selected]].kind),
         }
     }
 
@@ -147,8 +212,19 @@ impl Plugin for Menu {
         // The menu is static between selections, so it repaints on `redraw` only
         // (mode entry or a tap) — same cadence as the old Menu render arm.
         if ctx.redraw {
+            // #55: clamp the selection/window to the enabled-row count before drawing — the mask
+            // may have shrunk the subset out from under us since the last paint.
+            let (_, n) = enabled_indices(ctx.plugin_mask);
+            if self.selected >= n {
+                self.selected = n - 1;
+            }
+            if self.selected < self.win {
+                self.win = self.selected;
+            } else if self.selected >= self.win + VISIBLE {
+                self.win = self.selected + 1 - VISIBLE;
+            }
             ctx.display.clear(BinaryColor::Off).ok();
-            self.draw(ctx.display);
+            self.draw(ctx.display, ctx.plugin_mask);
             ctx.display.flush().ok();
         }
     }

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -58,6 +58,10 @@ pub use wifi::CFG_KEY_LED;
 // take_cfg_offer(U)). CFG_TARGET_ALL stays wifi-internal (only mode.rs/wifi.rs name it).
 #[cfg(feature = "espnow")]
 pub use wifi::CFG_KEY_UNITS;
+// #55 plugin-mask key — same `main`-bridge rationale (espnow leaf-apply path via
+// take_cfg_offer(P)). #52 adds `R` here.
+#[cfg(feature = "espnow")]
+pub use wifi::CFG_KEY_PLUGINS;
 
 // `try_time_sync` is the Phase-2 entry point; under `espnow`, `main` calls
 // `mode::start` instead, so only re-export it when espnow is NOT enabled.

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -51,9 +51,13 @@ pub use wifi::WifiPeripherals;
 #[cfg(feature = "espnow")]
 pub use wifi::CFG_KEY_SCREEN;
 // #48 LED mode key — same `main`-bridge rationale as the screen key (espnow leaf-apply path).
-// #43/#55/#52 add their keys (U/P/R) + CFG_TARGET_ALL here as each feature wires its apply.
+// #55/#52 add their keys (P/R) here as each feature wires its apply.
 #[cfg(feature = "espnow")]
 pub use wifi::CFG_KEY_LED;
+// #43 display-units key — same `main`-bridge rationale (espnow leaf-apply path via
+// take_cfg_offer(U)). CFG_TARGET_ALL stays wifi-internal (only mode.rs/wifi.rs name it).
+#[cfg(feature = "espnow")]
+pub use wifi::CFG_KEY_UNITS;
 
 // `try_time_sync` is the Phase-2 entry point; under `espnow`, `main` calls
 // `mode::start` instead, so only re-export it when espnow is NOT enabled.

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -50,6 +50,10 @@ pub use wifi::WifiPeripherals;
 // espnow-only — a wifi-only build reaches the const in-module (no re-export → no unused-import).
 #[cfg(feature = "espnow")]
 pub use wifi::CFG_KEY_SCREEN;
+// #48 LED mode key — same `main`-bridge rationale as the screen key (espnow leaf-apply path).
+// #43/#55/#52 add their keys (U/P/R) + CFG_TARGET_ALL here as each feature wires its apply.
+#[cfg(feature = "espnow")]
+pub use wifi::CFG_KEY_LED;
 
 // `try_time_sync` is the Phase-2 entry point; under `espnow`, `main` calls
 // `mode::start` instead, so only re-export it when espnow is NOT enabled.

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -59,9 +59,13 @@ pub use wifi::CFG_KEY_LED;
 #[cfg(feature = "espnow")]
 pub use wifi::CFG_KEY_UNITS;
 // #55 plugin-mask key — same `main`-bridge rationale (espnow leaf-apply path via
-// take_cfg_offer(P)). #52 adds `R` here.
+// take_cfg_offer(P)).
 #[cfg(feature = "espnow")]
 pub use wifi::CFG_KEY_PLUGINS;
+// #52 remote-reboot key — same `main`-bridge rationale (espnow leaf-apply path via
+// take_cfg_offer(R), with a boot-debounce before software_reset()).
+#[cfg(feature = "espnow")]
+pub use wifi::CFG_KEY_REBOOT;
 
 // `try_time_sync` is the Phase-2 entry point; under `espnow`, `main` calls
 // `mode::start` instead, so only re-export it when espnow is NOT enabled.

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -180,11 +180,15 @@ const CFG_PREFIX: &[u8] = b"SMOLv1 CFG "; // + "NNN" + KEY + verbatim "<value>"
 /// (a `take_cfg_offer(key)` + apply) and a gateway fill site in `mqtt_session`. Sized `[_; N]`
 /// (not `&[u8]`) so [`CfgTracker`] can allocate exactly one `.bss` buffer slot per key.
 /// An inbound key not listed is dropped at [`CfgTracker::set`] (never buffered/applied).
-const CFG_APPLY_KEYS: [u8; 4] = [
+const CFG_APPLY_KEYS: [u8; 5] = [
     crate::net::wifi::CFG_KEY_SCREEN,
     crate::net::wifi::CFG_KEY_LED,
     crate::net::wifi::CFG_KEY_UNITS,
     crate::net::wifi::CFG_KEY_PLUGINS,
+    // #52 remote reboot: R IS a buffered/applied key (a leaf takes it via take_cfg_offer(R)) but
+    // is NEVER put in cfg_cache/broadcast_cached_configs — the one-shot relay uses broadcast_config
+    // directly. The anti-reboot-loop invariant: R rides the CFG wire + apply path, not the cache.
+    crate::net::wifi::CFG_KEY_REBOOT,
 ];
 /// #50b leaf-status UPLINK tag: `"SMOLv1 STAT "` (12 B, trailing space) then `"NNN"`
 /// (3-ASCII zero-padded SENDER leaf id) then the verbatim live `<AppKind>:<page>` value
@@ -1608,6 +1612,7 @@ impl RadioManager {
         let mut ota_offer: Option<crate::ota::Announce> = None;
         let mut config_offer: Option<crate::app::DefaultScreen> = None;
         let mut _gw_own = crate::net::wifi::GwOwnCfg::new(); // #48: recovery burst never captures gateway-own cfg
+        let mut _reset_req = crate::net::wifi::ResetReq::new(); // #52: recovery burst issues no reboots
         let mut install_requested = false;
         let mut _leaf_install_seen = false; // #40 #1: a leaf's recovery burst is not a gateway relay
         let reached = match self.sta.as_mut() {
@@ -1626,6 +1631,7 @@ impl RadioManager {
                     &mut ota_offer,
                     &mut config_offer,
                     &mut _gw_own,
+                    &mut _reset_req,
                     &mut install_requested,
                     &mut _leaf_install_seen, // #40 #1: leaf recovery burst — never a gateway relay
                     &[], // #27: election-only recovery burst publishes no peers (leaf/v1)
@@ -2889,6 +2895,9 @@ impl RadioManager {
         // #48: capture the GATEWAY's OWN keyed configs (led/…) this flush surfaces, then inject
         // them into our own CfgTracker below so `main`'s take_cfg_offer(key) self-applies them.
         let mut gw_own = crate::net::wifi::GwOwnCfg::new();
+        // #52: capture any remote-reboot COMMANDS this flush surfaces (transient cmd/reset). Drained
+        // below into a ONE-SHOT relay per leaf target (NEVER cached) + a self-reboot inject if own.
+        let mut reset_req = crate::net::wifi::ResetReq::new();
         // #33: capture any OTA install command this flush surfaces.
         let mut install_requested = false;
         // #40 #1: set iff this flush SEES a retained leaf install (pre-arm) → latch pending below.
@@ -2928,6 +2937,7 @@ impl RadioManager {
                     &mut ota_offer,
                     &mut config_offer,
                     &mut gw_own, // #48: capture the gateway's own keyed configs
+                    &mut reset_req, // #52: capture remote-reboot commands (one-shot relay below)
                     &mut install_requested,
                     &mut leaf_install_seen, // #40 #1: latch pending on install-SEEN (below)
                     peers, // #27: gateway publishes its roster as retained smol/<id>/peers
@@ -2963,6 +2973,18 @@ impl RadioManager {
         // #55: the gateway's OWN plugin-visibility mask — same self-apply path (take_cfg_offer(P)).
         if let Some((buf, len)) = gw_own.plugins {
             self.cfg.set(crate::net::wifi::CFG_KEY_PLUGINS, &buf[..len]);
+        }
+        // #52 remote reboot — a COMMAND, not a config. Fire a ONE-SHOT `<id>R` frame per queued
+        // leaf target via `broadcast_config` DIRECTLY (NOT `cfg_cache` / `broadcast_cached_configs`):
+        // a cached/rebroadcast reboot = a permanent ~10 s reboot-loop soft-brick — the anti-loop
+        // invariant. Own id → inject R into our OWN CfgTracker so `main`'s take_cfg_offer(R) reboots
+        // us on the SAME boot-debounced path as a leaf (never a raw reset here). Empty value: the
+        // key IS the command. `reset_req` is a local (not `self`) → the borrow is disjoint.
+        for &leaf in reset_req.targets() {
+            self.broadcast_config(leaf, crate::net::wifi::CFG_KEY_REBOOT, b"");
+        }
+        if reset_req.own() {
+            self.cfg.set(crate::net::wifi::CFG_KEY_REBOOT, b"");
         }
         // #33: OR-in an install command (one-shot; `main`'s take clears it).
         if install_requested {

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -180,8 +180,11 @@ const CFG_PREFIX: &[u8] = b"SMOLv1 CFG "; // + "NNN" + KEY + verbatim "<value>"
 /// (a `take_cfg_offer(key)` + apply) and a gateway fill site in `mqtt_session`. Sized `[_; N]`
 /// (not `&[u8]`) so [`CfgTracker`] can allocate exactly one `.bss` buffer slot per key.
 /// An inbound key not listed is dropped at [`CfgTracker::set`] (never buffered/applied).
-const CFG_APPLY_KEYS: [u8; 2] =
-    [crate::net::wifi::CFG_KEY_SCREEN, crate::net::wifi::CFG_KEY_LED];
+const CFG_APPLY_KEYS: [u8; 3] = [
+    crate::net::wifi::CFG_KEY_SCREEN,
+    crate::net::wifi::CFG_KEY_LED,
+    crate::net::wifi::CFG_KEY_UNITS,
+];
 /// #50b leaf-status UPLINK tag: `"SMOLv1 STAT "` (12 B, trailing space) then `"NNN"`
 /// (3-ASCII zero-padded SENDER leaf id) then the verbatim live `<AppKind>:<page>` value
 /// (empty = none). Mirror of `CFG` but UPLINK (leaf → gateway): a leaf with no MQTT
@@ -2952,6 +2955,10 @@ impl RadioManager {
         if let Some((buf, len)) = gw_own.led {
             self.cfg.set(crate::net::wifi::CFG_KEY_LED, &buf[..len]);
         }
+        // #43: the gateway's OWN global display units — same self-apply path (take_cfg_offer(U)).
+        if let Some((buf, len)) = gw_own.units {
+            self.cfg.set(crate::net::wifi::CFG_KEY_UNITS, &buf[..len]);
+        }
         // #33: OR-in an install command (one-shot; `main`'s take clears it).
         if install_requested {
             self.install_requested = true;
@@ -3341,15 +3348,17 @@ impl RadioManager {
                 }
                 Some(Frame::Cfg { target, key, value }) => {
                     // #21/#56 leaf-relay: a gateway's keyed CONFIG downlink. Target-filter
-                    // FIRST (per-leaf) — only buffer if addressed to US; a config for any
-                    // other leaf is ignored here. `CfgTracker::set` then per-KEY-filters:
+                    // FIRST — buffer if addressed to US (`self.id`) OR to the #43 broadcast
+                    // sentinel CFG_TARGET_ALL (255, a fleet-global config like display units);
+                    // a config for any OTHER specific leaf is ignored here. `CfgTracker::set`
+                    // then per-KEY-filters:
                     // a key this build doesn't apply (a future channel from a newer gateway)
                     // is DROPPED (#56 forward-compat, #46 clamp). The value is opaque here;
                     // the matching `main` dispatch validates it (screen → strict/panic-free
                     // `parse_default_screen`: unknown/wrong-tier/bad-page → keep current;
                     // empty → clear). HARD BOUNDARY: screen config ONLY on `S` — never OTA.
                     // Buffering the raw bytes (not parsing here) keeps this arm total.
-                    if target == self.id {
+                    if target == self.id || target == crate::net::wifi::CFG_TARGET_ALL {
                         if self.cfg.set(key, value) {
                             log::info!(
                                 "smol #56: CFG frame for us (key '{}', {} B value) — buffered",

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1603,6 +1603,7 @@ impl RadioManager {
         // #6 OTA / #21 config / #33 install: a leaf's recovery burst can also surface these.
         let mut ota_offer: Option<crate::ota::Announce> = None;
         let mut config_offer: Option<crate::app::DefaultScreen> = None;
+        let mut _gw_own = crate::net::wifi::GwOwnCfg::new(); // #48: recovery burst never captures gateway-own cfg
         let mut install_requested = false;
         let mut _leaf_install_seen = false; // #40 #1: a leaf's recovery burst is not a gateway relay
         let reached = match self.sta.as_mut() {
@@ -1620,6 +1621,7 @@ impl RadioManager {
                     &mut elect,
                     &mut ota_offer,
                     &mut config_offer,
+                    &mut _gw_own,
                     &mut install_requested,
                     &mut _leaf_install_seen, // #40 #1: leaf recovery burst — never a gateway relay
                     &[], // #27: election-only recovery burst publishes no peers (leaf/v1)
@@ -2880,6 +2882,9 @@ impl RadioManager {
         let mut ota_offer: Option<crate::ota::Announce> = None;
         // #21: capture any default-screen config this flush surfaces.
         let mut config_offer: Option<crate::app::DefaultScreen> = None;
+        // #48: capture the GATEWAY's OWN keyed configs (led/…) this flush surfaces, then inject
+        // them into our own CfgTracker below so `main`'s take_cfg_offer(key) self-applies them.
+        let mut gw_own = crate::net::wifi::GwOwnCfg::new();
         // #33: capture any OTA install command this flush surfaces.
         let mut install_requested = false;
         // #40 #1: set iff this flush SEES a retained leaf install (pre-arm) → latch pending below.
@@ -2918,6 +2923,7 @@ impl RadioManager {
                     &mut elect,
                     &mut ota_offer,
                     &mut config_offer,
+                    &mut gw_own, // #48: capture the gateway's own keyed configs
                     &mut install_requested,
                     &mut leaf_install_seen, // #40 #1: latch pending on install-SEEN (below)
                     peers, // #27: gateway publishes its roster as retained smol/<id>/peers
@@ -2939,6 +2945,12 @@ impl RadioManager {
         // #21: stash any default-screen config this flush surfaced for `main`.
         if config_offer.is_some() {
             self.config_offer = config_offer;
+        }
+        // #48 GwOwnCfg: inject the gateway's OWN keyed configs into our (gateway-idle) CfgTracker
+        // so `main`'s take_cfg_offer(key) self-applies them — same path as a leaf's relayed config.
+        // `CfgTracker::set` key-filters (only CFG_APPLY_KEYS land), so a stray key is a no-op.
+        if let Some((buf, len)) = gw_own.led {
+            self.cfg.set(crate::net::wifi::CFG_KEY_LED, &buf[..len]);
         }
         // #33: OR-in an install command (one-shot; `main`'s take clears it).
         if install_requested {

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -180,7 +180,8 @@ const CFG_PREFIX: &[u8] = b"SMOLv1 CFG "; // + "NNN" + KEY + verbatim "<value>"
 /// (a `take_cfg_offer(key)` + apply) and a gateway fill site in `mqtt_session`. Sized `[_; N]`
 /// (not `&[u8]`) so [`CfgTracker`] can allocate exactly one `.bss` buffer slot per key.
 /// An inbound key not listed is dropped at [`CfgTracker::set`] (never buffered/applied).
-const CFG_APPLY_KEYS: [u8; 1] = [crate::net::wifi::CFG_KEY_SCREEN];
+const CFG_APPLY_KEYS: [u8; 2] =
+    [crate::net::wifi::CFG_KEY_SCREEN, crate::net::wifi::CFG_KEY_LED];
 /// #50b leaf-status UPLINK tag: `"SMOLv1 STAT "` (12 B, trailing space) then `"NNN"`
 /// (3-ASCII zero-padded SENDER leaf id) then the verbatim live `<AppKind>:<page>` value
 /// (empty = none). Mirror of `CFG` but UPLINK (leaf → gateway): a leaf with no MQTT

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -180,10 +180,11 @@ const CFG_PREFIX: &[u8] = b"SMOLv1 CFG "; // + "NNN" + KEY + verbatim "<value>"
 /// (a `take_cfg_offer(key)` + apply) and a gateway fill site in `mqtt_session`. Sized `[_; N]`
 /// (not `&[u8]`) so [`CfgTracker`] can allocate exactly one `.bss` buffer slot per key.
 /// An inbound key not listed is dropped at [`CfgTracker::set`] (never buffered/applied).
-const CFG_APPLY_KEYS: [u8; 3] = [
+const CFG_APPLY_KEYS: [u8; 4] = [
     crate::net::wifi::CFG_KEY_SCREEN,
     crate::net::wifi::CFG_KEY_LED,
     crate::net::wifi::CFG_KEY_UNITS,
+    crate::net::wifi::CFG_KEY_PLUGINS,
 ];
 /// #50b leaf-status UPLINK tag: `"SMOLv1 STAT "` (12 B, trailing space) then `"NNN"`
 /// (3-ASCII zero-padded SENDER leaf id) then the verbatim live `<AppKind>:<page>` value
@@ -2958,6 +2959,10 @@ impl RadioManager {
         // #43: the gateway's OWN global display units — same self-apply path (take_cfg_offer(U)).
         if let Some((buf, len)) = gw_own.units {
             self.cfg.set(crate::net::wifi::CFG_KEY_UNITS, &buf[..len]);
+        }
+        // #55: the gateway's OWN plugin-visibility mask — same self-apply path (take_cfg_offer(P)).
+        if let Some((buf, len)) = gw_own.plugins {
+            self.cfg.set(crate::net::wifi::CFG_KEY_PLUGINS, &buf[..len]);
         }
         // #33: OR-in an install command (one-shot; `main`'s take clears it).
         if install_requested {

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -792,6 +792,17 @@ pub const CFG_KEY_SCREEN: u8 = b'S';
 /// each feature lands, so the const stays used — no dead_code in the interim.)
 #[cfg(feature = "wifi")]
 pub const CFG_KEY_LED: u8 = b'L';
+/// #43 display-units channel (`<F|C>|<24|12>`). GLOBAL, not per-node: the retained topic is
+/// `smol/config/units` (no id). The gateway caches it under the broadcast target
+/// [`CFG_TARGET_ALL`] so ONE `SMOLv1 CFG <255>U<val>` frame reaches every leaf.
+#[cfg(feature = "wifi")]
+pub const CFG_KEY_UNITS: u8 = b'U';
+/// #43 broadcast TARGET sentinel for a fleet-global CFG frame. No node ever holds id 255
+/// (ids are 1..=254 by convention), so it can't collide with a real per-node target. A leaf
+/// applies a CFG frame whose target is its own id OR this sentinel (mode.rs `service()` CFG
+/// arm); the gateway caches global configs under `(255, key)` and relays them to all leaves.
+#[cfg(feature = "wifi")]
+pub const CFG_TARGET_ALL: u8 = 255;
 
 /// #48 (GwOwnCfg — approved arch): the GATEWAY's OWN per-node configs read from its own MQTT
 /// topics this burst. A leaf gets these RELAYED (→ its `CfgTracker`); the gateway reads them
@@ -805,12 +816,16 @@ pub const CFG_KEY_LED: u8 = b'L';
 pub struct GwOwnCfg {
     /// The gateway's own `smol/<id>/config/led` value `(buf, len)`, or `None` if absent this burst.
     pub led: Option<([u8; CFG_VALUE_MAX], usize)>,
+    /// #43 the GLOBAL `smol/config/units` value `(buf, len)`, or `None` if absent this burst.
+    /// The gateway applies its own display units directly (it also relays them to leaves under
+    /// the broadcast target); captured here so `service()` self-applies via the same path.
+    pub units: Option<([u8; CFG_VALUE_MAX], usize)>,
 }
 
 #[cfg(feature = "wifi")]
 impl GwOwnCfg {
     pub const fn new() -> Self {
-        Self { led: None }
+        Self { led: None, units: None }
     }
     /// Pack a payload into the `(buf, len)` a field holds (truncated to `CFG_VALUE_MAX`), so the
     /// mqtt-drain arms stay one-liners: `gw_own.led = Some(GwOwnCfg::val(payload));`.
@@ -1290,6 +1305,13 @@ fn mqtt_session(
         if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 10, b"smol/+/config/led") {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
+        // #43 display units (pid 11): the GLOBAL retained units topic `smol/config/units` (NO id
+        // — one setting for the whole fleet, so NOT a `smol/+/…` wildcard). The gateway caches it
+        // under the broadcast target CFG_TARGET_ALL (255) so ONE relayed `<255>U<val>` frame
+        // reaches every leaf, and self-applies its own display units (gw_own.units) below.
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 11, b"smol/config/units") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
     }
 
     // --- PUBLISH telemetry (transient) + discovery config (retained) per node ---
@@ -1617,6 +1639,23 @@ fn mqtt_session(
                             gw_own.led = Some(GwOwnCfg::val(payload));
                             log::info!("smol #48: gateway own led config captured ({} B)", payload.len());
                         }
+                    } else if topic == b"smol/config/units" {
+                        // #43 display units — GLOBAL (no id in the topic → an exact match, not the
+                        // `smol/<id>/…` wildcard parse). TWO effects, mirroring the own-led branch
+                        // above but fleet-wide: (1) cache under the broadcast target CFG_TARGET_ALL
+                        // so ONE relayed `<255>U<val>` frame reaches every leaf; (2) capture into
+                        // gw_own so `service()` self-applies the gateway's OWN display units. The
+                        // bytes are opaque here — the leaf's `Units::from_wire` validates them
+                        // (garbage/partial → keep current, #46 clamp).
+                        if let Some(cache) = cfg_cache.as_deref_mut() {
+                            let now = Instant::now().duration_since_epoch().as_millis();
+                            cache.set(CFG_TARGET_ALL, CFG_KEY_UNITS, payload, [0u8; 6], now);
+                        }
+                        gw_own.units = Some(GwOwnCfg::val(payload));
+                        log::info!(
+                            "smol #43: global display units captured ({} B) — cached (255,U) + self",
+                            payload.len()
+                        );
                     } else if let Some(leaf_id) = parse_leaf_install_topic(topic) {
                         // #40 (§B3): a wildcard-delivered leaf OTA install command. On a
                         // GATEWAY flush (cfg_cache = Some), an `INSTALL` for a leaf id ≠ self

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -234,17 +234,18 @@ fn parse_mesh_channel(payload: &[u8]) -> Option<(u8, u8, u32)> {
     Some((owner, ch, seq))
 }
 
-/// #21 leaf-relay: extract the leaf id `N` from a `smol/<N>/config/default_screen`
-/// topic (the shape the wildcard subscribe delivers). Total/panic-free: fixed
-/// prefix + exact suffix match + 1–3 ASCII-digit parse clamped to u8; anything else
-/// → `None`. The topic is broker-supplied, so parse defensively (not just trust the
-/// subscribe filter).
+/// #21/#48/#55 leaf-relay: extract the leaf id `N` from a `smol/<N><suffix>` topic (the shape
+/// the wildcard subscribe delivers), IFF the tail matches `suffix` (e.g. `/config/default_screen`,
+/// `/config/led`, `/config/plugins`). Total/panic-free: fixed prefix + exact suffix match + 1–3
+/// ASCII-digit parse clamped to u8; anything else → `None`. The topic is broker-supplied, so
+/// parse defensively (not just trust the subscribe filter). One helper serves every per-node
+/// config key so a new key = one call site, not a new parser.
 #[cfg(feature = "wifi")]
-fn parse_leaf_config_topic(topic: &[u8]) -> Option<u8> {
+fn parse_leaf_config_topic(topic: &[u8], suffix: &[u8]) -> Option<u8> {
     let rest = topic.strip_prefix(b"smol/")?;
     let slash = rest.iter().position(|&b| b == b'/')?;
     let (idb, tail) = rest.split_at(slash);
-    if tail != b"/config/default_screen" {
+    if tail != suffix {
         return None;
     }
     if idb.is_empty() || idb.len() > 3 {
@@ -784,6 +785,11 @@ pub const CFG_VALUE_MAX: usize = 16;
 /// ESP-NOW frame layer that RELAYS/parses it (espnow) both name it with no per-profile cfg.
 #[cfg(feature = "wifi")]
 pub const CFG_KEY_SCREEN: u8 = b'S';
+/// #48 blue-LED mode channel (`status`/`on`/`off`). Per-node retained `smol/<id>/config/led`.
+/// (#43/#55/#52 add their keys `U`/`P`/`R` + the `CFG_TARGET_ALL` global-units target here as
+/// each feature lands, so the const stays used — no dead_code in the interim.)
+#[cfg(feature = "wifi")]
+pub const CFG_KEY_LED: u8 = b'L';
 
 /// #40 #3: one relay attempt's diagnostic snapshot — gateway-side RX evidence PLUS the leaf's
 /// self-reported OTA state (captured from its `LDBG` beacon during the relay). Published to
@@ -1245,6 +1251,11 @@ fn mqtt_session(
         if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 9, b"smol/+/ota/install") {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
+        // #48 blue-LED mode (pid 10): wildcard-subscribe every leaf's retained led config so the
+        // gateway caches + relays it (key `L`) over ESP-NOW, twin of the default_screen wildcard.
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 10, b"smol/+/config/led") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
     }
 
     // --- PUBLISH telemetry (transient) + discovery config (retained) per node ---
@@ -1531,7 +1542,7 @@ fn mqtt_session(
                             crate::net::cast::set_enabled(on);
                             log::info!("smol #26: cast {}", if on { "ENABLED" } else { "disabled" });
                         }
-                    } else if let Some(leaf_id) = parse_leaf_config_topic(topic) {
+                    } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/config/default_screen") {
                         // #21 leaf-relay: a wildcard-delivered OTHER leaf's config. Cache
                         // the verbatim value bytes for the ESP-NOW relay (mode.rs
                         // broadcast_cached_configs). `leaf_id == node_id` is the gateway's
@@ -1548,6 +1559,21 @@ fn mqtt_session(
                                 cache.set(leaf_id, CFG_KEY_SCREEN, payload, [0u8; 6], now);
                                 log::info!(
                                     "smol #21/#56: cached leaf id{} screen config for relay ({} B)",
+                                    leaf_id,
+                                    payload.len()
+                                );
+                            }
+                        }
+                    } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/config/led") {
+                        // #48 blue-LED mode: twin of the default_screen arm — cache a leaf's led
+                        // config under key `L` for the ESP-NOW relay. Verbatim bytes; the leaf's
+                        // LedMode::from_wire validates (unknown → keep current).
+                        if leaf_id != node_id {
+                            if let Some(cache) = cfg_cache.as_deref_mut() {
+                                let now = Instant::now().duration_since_epoch().as_millis();
+                                cache.set(leaf_id, CFG_KEY_LED, payload, [0u8; 6], now);
+                                log::info!(
+                                    "smol #48: cached leaf id{} led config for relay ({} B)",
                                     leaf_id,
                                     payload.len()
                                 );

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -567,6 +567,7 @@ pub fn run_ntp_burst(
     let mqtt_port = 49152 + (rng.random() % 16384) as u16;
     let mut _leaf_seen_boot = false; // #40 #1: boot burst is not a gateway relay → never set
     let mut _ntp_gw_own = GwOwnCfg::new(); // #48: boot/NTP burst never captures gateway-own cfg (cfg_cache=None)
+    let mut _ntp_reset_req = ResetReq::new(); // #52: boot/NTP burst subscribes no cmd/reset (cfg_cache=None)
     let _ = mqtt_session(
         &mut iface,
         device,
@@ -581,6 +582,7 @@ pub fn run_ntp_burst(
         ota_offer,
         config_offer,
         &mut _ntp_gw_own,
+        &mut _ntp_reset_req,
         install_requested,
         &mut _leaf_seen_boot, // #40 #1: boot burst sees no leaf installs
         &[], // #27: boot NTP+downlink burst publishes no peers (no roster yet)
@@ -808,6 +810,19 @@ pub const CFG_TARGET_ALL: u8 = 255;
 /// Home menu; a leaf gets it relayed (key `P`), the gateway reads its own directly.
 #[cfg(feature = "wifi")]
 pub const CFG_KEY_PLUGINS: u8 = b'P';
+/// #52 remote-reboot COMMAND (key `R`). Rides the CFG WIRE (`SMOLv1 CFG <id>R`) and IS in
+/// `CFG_APPLY_KEYS` (a leaf buffers + applies it) — but is NEVER cached / rebroadcast: a
+/// cached reboot = a permanent ~10 s reboot-loop soft-brick. The gateway subscribes the
+/// TRANSIENT `smol/<id>/cmd/reset` (retain:false) and fires a ONE-SHOT `<id>R` frame on
+/// receipt only (own id → self-reboot). The leaf applies it once, with a boot-debounce.
+// allow(dead_code): unlike S/L/U/P, the reboot key is NEVER named in a wifi-tier fill arm — R is
+// cache-BYPASS (the #52 anti-reboot-loop rule), so the `/cmd/reset` arm captures into `ResetReq`
+// WITHOUT a `cache.set(.., R, ..)`. It's referenced only on espnow (mode.rs CFG_APPLY_KEYS + the
+// one-shot drain, main's apply, the net re-export), so a wifi-only build sees it unused. Keeping it
+// in the wifi-tier CFG-key family (beside S/L/U/P) reads clearer than cfg(espnow)-gating one key.
+#[cfg(feature = "wifi")]
+#[allow(dead_code)]
+pub const CFG_KEY_REBOOT: u8 = b'R';
 
 /// #48 (GwOwnCfg — approved arch): the GATEWAY's OWN per-node configs read from its own MQTT
 /// topics this burst. A leaf gets these RELAYED (→ its `CfgTracker`); the gateway reads them
@@ -846,6 +861,58 @@ impl GwOwnCfg {
         let n = value.len().min(CFG_VALUE_MAX);
         b[..n].copy_from_slice(&value[..n]);
         (b, n)
+    }
+}
+
+/// #52 how many distinct leaf reboot targets one burst can queue. A reset is TRANSIENT +
+/// re-pressable, so a full queue just drops extras (the user re-presses) — no soft state lost.
+#[cfg(feature = "wifi")]
+pub const RESET_REQ_MAX: usize = 8;
+
+/// #52 remote-reboot capture — the reset COMMANDS seen on the TRANSIENT `smol/+/cmd/reset` topics
+/// this burst. NOT a config: NEVER cached / rebroadcast (a cached reboot = a permanent ~10 s
+/// reboot-loop soft-brick). Bundled into ONE `mqtt_session`/`run_mqtt_burst` out-param (like
+/// `GwOwnCfg`). After the burst, `service()` fires a ONE-SHOT `broadcast_config(id, R, "")` per
+/// leaf target (direct ESP-NOW, bypassing `cfg_cache`) and injects R into its OWN `CfgTracker`
+/// if `own` — so `main`'s `take_cfg_offer(R)` self-reboots on the SAME boot-debounced path as a
+/// leaf. `#[allow(dead_code)]`: read only on espnow (mode.rs), write-only on a wifi-only build.
+#[cfg(feature = "wifi")]
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+pub struct ResetReq {
+    targets: [u8; RESET_REQ_MAX],
+    n: usize,
+    own: bool,
+}
+
+#[cfg(feature = "wifi")]
+#[allow(dead_code)]
+impl ResetReq {
+    pub const fn new() -> Self {
+        Self { targets: [0; RESET_REQ_MAX], n: 0, own: false }
+    }
+    /// Queue a leaf id for a one-shot reboot relay (deduped; dropped if full — re-pressable).
+    pub fn push_leaf(&mut self, id: u8) {
+        for i in 0..self.n {
+            if self.targets[i] == id {
+                return;
+            }
+        }
+        if self.n < RESET_REQ_MAX {
+            self.targets[self.n] = id;
+            self.n += 1;
+        }
+    }
+    /// Mark that THIS node's own `cmd/reset` fired this burst → self-reboot after the burst.
+    pub fn set_own(&mut self) {
+        self.own = true;
+    }
+    pub fn own(&self) -> bool {
+        self.own
+    }
+    /// The queued leaf reboot targets (to relay one-shot; NEVER cached).
+    pub fn targets(&self) -> &[u8] {
+        &self.targets[..self.n]
     }
 }
 
@@ -1109,6 +1176,10 @@ fn mqtt_session(
     // #48 GwOwnCfg: filled with the GATEWAY's OWN keyed configs (led, +units/plugins later) read
     // from its own MQTT topics this burst; `service()` injects them into the gateway's CfgTracker.
     gw_own: &mut GwOwnCfg,
+    // #52 remote reboot: filled with the reset COMMANDS seen on the transient `smol/+/cmd/reset`
+    // topics this burst; `service()` fires a one-shot `<id>R` relay per target (NEVER cached) +
+    // self-reboots if own. Separate from `gw_own` because R is a COMMAND, not a cached config.
+    reset_req: &mut ResetReq,
     // #33 HA Update entity: set true iff a retained `install` command is present for this
     // board (the native Install button) — the caller AND-gates the fetch on it.
     install_requested: &mut bool,
@@ -1327,6 +1398,12 @@ fn mqtt_session(
         // #55 plugin visibility (pid 12): wildcard-subscribe every leaf's retained plugin mask so
         // the gateway caches + relays it (key `P`) over ESP-NOW, twin of the led wildcard.
         if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 12, b"smol/+/config/plugins") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
+        // #52 remote reboot (pid 13): wildcard-subscribe the TRANSIENT `smol/+/cmd/reset` COMMAND
+        // topic (retain:false → seen only while we're connected, never replayed). On receipt the
+        // gateway fires a ONE-SHOT `<id>R` relay (never cached — anti-reboot-loop); own id → self.
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 13, b"smol/+/cmd/reset") {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
     }
@@ -1691,6 +1768,20 @@ fn mqtt_session(
                         } else {
                             gw_own.plugins = Some(GwOwnCfg::val(payload));
                             log::info!("smol #55: gateway own plugin mask captured ({} B)", payload.len());
+                        }
+                    } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/cmd/reset") {
+                        // #52 remote reboot — a COMMAND on a TRANSIENT topic (retain:false), so we
+                        // only see it when HA publishes DURING this session. NEVER cache it (a
+                        // cached/rebroadcast reboot = a permanent ~10 s reboot-loop soft-brick):
+                        // capture into `reset_req` for a ONE-SHOT relay after the burst. The topic
+                        // IS the command — any payload (incl. empty) triggers. OWN id → self-reboot
+                        // (routed through our CfgTracker below → the boot-debounced apply in main).
+                        if leaf_id == node_id {
+                            reset_req.set_own();
+                            log::info!("smol #52: OWN reset command — self-reboot after burst");
+                        } else {
+                            reset_req.push_leaf(leaf_id);
+                            log::info!("smol #52: leaf id{} reset command — one-shot relay queued", leaf_id);
                         }
                     } else if let Some(leaf_id) = parse_leaf_install_topic(topic) {
                         // #40 (§B3): a wildcard-delivered leaf OTA install command. On a
@@ -2162,6 +2253,8 @@ pub fn run_mqtt_burst(
     config_offer: &mut Option<crate::app::DefaultScreen>,
     // #48 GwOwnCfg: the gateway's own keyed configs (led/…) — forwarded to `mqtt_session`.
     gw_own: &mut GwOwnCfg,
+    // #52 remote reboot: reset commands seen this burst — forwarded to `mqtt_session`.
+    reset_req: &mut ResetReq,
     // #33: set true iff a retained OTA `install` command is present for this board.
     install_requested: &mut bool,
     // #40 #1: set true iff a retained leaf `install` (for another node) is seen this burst.
@@ -2362,6 +2455,7 @@ pub fn run_mqtt_burst(
         ota_offer,
         config_offer,
         gw_own, // #48: forward the gateway-own keyed-config capture
+        reset_req, // #52: forward the remote-reboot command capture
         install_requested,
         leaf_install_seen, // #40 #1: forward the leaf-install-seen latch
         peers, // #27: forward the caller's serialized roster to publish retained

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1892,7 +1892,11 @@ fn mqtt_session(
         let mut djson = MqttScratch::new();
         let _ = write!(
             djson,
-            "{{\"~\":\"smol/{}/ota\",\"stat_t\":\"~/state\",\"cmd_t\":\"~/install\",\"pl_inst\":\"INSTALL\",\"dev_cla\":\"firmware\",\"name\":\"Update\",\"has_entity_name\":true,\"uniq_id\":\"smol{}_update\",\"object_id\":\"smol_{}_update\",\"dev\":{{\"ids\":[\"smol{}\"]}}}}",
+            // #39: `retain:true` → HA publishes update.install (native tile + Lovelace update-action)
+            // to cmd_t RETAINED, so the node catches it on its next ~2 s burst (the fw acts ONLY on a
+            // retained install; a non-retained one is missed between bursts). Unifies Install into the
+            // native Update tile and lets the HA-side retained install buttons retire.
+            "{{\"~\":\"smol/{}/ota\",\"stat_t\":\"~/state\",\"cmd_t\":\"~/install\",\"pl_inst\":\"INSTALL\",\"retain\":true,\"dev_cla\":\"firmware\",\"name\":\"Update\",\"has_entity_name\":true,\"uniq_id\":\"smol{}_update\",\"object_id\":\"smol_{}_update\",\"dev\":{{\"ids\":[\"smol{}\"]}}}}",
             node_id, node_id, node_id, node_id
         );
         if let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, dtopic.as_bytes(), djson.as_bytes(), true) {
@@ -1946,7 +1950,10 @@ fn mqtt_session(
             let mut djson = MqttScratch::new();
             let _ = write!(
                 djson,
-                "{{\"~\":\"smol/{}/ota\",\"stat_t\":\"~/state\",\"cmd_t\":\"~/install\",\"pl_inst\":\"INSTALL\",\"dev_cla\":\"firmware\",\"name\":\"Update\",\"has_entity_name\":true,\"uniq_id\":\"smol{}_update\",\"object_id\":\"smol_{}_update\",\"dev\":{{\"ids\":[\"smol{}\"],\"name\":\"smol {} {}\"}}}}",
+                // #39: `retain:true` (see the gateway's own Update above) — HA publishes the leaf's
+                // install retained → the gateway wildcard-subs it + relays (§B3), so the native tile
+                // Install works for relayed leaves too, not just the retained HA-side buttons.
+                "{{\"~\":\"smol/{}/ota\",\"stat_t\":\"~/state\",\"cmd_t\":\"~/install\",\"pl_inst\":\"INSTALL\",\"retain\":true,\"dev_cla\":\"firmware\",\"name\":\"Update\",\"has_entity_name\":true,\"uniq_id\":\"smol{}_update\",\"object_id\":\"smol_{}_update\",\"dev\":{{\"ids\":[\"smol{}\"],\"name\":\"smol {} {}\"}}}}",
                 lid, lid, lid, lid, lid, noun
             );
             if let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, dtopic.as_bytes(), djson.as_bytes(), true) {

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -803,6 +803,11 @@ pub const CFG_KEY_UNITS: u8 = b'U';
 /// arm); the gateway caches global configs under `(255, key)` and relays them to all leaves.
 #[cfg(feature = "wifi")]
 pub const CFG_TARGET_ALL: u8 = 255;
+/// #55 plugin-visibility channel (ASCII-hex u16 mask, e.g. `007F`). Per-node retained
+/// `smol/<id>/config/plugins`. Bit i (see `app::plugin_bit`) set = that app is shown in the
+/// Home menu; a leaf gets it relayed (key `P`), the gateway reads its own directly.
+#[cfg(feature = "wifi")]
+pub const CFG_KEY_PLUGINS: u8 = b'P';
 
 /// #48 (GwOwnCfg — approved arch): the GATEWAY's OWN per-node configs read from its own MQTT
 /// topics this burst. A leaf gets these RELAYED (→ its `CfgTracker`); the gateway reads them
@@ -813,6 +818,11 @@ pub const CFG_TARGET_ALL: u8 = 255;
 /// on its own `config_offer` path (untouched). #43/#55 add `units`/`plugins` fields as they land.
 #[cfg(feature = "wifi")]
 #[derive(Clone, Copy)]
+// The fields are READ only on espnow (mode.rs gateway flush injects them into the CfgTracker);
+// a wifi-only build FILLS them in mqtt_session but has no RadioManager to read them back, so they
+// are write-only there → allow(dead_code) keeps the `-D warnings` clippy gate green in BOTH
+// configs (same cross-profile rationale as CfgCache above).
+#[allow(dead_code)]
 pub struct GwOwnCfg {
     /// The gateway's own `smol/<id>/config/led` value `(buf, len)`, or `None` if absent this burst.
     pub led: Option<([u8; CFG_VALUE_MAX], usize)>,
@@ -820,12 +830,14 @@ pub struct GwOwnCfg {
     /// The gateway applies its own display units directly (it also relays them to leaves under
     /// the broadcast target); captured here so `service()` self-applies via the same path.
     pub units: Option<([u8; CFG_VALUE_MAX], usize)>,
+    /// #55 the gateway's own `smol/<id>/config/plugins` value `(buf, len)`, or `None` if absent.
+    pub plugins: Option<([u8; CFG_VALUE_MAX], usize)>,
 }
 
 #[cfg(feature = "wifi")]
 impl GwOwnCfg {
     pub const fn new() -> Self {
-        Self { led: None, units: None }
+        Self { led: None, units: None, plugins: None }
     }
     /// Pack a payload into the `(buf, len)` a field holds (truncated to `CFG_VALUE_MAX`), so the
     /// mqtt-drain arms stay one-liners: `gw_own.led = Some(GwOwnCfg::val(payload));`.
@@ -1312,6 +1324,11 @@ fn mqtt_session(
         if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 11, b"smol/config/units") {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
+        // #55 plugin visibility (pid 12): wildcard-subscribe every leaf's retained plugin mask so
+        // the gateway caches + relays it (key `P`) over ESP-NOW, twin of the led wildcard.
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 12, b"smol/+/config/plugins") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
     }
 
     // --- PUBLISH telemetry (transient) + discovery config (retained) per node ---
@@ -1656,6 +1673,25 @@ fn mqtt_session(
                             "smol #43: global display units captured ({} B) — cached (255,U) + self",
                             payload.len()
                         );
+                    } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/config/plugins") {
+                        // #55 plugin visibility: twin of the led arm. OTHER leaf → cache under key
+                        // `P` for the ESP-NOW relay; OUR OWN id → capture into gw_own so `service()`
+                        // self-applies it. Verbatim bytes; the leaf's `parse_plugin_mask` validates
+                        // (bad/partial hex → keep current mask, never a blank menu).
+                        if leaf_id != node_id {
+                            if let Some(cache) = cfg_cache.as_deref_mut() {
+                                let now = Instant::now().duration_since_epoch().as_millis();
+                                cache.set(leaf_id, CFG_KEY_PLUGINS, payload, [0u8; 6], now);
+                                log::info!(
+                                    "smol #55: cached leaf id{} plugin mask for relay ({} B)",
+                                    leaf_id,
+                                    payload.len()
+                                );
+                            }
+                        } else {
+                            gw_own.plugins = Some(GwOwnCfg::val(payload));
+                            log::info!("smol #55: gateway own plugin mask captured ({} B)", payload.len());
+                        }
                     } else if let Some(leaf_id) = parse_leaf_install_topic(topic) {
                         // #40 (§B3): a wildcard-delivered leaf OTA install command. On a
                         // GATEWAY flush (cfg_cache = Some), an `INSTALL` for a leaf id ≠ self

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -566,6 +566,7 @@ pub fn run_ntp_burst(
     let mqtt_deadline = Instant::now() + MQTT_SESSION_BUDGET;
     let mqtt_port = 49152 + (rng.random() % 16384) as u16;
     let mut _leaf_seen_boot = false; // #40 #1: boot burst is not a gateway relay → never set
+    let mut _ntp_gw_own = GwOwnCfg::new(); // #48: boot/NTP burst never captures gateway-own cfg (cfg_cache=None)
     let _ = mqtt_session(
         &mut iface,
         device,
@@ -579,6 +580,7 @@ pub fn run_ntp_burst(
         elect,
         ota_offer,
         config_offer,
+        &mut _ntp_gw_own,
         install_requested,
         &mut _leaf_seen_boot, // #40 #1: boot burst sees no leaf installs
         &[], // #27: boot NTP+downlink burst publishes no peers (no roster yet)
@@ -790,6 +792,35 @@ pub const CFG_KEY_SCREEN: u8 = b'S';
 /// each feature lands, so the const stays used — no dead_code in the interim.)
 #[cfg(feature = "wifi")]
 pub const CFG_KEY_LED: u8 = b'L';
+
+/// #48 (GwOwnCfg — approved arch): the GATEWAY's OWN per-node configs read from its own MQTT
+/// topics this burst. A leaf gets these RELAYED (→ its `CfgTracker`); the gateway reads them
+/// DIRECTLY. Bundled into ONE `run_mqtt_burst`/`mqtt_session` out-param (net +1, not +N) — after
+/// the burst `service()` injects each present value into the gateway's OWN (otherwise-idle)
+/// `CfgTracker`, so `main`'s `take_cfg_offer(key)` applies it on the EXACT same path as a leaf's
+/// relayed config (a node is gateway XOR leaf → the one tracker has a single feeder). Screen stays
+/// on its own `config_offer` path (untouched). #43/#55 add `units`/`plugins` fields as they land.
+#[cfg(feature = "wifi")]
+#[derive(Clone, Copy)]
+pub struct GwOwnCfg {
+    /// The gateway's own `smol/<id>/config/led` value `(buf, len)`, or `None` if absent this burst.
+    pub led: Option<([u8; CFG_VALUE_MAX], usize)>,
+}
+
+#[cfg(feature = "wifi")]
+impl GwOwnCfg {
+    pub const fn new() -> Self {
+        Self { led: None }
+    }
+    /// Pack a payload into the `(buf, len)` a field holds (truncated to `CFG_VALUE_MAX`), so the
+    /// mqtt-drain arms stay one-liners: `gw_own.led = Some(GwOwnCfg::val(payload));`.
+    pub fn val(value: &[u8]) -> ([u8; CFG_VALUE_MAX], usize) {
+        let mut b = [0u8; CFG_VALUE_MAX];
+        let n = value.len().min(CFG_VALUE_MAX);
+        b[..n].copy_from_slice(&value[..n]);
+        (b, n)
+    }
+}
 
 /// #40 #3: one relay attempt's diagnostic snapshot — gateway-side RX evidence PLUS the leaf's
 /// self-reported OTA state (captured from its `LDBG` beacon during the relay). Published to
@@ -1048,6 +1079,9 @@ fn mqtt_session(
     // #21 node-manager: filled with the parsed retained default-screen command for
     // this board (Set/Clear), if present + valid; None = absent/invalid (keep current).
     config_offer: &mut Option<crate::app::DefaultScreen>,
+    // #48 GwOwnCfg: filled with the GATEWAY's OWN keyed configs (led, +units/plugins later) read
+    // from its own MQTT topics this burst; `service()` injects them into the gateway's CfgTracker.
+    gw_own: &mut GwOwnCfg,
     // #33 HA Update entity: set true iff a retained `install` command is present for this
     // board (the native Install button) — the caller AND-gates the fetch on it.
     install_requested: &mut bool,
@@ -1565,9 +1599,10 @@ fn mqtt_session(
                             }
                         }
                     } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/config/led") {
-                        // #48 blue-LED mode: twin of the default_screen arm — cache a leaf's led
-                        // config under key `L` for the ESP-NOW relay. Verbatim bytes; the leaf's
-                        // LedMode::from_wire validates (unknown → keep current).
+                        // #48 blue-LED mode: twin of the default_screen arm. OTHER leaf → cache
+                        // under key `L` for the ESP-NOW relay; OUR OWN id → capture into gw_own so
+                        // `service()` self-applies it (the gateway reads its own led directly, not
+                        // relayed). Verbatim bytes; the leaf's LedMode::from_wire validates.
                         if leaf_id != node_id {
                             if let Some(cache) = cfg_cache.as_deref_mut() {
                                 let now = Instant::now().duration_since_epoch().as_millis();
@@ -1578,6 +1613,9 @@ fn mqtt_session(
                                     payload.len()
                                 );
                             }
+                        } else {
+                            gw_own.led = Some(GwOwnCfg::val(payload));
+                            log::info!("smol #48: gateway own led config captured ({} B)", payload.len());
                         }
                     } else if let Some(leaf_id) = parse_leaf_install_topic(topic) {
                         // #40 (§B3): a wildcard-delivered leaf OTA install command. On a
@@ -2047,6 +2085,8 @@ pub fn run_mqtt_burst(
     ota_offer: &mut Option<crate::ota::Announce>,
     // #21: filled with the parsed default-screen config for this board, if present.
     config_offer: &mut Option<crate::app::DefaultScreen>,
+    // #48 GwOwnCfg: the gateway's own keyed configs (led/…) — forwarded to `mqtt_session`.
+    gw_own: &mut GwOwnCfg,
     // #33: set true iff a retained OTA `install` command is present for this board.
     install_requested: &mut bool,
     // #40 #1: set true iff a retained leaf `install` (for another node) is seen this burst.
@@ -2246,6 +2286,7 @@ pub fn run_mqtt_burst(
         elect,
         ota_offer,
         config_offer,
+        gw_own, // #48: forward the gateway-own keyed-config capture
         install_requested,
         leaf_install_seen, // #40 #1: forward the leaf-install-seen latch
         peers, // #27: forward the caller's serialized roster to publish retained

--- a/rust/clock/src/sensors.rs
+++ b/rust/clock/src/sensors.rs
@@ -189,11 +189,16 @@ impl core::fmt::Write for LineBuf {
 ///
 /// Temperature is rounded to a whole °C and voltage to one decimal, keeping the
 /// string to ~8–10 chars so it never overflows 72 px in FONT_5X8 (~12 chars).
-pub fn format_sensor_line(r: &Reading) -> LineBuf {
+pub fn format_sensor_line(r: &Reading, temp_f: bool) -> LineBuf {
     use core::fmt::Write;
     let mut line = LineBuf::new();
-    // e.g. "73F 3.9V"  (chip temp in Fahrenheit, rounded to int; volts to 1 decimal)
-    let f = r.chip_c * 9.0 / 5.0 + 32.0;
-    let _ = write!(line, "{}F {:.1}V", f as i32, r.batt_v);
+    // #43: chip temp in °F (default) or °C per the fleet-global units, rounded to a whole
+    // degree; volts to one decimal. e.g. "73F 3.9V" / "23C 3.9V".
+    if temp_f {
+        let f = r.chip_c * 9.0 / 5.0 + 32.0;
+        let _ = write!(line, "{}F {:.1}V", f as i32, r.batt_v);
+    } else {
+        let _ = write!(line, "{}C {:.1}V", r.chip_c as i32, r.batt_v);
+    }
     line
 }

--- a/rust/clock/src/units.rs
+++ b/rust/clock/src/units.rs
@@ -1,0 +1,58 @@
+//! #43 display units — fleet-global temperature (°F/°C) + clock (12h/24h) config.
+//!
+//! Unlike the per-node screen (#21) / LED (#48) / plugin-mask (#55) channels, display
+//! units are ONE fleet-wide setting (`smol/config/units`, no id in the topic). The gateway
+//! reads its own copy directly from MQTT and RELAYS it to every leaf over the keyed CFG
+//! channel under the broadcast target [`CFG_TARGET_ALL`](crate::net::CFG_TARGET_ALL) (255) —
+//! one cached `(255, 'U')` entry fans out to all leaves, and a leaf applies a CFG frame
+//! whose target is its own id OR the broadcast sentinel.
+//!
+//! The struct + render usage compile in EVERY profile (the CLOCK screen is universal);
+//! only espnow nodes actually receive a config (the relay/apply path is radio-only, exactly
+//! like the screen/LED channels). A non-espnow build shows the [`Units::default`] units.
+
+/// #43 (key `U`, GLOBAL): the fleet-wide display units. Wire form `<F|C>|<24|12>`
+/// (e.g. `F|24`, `C|12`) — mirrors the HA `smol/config/units` retained payload.
+///
+/// Defaults (`°F`, 24h) match the HA input_select `initial:` values, so a node with a live
+/// config and a node without one agree — no jarring 12h→24h flip when the first config lands.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Units {
+    /// `true` = temperature in °F (default), `false` = °C.
+    pub temp_f: bool,
+    /// `true` = 24-hour clock (default, `HH:MM`), `false` = 12-hour (`H:MM` + AM/PM).
+    pub clk_24h: bool,
+}
+
+impl Default for Units {
+    fn default() -> Self {
+        // °F + 24h. Matches the HA input_select `initial:` values (smol_mesh.yaml #43),
+        // so the FW no-config default equals the fleet standard the gateway relays.
+        Self { temp_f: true, clk_24h: true }
+    }
+}
+
+impl Units {
+    /// Parse a `smol/config/units` payload `<F|C>|<24|12>` (e.g. `F|24`, `C|12`). ANY
+    /// unrecognised / malformed token → `None`, so the caller KEEPS its current units
+    /// rather than half-applying a garbage frame (untrusted retained/relayed value — the
+    /// #46 clamp discipline; never panics). Whitespace-tolerant; empty → `None`.
+    pub fn from_wire(s: &str) -> Option<Units> {
+        let s = s.trim();
+        if s.is_empty() {
+            return None;
+        }
+        let mut it = s.split('|');
+        let temp_f = match it.next().unwrap_or("").trim() {
+            "F" => true,
+            "C" => false,
+            _ => return None,
+        };
+        let clk_24h = match it.next().unwrap_or("").trim() {
+            "24" => true,
+            "12" => false,
+            _ => return None,
+        };
+        Some(Units { temp_f, clk_24h })
+    }
+}

--- a/rust/clock/src/units.rs
+++ b/rust/clock/src/units.rs
@@ -26,9 +26,12 @@ pub struct Units {
 
 impl Default for Units {
     fn default() -> Self {
-        // °F + 24h. Matches the HA input_select `initial:` values (smol_mesh.yaml #43),
-        // so the FW no-config default equals the fleet standard the gateway relays.
-        Self { temp_f: true, clk_24h: true }
+        // °F + 12h == the PRE-#43 hardcoded render (sensors.rs was °F; clock.rs was 12h). Chosen
+        // to preserve the DEFAULT-BUILD INVARIANT: a build with no config path (default/wifi, and
+        // an espnow node before its first config lands) renders EXACTLY as before — #43's render
+        // is inert without a config. HA's retained `smol/config/units` (initial 24h) then drives
+        // the espnow FLEET to its chosen units; the guaranteed-green baseline never changes.
+        Self { temp_f: true, clk_24h: false }
     }
 }
 
@@ -37,6 +40,10 @@ impl Units {
     /// unrecognised / malformed token → `None`, so the caller KEEPS its current units
     /// rather than half-applying a garbage frame (untrusted retained/relayed value — the
     /// #46 clamp discipline; never panics). Whitespace-tolerant; empty → `None`.
+    ///
+    /// espnow-only: the config apply path (`take_cfg_offer(U)`) is radio-only, exactly like the
+    /// screen/LED channels — a non-espnow build has no feed, so it never parses (would be dead).
+    #[cfg(feature = "espnow")]
     pub fn from_wire(s: &str) -> Option<Units> {
         let s = s.trim();
         if s.is_empty() {


### PR DESCRIPTION
The keyed-CFG quartet on the #56 channel foundation.

- **#48** blue-LED control (key L): HA/dashboard status/on/off, leaf relay path.
- **#43** fleet-global display units (key U): °F/°C + 12h/24h via CFG_TARGET_ALL=255 broadcast. Default 12h preserves the default-build byte-behavior invariant; fleet converges to 24h via retained config (few-sec post-boot flip, self-correcting).
- **#55** per-node plugin/menu visibility (key P): ASCII-hex bitmask (bit0=Clock..bit6=About).
- **#52** remote reboot (key R): one-shot COMMAND, cache-BYPASS (a cached reboot = reboot-loop soft-brick) + leaf-side ~10s boot-debounce.
- **#39** update-entity install cmd retain:true — native HA Install tile works.

All CFG-gated for the default-build invariant; fixed 2 wifi-only dead_code traps. 4-profile compile + espnow-0-warnings per the agent report.

---
⏳ **Hardware validation deferred to the morning consolidated canary** (boards unplugged overnight). Merge criterion tonight: oracle-green + 4-profile compile-proof.