### PR TITLE
chore(fw): restore espnow-0-warnings invariant — never-used + ota_mesh clippy

### DIFF
--- a/rust/clock/src/app.rs
+++ b/rust/clock/src/app.rs
@@ -225,6 +225,10 @@ impl AppKind {
 
     /// #50: inverse of [`from_wire`] — the wire token for a live screen, for the
     /// `STAT|<screen>:<page>` status readback publish. Total (every variant maps).
+    // The only caller is the #50 STAT readback in `main` (`live_kind.as_wire()`),
+    // which is espnow-only — so gate to espnow to stay never-used-clean in a
+    // wifi-only build (the enclosing impl is cfg(wifi); espnow ⊃ wifi).
+    #[cfg(feature = "espnow")]
     pub fn as_wire(&self) -> &'static str {
         match self {
             AppKind::Menu => "Menu",
@@ -391,6 +395,9 @@ impl App {
     /// button handler mutates this live state), unlike the commanded `DefaultScreen`
     /// config (reading the config misses manual nav — the stopgap JP rejected).
     /// Page-capable screens (Batt/Grid) report their real page; others report 0.
+    // The only caller is the #50 STAT readback in `main`, which is espnow-only —
+    // gate to espnow so it is not never-used in the default/wifi builds.
+    #[cfg(feature = "espnow")]
     pub fn live_screen(&self) -> (AppKind, u8) {
         match self {
             App::Menu(_) => (AppKind::Menu, 0),

--- a/rust/clock/src/batt.rs
+++ b/rust/clock/src/batt.rs
@@ -188,6 +188,9 @@ impl BattState {
 
     /// #50: the live page index (raw; the renderer clamps `% page_count`). Read for
     /// the `smol/<id>/status` readback of the ACTUAL screen state.
+    // Sole caller is `App::live_screen` (espnow STAT readback); gate to espnow so it
+    // is not never-used in a wifi-only build. `set_page` (boot-page seed) stays wifi.
+    #[cfg(feature = "espnow")]
     pub fn page(&self) -> u8 {
         self.page
     }

--- a/rust/clock/src/grid.rs
+++ b/rust/clock/src/grid.rs
@@ -179,6 +179,9 @@ impl GridState {
 
     /// #50: the live page index (raw; the renderer clamps `% PAGE_COUNT`). Read for
     /// the `smol/<id>/status` readback of the ACTUAL screen state.
+    // Sole caller is `App::live_screen` (espnow STAT readback); gate to espnow so it
+    // is not never-used in a wifi-only build. `set_page` (boot-page seed) stays wifi.
+    #[cfg(feature = "espnow")]
     pub fn page(&self) -> u8 {
         self.page
     }

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -277,7 +277,7 @@ fn write_id3(id: u8, out: &mut [u8]) {
 
 /// `ceil(size / CHUNK_PAYLOAD)` — total chunks for an image of `size` bytes. Saturating.
 pub fn total_chunks(size: u32) -> u32 {
-    (size / CHUNK_PAYLOAD as u32).saturating_add((size % CHUNK_PAYLOAD as u32 != 0) as u32)
+    (size / CHUNK_PAYLOAD as u32).saturating_add((!size.is_multiple_of(CHUNK_PAYLOAD as u32)) as u32)
 }
 
 /// "All chunks present" bitmap mask for a window of `len` chunks (`len` ≤ 64). Shared by
@@ -488,6 +488,10 @@ impl OtaLeafSession {
     /// a flash op — the DoS/wear bound, attack row E). Then, and only then, parse M and
     /// apply the freshness gate (`build > running ∧ build > fresh_floor ∧ size ok`).
     /// `src` is the OTAM sender's MAC (the gateway); `my_id` is this leaf's id.
+    // Load-bearing signature: each param is a distinct signed-wire / RX-context value
+    // on the OTA receive path; bundling into a struct would just relocate the fields
+    // without simplifying the call site. Lint-only allow — no restructuring the hot path.
+    #[allow(clippy::too_many_arguments)]
     pub fn on_meta(
         &mut self,
         target: u8,
@@ -571,6 +575,10 @@ impl OtaLeafSession {
     /// and — on a completed window — flushes it to the (partition-scoped) inactive slot
     /// and advances (acking with an all-zero NAK). On the final window it finalizes
     /// (readback verify) and returns `Complete`. `out` receives an OTAN when one is due.
+    // Load-bearing signature: each param is a distinct signed-wire / RX-context value
+    // on the OTA receive path; bundling into a struct would just relocate the fields
+    // without simplifying the call site. Lint-only allow — no restructuring the hot path.
+    #[allow(clippy::too_many_arguments)]
     pub fn on_data(
         &mut self,
         target: u8,


### PR DESCRIPTION
Restore the 'espnow 0 warnings / clippy-clean' invariant that slipped on main (flagged by aurora during #26).

- Fix default/wifi never-used warnings (live_screen / as_wire / page).
- Fix ota_mesh.rs clippy (too_many_arguments ×2, manual is_multiple_of).
- No behavior change; all profiles.

---
⏳ **Hardware validation deferred to the morning consolidated canary** (boards unplugged overnight). Merge criterion tonight: oracle-green + 4-profile compile-proof.