### PR TITLE
feat(ha): dashboard node-box pass — #45 editor + #70/#74 device card + #55 plugin chips

### DIFF
--- a/ha/dashboard/build_control_room.py
+++ b/ha/dashboard/build_control_room.py
@@ -60,6 +60,44 @@ def ota_progress_card(nid):
             "icon":pre+"{{ pl[3] }}","icon_color":pre+"{{ pl[1] }}",
             "card_mod":{"style":{".":style,"mushroom-state-info$":info,"mushroom-shape-icon$":"--icon-symbol-size:22px"}}}
 
+# ---------- #70/#74 device alarm: self-hides when clean, shows the rollback/abnormal-reset story ----------
+# Shown ONLY when ota_outcome is bad (rolled-back / *-failed) OR reset_reason is abnormal (panic/wdt/
+# brownout/glitch) — the "what just happened to this board" surface #70 exists for. display:none when clean.
+def device_card(nid):
+    I=str(nid); oo=f"sensor.smol_{nid}_ota_outcome"; rr=f"sensor.smol_{nid}_reset_reason"
+    sl=f"sensor.smol_{nid}_boot_slot"; up=f"sensor.smol_{nid}_uptime"; hp=f"sensor.smol_{nid}_heap_free"
+    pre=("{% set oo=states('"+oo+"') %}{% set rr=states('"+rr+"') %}"
+         "{% set bad_o=oo in ['rolled-back','relay-failed','fetch-failed','mac-unknown'] %}"
+         "{% set bad_r=rr in ['panic','wdt','brownout','glitch'] %}{% set act=bad_o or bad_r %}"
+         "{% set col='#ff6b6b' if (oo=='rolled-back' or rr in ['panic','brownout']) else ('#ffc24b' if act else '#5bff9a') %}")
+    primary=pre+"{% if oo=='rolled-back' %}↩ OTA rolled back{% elif bad_o %}✗ OTA {{ oo }}{% elif bad_r %}⚠ reset: {{ rr }}{% else %}device{% endif %}"
+    secondary=pre+"slot {{ states('"+sl+"') }} · reset {{ rr }} · up {{ states('"+up+"') }}s · heap {{ states('"+hp+"') }}"
+    style=(pre+"ha-card{display:{% if act %}block{% else %}none{% endif %};border-radius:0;border-top:none;border-bottom:none;"
+           "margin-top:-2px;border-left:3px solid {{ col }};background:#0b0402;position:relative;overflow:hidden;}"
+           "ha-card:after{content:'◈ DEVICE · id"+I+"';position:absolute;top:6px;right:11px;font-size:8.5px;letter-spacing:1.5px;"
+           "color:{{ col }};opacity:.7;font-family:"+VT+";z-index:2;}")
+    info=(pre+".primary{font-family:"+VT+";font-size:17px;line-height:1;color:{{ col }}}.secondary{font-size:10px;opacity:.85}")
+    return {"type":"custom:mushroom-template-card","primary":primary,"secondary":secondary,
+            "icon":pre+"{% if oo=='rolled-back' or bad_r %}mdi:alert-octagram{% else %}mdi:chip{% endif %}",
+            "icon_color":pre+"{{ 'red' if col=='#ff6b6b' else ('amber' if col=='#ffc24b' else 'green') }}",
+            "card_mod":{"style":{".":style,"mushroom-state-info$":info,"mushroom-shape-icon$":"--icon-symbol-size:20px"}}}
+
+# ---------- #55 plugin visibility: compact toggle chips (fill = shown in boot menu) ----------
+PLUGS=[("clock","mdi:clock-outline"),("snake","mdi:snake"),("bench","mdi:test-tube"),("batt","mdi:battery"),
+       ("grid","mdi:transmission-tower"),("wled","mdi:led-strip-variant"),("about","mdi:information-outline")]
+def plugin_chips(nid, present):
+    chips=[{"type":"template","content":"plugins","icon":"mdi:puzzle-outline","icon_color":"grey"}]  # label chip
+    for name,icon in PLUGS:
+        e=f"input_boolean.smol_{nid}_plugin_{name}"
+        if e not in present: continue
+        chips.append({"type":"template","entity":e,"icon":icon,
+            "icon_color":"{{ 'green' if is_state('"+e+"','on') else 'disabled' }}",
+            "tap_action":{"action":"toggle"}})
+    if len(chips)<=1: return None
+    return {"type":"custom:mushroom-chips-card","alignment":"start","chips":chips,
+            "card_mod":{"style":"ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;padding:6px 8px 4px;"
+                        "background:var(--card-background-color);}"}}
+
 # ---------- node box = mushroom header + mushroom OLED + entities; span-4 in the VIEW grid ----------
 def node_card(nid, meta, present):
     gate=meta["gate"]; I=str(nid); on=f"is_state('binary_sensor.smol_{I}_online','on')"
@@ -93,8 +131,9 @@ def node_card(nid, meta, present):
     oled_p=("{% set scr="+scr+" %}{% set t=states('sensor.smol_"+I+"_temp') %}{% set g=states('sensor.smol_display_grid') %}{% set na="+NAJ+" %}"
             "{% if not "+on+" %}—{% elif scr=='Grid' %}{{ g.split('|')[1] if '|' in g else '—' }}"
             "{% elif scr=='Batt' %}{{ states('sensor.ev_battery_soc') }}%{% elif scr=='Clock' %}{{ now().strftime('%H:%M') }}"
+            "{% elif scr=='Custom' %}{{ states('sensor.smol_"+I+"_custom')[:8] if states('sensor.smol_"+I+"_custom') not in na else '—' }}"  # #45
             "{% else %}{{ t if t not in na else '—' }}{% endif %}")
-    oled_s=("{% set scr="+scr+" %}{{ scr|upper }} · {% if not "+on+" %}no link{% elif scr=='Grid' %}shared glass{% elif scr=='Batt' %}HV pack{% elif scr=='Clock' %}mesh time{% else %}live °F{% endif %}")
+    oled_s=("{% set scr="+scr+" %}{{ scr|upper }} · {% if not "+on+" %}no link{% elif scr=='Grid' %}shared glass{% elif scr=='Batt' %}HV pack{% elif scr=='Clock' %}mesh time{% elif scr=='Custom' %}user lines{% else %}live °F{% endif %}")
     oled={"type":"custom:mushroom-template-card","primary":oled_p,"secondary":oled_s,"icon":"mdi:blank",
           "card_mod":{"style":{".":("ha-card{background:#020402;border:1px solid var(--ha-card-border-color);border-radius:0;"
                 "box-shadow:inset 0 0 12px rgba(0,0,0,.9);position:relative;overflow:hidden;margin-top:-2px;opacity:{% if "+on+" %}1{% else %}.6{% endif %}}mushroom-shape-icon{display:none}"),
@@ -111,6 +150,7 @@ def node_card(nid, meta, present):
     prow(top,f"input_select.smol_{nid}_screen","default screen")
     prow(top,f"input_select.smol_{nid}_page","page")
     prow(top,f"input_select.smol_{nid}_led","LED (status / on / off)","mdi:led-on")            # #48
+    prow(top,f"input_text.smol_{nid}_custom","Custom lines (‹sa› text, | per line)","mdi:card-text")  # #45 · edit when screen=Custom
     prow(top,f"input_button.smol_{nid}_apply",f"Apply → id{nid}","mdi:send")
     prow(top,f"input_button.smol_{nid}_reset","Reset to board default","mdi:backup-restore")
     rb=f"input_button.smol_{nid}_reboot"                                                       # #52 tap-guarded reboot
@@ -154,7 +194,12 @@ def node_card(nid, meta, present):
     ctrl_bottom={"type":"entities","show_header_toggle":False,"entities":bot,
                  "card_mod":{"style":"ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px;"+OP+"}"}}
     ota=ota_progress_card(nid)   # #40 relay progress bar + phase chip — self-hides (display:none) when idle
-    return {"type":"vertical-stack","view_layout":{"grid-column":"span 4"},"cards":[header,oled,ctrl_top,cond_leaf,cond_gw,ota,ctrl_bottom]}
+    dev=device_card(nid)         # #70/#74 rollback / abnormal-reset alarm — self-hides when clean
+    plug=plugin_chips(nid,present)  # #55 plugin-visibility toggle chips
+    seq=[header,oled,ctrl_top,cond_leaf,cond_gw,ota,dev]
+    if plug: seq.append(plug)
+    seq.append(ctrl_bottom)
+    return {"type":"vertical-stack","view_layout":{"grid-column":"span 4"},"cards":seq}
 
 def legend_card(nodes, present):
     ents=[{"type":"section","label":"the mesh"}]

--- a/ha/dashboard/smol_control_room.yaml
+++ b/ha/dashboard/smol_control_room.yaml
@@ -72,7 +72,7 @@ cards:
 
         '
 - type: picture
-  image: /local/luna-cards/smol-topology.svg?v=1e40c11f
+  image: /local/luna-cards/smol-topology.svg?v=c8dbff72
   view_layout:
     grid-column: span 7
   card_mod:
@@ -106,20 +106,20 @@ cards:
     icon: mdi:sleep
   - type: section
     label: sigils & bonds (bond=RSSI · adrift when ch≠mesh)
-  - entity: binary_sensor.smol_8_online
-    name: ♛ Eldritch Nexus · id8
-  - entity: sensor.smol_8_rssi
-    name: '   ↳ bond (RSSI)'
-    icon: mdi:signal
-  - entity: sensor.smol_8_peers
-    name: '   ↳ peers'
-    icon: mdi:lan
   - entity: binary_sensor.smol_7_online
-    name: Draconic Dominion · id7
+    name: ♛ Draconic Dominion · id7
   - entity: sensor.smol_7_rssi
     name: '   ↳ bond (RSSI)'
     icon: mdi:signal
   - entity: sensor.smol_7_peers
+    name: '   ↳ peers'
+    icon: mdi:lan
+  - entity: binary_sensor.smol_8_online
+    name: Eldritch Nexus · id8
+  - entity: sensor.smol_8_rssi
+    name: '   ↳ bond (RSSI)'
+    icon: mdi:signal
+  - entity: sensor.smol_8_peers
     name: '   ↳ peers'
     icon: mdi:lan
   - entity: binary_sensor.smol_9_online
@@ -213,141 +213,6 @@ cards:
     grid-column: span 4
   cards:
   - type: custom:mushroom-template-card
-    primary: Eldritch Nexus
-    secondary: '{% set on=is_state(''binary_sensor.smol_8_online'',''on'') %}{% set gw=is_state(''sensor.smol_8_peers'',''gateway'') %}{% set t=states(''sensor.smol_8_temp'') %}{% set v=states(''sensor.smol_8_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id8 · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · {% if gw %}{% set u=states(''sensor.smol_8_nexus_uplink'') %}{% if u not in na %}{{ u }} dBm ↑{% else %}WiFi{% endif %}{% else %}{{ states(''sensor.smol_8_rssi'') if states(''sensor.smol_8_rssi'') not in na else ''—'' }} dBm{% endif %}'
-    icon: '{% if is_state(''sensor.smol_8_peers'',''gateway'') %}mdi:crown{% else %}mdi:chip{% endif %}'
-    icon_color: '{% if is_state(''sensor.smol_8_peers'',''gateway'') %}amber{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}green{% else %}red{% endif %}'
-    badge_icon: '{% if is_state(''sensor.smol_8_peers'',''gateway'') %}mdi:crown{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}mdi:leaf-circle{% else %}mdi:lan-disconnect{% endif %}'
-    badge_color: '{% if is_state(''sensor.smol_8_peers'',''gateway'') %}amber{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}green{% else %}red{% endif %}'
-    card_mod:
-      style:
-        .: ha-card{border-radius:10px 10px 0 0;border-bottom:none;position:relative;overflow:hidden;border:2px solid {% if is_state('sensor.smol_8_peers','gateway') %}var(--accent-color){% elif is_state('binary_sensor.smol_8_online','on') %}var(--ha-card-border-color){% else %}#ff6b6b{% endif %};opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %};box-shadow:{% if is_state('sensor.smol_8_peers','gateway') %}0 0 18px -3px var(--accent-color){% else %}none{% endif %}}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,{% if is_state('sensor.smol_8_peers','gateway') %}var(--accent-color){% else %}var(--primary-color){% endif %},transparent);opacity:.6}
-        mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:26px;line-height:.9}.secondary{font-size:11px}
-  - type: custom:mushroom-template-card
-    primary: '{% set scr=(states(''sensor.smol_8_screen'') if states(''sensor.smol_8_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_8_screen'')) %}{% set t=states(''sensor.smol_8_temp'') %}{% set g=states(''sensor.smol_display_grid'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not is_state(''binary_sensor.smol_8_online'',''on'') %}—{% elif scr==''Grid'' %}{{ g.split(''|'')[1] if ''|'' in g else ''—'' }}{% elif scr==''Batt'' %}{{ states(''sensor.ev_battery_soc'') }}%{% elif scr==''Clock'' %}{{ now().strftime(''%H:%M'') }}{% else %}{{ t if t not in na else ''—'' }}{% endif %}'
-    secondary: '{% set scr=(states(''sensor.smol_8_screen'') if states(''sensor.smol_8_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_8_screen'')) %}{{ scr|upper }} · {% if not is_state(''binary_sensor.smol_8_online'',''on'') %}no link{% elif scr==''Grid'' %}shared glass{% elif scr==''Batt'' %}HV pack{% elif scr==''Clock'' %}mesh time{% else %}live °F{% endif %}'
-    icon: mdi:blank
-    card_mod:
-      style:
-        .: ha-card{background:#020402;border:1px solid var(--ha-card-border-color);border-radius:0;box-shadow:inset 0 0 12px rgba(0,0,0,.9);position:relative;overflow:hidden;margin-top:-2px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}mushroom-shape-icon{display:none}
-        mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:44px;line-height:.8;color:var(--primary-color);text-shadow:0 0 7px rgba(91,255,154,.55)}.secondary{color:var(--primary-color);opacity:.7;font-size:10px}
-  - type: entities
-    show_header_toggle: false
-    entities:
-    - type: section
-      label: screen & mode
-    - entity: input_select.smol_8_screen
-      name: default screen
-    - entity: input_select.smol_8_page
-      name: page
-    - entity: input_select.smol_8_led
-      name: LED (status / on / off)
-      icon: mdi:led-on
-    - entity: input_button.smol_8_apply
-      name: Apply → id8
-      icon: mdi:send
-    - entity: input_button.smol_8_reset
-      name: Reset to board default
-      icon: mdi:backup-restore
-    - entity: input_button.smol_8_reboot
-      name: Reboot node
-      icon: mdi:restart-alert
-      tap_action:
-        action: perform-action
-        perform_action: input_button.press
-        target:
-          entity_id: input_button.smol_8_reboot
-        confirmation:
-          text: Reboot id8 (Eldritch Nexus)? It drops off the mesh briefly.
-    - type: section
-      label: readback
-    - entity: sensor.smol_8_config
-      name: default screen (commanded)
-      icon: mdi:monitor-dashboard
-    - entity: sensor.smol_8_screen
-      name: current screen (live)
-      icon: mdi:monitor-eye
-    - entity: sensor.smol_8_status
-      name: activity
-      icon: mdi:pulse
-    card_mod:
-      style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-2px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}
-  - type: conditional
-    conditions:
-    - entity: sensor.smol_8_peers
-      state_not: gateway
-    card:
-      type: entities
-      show_header_toggle: false
-      card_mod:
-        style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}
-      entities:
-      - type: section
-        label: mesh bond (leaf)
-      - entity: sensor.smol_8_rssi
-        name: bond (RSSI)
-        icon: mdi:signal
-      - entity: sensor.smol_8_rssi_band
-        name: bond band
-        icon: mdi:signal-cellular-2
-      - entity: binary_sensor.smol_8_resync
-        name: re-syncing
-        icon: mdi:sync
-  - type: conditional
-    conditions:
-    - entity: sensor.smol_8_peers
-      state: gateway
-    card:
-      type: entities
-      show_header_toggle: false
-      card_mod:
-        style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}
-      entities:
-      - type: section
-        label: gateway anchor · WiFi uplink
-      - entity: sensor.smol_8_nexus_uplink
-        name: WiFi uplink (RSSI)
-        icon: mdi:wifi-arrow-up
-      - type: attribute
-        entity: sensor.smol_mesh_channel
-        attribute: channel
-        name: mesh channel (owned)
-        icon: mdi:wifi
-      - type: attribute
-        entity: sensor.smol_mesh_channel
-        attribute: seq
-        name: mesh seq (advancing)
-        icon: mdi:counter
-      - entity: sensor.smol_8_peers
-        name: peers / roster
-        icon: mdi:lan
-  - type: custom:mushroom-template-card
-    primary: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_8_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_8_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_8_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}{{ (p ~ ''%'') if p not in na else ''•••'' }}'
-    secondary: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_8_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_8_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_8_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}{% set wt=state_attr(''sensor.smol_8_ota_relaydiag'',''wb_total'') %}{% set wd=state_attr(''sensor.smol_8_ota_relaydiag'',''wb_done'') %}{{ pl[0] }} · {% if wt %}{{ wd }}/{{ wt }} blk{% elif build not in na and staged not in na and staged!=''none'' %}run {{ build }}→{{ staged }}{% else %}awaiting relay{% endif %}'
-    icon: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_8_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_8_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_8_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}{{ pl[3] }}'
-    icon_color: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_8_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_8_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_8_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}{{ pl[1] }}'
-    card_mod:
-      style:
-        .: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_8_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_8_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_8_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}ha-card{display:{% if act %}block{% else %}none{% endif %};border-radius:0;border-top:none;border-bottom:none;margin-top:-2px;border-left:3px solid {{ pl[2] }};position:relative;overflow:hidden;background:repeating-linear-gradient(0deg,transparent 0 2px,rgba(0,0,0,.30) 2px 3px),linear-gradient(90deg,{{ pl[2] }}2e 0,{{ pl[2] }}2e {{ pf }}%,#04120a {{ pf }}%,#04120a 100%);}ha-card:before{content:'''';position:absolute;top:0;bottom:0;left:{{ pf }}%;width:2px;background:{{ pl[2] }};box-shadow:0 0 9px {{ pl[2] }},0 0 3px {{ pl[2] }};opacity:{% if pf>0 and pf<100 %}.95{% else %}0{% endif %};}ha-card:after{content:''◈ MESH-OTA · id8'';position:absolute;top:6px;right:11px;font-size:8.5px;letter-spacing:1.5px;color:{{ pl[2] }};opacity:.75;font-family:''VT323'',''IBM Plex Mono'',monospace;z-index:2;}'
-        mushroom-state-info$: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_8_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_8_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_8_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}.primary{font-family:''VT323'',''IBM Plex Mono'',monospace;font-size:30px;line-height:.85;color:{{ pl[2] }};text-shadow:0 0 8px {{ pl[2] }}66}.secondary{font-size:10.5px;opacity:.85;letter-spacing:.3px}'
-        mushroom-shape-icon$: --icon-symbol-size:22px
-  - type: entities
-    show_header_toggle: false
-    entities:
-    - type: section
-      label: firmware
-    - entity: update.smol_8_nexus_update
-      name: firmware (version + update)
-    - entity: input_button.smol_ota_install_8
-      name: Install staged (gateway consumes)
-      icon: mdi:rocket-launch
-    card_mod:
-      style: ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}
-- type: vertical-stack
-  view_layout:
-    grid-column: span 4
-  cards:
-  - type: custom:mushroom-template-card
     primary: Draconic Dominion
     secondary: '{% set on=is_state(''binary_sensor.smol_7_online'',''on'') %}{% set gw=is_state(''sensor.smol_7_peers'',''gateway'') %}{% set t=states(''sensor.smol_7_temp'') %}{% set v=states(''sensor.smol_7_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id7 · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · {% if gw %}{% set u=states(''sensor.smol_7_dominion_uplink'') %}{% if u not in na %}{{ u }} dBm ↑{% else %}WiFi{% endif %}{% else %}{{ states(''sensor.smol_7_rssi'') if states(''sensor.smol_7_rssi'') not in na else ''—'' }} dBm{% endif %}'
     icon: '{% if is_state(''sensor.smol_7_peers'',''gateway'') %}mdi:crown{% else %}mdi:chip{% endif %}'
@@ -359,8 +224,8 @@ cards:
         .: ha-card{border-radius:10px 10px 0 0;border-bottom:none;position:relative;overflow:hidden;border:2px solid {% if is_state('sensor.smol_7_peers','gateway') %}var(--accent-color){% elif is_state('binary_sensor.smol_7_online','on') %}var(--ha-card-border-color){% else %}#ff6b6b{% endif %};opacity:{% if is_state('binary_sensor.smol_7_online','on') %}1{% else %}.6{% endif %};box-shadow:{% if is_state('sensor.smol_7_peers','gateway') %}0 0 18px -3px var(--accent-color){% else %}none{% endif %}}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,{% if is_state('sensor.smol_7_peers','gateway') %}var(--accent-color){% else %}var(--primary-color){% endif %},transparent);opacity:.6}
         mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:26px;line-height:.9}.secondary{font-size:11px}
   - type: custom:mushroom-template-card
-    primary: '{% set scr=(states(''sensor.smol_7_screen'') if states(''sensor.smol_7_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_7_screen'')) %}{% set t=states(''sensor.smol_7_temp'') %}{% set g=states(''sensor.smol_display_grid'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not is_state(''binary_sensor.smol_7_online'',''on'') %}—{% elif scr==''Grid'' %}{{ g.split(''|'')[1] if ''|'' in g else ''—'' }}{% elif scr==''Batt'' %}{{ states(''sensor.ev_battery_soc'') }}%{% elif scr==''Clock'' %}{{ now().strftime(''%H:%M'') }}{% else %}{{ t if t not in na else ''—'' }}{% endif %}'
-    secondary: '{% set scr=(states(''sensor.smol_7_screen'') if states(''sensor.smol_7_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_7_screen'')) %}{{ scr|upper }} · {% if not is_state(''binary_sensor.smol_7_online'',''on'') %}no link{% elif scr==''Grid'' %}shared glass{% elif scr==''Batt'' %}HV pack{% elif scr==''Clock'' %}mesh time{% else %}live °F{% endif %}'
+    primary: '{% set scr=(states(''sensor.smol_7_screen'') if states(''sensor.smol_7_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_7_screen'')) %}{% set t=states(''sensor.smol_7_temp'') %}{% set g=states(''sensor.smol_display_grid'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not is_state(''binary_sensor.smol_7_online'',''on'') %}—{% elif scr==''Grid'' %}{{ g.split(''|'')[1] if ''|'' in g else ''—'' }}{% elif scr==''Batt'' %}{{ states(''sensor.ev_battery_soc'') }}%{% elif scr==''Clock'' %}{{ now().strftime(''%H:%M'') }}{% elif scr==''Custom'' %}{{ states(''sensor.smol_7_custom'')[:8] if states(''sensor.smol_7_custom'') not in na else ''—'' }}{% else %}{{ t if t not in na else ''—'' }}{% endif %}'
+    secondary: '{% set scr=(states(''sensor.smol_7_screen'') if states(''sensor.smol_7_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_7_screen'')) %}{{ scr|upper }} · {% if not is_state(''binary_sensor.smol_7_online'',''on'') %}no link{% elif scr==''Grid'' %}shared glass{% elif scr==''Batt'' %}HV pack{% elif scr==''Clock'' %}mesh time{% elif scr==''Custom'' %}user lines{% else %}live °F{% endif %}'
     icon: mdi:blank
     card_mod:
       style:
@@ -378,6 +243,9 @@ cards:
     - entity: input_select.smol_7_led
       name: LED (status / on / off)
       icon: mdi:led-on
+    - entity: input_text.smol_7_custom
+      name: Custom lines (‹sa› text, | per line)
+      icon: mdi:card-text
     - entity: input_button.smol_7_apply
       name: Apply → id7
       icon: mdi:send
@@ -466,6 +334,67 @@ cards:
         .: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_7_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_7_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_7_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}ha-card{display:{% if act %}block{% else %}none{% endif %};border-radius:0;border-top:none;border-bottom:none;margin-top:-2px;border-left:3px solid {{ pl[2] }};position:relative;overflow:hidden;background:repeating-linear-gradient(0deg,transparent 0 2px,rgba(0,0,0,.30) 2px 3px),linear-gradient(90deg,{{ pl[2] }}2e 0,{{ pl[2] }}2e {{ pf }}%,#04120a {{ pf }}%,#04120a 100%);}ha-card:before{content:'''';position:absolute;top:0;bottom:0;left:{{ pf }}%;width:2px;background:{{ pl[2] }};box-shadow:0 0 9px {{ pl[2] }},0 0 3px {{ pl[2] }};opacity:{% if pf>0 and pf<100 %}.95{% else %}0{% endif %};}ha-card:after{content:''◈ MESH-OTA · id7'';position:absolute;top:6px;right:11px;font-size:8.5px;letter-spacing:1.5px;color:{{ pl[2] }};opacity:.75;font-family:''VT323'',''IBM Plex Mono'',monospace;z-index:2;}'
         mushroom-state-info$: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_7_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_7_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_7_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}.primary{font-family:''VT323'',''IBM Plex Mono'',monospace;font-size:30px;line-height:.85;color:{{ pl[2] }};text-shadow:0 0 8px {{ pl[2] }}66}.secondary{font-size:10.5px;opacity:.85;letter-spacing:.3px}'
         mushroom-shape-icon$: --icon-symbol-size:22px
+  - type: custom:mushroom-template-card
+    primary: '{% set oo=states(''sensor.smol_7_ota_outcome'') %}{% set rr=states(''sensor.smol_7_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}{% if oo==''rolled-back'' %}↩ OTA rolled back{% elif bad_o %}✗ OTA {{ oo }}{% elif bad_r %}⚠ reset: {{ rr }}{% else %}device{% endif %}'
+    secondary: '{% set oo=states(''sensor.smol_7_ota_outcome'') %}{% set rr=states(''sensor.smol_7_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}slot {{ states(''sensor.smol_7_boot_slot'') }} · reset {{ rr }} · up {{ states(''sensor.smol_7_uptime'') }}s · heap {{ states(''sensor.smol_7_heap_free'') }}'
+    icon: '{% set oo=states(''sensor.smol_7_ota_outcome'') %}{% set rr=states(''sensor.smol_7_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}{% if oo==''rolled-back'' or bad_r %}mdi:alert-octagram{% else %}mdi:chip{% endif %}'
+    icon_color: '{% set oo=states(''sensor.smol_7_ota_outcome'') %}{% set rr=states(''sensor.smol_7_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}{{ ''red'' if col==''#ff6b6b'' else (''amber'' if col==''#ffc24b'' else ''green'') }}'
+    card_mod:
+      style:
+        .: '{% set oo=states(''sensor.smol_7_ota_outcome'') %}{% set rr=states(''sensor.smol_7_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}ha-card{display:{% if act %}block{% else %}none{% endif %};border-radius:0;border-top:none;border-bottom:none;margin-top:-2px;border-left:3px solid {{ col }};background:#0b0402;position:relative;overflow:hidden;}ha-card:after{content:''◈ DEVICE · id7'';position:absolute;top:6px;right:11px;font-size:8.5px;letter-spacing:1.5px;color:{{ col }};opacity:.7;font-family:''VT323'',''IBM Plex Mono'',monospace;z-index:2;}'
+        mushroom-state-info$: '{% set oo=states(''sensor.smol_7_ota_outcome'') %}{% set rr=states(''sensor.smol_7_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}.primary{font-family:''VT323'',''IBM Plex Mono'',monospace;font-size:17px;line-height:1;color:{{ col }}}.secondary{font-size:10px;opacity:.85}'
+        mushroom-shape-icon$: --icon-symbol-size:20px
+  - type: custom:mushroom-chips-card
+    alignment: start
+    chips:
+    - type: template
+      content: plugins
+      icon: mdi:puzzle-outline
+      icon_color: grey
+    - type: template
+      entity: input_boolean.smol_7_plugin_clock
+      icon: mdi:clock-outline
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_7_plugin_clock'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_7_plugin_snake
+      icon: mdi:snake
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_7_plugin_snake'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_7_plugin_bench
+      icon: mdi:test-tube
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_7_plugin_bench'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_7_plugin_batt
+      icon: mdi:battery
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_7_plugin_batt'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_7_plugin_grid
+      icon: mdi:transmission-tower
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_7_plugin_grid'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_7_plugin_wled
+      icon: mdi:led-strip-variant
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_7_plugin_wled'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_7_plugin_about
+      icon: mdi:information-outline
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_7_plugin_about'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    card_mod:
+      style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;padding:6px 8px 4px;background:var(--card-background-color);}
   - type: entities
     show_header_toggle: false
     entities:
@@ -483,6 +412,205 @@ cards:
     grid-column: span 4
   cards:
   - type: custom:mushroom-template-card
+    primary: Eldritch Nexus
+    secondary: '{% set on=is_state(''binary_sensor.smol_8_online'',''on'') %}{% set gw=is_state(''sensor.smol_8_peers'',''gateway'') %}{% set t=states(''sensor.smol_8_temp'') %}{% set v=states(''sensor.smol_8_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id8 · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · {% if gw %}{% set u=states(''sensor.smol_8_nexus_uplink'') %}{% if u not in na %}{{ u }} dBm ↑{% else %}WiFi{% endif %}{% else %}{{ states(''sensor.smol_8_rssi'') if states(''sensor.smol_8_rssi'') not in na else ''—'' }} dBm{% endif %}'
+    icon: '{% if is_state(''sensor.smol_8_peers'',''gateway'') %}mdi:crown{% else %}mdi:chip{% endif %}'
+    icon_color: '{% if is_state(''sensor.smol_8_peers'',''gateway'') %}amber{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}green{% else %}red{% endif %}'
+    badge_icon: '{% if is_state(''sensor.smol_8_peers'',''gateway'') %}mdi:crown{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}mdi:leaf-circle{% else %}mdi:lan-disconnect{% endif %}'
+    badge_color: '{% if is_state(''sensor.smol_8_peers'',''gateway'') %}amber{% elif is_state(''binary_sensor.smol_8_online'',''on'') %}green{% else %}red{% endif %}'
+    card_mod:
+      style:
+        .: ha-card{border-radius:10px 10px 0 0;border-bottom:none;position:relative;overflow:hidden;border:2px solid {% if is_state('sensor.smol_8_peers','gateway') %}var(--accent-color){% elif is_state('binary_sensor.smol_8_online','on') %}var(--ha-card-border-color){% else %}#ff6b6b{% endif %};opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %};box-shadow:{% if is_state('sensor.smol_8_peers','gateway') %}0 0 18px -3px var(--accent-color){% else %}none{% endif %}}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,{% if is_state('sensor.smol_8_peers','gateway') %}var(--accent-color){% else %}var(--primary-color){% endif %},transparent);opacity:.6}
+        mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:26px;line-height:.9}.secondary{font-size:11px}
+  - type: custom:mushroom-template-card
+    primary: '{% set scr=(states(''sensor.smol_8_screen'') if states(''sensor.smol_8_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_8_screen'')) %}{% set t=states(''sensor.smol_8_temp'') %}{% set g=states(''sensor.smol_display_grid'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not is_state(''binary_sensor.smol_8_online'',''on'') %}—{% elif scr==''Grid'' %}{{ g.split(''|'')[1] if ''|'' in g else ''—'' }}{% elif scr==''Batt'' %}{{ states(''sensor.ev_battery_soc'') }}%{% elif scr==''Clock'' %}{{ now().strftime(''%H:%M'') }}{% elif scr==''Custom'' %}{{ states(''sensor.smol_8_custom'')[:8] if states(''sensor.smol_8_custom'') not in na else ''—'' }}{% else %}{{ t if t not in na else ''—'' }}{% endif %}'
+    secondary: '{% set scr=(states(''sensor.smol_8_screen'') if states(''sensor.smol_8_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_8_screen'')) %}{{ scr|upper }} · {% if not is_state(''binary_sensor.smol_8_online'',''on'') %}no link{% elif scr==''Grid'' %}shared glass{% elif scr==''Batt'' %}HV pack{% elif scr==''Clock'' %}mesh time{% elif scr==''Custom'' %}user lines{% else %}live °F{% endif %}'
+    icon: mdi:blank
+    card_mod:
+      style:
+        .: ha-card{background:#020402;border:1px solid var(--ha-card-border-color);border-radius:0;box-shadow:inset 0 0 12px rgba(0,0,0,.9);position:relative;overflow:hidden;margin-top:-2px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}mushroom-shape-icon{display:none}
+        mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:44px;line-height:.8;color:var(--primary-color);text-shadow:0 0 7px rgba(91,255,154,.55)}.secondary{color:var(--primary-color);opacity:.7;font-size:10px}
+  - type: entities
+    show_header_toggle: false
+    entities:
+    - type: section
+      label: screen & mode
+    - entity: input_select.smol_8_screen
+      name: default screen
+    - entity: input_select.smol_8_page
+      name: page
+    - entity: input_select.smol_8_led
+      name: LED (status / on / off)
+      icon: mdi:led-on
+    - entity: input_text.smol_8_custom
+      name: Custom lines (‹sa› text, | per line)
+      icon: mdi:card-text
+    - entity: input_button.smol_8_apply
+      name: Apply → id8
+      icon: mdi:send
+    - entity: input_button.smol_8_reset
+      name: Reset to board default
+      icon: mdi:backup-restore
+    - entity: input_button.smol_8_reboot
+      name: Reboot node
+      icon: mdi:restart-alert
+      tap_action:
+        action: perform-action
+        perform_action: input_button.press
+        target:
+          entity_id: input_button.smol_8_reboot
+        confirmation:
+          text: Reboot id8 (Eldritch Nexus)? It drops off the mesh briefly.
+    - type: section
+      label: readback
+    - entity: sensor.smol_8_config
+      name: default screen (commanded)
+      icon: mdi:monitor-dashboard
+    - entity: sensor.smol_8_screen
+      name: current screen (live)
+      icon: mdi:monitor-eye
+    - entity: sensor.smol_8_status
+      name: activity
+      icon: mdi:pulse
+    card_mod:
+      style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-2px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}
+  - type: conditional
+    conditions:
+    - entity: sensor.smol_8_peers
+      state_not: gateway
+    card:
+      type: entities
+      show_header_toggle: false
+      card_mod:
+        style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}
+      entities:
+      - type: section
+        label: mesh bond (leaf)
+      - entity: sensor.smol_8_rssi
+        name: bond (RSSI)
+        icon: mdi:signal
+      - entity: sensor.smol_8_rssi_band
+        name: bond band
+        icon: mdi:signal-cellular-2
+      - entity: binary_sensor.smol_8_resync
+        name: re-syncing
+        icon: mdi:sync
+  - type: conditional
+    conditions:
+    - entity: sensor.smol_8_peers
+      state: gateway
+    card:
+      type: entities
+      show_header_toggle: false
+      card_mod:
+        style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}
+      entities:
+      - type: section
+        label: gateway anchor · WiFi uplink
+      - entity: sensor.smol_8_nexus_uplink
+        name: WiFi uplink (RSSI)
+        icon: mdi:wifi-arrow-up
+      - type: attribute
+        entity: sensor.smol_mesh_channel
+        attribute: channel
+        name: mesh channel (owned)
+        icon: mdi:wifi
+      - type: attribute
+        entity: sensor.smol_mesh_channel
+        attribute: seq
+        name: mesh seq (advancing)
+        icon: mdi:counter
+      - entity: sensor.smol_8_peers
+        name: peers / roster
+        icon: mdi:lan
+  - type: custom:mushroom-template-card
+    primary: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_8_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_8_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_8_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}{{ (p ~ ''%'') if p not in na else ''•••'' }}'
+    secondary: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_8_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_8_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_8_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}{% set wt=state_attr(''sensor.smol_8_ota_relaydiag'',''wb_total'') %}{% set wd=state_attr(''sensor.smol_8_ota_relaydiag'',''wb_done'') %}{{ pl[0] }} · {% if wt %}{{ wd }}/{{ wt }} blk{% elif build not in na and staged not in na and staged!=''none'' %}run {{ build }}→{{ staged }}{% else %}awaiting relay{% endif %}'
+    icon: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_8_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_8_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_8_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}{{ pl[3] }}'
+    icon_color: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_8_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_8_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_8_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}{{ pl[1] }}'
+    card_mod:
+      style:
+        .: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_8_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_8_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_8_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}ha-card{display:{% if act %}block{% else %}none{% endif %};border-radius:0;border-top:none;border-bottom:none;margin-top:-2px;border-left:3px solid {{ pl[2] }};position:relative;overflow:hidden;background:repeating-linear-gradient(0deg,transparent 0 2px,rgba(0,0,0,.30) 2px 3px),linear-gradient(90deg,{{ pl[2] }}2e 0,{{ pl[2] }}2e {{ pf }}%,#04120a {{ pf }}%,#04120a 100%);}ha-card:before{content:'''';position:absolute;top:0;bottom:0;left:{{ pf }}%;width:2px;background:{{ pl[2] }};box-shadow:0 0 9px {{ pl[2] }},0 0 3px {{ pl[2] }};opacity:{% if pf>0 and pf<100 %}.95{% else %}0{% endif %};}ha-card:after{content:''◈ MESH-OTA · id8'';position:absolute;top:6px;right:11px;font-size:8.5px;letter-spacing:1.5px;color:{{ pl[2] }};opacity:.75;font-family:''VT323'',''IBM Plex Mono'',monospace;z-index:2;}'
+        mushroom-state-info$: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_8_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_8_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_8_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}.primary{font-family:''VT323'',''IBM Plex Mono'',monospace;font-size:30px;line-height:.85;color:{{ pl[2] }};text-shadow:0 0 8px {{ pl[2] }}66}.secondary{font-size:10.5px;opacity:.85;letter-spacing:.3px}'
+        mushroom-shape-icon$: --icon-symbol-size:22px
+  - type: custom:mushroom-template-card
+    primary: '{% set oo=states(''sensor.smol_8_ota_outcome'') %}{% set rr=states(''sensor.smol_8_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}{% if oo==''rolled-back'' %}↩ OTA rolled back{% elif bad_o %}✗ OTA {{ oo }}{% elif bad_r %}⚠ reset: {{ rr }}{% else %}device{% endif %}'
+    secondary: '{% set oo=states(''sensor.smol_8_ota_outcome'') %}{% set rr=states(''sensor.smol_8_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}slot {{ states(''sensor.smol_8_boot_slot'') }} · reset {{ rr }} · up {{ states(''sensor.smol_8_uptime'') }}s · heap {{ states(''sensor.smol_8_heap_free'') }}'
+    icon: '{% set oo=states(''sensor.smol_8_ota_outcome'') %}{% set rr=states(''sensor.smol_8_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}{% if oo==''rolled-back'' or bad_r %}mdi:alert-octagram{% else %}mdi:chip{% endif %}'
+    icon_color: '{% set oo=states(''sensor.smol_8_ota_outcome'') %}{% set rr=states(''sensor.smol_8_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}{{ ''red'' if col==''#ff6b6b'' else (''amber'' if col==''#ffc24b'' else ''green'') }}'
+    card_mod:
+      style:
+        .: '{% set oo=states(''sensor.smol_8_ota_outcome'') %}{% set rr=states(''sensor.smol_8_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}ha-card{display:{% if act %}block{% else %}none{% endif %};border-radius:0;border-top:none;border-bottom:none;margin-top:-2px;border-left:3px solid {{ col }};background:#0b0402;position:relative;overflow:hidden;}ha-card:after{content:''◈ DEVICE · id8'';position:absolute;top:6px;right:11px;font-size:8.5px;letter-spacing:1.5px;color:{{ col }};opacity:.7;font-family:''VT323'',''IBM Plex Mono'',monospace;z-index:2;}'
+        mushroom-state-info$: '{% set oo=states(''sensor.smol_8_ota_outcome'') %}{% set rr=states(''sensor.smol_8_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}.primary{font-family:''VT323'',''IBM Plex Mono'',monospace;font-size:17px;line-height:1;color:{{ col }}}.secondary{font-size:10px;opacity:.85}'
+        mushroom-shape-icon$: --icon-symbol-size:20px
+  - type: custom:mushroom-chips-card
+    alignment: start
+    chips:
+    - type: template
+      content: plugins
+      icon: mdi:puzzle-outline
+      icon_color: grey
+    - type: template
+      entity: input_boolean.smol_8_plugin_clock
+      icon: mdi:clock-outline
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_8_plugin_clock'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_8_plugin_snake
+      icon: mdi:snake
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_8_plugin_snake'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_8_plugin_bench
+      icon: mdi:test-tube
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_8_plugin_bench'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_8_plugin_batt
+      icon: mdi:battery
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_8_plugin_batt'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_8_plugin_grid
+      icon: mdi:transmission-tower
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_8_plugin_grid'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_8_plugin_wled
+      icon: mdi:led-strip-variant
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_8_plugin_wled'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_8_plugin_about
+      icon: mdi:information-outline
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_8_plugin_about'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    card_mod:
+      style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;padding:6px 8px 4px;background:var(--card-background-color);}
+  - type: entities
+    show_header_toggle: false
+    entities:
+    - type: section
+      label: firmware
+    - entity: update.smol_8_nexus_update
+      name: firmware (version + update)
+    - entity: input_button.smol_ota_install_8
+      name: Install staged (gateway consumes)
+      icon: mdi:rocket-launch
+    card_mod:
+      style: ha-card{border-radius:0 0 10px 10px;border-top:none;margin-top:-1px;opacity:{% if is_state('binary_sensor.smol_8_online','on') %}1{% else %}.6{% endif %}}
+- type: vertical-stack
+  view_layout:
+    grid-column: span 4
+  cards:
+  - type: custom:mushroom-template-card
     primary: Jade Herald
     secondary: '{% set on=is_state(''binary_sensor.smol_9_online'',''on'') %}{% set gw=is_state(''sensor.smol_9_peers'',''gateway'') %}{% set t=states(''sensor.smol_9_temp'') %}{% set v=states(''sensor.smol_9_voltage'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not on %}⛔ OFFLINE{% elif gw %}👑 GATEWAY{% else %}◈ leaf{% endif %} · id9 · {{ t if t not in na else ''—'' }}° · {{ v if v not in na else ''—'' }}V · {% if gw %}{% set u=states(''sensor.smol_9_herald_uplink'') %}{% if u not in na %}{{ u }} dBm ↑{% else %}WiFi{% endif %}{% else %}{{ states(''sensor.smol_9_rssi'') if states(''sensor.smol_9_rssi'') not in na else ''—'' }} dBm{% endif %}'
     icon: '{% if is_state(''sensor.smol_9_peers'',''gateway'') %}mdi:crown{% else %}mdi:chip{% endif %}'
@@ -494,8 +622,8 @@ cards:
         .: ha-card{border-radius:10px 10px 0 0;border-bottom:none;position:relative;overflow:hidden;border:2px solid {% if is_state('sensor.smol_9_peers','gateway') %}var(--accent-color){% elif is_state('binary_sensor.smol_9_online','on') %}var(--ha-card-border-color){% else %}#ff6b6b{% endif %};opacity:{% if is_state('binary_sensor.smol_9_online','on') %}1{% else %}.6{% endif %};box-shadow:{% if is_state('sensor.smol_9_peers','gateway') %}0 0 18px -3px var(--accent-color){% else %}none{% endif %}}ha-card:before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,{% if is_state('sensor.smol_9_peers','gateway') %}var(--accent-color){% else %}var(--primary-color){% endif %},transparent);opacity:.6}
         mushroom-state-info$: .primary{font-family:'VT323','IBM Plex Mono',monospace;font-size:26px;line-height:.9}.secondary{font-size:11px}
   - type: custom:mushroom-template-card
-    primary: '{% set scr=(states(''sensor.smol_9_screen'') if states(''sensor.smol_9_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_9_screen'')) %}{% set t=states(''sensor.smol_9_temp'') %}{% set g=states(''sensor.smol_display_grid'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not is_state(''binary_sensor.smol_9_online'',''on'') %}—{% elif scr==''Grid'' %}{{ g.split(''|'')[1] if ''|'' in g else ''—'' }}{% elif scr==''Batt'' %}{{ states(''sensor.ev_battery_soc'') }}%{% elif scr==''Clock'' %}{{ now().strftime(''%H:%M'') }}{% else %}{{ t if t not in na else ''—'' }}{% endif %}'
-    secondary: '{% set scr=(states(''sensor.smol_9_screen'') if states(''sensor.smol_9_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_9_screen'')) %}{{ scr|upper }} · {% if not is_state(''binary_sensor.smol_9_online'',''on'') %}no link{% elif scr==''Grid'' %}shared glass{% elif scr==''Batt'' %}HV pack{% elif scr==''Clock'' %}mesh time{% else %}live °F{% endif %}'
+    primary: '{% set scr=(states(''sensor.smol_9_screen'') if states(''sensor.smol_9_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_9_screen'')) %}{% set t=states(''sensor.smol_9_temp'') %}{% set g=states(''sensor.smol_display_grid'') %}{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% if not is_state(''binary_sensor.smol_9_online'',''on'') %}—{% elif scr==''Grid'' %}{{ g.split(''|'')[1] if ''|'' in g else ''—'' }}{% elif scr==''Batt'' %}{{ states(''sensor.ev_battery_soc'') }}%{% elif scr==''Clock'' %}{{ now().strftime(''%H:%M'') }}{% elif scr==''Custom'' %}{{ states(''sensor.smol_9_custom'')[:8] if states(''sensor.smol_9_custom'') not in na else ''—'' }}{% else %}{{ t if t not in na else ''—'' }}{% endif %}'
+    secondary: '{% set scr=(states(''sensor.smol_9_screen'') if states(''sensor.smol_9_screen'') not in [''unavailable'',''unknown'',''none'',''None'',''''] else states(''input_select.smol_9_screen'')) %}{{ scr|upper }} · {% if not is_state(''binary_sensor.smol_9_online'',''on'') %}no link{% elif scr==''Grid'' %}shared glass{% elif scr==''Batt'' %}HV pack{% elif scr==''Clock'' %}mesh time{% elif scr==''Custom'' %}user lines{% else %}live °F{% endif %}'
     icon: mdi:blank
     card_mod:
       style:
@@ -513,6 +641,9 @@ cards:
     - entity: input_select.smol_9_led
       name: LED (status / on / off)
       icon: mdi:led-on
+    - entity: input_text.smol_9_custom
+      name: Custom lines (‹sa› text, | per line)
+      icon: mdi:card-text
     - entity: input_button.smol_9_apply
       name: Apply → id9
       icon: mdi:send
@@ -601,6 +732,67 @@ cards:
         .: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_9_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_9_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_9_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}ha-card{display:{% if act %}block{% else %}none{% endif %};border-radius:0;border-top:none;border-bottom:none;margin-top:-2px;border-left:3px solid {{ pl[2] }};position:relative;overflow:hidden;background:repeating-linear-gradient(0deg,transparent 0 2px,rgba(0,0,0,.30) 2px 3px),linear-gradient(90deg,{{ pl[2] }}2e 0,{{ pl[2] }}2e {{ pf }}%,#04120a {{ pf }}%,#04120a 100%);}ha-card:before{content:'''';position:absolute;top:0;bottom:0;left:{{ pf }}%;width:2px;background:{{ pl[2] }};box-shadow:0 0 9px {{ pl[2] }},0 0 3px {{ pl[2] }};opacity:{% if pf>0 and pf<100 %}.95{% else %}0{% endif %};}ha-card:after{content:''◈ MESH-OTA · id9'';position:absolute;top:6px;right:11px;font-size:8.5px;letter-spacing:1.5px;color:{{ pl[2] }};opacity:.75;font-family:''VT323'',''IBM Plex Mono'',monospace;z-index:2;}'
         mushroom-state-info$: '{% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set p=states(''sensor.smol_9_ota_relaydiag'') %}{% set pf=(p|float(0)) if p not in na else 0 %}{% set ph=states(''sensor.smol_9_ota_diag'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}{% set staged=states(''sensor.smol_ota_staged'') %}{% set build=states(''sensor.smol_9_build'') %}{% set act=(staged not in na and staged!=''none'' and staged!=build) or (ph not in na and ph!=''confirmed'') %}.primary{font-family:''VT323'',''IBM Plex Mono'',monospace;font-size:30px;line-height:.85;color:{{ pl[2] }};text-shadow:0 0 8px {{ pl[2] }}66}.secondary{font-size:10.5px;opacity:.85;letter-spacing:.3px}'
         mushroom-shape-icon$: --icon-symbol-size:22px
+  - type: custom:mushroom-template-card
+    primary: '{% set oo=states(''sensor.smol_9_ota_outcome'') %}{% set rr=states(''sensor.smol_9_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}{% if oo==''rolled-back'' %}↩ OTA rolled back{% elif bad_o %}✗ OTA {{ oo }}{% elif bad_r %}⚠ reset: {{ rr }}{% else %}device{% endif %}'
+    secondary: '{% set oo=states(''sensor.smol_9_ota_outcome'') %}{% set rr=states(''sensor.smol_9_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}slot {{ states(''sensor.smol_9_boot_slot'') }} · reset {{ rr }} · up {{ states(''sensor.smol_9_uptime'') }}s · heap {{ states(''sensor.smol_9_heap_free'') }}'
+    icon: '{% set oo=states(''sensor.smol_9_ota_outcome'') %}{% set rr=states(''sensor.smol_9_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}{% if oo==''rolled-back'' or bad_r %}mdi:alert-octagram{% else %}mdi:chip{% endif %}'
+    icon_color: '{% set oo=states(''sensor.smol_9_ota_outcome'') %}{% set rr=states(''sensor.smol_9_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}{{ ''red'' if col==''#ff6b6b'' else (''amber'' if col==''#ffc24b'' else ''green'') }}'
+    card_mod:
+      style:
+        .: '{% set oo=states(''sensor.smol_9_ota_outcome'') %}{% set rr=states(''sensor.smol_9_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}ha-card{display:{% if act %}block{% else %}none{% endif %};border-radius:0;border-top:none;border-bottom:none;margin-top:-2px;border-left:3px solid {{ col }};background:#0b0402;position:relative;overflow:hidden;}ha-card:after{content:''◈ DEVICE · id9'';position:absolute;top:6px;right:11px;font-size:8.5px;letter-spacing:1.5px;color:{{ col }};opacity:.7;font-family:''VT323'',''IBM Plex Mono'',monospace;z-index:2;}'
+        mushroom-state-info$: '{% set oo=states(''sensor.smol_9_ota_outcome'') %}{% set rr=states(''sensor.smol_9_reset_reason'') %}{% set bad_o=oo in [''rolled-back'',''relay-failed'',''fetch-failed'',''mac-unknown''] %}{% set bad_r=rr in [''panic'',''wdt'',''brownout'',''glitch''] %}{% set act=bad_o or bad_r %}{% set col=''#ff6b6b'' if (oo==''rolled-back'' or rr in [''panic'',''brownout'']) else (''#ffc24b'' if act else ''#5bff9a'') %}.primary{font-family:''VT323'',''IBM Plex Mono'',monospace;font-size:17px;line-height:1;color:{{ col }}}.secondary{font-size:10px;opacity:.85}'
+        mushroom-shape-icon$: --icon-symbol-size:20px
+  - type: custom:mushroom-chips-card
+    alignment: start
+    chips:
+    - type: template
+      content: plugins
+      icon: mdi:puzzle-outline
+      icon_color: grey
+    - type: template
+      entity: input_boolean.smol_9_plugin_clock
+      icon: mdi:clock-outline
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_9_plugin_clock'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_9_plugin_snake
+      icon: mdi:snake
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_9_plugin_snake'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_9_plugin_bench
+      icon: mdi:test-tube
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_9_plugin_bench'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_9_plugin_batt
+      icon: mdi:battery
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_9_plugin_batt'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_9_plugin_grid
+      icon: mdi:transmission-tower
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_9_plugin_grid'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_9_plugin_wled
+      icon: mdi:led-strip-variant
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_9_plugin_wled'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_9_plugin_about
+      icon: mdi:information-outline
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_9_plugin_about'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    card_mod:
+      style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;padding:6px 8px 4px;background:var(--card-background-color);}
   - type: entities
     show_header_toggle: false
     entities:
@@ -735,10 +927,10 @@ cards:
       staged **{% set s=states(''sensor.smol_ota_staged'') %}{{ s if s not in [''unavailable'',''unknown'',''none'',''None'',''''] else ''— none'' }}**
 
 
-      {% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set s=states(''sensor.smol_ota_staged'') %}{% set b=states(''sensor.smol_8_build'') %}{% set ph=states(''sensor.smol_8_ota_diag'') %}{% set p=states(''sensor.smol_8_ota_relaydiag'') %}{% set on=is_state(''binary_sensor.smol_8_online'',''on'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}**id8** Nexus ⚑ — {% if not on %}·offline·{% elif s in na or s==''none'' %}run **{{ b }}** · no image staged{% elif b==s %}✓ **{{ b }}** current{% else %}run **{{ b }}** → **{{ s }}** · {% if p not in na %}**{{ p }}%** {% endif %}{{ pl[0] if ph not in na and ph!=''none'' else ''↑ pending'' }}{% endif %}
+      {% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set s=states(''sensor.smol_ota_staged'') %}{% set b=states(''sensor.smol_7_build'') %}{% set ph=states(''sensor.smol_7_ota_diag'') %}{% set p=states(''sensor.smol_7_ota_relaydiag'') %}{% set on=is_state(''binary_sensor.smol_7_online'',''on'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}**id7** Dominion ⚑ — {% if not on %}·offline·{% elif s in na or s==''none'' %}run **{{ b }}** · no image staged{% elif b==s %}✓ **{{ b }}** current{% else %}run **{{ b }}** → **{{ s }}** · {% if p not in na %}**{{ p }}%** {% endif %}{{ pl[0] if ph not in na and ph!=''none'' else ''↑ pending'' }}{% endif %}
 
 
-      {% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set s=states(''sensor.smol_ota_staged'') %}{% set b=states(''sensor.smol_7_build'') %}{% set ph=states(''sensor.smol_7_ota_diag'') %}{% set p=states(''sensor.smol_7_ota_relaydiag'') %}{% set on=is_state(''binary_sensor.smol_7_online'',''on'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}**id7** Dominion — {% if not on %}·offline·{% elif s in na or s==''none'' %}run **{{ b }}** · no image staged{% elif b==s %}✓ **{{ b }}** current{% else %}run **{{ b }}** → **{{ s }}** · {% if p not in na %}**{{ p }}%** {% endif %}{{ pl[0] if ph not in na and ph!=''none'' else ''↑ pending'' }}{% endif %}
+      {% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set s=states(''sensor.smol_ota_staged'') %}{% set b=states(''sensor.smol_8_build'') %}{% set ph=states(''sensor.smol_8_ota_diag'') %}{% set p=states(''sensor.smol_8_ota_relaydiag'') %}{% set on=is_state(''binary_sensor.smol_8_online'',''on'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}**id8** Nexus — {% if not on %}·offline·{% elif s in na or s==''none'' %}run **{{ b }}** · no image staged{% elif b==s %}✓ **{{ b }}** current{% else %}run **{{ b }}** → **{{ s }}** · {% if p not in na %}**{{ p }}%** {% endif %}{{ pl[0] if ph not in na and ph!=''none'' else ''↑ pending'' }}{% endif %}
 
 
       {% set na=[''unavailable'',''unknown'',''none'',''None'',''''] %}{% set s=states(''sensor.smol_ota_staged'') %}{% set b=states(''sensor.smol_9_build'') %}{% set ph=states(''sensor.smol_9_ota_diag'') %}{% set p=states(''sensor.smol_9_ota_relaydiag'') %}{% set on=is_state(''binary_sensor.smol_9_online'',''on'') %}{% set pm={''confirmed'':[''✓ confirmed'',''green'',''#5bff9a'',''mdi:check-decagram''],''leaf-timeout'':[''⧗ leaf-timeout'',''amber'',''#ffc24b'',''mdi:timer-sand-complete''],''relay-failed'':[''✗ relay-failed'',''red'',''#ff6b6b'',''mdi:close-octagon''],''fetch-failed'':[''✗ fetch-failed'',''red'',''#ff6b6b'',''mdi:cloud-alert''],''mac-unknown'':[''? mac-unknown'',''red'',''#ff6b6b'',''mdi:help-rhombus''],''rolled-back'':[''↩ rolled-back'',''red'',''#ff6b6b'',''mdi:backup-restore'']} %}{% set pl=pm.get(ph,[''↑ relaying'',''blue'',''#5bd0ff'',''mdi:progress-upload'']) %}**id9** Herald — {% if not on %}·offline·{% elif s in na or s==''none'' %}run **{{ b }}** · no image staged{% elif b==s %}✓ **{{ b }}** current{% else %}run **{{ b }}** → **{{ s }}** · {% if p not in na %}**{{ p }}%** {% endif %}{{ pl[0] if ph not in na and ph!=''none'' else ''↑ pending'' }}{% endif %}'
@@ -759,11 +951,11 @@ cards:
     entities:
     - type: section
       label: install staged → node · canary-first, one at a time
-    - entity: input_button.smol_ota_install_8
-      name: Install → id8 Nexus · canary / the Seat
-      icon: mdi:rocket-launch
     - entity: input_button.smol_ota_install_7
-      name: Install → id7 Dominion
+      name: Install → id7 Dominion · canary / the Seat
+      icon: mdi:rocket-launch
+    - entity: input_button.smol_ota_install_8
+      name: Install → id8 Nexus
       icon: mdi:rocket-launch-outline
     - entity: input_button.smol_ota_install_9
       name: Install → id9 Herald


### PR DESCRIPTION
The staged post-#77 dashboard pass — one `build_control_room.py` change (off main 9def910, which has #77's regex fix + the observability fw). Deployed live via WS `lovelace/config/save`, structure verified.

## Node-box additions
- **#45 Custom editor** — `input_text.smol_<id>_custom` row in *screen & mode* + a `Custom` branch in the mini-OLED preview (shows `sensor.smol_<id>_custom`'s first resolved line). Pairs with the #45 HA-side compose pipeline (PR #81).
- **#70/#74 device alarm** — a `mushroom-template-card` that **self-hides when clean** and surfaces the *rollback / abnormal-reset* story (slot · reset · up · heap) when `ota_outcome` is bad OR `reset_reason` is abnormal (panic/wdt/brownout/glitch). Raw `reset_reason` passes through (incl. vesper's `panic`) with red/amber severity — #70's "what just happened to this board" surface.
- **#55 plugin chips** — the 7 `input_boolean.smol_<id>_plugin_*` as a compact mushroom-chips row (fill = shown in boot menu). Toggling composes the hex mask (smol_mesh.yaml automation, PR #81). Safe: fw keeps-all on empty/all-off.

## #52 — NO change (and a correction)
The reset/reboot "duplicate" flagged earlier is **two distinct functions**: `_reset` = #21 config-reset (→ empty retained config), `_reboot` = #52 reboot (→ `cmd/reset`, **`retain:false`** verified line 23). The node_card already correctly uses `_reboot` with a tap-guard. Morpheus's proposed retire-`_reboot`/re-point-to-`_reset` was a misread that would have broken #52 — **not done**; existing wiring is correct + safe.

## Verified
Deployed live: 3 editor rows, 3 chips cards (42 plugin refs), 3 device cards, Custom oled branch present; `#52` reboot still → `_reboot` (not re-pointed). Reference export refreshed. Cards render degrade-safe (dimmed while boards are unplugged overnight; device card stays hidden until a real rollback). **Live visual best confirmed by opening the dashboard** (headless screenshot blocked by HA auth); structure is machine-verified.

## Depends
References entities from PR #81 (#45 input_text / #55 booleans / #70/#74 sensors) — all deployed live, so the generator resolves them. Different file from #81 (build_control_room.py vs smol_mesh.yaml) — no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)