### PR TITLE
fix(fw): #30 suppress the flush sync-spinner off the idle Clock face

### DIFF
--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -966,6 +966,17 @@ fn main() -> ! {
                     let (_, soak_rx0, soak_lost0, _) = r.soak_counts();
                     let mut flush_abort = false;
                     let mut flush_draw_ms = 0u64;
+                    // #30: draw the sync spinner ONLY on the idle Clock face. The flush is
+                    // sub-second and already deferred until >= FLUSH_IDLE_MS of no input (the #20
+                    // idle-defer above), so the user is never mid-navigation when it fires — the
+                    // one residual is the overlay flashing over whatever screen was LEFT on display
+                    // (e.g. a static Home menu). Suppressing it everywhere but the Clock lets that
+                    // frame simply hold for the sub-second flush (the render loop repaints after),
+                    // while the Clock — the ambient idle face — keeps its expected brief sync glyph.
+                    // The LED WifiSync cue below still fires on every screen (non-disruptive). This
+                    // retires the visible #20/#30 residual WITHOUT touching the HW-proven flush poll
+                    // (the cooperative/non-blocking-poll rewrite is filed separately, HW-canary-gated).
+                    let show_sync = matches!(app, App::Clock(_));
                     // #40: a flush that hears a leaf's retained OTA install surfaces
                     // `(leaf_id, staged announce)` here → relayed below.
                     let mut leaf_ota: Option<(u8, ota::Announce)> = None;
@@ -975,7 +986,7 @@ fn main() -> ! {
                         if matches!(button.poll(t), Some(input::Press::Long)) {
                             flush_abort = true;
                         }
-                        if t.saturating_sub(flush_draw_ms) >= SYNC_REDRAW_MS {
+                        if show_sync && t.saturating_sub(flush_draw_ms) >= SYNC_REDRAW_MS {
                             flush_draw_ms = t;
                             draw_syncing(&mut display, (t / SYNC_REDRAW_MS) as u8);
                         }


### PR DESCRIPTION
LADDER-2 R1. Retires the visible #20/#30 residual sync-screen on the gateway.

## Root cause (verified before coding)
- The gateway flush is **already deferred during active interaction** — main.rs runs it only when `idle` (no input for `FLUSH_IDLE_MS`=3s) or `capped` (120s continuous) — added by `0ce1ce9` (#20). So navigating the menu never triggers a flush; #30's headline was already mitigated.
- The flush is **sub-second** (coexist #23 retired the multi-second burst).
- **True residual:** after ≥3s idle, a flush fires and the tick's `draw_syncing` overdraws whatever screen was left on display (e.g. a static Home menu) with the spinner for <1s. Cosmetic.

## Fix (option B — small, safe)
Gate the flush-tick spinner on the idle Clock face: `show_sync = matches!(app, App::Clock(_))`. On the menu / any app screen the flush leaves the existing frame untouched for its sub-second duration (the render loop repaints after), so nothing flashes; on the Clock (ambient idle face) the brief sync glyph is retained. The LED WifiSync cue still fires on every screen. **The hardware-proven blocking flush poll is untouched.**

1 commit, `main.rs` only (~2 functional lines + comment). Inside the espnow-gated gateway loop.

## Deferred (option A → #91)
The issue's "real fix" — a cooperative/non-blocking poll — is a state-machine **rewrite of the brick-sensitive, hardware-proven flush path** and can't be canaried tonight. Filed as **#91**, flagged needs-HW-canary (do not merge on compile-proof alone). Not attempted here.

## Verification
4-profile serial build (riscv32imc), all clean:
- `default` ✅ 1.41s · `wifi` ✅ 2.82s · `wled` ✅ 8.97s
- `espnow`: `cargo clippy --release --features espnow -- -D warnings` ✅ **0 warnings** 1.00s

default-build invariant holds (change is in the espnow-gated gateway loop).

---
⏳ Cosmetic UX; no hardware canary required to merge (option A/#91 carries the canary-gated work).
