### PR TITLE
feat(fw): #45 Custom-screen render (plugin + CFG key Y)

### DIFF
--- a/rust/clock/src/app.rs
+++ b/rust/clock/src/app.rs
@@ -131,6 +131,11 @@ pub struct Ctx<'a> {
     /// relay/LED) is serviced by `main` BEFORE dispatch, so no double-drive.
     #[cfg(feature = "espnow")]
     pub radio: Option<&'a mut crate::net::mode::RadioManager>,
+    /// #45 the held Custom-screen layout wire (`<count>|<size><align>text;…`, entities
+    /// pre-resolved HA-side), owned by `main` and updated from the relayed / gateway-own
+    /// `smol/<id>/config/custom` (key `Y`). Empty = no custom set. Read by the Custom plugin.
+    #[cfg(feature = "espnow")]
+    pub custom: &'a [u8],
 }
 
 /// What a plugin asks `main` to do after a button gesture.
@@ -184,6 +189,11 @@ pub enum AppKind {
     // construct it), like Batt/Grid → no dead_code allow needed. cfg(wled) = espnow+.
     #[cfg(feature = "wled")]
     WledRemote,
+    // #45 Custom screen — per-node user text/entities. espnow-gated: its config arrives ONLY over
+    // the CFG relay / gateway-own MQTT (a radio path), so a default/wifi build has no way to fill
+    // it — a Custom menu row there would always be blank. LIVE on espnow (REGISTRY row + enter).
+    #[cfg(feature = "espnow")]
+    Custom,
 }
 
 /// #21 node-manager CONSUME — the parsed retained `smol/<id>/config/default_screen`
@@ -227,6 +237,10 @@ impl AppKind {
             // #25: a leaf's default screen can be set to the WLED remote via #21 too.
             #[cfg(feature = "wled")]
             "WledRemote" => AppKind::WledRemote,
+            // #45: a node's default screen can be set to Custom (matches luna's #81 screen
+            // input_select option "Custom"). espnow-only, like the AppKind variant.
+            #[cfg(feature = "espnow")]
+            "Custom" => AppKind::Custom,
             _ => return None,
         })
     }
@@ -253,6 +267,8 @@ impl AppKind {
             AppKind::MeshSnake => "MeshSnake",
             #[cfg(feature = "wled")]
             AppKind::WledRemote => "WledRemote",
+            #[cfg(feature = "espnow")]
+            AppKind::Custom => "Custom",
         }
     }
 }
@@ -310,6 +326,8 @@ pub enum App {
     MeshSnake(crate::mesh_snake::MeshSnake),
     #[cfg(feature = "wled")]
     WledRemote(crate::net::wled::WledRemoteState),
+    #[cfg(feature = "espnow")]
+    Custom(crate::custom::CustomState),
 }
 
 impl App {
@@ -335,6 +353,8 @@ impl App {
             AppKind::WledRemote => {
                 App::WledRemote(crate::net::wled::WledRemoteState::new(ctx.now_ms))
             }
+            #[cfg(feature = "espnow")]
+            AppKind::Custom => App::Custom(crate::custom::CustomState::new()),
         }
     }
 
@@ -362,6 +382,8 @@ impl App {
             App::MeshSnake(s) => Plugin::on_button(s, press, ctx),
             #[cfg(feature = "wled")]
             App::WledRemote(s) => Plugin::on_button(s, press, ctx),
+            #[cfg(feature = "espnow")]
+            App::Custom(s) => Plugin::on_button(s, press, ctx),
         }
     }
 
@@ -382,6 +404,8 @@ impl App {
             App::MeshSnake(s) => Plugin::update(s, ctx),
             #[cfg(feature = "wled")]
             App::WledRemote(s) => Plugin::update(s, ctx),
+            #[cfg(feature = "espnow")]
+            App::Custom(s) => Plugin::update(s, ctx),
         }
     }
 
@@ -422,6 +446,8 @@ impl App {
             App::MeshSnake(_) => (AppKind::MeshSnake, 0),
             #[cfg(feature = "wled")]
             App::WledRemote(_) => (AppKind::WledRemote, 0),
+            #[cfg(feature = "espnow")]
+            App::Custom(_) => (AppKind::Custom, 0),
         }
     }
 }
@@ -461,6 +487,10 @@ pub const REGISTRY: &[AppDesc] = &[
     #[cfg(feature = "wled")]
     AppDesc { title: "WLED", kind: AppKind::WledRemote },
     AppDesc { title: "About", kind: AppKind::About },
+    // #45 Custom — espnow-only (content arrives only over the radio config path). Last menu row,
+    // matching luna's #81 screen input_select order (…About, Custom).
+    #[cfg(feature = "espnow")]
+    AppDesc { title: "Custom", kind: AppKind::Custom },
 ];
 
 /// #55 plugin visibility: the STABLE mask bit for an app kind, INDEPENDENT of the (cfg-gated)
@@ -487,6 +517,11 @@ pub const fn plugin_bit(kind: AppKind) -> Option<u8> {
         #[cfg(feature = "wled")]
         AppKind::WledRemote => Some(5),
         AppKind::About => Some(6),
+        // #45 Custom is NON-maskable (like Menu): luna's #55 mask is the original 7 plugins
+        // (bits 0..6, all-on 007F) and predates Custom — giving Custom bit 7 would let a 007F
+        // mask HIDE it permanently. `None` ⇒ always shown, no rework to the live #55 contract.
+        #[cfg(feature = "espnow")]
+        AppKind::Custom => None,
         AppKind::Menu => None,
     }
 }

--- a/rust/clock/src/custom.rs
+++ b/rust/clock/src/custom.rs
@@ -1,0 +1,132 @@
+//! #45 CUSTOM screen — per-node user-authored text/entities.
+//!
+//! A [`Plugin`] that renders the layout HA composes for this node (issue #45). The user authors
+//! lines in a dashboard `input_text`; HA resolves any `{entity_id}` refs and publishes the
+//! RESOLVED wire to retained `smol/<id>/config/custom` (CFG key `Y`), relayed to leaves over the
+//! #21/#56 CFG mesh frame. This module NEVER resolves entities — it renders the plain bytes it
+//! is handed (via [`Ctx::custom`]).
+//!
+//! ## Wire (luna's #81 compose contract)
+//! `"<count>|<size><align>text;<size><align>text;…"` — `count` 1..4 (advisory; we parse the
+//! actual `;`-separated segments), each segment is `<size><align>text` where `size ∈ {s,m,l}`
+//! (fonts 5x8 / 6x10 / 10x20) and `align ∈ {l,c,r}` (left / centre / right within the 72 px row).
+//! Empty payload = no custom set. Segments stack top→bottom; a segment that would overflow the
+//! 40 px panel is dropped. TOTALLY panic-free — a malformed segment is skipped, never a crash.
+//!
+//! espnow-only: the config only ever arrives over the radio path (CFG relay / gateway-own MQTT),
+//! so a default/wifi build has nothing to render and never compiles this screen.
+
+use embedded_graphics::{
+    mono_font::{ascii::FONT_10X20, ascii::FONT_5X8, ascii::FONT_6X10, MonoTextStyleBuilder},
+    pixelcolor::BinaryColor,
+    prelude::*,
+    text::{Baseline, Text},
+};
+
+use crate::app::{AppKind, Ctx, Plugin, Transition};
+use crate::input::Press;
+
+/// The 72×40 OLED panel bounds used for layout (matches the other screens).
+const PANEL_W: i32 = 72;
+const PANEL_H: i32 = 40;
+
+/// CUSTOM state: a content dedup so the panel repaints once per CHANGE (config update or a
+/// re-resolved entity value) plus on any forced `redraw` — not every subtick. FNV-1a over the
+/// wire bytes is enough to detect a change cheaply without storing the whole payload twice.
+pub struct CustomState {
+    last_hash: u32,
+    drawn: bool,
+}
+
+impl CustomState {
+    pub fn new() -> Self {
+        Self { last_hash: 0, drawn: false }
+    }
+}
+
+impl Plugin for CustomState {
+    fn on_button(&mut self, press: Press, _ctx: &mut Ctx) -> Transition {
+        match press {
+            // Uniform grammar: long press leaves to the menu. Short taps do nothing (static screen).
+            Press::Long => Transition::Switch(AppKind::Menu),
+            Press::Short => Transition::Stay,
+        }
+    }
+
+    fn update(&mut self, ctx: &mut Ctx) {
+        let h = fnv1a(ctx.custom);
+        if ctx.redraw || !self.drawn || h != self.last_hash {
+            self.last_hash = h;
+            self.drawn = true;
+            ctx.display.clear(BinaryColor::Off).ok();
+            draw_custom(ctx.display, ctx.custom);
+            ctx.display.flush().ok();
+        }
+    }
+}
+
+/// FNV-1a over the wire bytes — a cheap change detector for the repaint dedup.
+fn fnv1a(bytes: &[u8]) -> u32 {
+    let mut h: u32 = 0x811c_9dc5;
+    for &b in bytes {
+        h ^= b as u32;
+        h = h.wrapping_mul(0x0100_0193);
+    }
+    h
+}
+
+/// Render the composed layout. `wire` is `"<count>|seg;seg;…"` (see module docs). Generic over
+/// the draw target so it stays testable in principle (mirrors `draw_clock`). Panic-free.
+fn draw_custom<D>(display: &mut D, wire: &[u8])
+where
+    D: DrawTarget<Color = BinaryColor>,
+{
+    // Segments live after the FIRST '|' (the `<count>` prefix is advisory — we render whatever
+    // segments are actually present). No '|' at all ⇒ treat the whole payload as absent.
+    let body = match wire.iter().position(|&b| b == b'|') {
+        Some(i) => &wire[i + 1..],
+        None => &[][..],
+    };
+
+    let mut y: i32 = 0;
+    let mut rendered = 0u8;
+    for seg in body.split(|&b| b == b';') {
+        // `<size><align>text` — need at least the 2 prefix bytes.
+        if seg.len() < 2 {
+            continue;
+        }
+        // (font, glyph width, line height) per size byte. Inference pins `font` to
+        // `&'static MonoFont<'static>`; the `i32` literals match the layout arithmetic.
+        let (font, char_w, line_h) = match seg[0] {
+            b'l' => (&FONT_10X20, 10i32, 20i32),
+            b'm' => (&FONT_6X10, 6i32, 10i32),
+            _ => (&FONT_5X8, 5i32, 8i32), // 's' or anything unknown → smallest (safe default)
+        };
+        // Drop a segment that can't fit in the remaining panel height (clip, never overflow).
+        if y + line_h > PANEL_H {
+            break;
+        }
+        let text = core::str::from_utf8(&seg[2..]).unwrap_or("");
+        // Width in glyphs (ASCII font → 1 glyph per char); align within the 72 px row.
+        let tw = text.chars().count() as i32 * char_w;
+        let x = match seg[1] {
+            b'c' => ((PANEL_W - tw) / 2).max(0),
+            b'r' => (PANEL_W - tw).max(0),
+            _ => 2, // 'l' or unknown → left margin (matches clock/menu x=2)
+        };
+        let style = MonoTextStyleBuilder::new().font(font).text_color(BinaryColor::On).build();
+        Text::with_baseline(text, Point::new(x, y), style, Baseline::Top).draw(display).ok();
+        y += line_h + 1; // 1 px inter-line gap
+        rendered = rendered.saturating_add(1);
+    }
+
+    // Nothing to show (empty / all-malformed): a placeholder so the screen is never a mystery
+    // blank — the node's own noun, centred, tells the user which node + that no custom is set.
+    if rendered == 0 {
+        let noun = crate::net::names::name_for_id(crate::node_id()).1;
+        let style = MonoTextStyleBuilder::new().font(&FONT_6X10).text_color(BinaryColor::On).build();
+        let tw = noun.chars().count() as i32 * 6;
+        let x = ((PANEL_W - tw) / 2).max(0);
+        Text::with_baseline(noun, Point::new(x, 15), style, Baseline::Top).draw(display).ok();
+    }
+}

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -104,6 +104,10 @@ mod input;
 // the module only needs esp-hal GPIO so it could be reused elsewhere.
 #[cfg(feature = "espnow")]
 mod led;
+// #45 CUSTOM screen — per-node user text/entities, driven by the relayed CFG key `Y`.
+// espnow-only (the config only ever arrives over the radio path), like `led`.
+#[cfg(feature = "espnow")]
+mod custom;
 // Home menu + AppMode dispatcher enum. Always compiled.
 mod menu;
 // WiFi/SNTP (Phase 2) + ESP-NOW/radio switching (Phase 3). Feature-gated inside.
@@ -587,6 +591,14 @@ fn main() -> ! {
     // `smol/<id>/config/led` (key `L`). Default `Status` = the pre-#48 peer-state indicator.
     #[cfg(feature = "espnow")]
     let mut led_mode = led::LedMode::default();
+
+    // #45 CUSTOM screen layout — the resolved wire from `smol/<id>/config/custom` (key `Y`),
+    // held across the loop and updated via take_cfg_offer(Y). `custom_len` = 0 → no custom set
+    // (the Custom plugin then shows a placeholder). Sized to the max keyed value.
+    #[cfg(feature = "espnow")]
+    let mut custom_buf = [0u8; crate::net::CFG_VALUE_MAX];
+    #[cfg(feature = "espnow")]
+    let mut custom_len: usize = 0;
 
     // #43 display units (°F/°C · 12h/24h), fleet-global. Held across the loop; on espnow the
     // relayed / gateway-own `smol/config/units` (key `U`, broadcast target 255) updates it.
@@ -1103,6 +1115,17 @@ fn main() -> ! {
                 }
             }
 
+            // #45: pull the relayed / gateway-own Custom-screen layout (key `Y`) and store the raw
+            // RESOLVED wire (entities already substituted HA-side) for the Custom plugin to render.
+            // Edge-triggered; an empty value clears it (→ placeholder). No parse here — the Custom
+            // plugin parses the layout panic-free at render time.
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_CUSTOM) {
+                let n = o.len.min(custom_buf.len());
+                custom_buf[..n].copy_from_slice(&o.buf[..n]);
+                custom_len = n;
+                log::info!("smol #45: custom screen layout updated ({} B)", n);
+            }
+
             // #52: a remote reboot command (key `R`) — a COMMAND (cache-bypass, one-shot). Applied
             // once (edge — `take` clears it); the value is empty (the key IS the command). Feeds
             // BOTH a leaf (relayed `<id>R`) and the gateway's OWN reset (injected into `self.cfg`),
@@ -1203,6 +1226,9 @@ fn main() -> ! {
             },
             #[cfg(feature = "espnow")]
             radio: radio.as_mut(),
+            // #45 the held Custom-screen layout (empty slice = none) — read by the Custom plugin.
+            #[cfg(feature = "espnow")]
+            custom: &custom_buf[..custom_len],
         };
 
         // Issue #18: one-shot entry into the configured boot screen, now that a

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -66,6 +66,14 @@ pub use wifi::CFG_KEY_PLUGINS;
 // take_cfg_offer(R), with a boot-debounce before software_reset()).
 #[cfg(feature = "espnow")]
 pub use wifi::CFG_KEY_REBOOT;
+// #45 custom-screen key — same `main`-bridge rationale (espnow leaf-apply path via
+// take_cfg_offer(Y); the held layout feeds the Custom plugin render).
+#[cfg(feature = "espnow")]
+pub use wifi::CFG_KEY_CUSTOM;
+// #45: `main` sizes its held Custom-layout buffer to the max keyed value — bridge the const out
+// of the private `wifi` module (espnow-only: only the Custom apply path names it).
+#[cfg(feature = "espnow")]
+pub use wifi::CFG_VALUE_MAX;
 
 // #71 on-demand WiFi-scan key — same `main`-bridge rationale (espnow apply path via
 // take_cfg_offer(W) → run_scan).

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -180,11 +180,12 @@ const CFG_PREFIX: &[u8] = b"SMOLv1 CFG "; // + "NNN" + KEY + verbatim "<value>"
 /// (a `take_cfg_offer(key)` + apply) and a gateway fill site in `mqtt_session`. Sized `[_; N]`
 /// (not `&[u8]`) so [`CfgTracker`] can allocate exactly one `.bss` buffer slot per key.
 /// An inbound key not listed is dropped at [`CfgTracker::set`] (never buffered/applied).
-const CFG_APPLY_KEYS: [u8; 6] = [
+const CFG_APPLY_KEYS: [u8; 7] = [
     crate::net::wifi::CFG_KEY_SCREEN,
     crate::net::wifi::CFG_KEY_LED,
     crate::net::wifi::CFG_KEY_UNITS,
     crate::net::wifi::CFG_KEY_PLUGINS,
+    crate::net::wifi::CFG_KEY_CUSTOM, // #45 custom-screen layout (cached + relayed like S/L/U/P)
     // #52 remote reboot: R IS a buffered/applied key (a leaf takes it via take_cfg_offer(R)) but
     // is NEVER put in cfg_cache/broadcast_cached_configs — the one-shot relay uses broadcast_config
     // directly. The anti-reboot-loop invariant: R rides the CFG wire + apply path, not the cache.
@@ -3311,6 +3312,10 @@ impl RadioManager {
         // #55: the gateway's OWN plugin-visibility mask — same self-apply path (take_cfg_offer(P)).
         if let Some((buf, len)) = gw_own.plugins {
             self.cfg.set(crate::net::wifi::CFG_KEY_PLUGINS, &buf[..len]);
+        }
+        // #45: the gateway's OWN custom-screen layout — same self-apply path (take_cfg_offer(Y)).
+        if let Some((buf, len)) = gw_own.custom {
+            self.cfg.set(crate::net::wifi::CFG_KEY_CUSTOM, &buf[..len]);
         }
         // #52 remote reboot — a COMMAND, not a config. Fire a ONE-SHOT `<id>R` frame per queued
         // leaf target via `broadcast_config` DIRECTLY (NOT `cfg_cache` / `broadcast_cached_configs`):

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -786,13 +786,19 @@ static mut MQTT_JSON: JsonScratch = JsonScratch::new();
 #[cfg(feature = "wifi")]
 static mut MQTT_ACC: [u8; 512] = [0; 512];
 
-/// #21 leaf-relay: max bytes of a relayed default-screen value (`<AppKind>:<page>`,
-/// ≤ 12 by the #21 grammar; 16 gives margin). Lives here (not `net::mode`) because
-/// the gateway FILLS the cache from MQTT in `mqtt_session` (compiled under `wifi`),
-/// while the ESP-NOW frame layer that CONSUMES it is `#[cfg(espnow)]` — and
-/// `espnow ⊃ wifi`, so a wifi-level type is namable from both with no signature cfg.
+/// #21 leaf-relay: max bytes of a relayed keyed-CFG value. Lives here (not `net::mode`) because
+/// the gateway FILLS the cache from MQTT in `mqtt_session` (compiled under `wifi`), while the
+/// ESP-NOW frame layer that CONSUMES it is `#[cfg(espnow)]` — and `espnow ⊃ wifi`, so a
+/// wifi-level type is namable from both with no signature cfg.
+///
+/// **64** (was 16): the #45 Custom-screen wire (`<count>|<size><align>text;…`, up to 4 segments
+/// clipped to 12 chars → ≈ 61 B) is the largest keyed value; screen/led/units/plugins/reboot all
+/// stay ≤ 12 B. Sizing the ONE uniform buffer to the largest key reuses the CFG frame verbatim
+/// (issue #45: "reuse that frame, don't invent one") rather than a per-key buffer or a second
+/// transport. Also removes the old 16-B truncation risk on the STAT uplink (which reuses this).
+/// Cost: ~2 KB `.bss` across cfg_cache + stat_cache + the tracker — comfortable on the C3.
 #[cfg(feature = "wifi")]
-pub const CFG_VALUE_MAX: usize = 16;
+pub const CFG_VALUE_MAX: usize = 64;
 
 /// #56 keyed CFG: the single-ASCII config KEY that follows the 3-digit target id in a
 /// `SMOLv1 CFG` frame (`<NNN><KEY><value>`). ONE relay now carries N per-node config
@@ -836,6 +842,11 @@ pub const CFG_KEY_PLUGINS: u8 = b'P';
 #[cfg(feature = "wifi")]
 #[allow(dead_code)]
 pub const CFG_KEY_REBOOT: u8 = b'R';
+/// #45 Custom-screen channel (key `Y`). Per-node retained `smol/<id>/config/custom` = the compose
+/// wire `<count>|<size><align>text;…` (entities pre-resolved HA-side; empty = clear). A leaf gets
+/// it relayed; the gateway reads its own directly. The largest keyed value (drives CFG_VALUE_MAX).
+#[cfg(feature = "wifi")]
+pub const CFG_KEY_CUSTOM: u8 = b'Y';
 
 /// #71 on-demand WiFi-scan COMMAND (key `W`). EXACT twin of `R` (#52): rides the CFG WIRE
 /// (`SMOLv1 CFG <id>W`), IS in `CFG_APPLY_KEYS` (a node buffers + applies it), but is NEVER
@@ -871,12 +882,14 @@ pub struct GwOwnCfg {
     pub units: Option<([u8; CFG_VALUE_MAX], usize)>,
     /// #55 the gateway's own `smol/<id>/config/plugins` value `(buf, len)`, or `None` if absent.
     pub plugins: Option<([u8; CFG_VALUE_MAX], usize)>,
+    /// #45 the gateway's own `smol/<id>/config/custom` value `(buf, len)`, or `None` if absent.
+    pub custom: Option<([u8; CFG_VALUE_MAX], usize)>,
 }
 
 #[cfg(feature = "wifi")]
 impl GwOwnCfg {
     pub const fn new() -> Self {
-        Self { led: None, units: None, plugins: None }
+        Self { led: None, units: None, plugins: None, custom: None }
     }
     /// Pack a payload into the `(buf, len)` a field holds (truncated to `CFG_VALUE_MAX`), so the
     /// mqtt-drain arms stay one-liners: `gw_own.led = Some(GwOwnCfg::val(payload));`.
@@ -1597,6 +1610,12 @@ fn mqtt_session(
         if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 14, b"smol/+/cmd/scan") {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
+        // #45 Custom screen (pid 15): wildcard-subscribe every leaf's retained custom-screen layout
+        // so the gateway caches + relays it (key `Y`) over ESP-NOW, twin of the led/plugins wildcard.
+        // (pid 15 — #71's scan took 14 in the merge; distinct pid per concurrent SUBSCRIBE.)
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 15, b"smol/+/config/custom") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
     }
 
     // --- PUBLISH telemetry (transient) + discovery config (retained) per node ---
@@ -2023,6 +2042,25 @@ fn mqtt_session(
                         } else {
                             gw_own.plugins = Some(GwOwnCfg::val(payload));
                             log::info!("smol #55: gateway own plugin mask captured ({} B)", payload.len());
+                        }
+                    } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/config/custom") {
+                        // #45 Custom screen: twin of the led/plugins arm. OTHER leaf → cache under
+                        // key `Y` for the ESP-NOW relay; OUR OWN id → capture into gw_own so
+                        // `service()` self-applies it. Verbatim RESOLVED bytes (entities already
+                        // substituted HA-side); the Custom plugin parses the layout wire panic-free.
+                        if leaf_id != node_id {
+                            if let Some(cache) = cfg_cache.as_deref_mut() {
+                                let now = Instant::now().duration_since_epoch().as_millis();
+                                cache.set(leaf_id, CFG_KEY_CUSTOM, payload, [0u8; 6], now);
+                                log::info!(
+                                    "smol #45: cached leaf id{} custom screen for relay ({} B)",
+                                    leaf_id,
+                                    payload.len()
+                                );
+                            }
+                        } else {
+                            gw_own.custom = Some(GwOwnCfg::val(payload));
+                            log::info!("smol #45: gateway own custom screen captured ({} B)", payload.len());
                         }
                     } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/cmd/reset") {
                         // #52 remote reboot — a COMMAND on a TRANSIENT topic (retain:false), so we


### PR DESCRIPTION
The FW render side of #45 (HA editors shipped in luna's #81). Adds a per-node **Custom** screen: user-authored text/entities, editable from the dashboard node box.

## What it does
- New `Custom` AppKind + menu row + `custom.rs` plugin. HA resolves `{entity}` refs and publishes the **resolved** layout to retained `smol/<id>/config/custom` (CFG key `Y`), relayed to leaves over the #21/#56 keyed CFG mesh frame — reusing the frame, not a new transport.
- Wire (luna's #81 compose contract): `<count>|<size><align>text;…` — `size ∈ s/m/l` → fonts 5x8/6x10/10x20, `align ∈ l/c/r` within 72 px, ≤4 segments, entities pre-resolved HA-side. The FW renders resolved bytes **verbatim** (zero interpolation), stacks segments top→bottom, clips overflow, and shows the node noun as a placeholder when empty. Totally panic-free (a malformed segment is skipped).

## Design notes
- **`CFG_VALUE_MAX` 16 → 64.** The custom wire (≈61 B) is the largest keyed value; sizing the one uniform CFG cache/tracker buffer to it reuses the frame (per the issue) rather than a per-key buffer or a second transport. Also retires a latent 16-B truncation risk on the STAT uplink (shares the const). ~2 KB `.bss` across cfg_cache + stat_cache + tracker — comfortable on the C3. **← oracle: please scrutinize the RAM headroom + the CfgCache/CfgTracker/GwOwnCfg auto-sizing.**
- **Custom is espnow-gated** (like Bench/MeshSnake): its config only arrives over the radio path, so default/wifi builds never compile the screen (a Custom menu row there would always be blank).
- **Custom is NON-maskable** (`plugin_bit → None`): luna's merged #55 mask is the original 7 plugins (bits 0..6, all-on `007F`) and predates Custom — a bit-7 Custom would be *hidden* by a `007F` mask. So it's always shown, zero rework to the live #55 contract. (Flagged luna the optional bit-7 + 8th-boolean path for later.)
- **Frame reconciliation:** the #56/#45 design docs describe a separate `SMOLv1 KV` frame (`KV_VALUE_MAX=64`), but #56 *shipped* the keyed channel on `SMOLv1 CFG`. Verified against the code (no KV symbols exist) + confirmed with luna: code is source of truth, custom rides CFG key Y. The docs are stale (routed to hypnos for reconciliation).

## Plumbing (twin of #48/#55)
`CFG_KEY_CUSTOM=b'Y'`; `GwOwnCfg.custom` + gateway self-apply inject; gateway subscribe `smol/+/config/custom` (**pid 15** — #71's scan took 14 in the merge); fill arm; `CFG_APPLY_KEYS` → `S,L,U,P,Y,R,W` (7); net re-exports. `app.rs`: `AppKind::Custom` + `from_wire`/`as_wire` "Custom" + `App::Custom` + `enter` + dispatch + REGISTRY row + `Ctx.custom`. `main`: hold layout + apply(Y).

## Rebase
Rebased onto origin/main `5e7b541` (past #71 WiFi-scan). One real conflict — a **pid-14 collision** (both #71 scan and #45 custom claimed pid 14): kept #71's scan on 14, moved custom to 15. Caught a silent auto-merge bug: both branches grew `CFG_APPLY_KEYS` 5→6 independently, so the body gained *both* W and Y (7 elements) while the count auto-merged to `[u8; 6]` — fixed to `[u8; 7]`. #52's R cache-bypass invariant + #71's W discipline both intact.

## Testing
- **4-profile compile ALL GREEN**: `default` ✅ · `wifi` ✅ · `espnow` ✅ · `wled` ✅.
- **espnow `cargo clippy --release --features espnow -- -D warnings` = 0** ✅.
- **Hardware validation DEFERRED to the morning consolidated canary** (boards unplugged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
