### PR TITLE
feat(fw): #58 Marauder's Watch + #60 treasure-hunt — roster-RSSI screens

### DIFF
--- a/rust/clock/src/app.rs
+++ b/rust/clock/src/app.rs
@@ -185,6 +185,12 @@ pub enum AppKind {
     Bench,
     #[cfg(feature = "espnow")]
     MeshSnake,
+    // #58 Marauder's Watch + #60 treasure-hunt — roster-RSSI screens. LIVE whenever
+    // compiled (REGISTRY row + `enter` + `from_wire` construct them) → no dead_code allow.
+    #[cfg(feature = "espnow")]
+    Watch,
+    #[cfg(feature = "espnow")]
+    Hunt,
     // #25 WLED remote. LIVE whenever compiled (REGISTRY row + `enter` + `from_wire`
     // construct it), like Batt/Grid → no dead_code allow needed. cfg(wled) = espnow+.
     #[cfg(feature = "wled")]
@@ -234,6 +240,10 @@ impl AppKind {
             "Bench" => AppKind::Bench,
             #[cfg(feature = "espnow")]
             "MeshSnake" => AppKind::MeshSnake,
+            #[cfg(feature = "espnow")]
+            "Watch" => AppKind::Watch,
+            #[cfg(feature = "espnow")]
+            "Hunt" => AppKind::Hunt,
             // #25: a leaf's default screen can be set to the WLED remote via #21 too.
             #[cfg(feature = "wled")]
             "WledRemote" => AppKind::WledRemote,
@@ -265,6 +275,10 @@ impl AppKind {
             AppKind::Bench => "Bench",
             #[cfg(feature = "espnow")]
             AppKind::MeshSnake => "MeshSnake",
+            #[cfg(feature = "espnow")]
+            AppKind::Watch => "Watch",
+            #[cfg(feature = "espnow")]
+            AppKind::Hunt => "Hunt",
             #[cfg(feature = "wled")]
             AppKind::WledRemote => "WledRemote",
             #[cfg(feature = "espnow")]
@@ -324,6 +338,10 @@ pub enum App {
     Bench(crate::bench::BenchState),
     #[cfg(feature = "espnow")]
     MeshSnake(crate::mesh_snake::MeshSnake),
+    #[cfg(feature = "espnow")]
+    Watch(crate::watch::WatchState),
+    #[cfg(feature = "espnow")]
+    Hunt(crate::hunt::HuntState),
     #[cfg(feature = "wled")]
     WledRemote(crate::net::wled::WledRemoteState),
     #[cfg(feature = "espnow")]
@@ -349,6 +367,10 @@ impl App {
             AppKind::MeshSnake => {
                 App::MeshSnake(crate::mesh_snake::MeshSnake::new(ctx.node_id, ctx.now_ms as u32))
             }
+            #[cfg(feature = "espnow")]
+            AppKind::Watch => App::Watch(crate::watch::WatchState::new()),
+            #[cfg(feature = "espnow")]
+            AppKind::Hunt => App::Hunt(crate::hunt::HuntState::new()),
             #[cfg(feature = "wled")]
             AppKind::WledRemote => {
                 App::WledRemote(crate::net::wled::WledRemoteState::new(ctx.now_ms))
@@ -380,6 +402,10 @@ impl App {
             App::Bench(s) => Plugin::on_button(s, press, ctx),
             #[cfg(feature = "espnow")]
             App::MeshSnake(s) => Plugin::on_button(s, press, ctx),
+            #[cfg(feature = "espnow")]
+            App::Watch(s) => Plugin::on_button(s, press, ctx),
+            #[cfg(feature = "espnow")]
+            App::Hunt(s) => Plugin::on_button(s, press, ctx),
             #[cfg(feature = "wled")]
             App::WledRemote(s) => Plugin::on_button(s, press, ctx),
             #[cfg(feature = "espnow")]
@@ -402,6 +428,10 @@ impl App {
             App::Bench(s) => Plugin::update(s, ctx),
             #[cfg(feature = "espnow")]
             App::MeshSnake(s) => Plugin::update(s, ctx),
+            #[cfg(feature = "espnow")]
+            App::Watch(s) => Plugin::update(s, ctx),
+            #[cfg(feature = "espnow")]
+            App::Hunt(s) => Plugin::update(s, ctx),
             #[cfg(feature = "wled")]
             App::WledRemote(s) => Plugin::update(s, ctx),
             #[cfg(feature = "espnow")]
@@ -444,6 +474,10 @@ impl App {
             App::Bench(_) => (AppKind::Bench, 0),
             #[cfg(feature = "espnow")]
             App::MeshSnake(_) => (AppKind::MeshSnake, 0),
+            #[cfg(feature = "espnow")]
+            App::Watch(_) => (AppKind::Watch, 0),
+            #[cfg(feature = "espnow")]
+            App::Hunt(_) => (AppKind::Hunt, 0),
             #[cfg(feature = "wled")]
             App::WledRemote(_) => (AppKind::WledRemote, 0),
             #[cfg(feature = "espnow")]
@@ -478,6 +512,11 @@ pub const REGISTRY: &[AppDesc] = &[
     AppDesc { title: "Snake", kind: SNAKE_KIND },
     #[cfg(feature = "espnow")]
     AppDesc { title: "Bench", kind: AppKind::Bench },
+    // #58 Marauder's Watch + #60 treasure-hunt (roster-RSSI screens).
+    #[cfg(feature = "espnow")]
+    AppDesc { title: "Watch", kind: AppKind::Watch },
+    #[cfg(feature = "espnow")]
+    AppDesc { title: "Hunt", kind: AppKind::Hunt },
     #[cfg(feature = "wifi")]
     AppDesc { title: "Batt", kind: AppKind::Batt },
     #[cfg(feature = "wifi")]
@@ -510,6 +549,13 @@ pub const fn plugin_bit(kind: AppKind) -> Option<u8> {
         AppKind::MeshSnake => Some(1), // SNAKE_KIND alias → same "Snake" bit
         #[cfg(feature = "espnow")]
         AppKind::Bench => Some(2),
+        // #58/#60: not yet #55-maskable — `None` ⇒ always shown (`kind_enabled` treats
+        // `None` as visible). Wiring them into the plugins mask needs a paired HA change
+        // (new bits + toggles); until then a partial mask that predates them can't hide them.
+        #[cfg(feature = "espnow")]
+        AppKind::Watch => None,
+        #[cfg(feature = "espnow")]
+        AppKind::Hunt => None,
         #[cfg(feature = "wifi")]
         AppKind::Batt => Some(3),
         #[cfg(feature = "wifi")]

--- a/rust/clock/src/hunt.rs
+++ b/rust/clock/src/hunt.rs
@@ -1,0 +1,259 @@
+//! Treasure-hunt (#60) — an RSSI warmer/colder game: pick a target node, walk
+//! toward it guided by signal strength.
+//!
+//! `espnow`-only. A pure consumer of [`crate::net::mode::RadioManager::roster`] —
+//! **no new frames, no radio traffic** (the target just broadcasts its ordinary
+//! HELLO/BEACON, which every node already does). Shares the smoothing + proximity
+//! mapping with the Watch ([`crate::rssi`]).
+//!
+//! One-button UX: **short tap** cycles the target to the next peer, **long press**
+//! returns to the Menu. The big warmer/colder trend (smoothed RSSI now vs ~1.5 s
+//! ago, with a ±2 dB deadband) is the hero — readable while walking. Cheat-/jitter-
+//! resistance: EWMA smoothing + the deadband + a hold-to-confirm FOUND so a single
+//! lucky spike can't declare victory.
+
+use core::fmt::Write;
+
+use embedded_graphics::{
+    mono_font::{ascii::FONT_5X8, ascii::FONT_6X10, MonoTextStyleBuilder},
+    pixelcolor::BinaryColor,
+    prelude::*,
+    primitives::{PrimitiveStyle, Rectangle},
+    text::{Baseline, Text},
+};
+
+use crate::app::{AppKind, Ctx, Plugin, Transition};
+use crate::input::Press;
+use crate::net::mode::RosterView;
+use crate::net::names::name_for_id;
+use crate::rssi::{bar_px, clip, label, proximity, Line, RssiSmoother};
+
+/// Compare the smoothed RSSI against its value this many ms ago for the trend.
+const TREND_LAG_MS: u64 = 1500;
+/// Trend deadband (dB): |delta| below this reads as SAME, not warmer/colder — below
+/// the smoothed reading's noise floor, so standing still never flickers.
+const TREND_DEADBAND: i32 = 2;
+/// Smoothed RSSI (dBm) at/above which the target counts as "found"…
+const FOUND_RSSI: i32 = -40;
+/// …once held for this long (a lucky spike can't declare victory).
+const FOUND_HOLD_MS: u64 = 1000;
+
+pub struct HuntState {
+    smoother: RssiSmoother,
+    /// Current target node id (None until a peer exists to hunt).
+    target: Option<u8>,
+    /// Smoothed RSSI captured ~`TREND_LAG_MS` ago (the trend reference).
+    trend_ref: i32,
+    trend_ref_ms: u64,
+    /// When the smoothed RSSI first crossed `FOUND_RSSI` (None = not currently over).
+    found_since_ms: Option<u64>,
+}
+
+impl Default for HuntState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HuntState {
+    pub fn new() -> Self {
+        Self {
+            smoother: RssiSmoother::new(),
+            target: None,
+            trend_ref: -100,
+            trend_ref_ms: 0,
+            found_since_ms: None,
+        }
+    }
+
+    /// Reset the trend + found state to the current reading — called when the target
+    /// changes so a fresh hunt never inherits the previous target's warmth.
+    fn arm(&mut self, rssi: i32, now: u64) {
+        self.trend_ref = rssi;
+        self.trend_ref_ms = now;
+        self.found_since_ms = None;
+    }
+
+    /// The id-bearing peer ids in the roster, in order (RSSI-desc). Returns the
+    /// filled prefix + count (heap-free).
+    fn known_ids(roster: &RosterView) -> ([u8; 16], usize) {
+        let mut ids = [0u8; 16];
+        let mut n = 0;
+        for node in &roster.nodes[..roster.count] {
+            if node.id_known && n < ids.len() {
+                ids[n] = node.id;
+                n += 1;
+            }
+        }
+        (ids, n)
+    }
+}
+
+fn style_5x8() -> embedded_graphics::mono_font::MonoTextStyle<'static, BinaryColor> {
+    MonoTextStyleBuilder::new()
+        .font(&FONT_5X8)
+        .text_color(BinaryColor::On)
+        .build()
+}
+fn style_6x10() -> embedded_graphics::mono_font::MonoTextStyle<'static, BinaryColor> {
+    MonoTextStyleBuilder::new()
+        .font(&FONT_6X10)
+        .text_color(BinaryColor::On)
+        .build()
+}
+
+impl Plugin for HuntState {
+    fn on_button(&mut self, press: Press, ctx: &mut Ctx) -> Transition {
+        match press {
+            Press::Long => Transition::Switch(AppKind::Menu),
+            Press::Short => {
+                // Cycle the target to the next id-bearing peer (wraps).
+                let roster = match ctx.radio.as_deref() {
+                    Some(r) => r.roster(ctx.now_ms),
+                    None => return Transition::Stay,
+                };
+                let (ids, n) = Self::known_ids(&roster);
+                if n > 0 {
+                    let next = match self.target.and_then(|t| ids[..n].iter().position(|&i| i == t))
+                    {
+                        Some(pos) => ids[(pos + 1) % n],
+                        None => ids[0],
+                    };
+                    self.target = Some(next);
+                    // Re-arm the trend from the new target's known/last reading.
+                    let seed = self.smoother.get(next).unwrap_or(-100);
+                    self.arm(seed, ctx.now_ms);
+                }
+                ctx.redraw = true;
+                Transition::Stay
+            }
+        }
+    }
+
+    fn update(&mut self, ctx: &mut Ctx) {
+        let roster = match ctx.radio.as_deref_mut() {
+            Some(r) => r.roster(ctx.now_ms),
+            None => return,
+        };
+        let now = ctx.now_ms;
+
+        // Acquire a target on first sight (strongest id-bearing peer = nodes[0..]).
+        if self.target.is_none() {
+            let (ids, n) = Self::known_ids(&roster);
+            if n > 0 {
+                self.target = Some(ids[0]);
+                self.arm(self.smoother.get(ids[0]).unwrap_or(-100), now);
+            }
+        }
+
+        // Locate the target in the current roster; update its EWMA if present.
+        let (present, smoothed) = match self.target {
+            Some(t) => match roster.nodes[..roster.count].iter().find(|n| n.id_known && n.id == t) {
+                Some(node) => (true, self.smoother.update(t, node.rssi)),
+                None => (false, self.smoother.get(t).unwrap_or(-100)),
+            },
+            None => (false, -100),
+        };
+
+        // Trend: compare to the ~TREND_LAG_MS-ago reference, then roll the reference.
+        let delta = smoothed - self.trend_ref;
+        if now.saturating_sub(self.trend_ref_ms) >= TREND_LAG_MS {
+            self.trend_ref = smoothed;
+            self.trend_ref_ms = now;
+        }
+
+        // FOUND: hold-to-confirm above the threshold (only while present).
+        let found = if present && smoothed >= FOUND_RSSI {
+            let since = *self.found_since_ms.get_or_insert(now);
+            now.saturating_sub(since) >= FOUND_HOLD_MS
+        } else {
+            self.found_since_ms = None;
+            false
+        };
+
+        // ---- render ----------------------------------------------------------
+        ctx.display.clear(BinaryColor::Off).ok();
+
+        // Row 0: "SEEK <Noun>".
+        let mut hdr = Line::new();
+        match self.target {
+            Some(t) => {
+                let _ = write!(hdr, "SEEK {}", clip(name_for_id(t).1, 7));
+            }
+            None => {
+                let _ = write!(hdr, "SEEK --");
+            }
+        }
+        Text::with_baseline(hdr.as_str(), Point::new(0, 0), style_5x8(), Baseline::Top)
+            .draw(ctx.display)
+            .ok();
+
+        if self.target.is_none() {
+            Text::with_baseline("no peers", Point::new(0, 16), style_6x10(), Baseline::Top)
+                .draw(ctx.display)
+                .ok();
+            ctx.display.flush().ok();
+            return;
+        }
+
+        // Hero line (y≈11): FOUND! / LOST / the warmer-colder trend.
+        let hero: &str = if found {
+            "FOUND!"
+        } else if !present {
+            "LOST"
+        } else if delta > TREND_DEADBAND {
+            "WARMER"
+        } else if delta < -TREND_DEADBAND {
+            "COLDER"
+        } else {
+            "SAME"
+        };
+        Text::with_baseline(hero, Point::new(0, 11), style_6x10(), Baseline::Top)
+            .draw(ctx.display)
+            .ok();
+        // A trailing arrow glyph for the trend (skip for FOUND/LOST/SAME).
+        // ASCII arrows only — the embedded-graphics `ascii::FONT_6X10` has no
+        // Unicode glyphs, so `^`/`v` are what actually render.
+        let arrow = if found || !present {
+            ""
+        } else if delta > TREND_DEADBAND {
+            "^"
+        } else if delta < -TREND_DEADBAND {
+            "v"
+        } else {
+            ""
+        };
+        if !arrow.is_empty() {
+            Text::with_baseline(arrow, Point::new(60, 11), style_6x10(), Baseline::Top)
+                .draw(ctx.display)
+                .ok();
+        }
+
+        // Proximity bar (y=24): smoothed RSSI, full width (70 px), outlined + filled.
+        let bw = bar_px(smoothed, 70);
+        Rectangle::new(Point::new(0, 24), Size::new(70, 8))
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+            .draw(ctx.display)
+            .ok();
+        if bw > 0 {
+            Rectangle::new(Point::new(0, 24), Size::new(bw as u32, 8))
+                .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
+                .draw(ctx.display)
+                .ok();
+        }
+
+        // Bottom (y=32): "<rssi>dBm  <BUCKET>" (raw smoothed dBm + tier word). When
+        // LOST, show the reacquiring hint instead of a stale dBm.
+        let mut bot = Line::new();
+        if present {
+            let _ = write!(bot, "{}dBm {}", smoothed, label(proximity(smoothed)));
+        } else {
+            let _ = write!(bot, "reacquiring");
+        }
+        Text::with_baseline(bot.as_str(), Point::new(0, 32), style_5x8(), Baseline::Top)
+            .draw(ctx.display)
+            .ok();
+
+        ctx.display.flush().ok();
+    }
+}

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -118,6 +118,16 @@ mod snake;
 // espnow-only (needs the mesh) → zero code in default/wifi builds.
 #[cfg(feature = "espnow")]
 mod mesh_snake;
+// #58/#60 shared RSSI smoothing + proximity mapping for the roster-consuming screens.
+// espnow-only (consumes the mesh roster); no new frames / no radio traffic.
+#[cfg(feature = "espnow")]
+mod rssi;
+// #58 Marauder's Watch — every other node by name + a signal-strength glyph (roster RSSI).
+#[cfg(feature = "espnow")]
+mod watch;
+// #60 treasure-hunt — RSSI warmer/colder game over the roster.
+#[cfg(feature = "espnow")]
+mod hunt;
 // On-board sensors: chip die-temp (tsens) + battery ADC on GPIO4. Always on.
 mod sensors;
 // #43 display units (°F/°C · 12h/24h): the fleet-global `Units` config + wire parse.

--- a/rust/clock/src/rssi.rs
+++ b/rust/clock/src/rssi.rs
@@ -1,0 +1,174 @@
+//! Shared RSSI smoothing + proximity mapping for the roster-consuming screens
+//! (#58 Marauder's Watch, #60 treasure-hunt).
+//!
+//! App-layer, `espnow`-only: a pure consumer of the roster
+//! [`crate::net::mode::RadioManager`] already tracks — **no new frames, no radio
+//! traffic**. Both screens share ONE smoother + one proximity mapping so the two
+//! features read identically (a peer is exactly as "near" on the Watch as it is on
+//! the treasure-hunt).
+//!
+//! Raw ESP-NOW RSSI swings ±5–10 dB frame-to-frame from multipath, so an
+//! exponentially-weighted moving average (EWMA) is applied per peer before any
+//! bar/word/trend is derived. All integer math — no `f32` on the `no_std` path.
+
+/// EWMA factor as a /256 fixed-point numerator. α ≈ 0.30 → `77/256`. A new sample
+/// moves the smoothed value ~30% of the way toward it: fast enough to track a
+/// walking user, slow enough to kill the per-frame jitter.
+const ALPHA_NUM: i32 = 77;
+
+/// Max distinct peers tracked. The fleet is tiny; a linear scan over this is free.
+/// Independent of the roster cap (this only needs to exceed the live peer count).
+const CAP: usize = 16;
+
+/// Per-peer smoothed-RSSI table, keyed by node id. Fixed capacity, heap-free.
+pub struct RssiSmoother {
+    ids: [u8; CAP],
+    /// Smoothed dBm (integer). Valid for `..len`.
+    vals: [i32; CAP],
+    len: usize,
+}
+
+impl Default for RssiSmoother {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RssiSmoother {
+    pub const fn new() -> Self {
+        Self {
+            ids: [0; CAP],
+            vals: [0; CAP],
+            len: 0,
+        }
+    }
+
+    /// Fold a fresh raw RSSI for `id` into its EWMA and return the smoothed value.
+    /// First sight seeds with the raw sample (no ramp-in from zero). Table-full is
+    /// impossible for the real fleet; if it ever happened, an unknown id returns the
+    /// raw sample unsmoothed (still correct, just un-averaged).
+    pub fn update(&mut self, id: u8, raw: i32) -> i32 {
+        for i in 0..self.len {
+            if self.ids[i] == id {
+                // smoothed += (raw - smoothed) * α
+                self.vals[i] += (raw - self.vals[i]) * ALPHA_NUM / 256;
+                return self.vals[i];
+            }
+        }
+        if self.len < CAP {
+            self.ids[self.len] = id;
+            self.vals[self.len] = raw;
+            self.len += 1;
+        }
+        raw
+    }
+
+    /// The smoothed value for `id` without updating it, if seen. Used by the
+    /// treasure-hunt to read the target between updates.
+    pub fn get(&self, id: u8) -> Option<i32> {
+        for i in 0..self.len {
+            if self.ids[i] == id {
+                return Some(self.vals[i]);
+            }
+        }
+        None
+    }
+}
+
+/// Coarse nearness tiers from a (smoothed) RSSI. Thresholds per the #58 spec.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Proximity {
+    Here,
+    Near,
+    Room,
+    Far,
+    Gone,
+}
+
+/// Map a smoothed RSSI (dBm) to a nearness tier.
+pub fn proximity(rssi: i32) -> Proximity {
+    if rssi >= -45 {
+        Proximity::Here
+    } else if rssi >= -60 {
+        Proximity::Near
+    } else if rssi >= -75 {
+        Proximity::Room
+    } else if rssi >= -88 {
+        Proximity::Far
+    } else {
+        Proximity::Gone
+    }
+}
+
+/// Fixed-width (4 char) label for a tier — survives OLED clipping; padded so
+/// columns don't ragged.
+pub fn label(p: Proximity) -> &'static str {
+    match p {
+        Proximity::Here => "HERE",
+        Proximity::Near => "NEAR",
+        Proximity::Room => "ROOM",
+        Proximity::Far => "FAR ",
+        Proximity::Gone => "GONE",
+    }
+}
+
+/// Signal-bar count (0..=4) for a tier — the phone-style strength glyph on the
+/// Watch: `Here`=4 … `Gone`=0.
+pub fn tier_bars(p: Proximity) -> u8 {
+    match p {
+        Proximity::Here => 4,
+        Proximity::Near => 3,
+        Proximity::Room => 2,
+        Proximity::Far => 1,
+        Proximity::Gone => 0,
+    }
+}
+
+/// Fill length in pixels (0..=`width`) for a proximity bar: linear over the useful
+/// RSSI span `[-90, -35] → [0, width]`, clamped. Used by the treasure-hunt's hero
+/// bar.
+pub fn bar_px(rssi: i32, width: i32) -> i32 {
+    let clamped = rssi.clamp(-90, -35);
+    ((clamped + 90) * width) / 55
+}
+
+/// A tiny fixed-capacity, heap-free line builder for one 72 px OLED row (~12 chars
+/// in `FONT_5X8`). Overflow is silently dropped — every line built here is bounded
+/// and short by construction. Shared by the Watch + treasure-hunt renderers.
+pub struct Line {
+    buf: [u8; 24],
+    len: usize,
+}
+
+impl Default for Line {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Line {
+    pub fn new() -> Self {
+        Self { buf: [0; 24], len: 0 }
+    }
+    pub fn as_str(&self) -> &str {
+        core::str::from_utf8(&self.buf[..self.len]).unwrap_or("")
+    }
+}
+
+impl core::fmt::Write for Line {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        for &b in s.as_bytes() {
+            if self.len < self.buf.len() {
+                self.buf[self.len] = b;
+                self.len += 1;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// ASCII-safe left-truncate to `n` bytes (magical nouns are ASCII, so a byte
+/// boundary is a char boundary — never panics).
+pub fn clip(s: &str, n: usize) -> &str {
+    &s[..s.len().min(n)]
+}

--- a/rust/clock/src/watch.rs
+++ b/rust/clock/src/watch.rs
@@ -1,0 +1,174 @@
+//! Marauder's Watch (#58) — a presence screen: every OTHER node by name with a
+//! phone-style signal-strength glyph, from the ESP-NOW roster RSSI the mesh already
+//! tracks.
+//!
+//! `espnow`-only. A pure consumer of [`crate::net::mode::RadioManager::roster`] —
+//! **no new frames, no radio traffic**. RSSI is smoothed per peer (shared
+//! [`crate::rssi::RssiSmoother`]) so the bars don't strobe on multipath jitter.
+//! Peers render strongest-first (the roster is already RSSI-desc), so the nearest
+//! node is always on top. Paginates like Bench when there are more peers than rows.
+
+use core::fmt::Write;
+
+use embedded_graphics::{
+    mono_font::{ascii::FONT_5X8, MonoTextStyleBuilder},
+    pixelcolor::BinaryColor,
+    prelude::*,
+    primitives::{PrimitiveStyle, Rectangle},
+    text::{Baseline, Text},
+};
+
+use crate::app::{AppKind, Ctx, Plugin, Transition};
+use crate::input::Press;
+use crate::net::names::name_for_id;
+use crate::rssi::{clip, proximity, tier_bars, Line, RssiSmoother};
+
+/// Peer rows per page: a title row + 4 rows fills the 40 px height at 8 px pitch.
+const PEERS_PER_PAGE: usize = 4;
+
+/// Marauder's Watch state: the shared RSSI smoother + which page is showing.
+pub struct WatchState {
+    smoother: RssiSmoother,
+    page: u8,
+}
+
+impl Default for WatchState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WatchState {
+    pub fn new() -> Self {
+        Self {
+            smoother: RssiSmoother::new(),
+            page: 0,
+        }
+    }
+
+    /// Total pages = ⌈count / PEERS_PER_PAGE⌉, at least 1 (an empty roster still
+    /// shows the "no peers" page).
+    fn page_count(count: usize) -> usize {
+        count.div_ceil(PEERS_PER_PAGE).max(1)
+    }
+}
+
+fn text_style() -> embedded_graphics::mono_font::MonoTextStyle<'static, BinaryColor> {
+    MonoTextStyleBuilder::new()
+        .font(&FONT_5X8)
+        .text_color(BinaryColor::On)
+        .build()
+}
+
+/// Draw the 4-bar phone-style strength glyph at the right of a peer row: bar `i`
+/// (0..4) is filled iff `i < bars`, else outlined — increasing height, bottom-
+/// aligned to the row so it reads as signal strength at a glance.
+fn draw_signal<D>(display: &mut D, y: i32, bars: u8)
+where
+    D: DrawTarget<Color = BinaryColor>,
+{
+    let fill = PrimitiveStyle::with_fill(BinaryColor::On);
+    let outline = PrimitiveStyle::with_stroke(BinaryColor::On, 1);
+    for i in 0..4u8 {
+        let h = 2 + i as i32 * 2; // 2,4,6,8 px
+        let x = 46 + i as i32 * 6; // 46,52,58,64
+        let top = y + 8 - h;
+        let style = if i < bars { fill } else { outline };
+        Rectangle::new(Point::new(x, top), Size::new(4, h as u32))
+            .into_styled(style)
+            .draw(display)
+            .ok();
+    }
+}
+
+/// One peer row: noun (≤7, from the id) at x=0, then the signal glyph. Unknown-id
+/// peers show `?` (mirrors Bench).
+fn draw_peer_row<D>(display: &mut D, y: i32, id: u8, id_known: bool, bars: u8)
+where
+    D: DrawTarget<Color = BinaryColor>,
+{
+    let noun = if id_known { name_for_id(id).1 } else { "?" };
+    Text::with_baseline(clip(noun, 7), Point::new(0, y), text_style(), Baseline::Top)
+        .draw(display)
+        .ok();
+    draw_signal(display, y, bars);
+}
+
+/// The `p/N` page indicator, top-right (1-based). Shared shape with Bench.
+fn draw_page_tag<D>(display: &mut D, page: usize, n_pages: usize)
+where
+    D: DrawTarget<Color = BinaryColor>,
+{
+    let mut t = Line::new();
+    let _ = write!(t, "{}/{}", page, n_pages);
+    Text::with_baseline(t.as_str(), Point::new(57, 0), text_style(), Baseline::Top)
+        .draw(display)
+        .ok();
+}
+
+impl Plugin for WatchState {
+    fn on_button(&mut self, press: Press, ctx: &mut Ctx) -> Transition {
+        match press {
+            Press::Long => Transition::Switch(AppKind::Menu),
+            Press::Short => {
+                let count = match ctx.radio.as_deref() {
+                    Some(r) => r.roster(ctx.now_ms).count,
+                    None => 0,
+                };
+                let n_pages = Self::page_count(count);
+                self.page = ((self.page as usize + 1) % n_pages) as u8;
+                ctx.redraw = true;
+                Transition::Stay
+            }
+        }
+    }
+
+    fn update(&mut self, ctx: &mut Ctx) {
+        // Snapshot the roster (Copy) and release the radio borrow before drawing —
+        // the exact pattern Bench uses.
+        let roster = match ctx.radio.as_deref_mut() {
+            Some(r) => r.roster(ctx.now_ms),
+            None => return, // radio bring-up failed: render nothing (like Bench)
+        };
+
+        // Fold each fresh peer's RSSI into its per-id EWMA (only id-bearing peers —
+        // an unknown id can't be a stable smoother key).
+        for n in &roster.nodes[..roster.count] {
+            if n.id_known {
+                self.smoother.update(n.id, n.rssi);
+            }
+        }
+
+        let n_pages = Self::page_count(roster.count);
+        // The roster can shrink between ticks — clamp the page.
+        if self.page as usize >= n_pages {
+            self.page = 0;
+        }
+
+        ctx.display.clear(BinaryColor::Off).ok();
+
+        // Title: "WATCH <count>".
+        let mut hdr = Line::new();
+        let _ = write!(hdr, "WATCH {}", roster.count);
+        Text::with_baseline(hdr.as_str(), Point::new(0, 0), text_style(), Baseline::Top)
+            .draw(ctx.display)
+            .ok();
+        draw_page_tag(ctx.display, self.page as usize + 1, n_pages);
+
+        // Peer rows for this page.
+        let start = self.page as usize * PEERS_PER_PAGE;
+        for row in 0..PEERS_PER_PAGE {
+            let idx = start + row;
+            if idx >= roster.count {
+                break;
+            }
+            let n = &roster.nodes[idx];
+            // Prefer the smoothed value; fall back to the raw sample first-sight.
+            let rssi = self.smoother.get(n.id).unwrap_or(n.rssi);
+            let bars = tier_bars(proximity(rssi));
+            draw_peer_row(ctx.display, 8 + row as i32 * 8, n.id, n.id_known, bars);
+        }
+
+        ctx.display.flush().ok();
+    }
+}


### PR DESCRIPTION
## #58 Marauder's Watch + #60 treasure-hunt — roster-RSSI screens

Two new `espnow` screens built on ONE shared foundation (`src/rssi.rs`), per the wisp-58/wisp-60 design specs. Both are **pure consumers of `RadioManager::roster()`** — no new frames, no radio traffic, **zero net/mode.rs edits** (minimal rebase surface).

- **`src/rssi.rs`** — shared: per-id integer EWMA smoother (α≈0.3, no float on `no_std`), proximity buckets (HERE/NEAR/ROOM/FAR/GONE), bar + signal-tier helpers, a heap-free `Line`. Both screens read a peer identically.
- **`src/watch.rs` (#58)** — every other node by noun + a 4-bar phone-style signal glyph, strongest-first, paginated like Bench. Long→Menu, short→page.
- **`src/hunt.rs` (#60)** — warmer/colder game: short = cycle target, big trend hero (smoothed RSSI vs ~1.5 s ago, ±2 dB deadband), proximity bar, hold-to-confirm FOUND. Cheat/jitter-resistance = EWMA + deadband + FOUND hold.

Wired via the standard `app.rs` recipe (AppKind/App/enter/on_button/update/live_screen/as_wire/from_wire/REGISTRY/plugin_bit) + 3 `mod` lines. `plugin_bit → None` for both (always-shown; not yet #55-maskable — a partial mask predating them can't hide them), matching #45 Custom's same call. `Default` impls guard `new_without_default`. ASCII-only literals.

### Compile-proof — 4-profile serial build + clippy `-D warnings` (rebased onto b13ac88)

| Profile | clippy `-D warnings` | warnings |
|---|---|---|
| default | ✅ exit 0 | **0** |
| wifi | ✅ exit 0 | **0** |
| **espnow** | ✅ exit 0 · `cargo build --release` links (exit 0) | **0** |
| wled | ✅ exit 0 | **0** |
| cast (bonus) | ✅ exit 0 | **0** |

Serial (one cargo at a time, OOM rule), toolchain 1.96.1, target `riscv32imc-unknown-none-elf`. HW canary deferred to the morning per the unplugged-boards policy.
