### PR TITLE
feat(fw): #74 obs wave-2 STAGE 1 — DIAG link-quality/time-sync/LED fold-ins

### DIFF
--- a/rust/clock/src/led.rs
+++ b/rust/clock/src/led.rs
@@ -112,6 +112,18 @@ impl LedMode {
             _ => None,
         }
     }
+
+    /// #74: the wire token for the LED-mode readback (`led=<mode>:<state>` in the DIAG record).
+    /// Inverse of [`from_wire`]; matches luna's HA input_select options exactly.
+    ///
+    /// [`from_wire`]: LedMode::from_wire
+    pub fn to_wire(self) -> &'static str {
+        match self {
+            LedMode::Status => "status",
+            LedMode::On => "on",
+            LedMode::Off => "off",
+        }
+    }
 }
 
 /// Square-wave phase: true for the first half-period, false for the second.

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -899,6 +899,22 @@ fn main() -> ! {
             // cheap) so `hmin` tracks leak/pressure at finer resolution than the diag publish.
             if (now / 10_000) != ((now.saturating_sub(SUBTICK_MS as u64)) / 10_000) {
                 r.diag_sample_heap();
+                // #74 wave-2: mirror main-owned node state into the DIAG builder — the LED mode +
+                // its actual lit state (mode `Status` resolves via the live peer-link state), and
+                // the time-sync age + source. Read back by `diag_record` as led/tage/tsrc.
+                let ls = r.peer_led_state(now);
+                let led_on = match led_mode {
+                    led::LedMode::Status => ls.is_lit(now),
+                    led::LedMode::On => true,
+                    led::LedMode::Off => false,
+                };
+                let tage_s = (now.saturating_sub(anchor_ms) / 1000) as u32;
+                let tsrc = match time_source {
+                    app::TimeSource::NtpRoot => "ntp",
+                    app::TimeSource::Adopted(_) => "mesh",
+                    app::TimeSource::None => "none",
+                };
+                r.set_diag_extra(led_mode.to_wire(), led_on, tage_s, tsrc);
             }
             // #70/#49: a LEAF broadcasts its compact DIAG record on a SLOW ~60 s cadence (diag is
             // slow-moving — keep mesh airtime low), expedited by a BOOT-button press (rate-limited

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -411,6 +411,28 @@ impl DiagCounters {
     }
 }
 
+/// #74 obs wave-2: node state that lives in `main` (the LED mode + the clock), pushed into the
+/// RadioManager each cadence via `set_diag_extra` so BOTH diag builders (the leaf broadcast + the
+/// gateway flush) read one stored copy — `main` owns these, RadioManager only mirrors them for the
+/// DIAG record. `Copy`. Folds `led`/`tage`/`tsrc` onto the record (rtt/rx/tx come from `bench`).
+#[derive(Clone, Copy)]
+struct DiagExtra {
+    /// #74 item 6: commanded LED mode wire token ("status"/"on"/"off").
+    led_mode: &'static str,
+    /// #74 item 6: the LED's actual lit state right now (mode `Status` resolves via link state).
+    led_on: bool,
+    /// #74 item 8: seconds since the last time-sync (`(now - anchor)/1000`).
+    tage_s: u32,
+    /// #74 item 8: time source token ("ntp"/"mesh"/"none") — maps `TimeSource`.
+    tsrc: &'static str,
+}
+
+impl DiagExtra {
+    const fn new() -> Self {
+        Self { led_mode: "status", led_on: false, tage_s: 0, tsrc: "none" }
+    }
+}
+
 /// Tracks the two timestamps that define the peer link state. Monotonic ms
 /// (`Instant::now().duration_since_epoch().as_millis()`); 0 = "never seen".
 struct PeerTracker {
@@ -1470,6 +1492,8 @@ pub struct RadioManager {
     /// #70/#49 observability: this node's own live diag counters (min-heap watermark + BOOT-button
     /// press counters; #49 adds flush/verify counters). Folded into the DIAG record each cadence.
     diag: DiagCounters,
+    /// #74 obs wave-2: node state mirrored from `main` (LED mode + time-sync) for the DIAG record.
+    diag_extra: DiagExtra,
     /// #40 leaf-mesh-OTA: the LEAF receive state machine (verify-sig → signed-bounds →
     /// window reassembly → readback verify → activate). Idle except during a transfer.
     /// Unused on a gateway (which drives the RELAY side via `run_leaf_ota_relay`).
@@ -1627,6 +1651,7 @@ impl RadioManager {
             scan_cache: crate::net::wifi::RelayCache::new(),
             own_scan: None,
             diag: DiagCounters::new(),
+            diag_extra: DiagExtra::new(),
             ota_leaf: crate::ota_mesh::OtaLeafSession::new(),
             #[cfg(feature = "wled")]
             wled_seq: 0,
@@ -2243,6 +2268,13 @@ impl RadioManager {
         }
     }
 
+    /// #74: mirror `main`-owned node state (LED mode + its lit state, time-sync age + source) into
+    /// the RadioManager so the DIAG record can fold in `led`/`tage`/`tsrc`. `main` calls this on the
+    /// ~10 s diag-sample tick; both diag builders (leaf broadcast + gateway flush) read the copy.
+    pub fn set_diag_extra(&mut self, led_mode: &'static str, led_on: bool, tage_s: u32, tsrc: &'static str) {
+        self.diag_extra = DiagExtra { led_mode, led_on, tage_s, tsrc };
+    }
+
     /// #70/#49: build this node's compact DIAG record for retained `smol/<id>/diag`. Format matches
     /// luna's DEPLOYED HA parser (PR #81): literal `DIAG` first field, then `key=value` pairs
     /// PIPE-separated, order-independent, forward-compatible (HA picks by key, unknown keys ignored,
@@ -2264,8 +2296,16 @@ impl RadioManager {
         let heap = esp_alloc::HEAP.free();
         let (vok, vfl) = self.ota_leaf.verify_counts();
         let loss = self.bench.loss_pct();
+        // #74 wave-2 fold-ins: mesh RTT + cumulative rx/tx (from `bench`), LED mode:state + time
+        // age/source (mirrored from `main` via `set_diag_extra`). `loss`/`rtt`/`rx`/`tx` = the #49
+        // link-quality set; `led`/`tage`/`tsrc` = items 6/8. (`toff`/`cfg` deferred — see luna Q.)
+        let rtt = self.bench.last_rtt_ms.unwrap_or(0);
+        let rx = self.bench.rx_count;
+        let tx = self.bench.tx_count;
+        let e = self.diag_extra;
+        let led_state = if e.led_on { "on" } else { "off" };
         alloc::format!(
-            "DIAG|slot={}|rst={}|boot={}|ota={}|up={}|heap={}|hmin={}|btn={}|btnl={}|fok={}|ffl={}|vok={}|vfl={}|loss={}",
+            "DIAG|slot={}|rst={}|boot={}|ota={}|up={}|heap={}|hmin={}|btn={}|btnl={}|fok={}|ffl={}|vok={}|vfl={}|loss={}|rtt={}|rx={}|tx={}|led={}:{}|tage={}|tsrc={}",
             d.boot_slot,
             d.reset_reason,
             d.boot_count,
@@ -2280,6 +2320,13 @@ impl RadioManager {
             vok,
             vfl,
             loss,
+            rtt,
+            rx,
+            tx,
+            e.led_mode,
+            led_state,
+            e.tage_s,
+            e.tsrc,
         )
     }
 

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1185,9 +1185,11 @@ impl CfgCache {
 /// #70/#71 observability: max bytes of a relayed DIAG or SCAN record value. Larger than
 /// `CFG_VALUE_MAX` (16, sized for a screen string) because a diag/scan record is a multi-field
 /// line (~130 B) — but still well under the ~250 B ESP-NOW frame budget once the 12 B frame
-/// prefix + 3 B id are added.
+/// prefix + 3 B id are added. #74 wave-2 folds ~7 more keys onto the DIAG record (led/rtt/rx/tx/
+/// tage/tsrc/loss), so 224 — the ESP-NOW frame is then 12 (prefix) + 3 (id) + 224 = 239 B, still
+/// under the ~250 B ESP-NOW ceiling with margin.
 #[cfg(feature = "wifi")]
-pub const RELAY_VALUE_MAX: usize = 200;
+pub const RELAY_VALUE_MAX: usize = 224;
 
 #[cfg(feature = "wifi")]
 const RELAY_CACHE_CAP: usize = 12;


### PR DESCRIPTION
## #74 obs wave-2 — STAGE 1 (DIAG fold-ins). Partial — does NOT close #74.

Per hypnos's capacity split: this ships the DIAG-record fold-ins; stages 2-4 (cfg=, peers-from-every-node, display mirror, OTA-history ring) are a **fresh continuation** — handoff in `scratch/session-596d190f/vesper-74-continuation-handoff.md`.

Conforms exactly to luna's deployed #74 parsers (merged #81; `luna-74-diag-sensors.yaml` + `luna-74-ha-staging.md`) — all sensors degrade-safe, light up on emit.

### Adds to the retained `smol/<id>/diag` record (order-independent, pipe-keyed):
- **item 7 link-quality** (from Bench): `rtt=<ms>`, `rx=<n>` `tx=<n>` (cumulative, total_increasing), + existing `loss=<pct>`.
- **item 6 LED readback** (→ #48): `led=<mode>:<state>` (status/on/off : on/off).
- **item 8 time-sync** (from the clock): `tage=<s>` (since last sync), `tsrc=<ntp|mesh|none>` (TimeSource map).

### Plumbing
`led`/`tage`/`tsrc` live in `main` → pushed into RadioManager each ~10 s tick via `set_diag_extra` (Copy `DiagExtra`); both diag builders read the one copy. `rtt`/`rx`/`tx` read `bench` directly. `RELAY_VALUE_MAX` 200→224 for the longer record (ESP-NOW frame 239 B < 250 ceiling).

### Deferred / staged (continuation handoff)
- **cfg=** config-drift STRING (luna's priority #2, marquee item) — `<screen>:<page>,<led>,<plugins4hex>,<units>`. All source fields located; first item in the handoff.
- **peers-from-every-node** (RSSI matrix, rides existing #27 `/peers` — leaves must uplink their roster).
- **display mirror** `smol/<id>/display` + **OTA-history ring** `smol/<id>/ota/history`.
- **toff=** — skipped per luna (last-sync-correction; her sensor degrade-safe).

### Verification
All 4 profiles `cargo check` clean; 0 new warnings; cfg-gated (default build byte-unaffected). Full 4-profile release build + espnow `clippy -D warnings` pending the queued serial window. HW validation → morning canary.

Refs #74 #49 #48 #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)