### PR TITLE
perf(fw): #69 IRAM placement for the hot leaf-OTA RX/NAK path

### DIFF
--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -124,6 +124,10 @@ pub enum OtaFrame<'a> {
 
 /// Parse one #40 OTA frame. Returns `None` on ANY malformed input (never panics,
 /// never indexes past the slice) — the caller treats `None` as "not an OTA frame".
+// #69 IRAM: on the per-chunk RX hot path (parsed for every OTAD during a leaf mesh-OTA). Placed in
+// IRAM so it runs at full speed right after each flash write invalidates the XIP cache — fewer
+// stalled drain iterations → fewer dropped chunks → fewer NAK repairs. Small + pure → cheap IRAM.
+#[esp_hal::ram]
 pub fn parse_ota_frame(data: &[u8]) -> Option<OtaFrame<'_>> {
     if let Some(rest) = data.strip_prefix(OTAM_PREFIX) {
         // target[3] session[2] M_len[1] M[M_len] sig[64]
@@ -233,6 +237,9 @@ pub fn encode_otad(target_id: u8, session: u16, seq: u16, payload: &[u8], out: &
 }
 
 /// Encode an `OTAN`. `bitmap` is truncated to [`OTAN_BITMAP_BYTES`]; returns the length.
+// #69 IRAM: the NAK-send hot path — built every time a window has gaps / needs a re-ack during the
+// flash-write phase. IRAM-resident so it runs without a post-write XIP-refill stall. Small + pure.
+#[esp_hal::ram]
 pub fn encode_otan(origin_id: u8, session: u16, window_base: u16, bitmap: &[u8], out: &mut [u8]) -> usize {
     let blen = bitmap.len().min(OTAN_BITMAP_BYTES);
     let mut n = 0;
@@ -282,6 +289,8 @@ pub fn total_chunks(size: u32) -> u32 {
 
 /// "All chunks present" bitmap mask for a window of `len` chunks (`len` ≤ 64). Shared by
 /// the leaf (completeness check) and the gateway (retransmit set).
+// #69 IRAM: tiny + on the per-chunk completeness check inside `on_data`. Negligible IRAM cost.
+#[esp_hal::ram]
 pub fn window_full_mask(len: u32) -> u64 {
     if len >= 64 {
         u64::MAX
@@ -595,6 +604,13 @@ impl OtaLeafSession {
     // on the OTA receive path; bundling into a struct would just relocate the fields
     // without simplifying the call site. Lint-only allow — no restructuring the hot path.
     #[allow(clippy::too_many_arguments)]
+    // #69 IRAM: THE per-chunk hot path — bounds-check + window-buffer copy + bitmap track for every
+    // OTAD, and the once-per-window flash flush. Placed in IRAM so the per-chunk RX work runs at
+    // full speed immediately after each flash write cold-invalidates the XIP cache (the stall the
+    // #40 canary saw as 1721 NAK repairs). The `feed_window` flash write it calls owns its own
+    // cache-off window (unchanged). Largest of the #69 placements — first to back off if a profile
+    // overflows the IRAM region.
+    #[esp_hal::ram]
     pub fn on_data(
         &mut self,
         target: u8,


### PR DESCRIPTION
Cuts chunk loss during leaf mesh-OTA flash writes by placing the small, hottest RX/NAK fns in IRAM.

## Why
The C3 does **zero** explicit IRAM placement — all app code is XIP-from-flash. Every flash write disables the XIP cache, stalling flash-resident code including the loop that drains ESP-NOW RX. The #40 canary (2026-07-11) needed **1721 NAK repairs** over ~4341 chunks, consistent with loss concentrated in the write phase.

## What
`#[esp_hal::ram]` on the **small** leaf-OTA receive/NAK hot path so it runs at full speed right after each flash write cold-invalidates the XIP cache:

| fn (ota_mesh.rs) | role | size |
|---|---|---|
| `OtaLeafSession::on_data` | per-chunk bounds + window-buffer + bitmap; once/window flash flush | 676 B |
| `parse_ota_frame` | parses every inbound OTAD | 470 B |
| `encode_otan` | builds the windowed NAK | 234 B |
| `window_full_mask` | per-chunk completeness check | 76 B |

**IRAM added ≈ 1.4 KB.** App `.rwtext` = 3.5 KB atop esp-wifi's 29.5 KB — comfortable region headroom.

## IRAM budget / LINK gate (the #69 gotcha)
`ota_mesh` is **espnow-only**, so default/wifi carry no IRAM change (link unchanged); espnow + wled carry the placements.

- **4-profile build ALL LINK** (no region overflow): `default` ✅ · `wifi` ✅ · `espnow` ✅ · `wled` ✅.
- **espnow `cargo clippy --release --features espnow -- -D warnings` = 0** ✅.

**← oracle: IRAM-budget/link scrutiny requested** — headroom confirmed (all link; ~1.4 KB app IRAM added).

## Deliberately conservative (measure-first)
- The flash write itself (`feed_window`) keeps its own cache-off window — unchanged.
- `bitmap_to_u64` is gateway-side (decodes leaf NAKs, not on the leaf write-stall path) — skipped.
- `handle_ota_frame` / the `service()` dispatch are follow-up candidates **if** the canary shows codec-only placement is insufficient.

NOT a #40 correctness change (NAK repair already completes the transfer — this cuts the repair *count*). **HW measurement (chunk-gap with/without) deferred to the morning consolidated canary.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)