### PR TITLE
fix(ha): canary follow-ups — re-land #49/#55, #52 qos:1, #57 bit-7 (flap-tune dropped)

### DIFF
--- a/ha/dashboard/build_control_room.py
+++ b/ha/dashboard/build_control_room.py
@@ -84,7 +84,8 @@ def device_card(nid):
 
 # ---------- #55 plugin visibility: compact toggle chips (fill = shown in boot menu) ----------
 PLUGS=[("clock","mdi:clock-outline"),("snake","mdi:snake"),("bench","mdi:test-tube"),("batt","mdi:battery"),
-       ("grid","mdi:transmission-tower"),("wled","mdi:led-strip-variant"),("about","mdi:information-outline")]
+       ("grid","mdi:transmission-tower"),("wled","mdi:led-strip-variant"),("about","mdi:information-outline"),
+       ("familiar","mdi:paw")]   # #57 bit-7 — Familiar screen toggle (all-on now composes 00FF)
 def plugin_chips(nid, present):
     chips=[{"type":"template","content":"plugins","icon":"mdi:puzzle-outline","icon_color":"grey"}]  # label chip
     for name,icon in PLUGS:

--- a/ha/dashboard/smol_control_room.yaml
+++ b/ha/dashboard/smol_control_room.yaml
@@ -72,7 +72,7 @@ cards:
 
         '
 - type: picture
-  image: /local/luna-cards/smol-topology.svg?v=c8dbff72
+  image: /local/luna-cards/smol-topology.svg?v=4cf1878d
   view_layout:
     grid-column: span 7
   card_mod:
@@ -393,6 +393,12 @@ cards:
       icon_color: '{{ ''green'' if is_state(''input_boolean.smol_7_plugin_about'',''on'') else ''disabled'' }}'
       tap_action:
         action: toggle
+    - type: template
+      entity: input_boolean.smol_7_plugin_familiar
+      icon: mdi:paw
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_7_plugin_familiar'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
     card_mod:
       style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;padding:6px 8px 4px;background:var(--card-background-color);}
   - type: entities
@@ -592,6 +598,12 @@ cards:
       icon_color: '{{ ''green'' if is_state(''input_boolean.smol_8_plugin_about'',''on'') else ''disabled'' }}'
       tap_action:
         action: toggle
+    - type: template
+      entity: input_boolean.smol_8_plugin_familiar
+      icon: mdi:paw
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_8_plugin_familiar'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
     card_mod:
       style: ha-card{border-radius:0;border-top:none;border-bottom:none;margin-top:-1px;padding:6px 8px 4px;background:var(--card-background-color);}
   - type: entities
@@ -789,6 +801,12 @@ cards:
       entity: input_boolean.smol_9_plugin_about
       icon: mdi:information-outline
       icon_color: '{{ ''green'' if is_state(''input_boolean.smol_9_plugin_about'',''on'') else ''disabled'' }}'
+      tap_action:
+        action: toggle
+    - type: template
+      entity: input_boolean.smol_9_plugin_familiar
+      icon: mdi:paw
+      icon_color: '{{ ''green'' if is_state(''input_boolean.smol_9_plugin_familiar'',''on'') else ''disabled'' }}'
       tap_action:
         action: toggle
     card_mod:

--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -1913,7 +1913,10 @@ automation:
         data:
           topic: "smol/{{ trigger.entity_id.split('.')[1].split('_')[1] }}/cmd/reset"
           retain: false
-          qos: 0
+          qos: 1     # #52 transient cmd — qos:1 REQUIRED: the gateway drops qos:0 (~5% loss →
+          # unreliable reboot). retain:false stays (a retained reset = reboot-loop); qos:1 gives
+          # at-least-once delivery of the momentary RESET. (Retained config topics tolerate qos:0
+          # via reconnect-redelivery; only TRANSIENT cmd/ needs qos:1 — canary finding 2026-07-12.)
           payload: "RESET"
 
   - id: smol_all_reboot_fanout

--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -1208,6 +1208,129 @@ mqtt:
         {% set ns = namespace(v='0') %}
         {% for kv in value.split('|') %}{% if kv.startswith('btnl=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}
         {{ ns.v | int(0) }}
+    # --- #49 DIAG counters (vesper folds into the same smol/<id>/diag record) —
+    # flush ok/fail + OTA-verify ok/fail. Same key-picker; forward-compat (parser
+    # already ignores unknown keys). total_increasing; degrade-safe (0 until fw). ---
+    - name: "smol 7 flush ok"
+      unique_id: smol_7_flush_ok_mirror
+      state_topic: "smol/7/diag"
+      entity_category: diagnostic
+      state_class: total_increasing
+      icon: "mdi:check-network-outline"
+      value_template: >-
+        {% set ns = namespace(v='0') %}
+        {% for kv in value.split('|') %}{% if kv.startswith('fok=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}
+        {{ ns.v | int(0) }}
+    - name: "smol 7 flush fail"
+      unique_id: smol_7_flush_fail_mirror
+      state_topic: "smol/7/diag"
+      entity_category: diagnostic
+      state_class: total_increasing
+      icon: "mdi:close-network-outline"
+      value_template: >-
+        {% set ns = namespace(v='0') %}
+        {% for kv in value.split('|') %}{% if kv.startswith('ffl=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}
+        {{ ns.v | int(0) }}
+    - name: "smol 7 verify ok"
+      unique_id: smol_7_verify_ok_mirror
+      state_topic: "smol/7/diag"
+      entity_category: diagnostic
+      state_class: total_increasing
+      icon: "mdi:shield-check-outline"
+      value_template: >-
+        {% set ns = namespace(v='0') %}
+        {% for kv in value.split('|') %}{% if kv.startswith('vok=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}
+        {{ ns.v | int(0) }}
+    - name: "smol 7 verify fail"
+      unique_id: smol_7_verify_fail_mirror
+      state_topic: "smol/7/diag"
+      entity_category: diagnostic
+      state_class: total_increasing
+      icon: "mdi:shield-alert-outline"
+      value_template: >-
+        {% set ns = namespace(v='0') %}
+        {% for kv in value.split('|') %}{% if kv.startswith('vfl=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}
+        {{ ns.v | int(0) }}
+    - name: "smol 8 flush ok"
+      unique_id: smol_8_flush_ok_mirror
+      state_topic: "smol/8/diag"
+      entity_category: diagnostic
+      state_class: total_increasing
+      icon: "mdi:check-network-outline"
+      value_template: >-
+        {% set ns = namespace(v='0') %}
+        {% for kv in value.split('|') %}{% if kv.startswith('fok=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}
+        {{ ns.v | int(0) }}
+    - name: "smol 8 flush fail"
+      unique_id: smol_8_flush_fail_mirror
+      state_topic: "smol/8/diag"
+      entity_category: diagnostic
+      state_class: total_increasing
+      icon: "mdi:close-network-outline"
+      value_template: >-
+        {% set ns = namespace(v='0') %}
+        {% for kv in value.split('|') %}{% if kv.startswith('ffl=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}
+        {{ ns.v | int(0) }}
+    - name: "smol 8 verify ok"
+      unique_id: smol_8_verify_ok_mirror
+      state_topic: "smol/8/diag"
+      entity_category: diagnostic
+      state_class: total_increasing
+      icon: "mdi:shield-check-outline"
+      value_template: >-
+        {% set ns = namespace(v='0') %}
+        {% for kv in value.split('|') %}{% if kv.startswith('vok=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}
+        {{ ns.v | int(0) }}
+    - name: "smol 8 verify fail"
+      unique_id: smol_8_verify_fail_mirror
+      state_topic: "smol/8/diag"
+      entity_category: diagnostic
+      state_class: total_increasing
+      icon: "mdi:shield-alert-outline"
+      value_template: >-
+        {% set ns = namespace(v='0') %}
+        {% for kv in value.split('|') %}{% if kv.startswith('vfl=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}
+        {{ ns.v | int(0) }}
+    - name: "smol 9 flush ok"
+      unique_id: smol_9_flush_ok_mirror
+      state_topic: "smol/9/diag"
+      entity_category: diagnostic
+      state_class: total_increasing
+      icon: "mdi:check-network-outline"
+      value_template: >-
+        {% set ns = namespace(v='0') %}
+        {% for kv in value.split('|') %}{% if kv.startswith('fok=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}
+        {{ ns.v | int(0) }}
+    - name: "smol 9 flush fail"
+      unique_id: smol_9_flush_fail_mirror
+      state_topic: "smol/9/diag"
+      entity_category: diagnostic
+      state_class: total_increasing
+      icon: "mdi:close-network-outline"
+      value_template: >-
+        {% set ns = namespace(v='0') %}
+        {% for kv in value.split('|') %}{% if kv.startswith('ffl=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}
+        {{ ns.v | int(0) }}
+    - name: "smol 9 verify ok"
+      unique_id: smol_9_verify_ok_mirror
+      state_topic: "smol/9/diag"
+      entity_category: diagnostic
+      state_class: total_increasing
+      icon: "mdi:shield-check-outline"
+      value_template: >-
+        {% set ns = namespace(v='0') %}
+        {% for kv in value.split('|') %}{% if kv.startswith('vok=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}
+        {{ ns.v | int(0) }}
+    - name: "smol 9 verify fail"
+      unique_id: smol_9_verify_fail_mirror
+      state_topic: "smol/9/diag"
+      entity_category: diagnostic
+      state_class: total_increasing
+      icon: "mdi:shield-alert-outline"
+      value_template: >-
+        {% set ns = namespace(v='0') %}
+        {% for kv in value.split('|') %}{% if kv.startswith('vfl=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}
+        {{ ns.v | int(0) }}
 
 # =====================================================================
 # MESH TOPOLOGY derived sensors (issue #27) — HELD; back the topology card.

--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -175,6 +175,10 @@ input_boolean:
     name: "smol 7 · About visible"
     icon: "mdi:information-outline"
     initial: true
+  smol_7_plugin_familiar:
+    name: "smol 7 · Familiar visible"
+    icon: "mdi:paw"
+    initial: true
   smol_8_plugin_clock:
     name: "smol 8 · Clock visible"
     icon: "mdi:clock-outline"
@@ -203,6 +207,10 @@ input_boolean:
     name: "smol 8 · About visible"
     icon: "mdi:information-outline"
     initial: true
+  smol_8_plugin_familiar:
+    name: "smol 8 · Familiar visible"
+    icon: "mdi:paw"
+    initial: true
   smol_9_plugin_clock:
     name: "smol 9 · Clock visible"
     icon: "mdi:clock-outline"
@@ -230,6 +238,10 @@ input_boolean:
   smol_9_plugin_about:
     name: "smol 9 · About visible"
     icon: "mdi:information-outline"
+    initial: true
+  smol_9_plugin_familiar:
+    name: "smol 9 · Familiar visible"
+    icon: "mdi:paw"
     initial: true
 
 # =====================================================================
@@ -496,7 +508,7 @@ mqtt:
       value_template: "{{ value.split('|')[1] if '|' in value else value }}"
       json_attributes_topic: "smol/7/status"
       json_attributes_template: "{% set p = value.split('|') %}{{ ({'build': p[2]} if p | length >= 3 else {}) | tojson }}"
-      expire_after: 90   # #68: STAT is cache-republished every flush (F6-gated 45s); ages out
+      expire_after: 180  # #68/#94 flap-tune: bumped 90→180 = 2x the ~90s status-republish cadence measured at the all-192 canary (90 sat on the edge → id7/8/9 online flapped). Ages out
       # when the gateway stops refreshing a dead leaf. Drives binary_sensor.smol_<id>_online.
       icon: "mdi:chip"
     - name: "smol 8 screen"
@@ -505,7 +517,7 @@ mqtt:
       value_template: "{{ value.split('|')[1] if '|' in value else value }}"
       json_attributes_topic: "smol/8/status"
       json_attributes_template: "{% set p = value.split('|') %}{{ ({'build': p[2]} if p | length >= 3 else {}) | tojson }}"
-      expire_after: 90   # #68: STAT is cache-republished every flush (F6-gated 45s); ages out
+      expire_after: 180  # #68/#94 flap-tune: bumped 90→180 = 2x the ~90s status-republish cadence measured at the all-192 canary (90 sat on the edge → id7/8/9 online flapped). Ages out
       # when the gateway stops refreshing a dead leaf. Drives binary_sensor.smol_<id>_online.
       icon: "mdi:chip"
     - name: "smol 9 screen"
@@ -514,7 +526,7 @@ mqtt:
       value_template: "{{ value.split('|')[1] if '|' in value else value }}"
       json_attributes_topic: "smol/9/status"
       json_attributes_template: "{% set p = value.split('|') %}{{ ({'build': p[2]} if p | length >= 3 else {}) | tojson }}"
-      expire_after: 90   # #68: STAT is cache-republished every flush (F6-gated 45s); ages out
+      expire_after: 180  # #68/#94 flap-tune: bumped 90→180 = 2x the ~90s status-republish cadence measured at the all-192 canary (90 sat on the edge → id7/8/9 online flapped). Ages out
       # when the gateway stops refreshing a dead leaf. Drives binary_sensor.smol_<id>_online.
       icon: "mdi:chip"
     # --- #40 running BUILD# as a first-class device-merged value (JP ask 2026-07-11) ---
@@ -2202,6 +2214,7 @@ automation:
           - input_boolean.smol_7_plugin_grid
           - input_boolean.smol_7_plugin_wled
           - input_boolean.smol_7_plugin_about
+          - input_boolean.smol_7_plugin_familiar
           - input_boolean.smol_8_plugin_clock
           - input_boolean.smol_8_plugin_snake
           - input_boolean.smol_8_plugin_bench
@@ -2209,6 +2222,7 @@ automation:
           - input_boolean.smol_8_plugin_grid
           - input_boolean.smol_8_plugin_wled
           - input_boolean.smol_8_plugin_about
+          - input_boolean.smol_8_plugin_familiar
           - input_boolean.smol_9_plugin_clock
           - input_boolean.smol_9_plugin_snake
           - input_boolean.smol_9_plugin_bench
@@ -2216,6 +2230,7 @@ automation:
           - input_boolean.smol_9_plugin_grid
           - input_boolean.smol_9_plugin_wled
           - input_boolean.smol_9_plugin_about
+          - input_boolean.smol_9_plugin_familiar
       - platform: homeassistant
         event: start
     action:
@@ -2226,7 +2241,7 @@ automation:
                 n: "{{ repeat.item }}"
                 mask: >-
                   {% set b = namespace(m=0) %}
-                  {% for name, val in [['clock',1],['snake',2],['bench',4],['batt',8],['grid',16],['wled',32],['about',64]] %}
+                  {% for name, val in [['clock',1],['snake',2],['bench',4],['batt',8],['grid',16],['wled',32],['about',64],['familiar',128]] %}
                   {% if is_state('input_boolean.smol_' ~ n ~ '_plugin_' ~ name, 'on') %}{% set b.m = b.m + val %}{% endif %}
                   {% endfor %}
                   {{ '%04X' | format(b.m) }}

--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -508,7 +508,7 @@ mqtt:
       value_template: "{{ value.split('|')[1] if '|' in value else value }}"
       json_attributes_topic: "smol/7/status"
       json_attributes_template: "{% set p = value.split('|') %}{{ ({'build': p[2]} if p | length >= 3 else {}) | tojson }}"
-      expire_after: 180  # #68/#94 flap-tune: bumped 90→180 = 2x the ~90s status-republish cadence measured at the all-192 canary (90 sat on the edge → id7/8/9 online flapped). Ages out
+      expire_after: 90   # #68/#94: online source. Flap-tune (90→180) was CONSIDERED then DROPPED — the all-192 flap was a mesh-SETTLING artifact (cadence briefly ~90s); at healthy steady-state status republishes ~11s, far under 90, so online is stable. F6-gated republish, ages out
       # when the gateway stops refreshing a dead leaf. Drives binary_sensor.smol_<id>_online.
       icon: "mdi:chip"
     - name: "smol 8 screen"
@@ -517,7 +517,7 @@ mqtt:
       value_template: "{{ value.split('|')[1] if '|' in value else value }}"
       json_attributes_topic: "smol/8/status"
       json_attributes_template: "{% set p = value.split('|') %}{{ ({'build': p[2]} if p | length >= 3 else {}) | tojson }}"
-      expire_after: 180  # #68/#94 flap-tune: bumped 90→180 = 2x the ~90s status-republish cadence measured at the all-192 canary (90 sat on the edge → id7/8/9 online flapped). Ages out
+      expire_after: 90   # #68/#94: online source. Flap-tune (90→180) was CONSIDERED then DROPPED — the all-192 flap was a mesh-SETTLING artifact (cadence briefly ~90s); at healthy steady-state status republishes ~11s, far under 90, so online is stable. F6-gated republish, ages out
       # when the gateway stops refreshing a dead leaf. Drives binary_sensor.smol_<id>_online.
       icon: "mdi:chip"
     - name: "smol 9 screen"
@@ -526,7 +526,7 @@ mqtt:
       value_template: "{{ value.split('|')[1] if '|' in value else value }}"
       json_attributes_topic: "smol/9/status"
       json_attributes_template: "{% set p = value.split('|') %}{{ ({'build': p[2]} if p | length >= 3 else {}) | tojson }}"
-      expire_after: 180  # #68/#94 flap-tune: bumped 90→180 = 2x the ~90s status-republish cadence measured at the all-192 canary (90 sat on the edge → id7/8/9 online flapped). Ages out
+      expire_after: 90   # #68/#94: online source. Flap-tune (90→180) was CONSIDERED then DROPPED — the all-192 flap was a mesh-SETTLING artifact (cadence briefly ~90s); at healthy steady-state status republishes ~11s, far under 90, so online is stable. F6-gated republish, ages out
       # when the gateway stops refreshing a dead leaf. Drives binary_sensor.smol_<id>_online.
       icon: "mdi:chip"
     # --- #40 running BUILD# as a first-class device-merged value (JP ask 2026-07-11) ---

--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -144,6 +144,93 @@ input_boolean:
   smol_display_override:
     name: "smol display override"
     icon: "mdi:pencil"
+  # --- #55 plugin visibility (per-node) — one input_boolean per maskable AppKind. The compose
+  # automation ORs the set bits (stable bit0..6) → retained smol/<id>/config/plugins = 4-hex u16.
+  # Default ALL ON (=007F); fw: 0000/bad/empty → keep-all (safety), masked live screen → board default.
+  smol_7_plugin_clock:
+    name: "smol 7 · Clock visible"
+    icon: "mdi:clock-outline"
+    initial: true
+  smol_7_plugin_snake:
+    name: "smol 7 · Snake visible"
+    icon: "mdi:snake"
+    initial: true
+  smol_7_plugin_bench:
+    name: "smol 7 · Bench visible"
+    icon: "mdi:test-tube"
+    initial: true
+  smol_7_plugin_batt:
+    name: "smol 7 · Batt visible"
+    icon: "mdi:battery"
+    initial: true
+  smol_7_plugin_grid:
+    name: "smol 7 · Grid visible"
+    icon: "mdi:transmission-tower"
+    initial: true
+  smol_7_plugin_wled:
+    name: "smol 7 · Wled visible"
+    icon: "mdi:led-strip-variant"
+    initial: true
+  smol_7_plugin_about:
+    name: "smol 7 · About visible"
+    icon: "mdi:information-outline"
+    initial: true
+  smol_8_plugin_clock:
+    name: "smol 8 · Clock visible"
+    icon: "mdi:clock-outline"
+    initial: true
+  smol_8_plugin_snake:
+    name: "smol 8 · Snake visible"
+    icon: "mdi:snake"
+    initial: true
+  smol_8_plugin_bench:
+    name: "smol 8 · Bench visible"
+    icon: "mdi:test-tube"
+    initial: true
+  smol_8_plugin_batt:
+    name: "smol 8 · Batt visible"
+    icon: "mdi:battery"
+    initial: true
+  smol_8_plugin_grid:
+    name: "smol 8 · Grid visible"
+    icon: "mdi:transmission-tower"
+    initial: true
+  smol_8_plugin_wled:
+    name: "smol 8 · Wled visible"
+    icon: "mdi:led-strip-variant"
+    initial: true
+  smol_8_plugin_about:
+    name: "smol 8 · About visible"
+    icon: "mdi:information-outline"
+    initial: true
+  smol_9_plugin_clock:
+    name: "smol 9 · Clock visible"
+    icon: "mdi:clock-outline"
+    initial: true
+  smol_9_plugin_snake:
+    name: "smol 9 · Snake visible"
+    icon: "mdi:snake"
+    initial: true
+  smol_9_plugin_bench:
+    name: "smol 9 · Bench visible"
+    icon: "mdi:test-tube"
+    initial: true
+  smol_9_plugin_batt:
+    name: "smol 9 · Batt visible"
+    icon: "mdi:battery"
+    initial: true
+  smol_9_plugin_grid:
+    name: "smol 9 · Grid visible"
+    icon: "mdi:transmission-tower"
+    initial: true
+  smol_9_plugin_wled:
+    name: "smol 9 · Wled visible"
+    icon: "mdi:led-strip-variant"
+    initial: true
+  smol_9_plugin_about:
+    name: "smol 9 · About visible"
+    icon: "mdi:information-outline"
+    initial: true
 
 # =====================================================================
 # KEYED CFG RELAY (issue #56) — the ONE wire that carries ALL per-node config
@@ -357,6 +444,19 @@ mqtt:
       icon: "mdi:card-text-outline"
       value_template: >-
         {% set p = value.split('|', 1) %}{% if p | length > 1 and p[1] %}{{ p[1].split(';')[0][2:] }}{% else %}(none){% endif %}
+    # --- #55 plugin-mask mirror (read back the retained hex the compose published) ---
+    - name: "smol 7 plugins"
+      unique_id: smol_7_plugins_mirror
+      state_topic: "smol/7/config/plugins"
+      icon: "mdi:puzzle-outline"
+    - name: "smol 8 plugins"
+      unique_id: smol_8_plugins_mirror
+      state_topic: "smol/8/config/plugins"
+      icon: "mdi:puzzle-outline"
+    - name: "smol 9 plugins"
+      unique_id: smol_9_plugins_mirror
+      state_topic: "smol/9/config/plugins"
+      icon: "mdi:puzzle-outline"
     # --- #43 display units (GLOBAL) — mirror of the retained smol/config/units ---
     - name: "smol units"
       unique_id: smol_units_mirror
@@ -2086,3 +2186,53 @@ automation:
                 retain: true
                 qos: 0
                 payload: "{{ states('sensor.smol_' ~ repeat.item ~ '_custom_lay') }}"
+
+  # --- #55 publish per-node plugin visibility mask (retained → smol/<id>/config/plugins) ---
+  - id: smol_publish_plugins
+    alias: "smol: publish per-node plugin visibility mask (retained, #55)"
+    mode: single
+    max_exceeded: silent
+    trigger:
+      - platform: state
+        entity_id:
+          - input_boolean.smol_7_plugin_clock
+          - input_boolean.smol_7_plugin_snake
+          - input_boolean.smol_7_plugin_bench
+          - input_boolean.smol_7_plugin_batt
+          - input_boolean.smol_7_plugin_grid
+          - input_boolean.smol_7_plugin_wled
+          - input_boolean.smol_7_plugin_about
+          - input_boolean.smol_8_plugin_clock
+          - input_boolean.smol_8_plugin_snake
+          - input_boolean.smol_8_plugin_bench
+          - input_boolean.smol_8_plugin_batt
+          - input_boolean.smol_8_plugin_grid
+          - input_boolean.smol_8_plugin_wled
+          - input_boolean.smol_8_plugin_about
+          - input_boolean.smol_9_plugin_clock
+          - input_boolean.smol_9_plugin_snake
+          - input_boolean.smol_9_plugin_bench
+          - input_boolean.smol_9_plugin_batt
+          - input_boolean.smol_9_plugin_grid
+          - input_boolean.smol_9_plugin_wled
+          - input_boolean.smol_9_plugin_about
+      - platform: homeassistant
+        event: start
+    action:
+      - repeat:
+          for_each: ["7", "8", "9"]
+          sequence:
+            - variables:
+                n: "{{ repeat.item }}"
+                mask: >-
+                  {% set b = namespace(m=0) %}
+                  {% for name, val in [['clock',1],['snake',2],['bench',4],['batt',8],['grid',16],['wled',32],['about',64]] %}
+                  {% if is_state('input_boolean.smol_' ~ n ~ '_plugin_' ~ name, 'on') %}{% set b.m = b.m + val %}{% endif %}
+                  {% endfor %}
+                  {{ '%04X' | format(b.m) }}
+            - service: mqtt.publish
+              data:
+                topic: "smol/{{ n }}/config/plugins"
+                retain: true
+                qos: 0
+                payload: "{{ mask }}"


### PR DESCRIPTION
Canary payoff-pass follow-ups (smol_mesh.yaml + build_control_room.py). **Deployed live + verified, live==repo.** Oracle-gated.

## Re-land stranded #81 commits (merge gap)
`edd1e6f` (#49 flush/verify counters) + `91a09f4` (#55 plugin booleans/compose/mirror) were pushed to `ha/obs-wave` **after PR #81 merged** (7e3fefc) → stranded, missing from main → `flush_ok`/`plugins` unavailable + the #90 plugin chips referenced non-existent entities. Cherry-picked here. **Verified live: `flush_ok`=36** (from the DIAG record `fok=`), plugins mirror + booleans populate, chips now backed.

## #52 reboot → qos:1  *(canary reliability finding)*
The gateway drops qos:0 publishes (~5% loss; 15 qos:0 resets missed vs 1 qos:1 landed). `smol_reboot_publish` was `retain:false` + **qos:0** → ~5%-unreliable reboot button. Fixed → **qos:1** (at-least-once); `retain:false` unchanged (retained reset = reboot-loop). One fix covers per-node + all-reboot (fanout routes through it). #71 scan has no HA automation yet — annotated for when it's built.

## #57 bit-7 Familiar toggle
`input_boolean.smol_<id>_plugin_familiar` (×3) + compose `familiar=128` → all-on now composes **`00FF`** (verified live round-trip) so the Familiar screen (#57 mask bit 7) is user-toggleable + not menu-hidden on a legacy `0x7F` leaf. + 8th chip in the node-box plugin grid.

## #94 flap-tune — CONSIDERED then DROPPED (per the falsifier gate)
The all-192 online flap was a mesh-**settling** artifact, not steady-state. Live re-check at the settled fleet: `smol/<id>/status` republishes **~11s** (far under the 90s expire_after) → online stable (id7/8/9 all on, no flap, no empty-status oscillation). So `expire_after:90` (the merged #94 value) is correct; 180 was over-tuning → reverted 90→180→90. **KEEP if PERSISTS / DROP if RESOLVED → RESOLVED → dropped.**

## Held
cfg-drift `_expected`+drift comparator — fw not emitting `cfg=` yet (deferred stage-2, per vesper). `config_applied` reads unknown until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)