### PR TITLE
feat(site): #75 dollhouse — interactive per-room-panels design preview

### DIFF
--- a/site/dollhouse.html
+++ b/site/dollhouse.html
@@ -1,0 +1,460 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>smol · the dollhouse — per-room panels (#75 · design preview)</title>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><rect width='16' height='16' rx='3' fill='%23070b0c'/><path d='M3 8 L8 4 L13 8' fill='none' stroke='%237df9ff' stroke-width='1'/><rect x='4.5' y='8' width='7' height='5' fill='none' stroke='%237df9ff' stroke-width='1'/><rect x='6.5' y='9.5' width='3' height='3.5' fill='%23ffb454'/></svg>" />
+<meta name="theme-color" content="#070b0c" media="(prefers-color-scheme: dark)" />
+<meta name="theme-color" content="#e9efee" media="(prefers-color-scheme: light)" />
+<meta name="description" content="A design preview for smol issue #75 — one $9 smol per room as an OLED smart-home panel. Vision, not built." />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Silkscreen:wght@400;700&family=JetBrains+Mono:wght@400;500;700&family=Sora:wght@300;400;600;800&display=swap" rel="stylesheet" />
+<style>
+:root{
+  --bg:#070b0c; --bg2:#0a1113; --panel:#0d1719; --panel2:#122024;
+  --ink:#e4f3f4; --dim:#7d9498; --faint:#4a5f63;
+  --line:rgba(125,249,255,.12); --line2:rgba(125,249,255,.06);
+  --glow:#7df9ff; --glow-soft:rgba(125,249,255,.35);
+  --amber:#ffb454; --lime:#b6ff5b; --red:#ff5d6c;
+  /* OLED phosphor — fixed across themes: a real panel is always lit-on-dark */
+  --oled-bg:#02100f; --oled-lit:#7df9ff;
+  --pixel:"Silkscreen",monospace; --mono:"JetBrains Mono",ui-monospace,monospace; --sans:"Sora",system-ui,sans-serif;
+  --maxw:1180px;
+}
+*{box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  margin:0; background:var(--bg); color:var(--ink);
+  font-family:var(--sans); font-weight:300; line-height:1.6;
+  -webkit-font-smoothing:antialiased; overflow-x:hidden;
+  background-image:
+    radial-gradient(900px 500px at 72% -8%, rgba(125,249,255,.10), transparent 60%),
+    radial-gradient(700px 600px at 8% 108%, rgba(255,180,84,.06), transparent 55%),
+    radial-gradient(circle at center, rgba(125,249,255,.05) 1px, transparent 1.4px);
+  background-size:auto,auto,26px 26px;
+  background-attachment:fixed;
+}
+body::after{
+  content:""; position:fixed; inset:0; pointer-events:none; z-index:9998; opacity:.045; mix-blend-mode:overlay;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+a{color:inherit;text-decoration:none}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
+.mono{font-family:var(--mono)}
+.kicker{font-family:var(--mono);font-size:.72rem;letter-spacing:.28em;text-transform:uppercase;color:var(--glow);font-weight:500}
+code{font-family:var(--mono);font-size:.86em;background:rgba(125,249,255,.06);padding:1px 6px;border-radius:5px;color:var(--ink)}
+
+/* ---------- top bar ---------- */
+header{position:sticky;top:0;z-index:100;backdrop-filter:blur(12px);
+  background:linear-gradient(to bottom,rgba(7,11,12,.9),rgba(7,11,12,.55));
+  border-bottom:1px solid var(--line2)}
+.bar{display:flex;align-items:center;justify-content:space-between;height:60px;gap:16px}
+.brand{font-family:var(--pixel);font-size:1.3rem;color:var(--ink);letter-spacing:.02em;display:flex;align-items:center;gap:.15em}
+.brand .dot{color:var(--glow);text-shadow:0 0 12px var(--glow-soft)}
+nav{display:flex;gap:26px;font-family:var(--mono);font-size:.8rem;color:var(--dim)}
+nav a{position:relative;transition:color .2s}
+nav a:hover{color:var(--glow)}
+nav a::after{content:"";position:absolute;left:0;right:100%;bottom:-6px;height:1px;background:var(--glow);transition:right .25s;box-shadow:0 0 8px var(--glow-soft)}
+nav a:hover::after{right:0}
+.tag-pill{font-family:var(--mono);font-size:.68rem;letter-spacing:.14em;text-transform:uppercase;color:var(--amber);
+  border:1px solid color-mix(in srgb,var(--amber) 45%,transparent);border-radius:999px;padding:5px 11px;white-space:nowrap}
+.back{font-family:var(--mono);font-size:.8rem;color:var(--dim)}
+.back:hover{color:var(--glow)}
+@media(max-width:760px){nav{display:none}}
+
+/* ---------- hero ---------- */
+.hero{position:relative;padding:64px 0 30px}
+.h1{font-family:var(--sans);font-weight:800;font-size:clamp(2.2rem,5.4vw,3.9rem);line-height:1;letter-spacing:-.02em;margin:16px 0 0}
+.h1 em{font-style:normal;color:var(--glow);text-shadow:0 0 30px var(--glow-soft)}
+.lead{font-size:1.1rem;color:var(--dim);max-width:60ch;margin:20px 0 0}
+.chips{display:flex;flex-wrap:wrap;gap:10px;margin-top:26px}
+.chip{font-family:var(--mono);font-size:.72rem;color:var(--ink);border:1px solid var(--line);border-radius:999px;padding:7px 13px;background:rgba(125,249,255,.03)}
+.chip b{color:var(--glow);font-weight:700}
+.disclaimer{margin-top:26px;border:1px solid color-mix(in srgb,var(--amber) 32%,transparent);
+  background:color-mix(in srgb,var(--amber) 7%,transparent);border-radius:12px;padding:14px 18px;
+  font-family:var(--mono);font-size:.82rem;color:var(--dim);max-width:74ch;line-height:1.55}
+.disclaimer b{color:var(--amber);font-weight:700}
+
+/* ---------- sections ---------- */
+section{padding:56px 0;border-top:1px solid var(--line2);position:relative}
+.sec-head{margin-bottom:30px;max-width:70ch}
+.sec-head h2{font-size:clamp(1.5rem,3vw,2.1rem);font-weight:800;letter-spacing:-.02em;margin:12px 0 10px}
+.sec-head p{color:var(--dim);margin:0}
+.sec-head p b{color:var(--ink);font-weight:600}
+.reveal{opacity:0;transform:translateY(22px)}
+.reveal.in{opacity:1;transform:none;transition:opacity .7s cubic-bezier(.2,.7,.2,1),transform .7s cubic-bezier(.2,.7,.2,1)}
+
+/* ---------- the house ---------- */
+.controls{display:flex;gap:12px;flex-wrap:wrap;margin:0 0 22px}
+button.btn{font-family:var(--mono);font-size:.8rem;background:var(--panel2);color:var(--ink);
+  border:1px solid var(--line);border-bottom-width:2px;border-radius:9px;padding:9px 15px;cursor:pointer;transition:.16s}
+button.btn:hover{border-color:var(--glow);color:var(--glow);box-shadow:0 0 16px -6px var(--glow-soft);transform:translateY(-1px)}
+button.btn:active{transform:translateY(0)}
+.house{position:relative;background:linear-gradient(180deg,var(--panel),var(--bg2));
+  border:1px solid var(--line);border-radius:16px 16px 10px 10px;padding:14px;
+  box-shadow:0 30px 70px -34px rgba(0,0,0,.85),0 0 60px -30px var(--glow-soft)}
+.house::before{content:"";position:absolute;left:22px;right:22px;top:-1px;height:2px;
+  background:linear-gradient(90deg,transparent,var(--glow-soft),transparent);opacity:.6}
+.grid{display:grid;grid-template-columns:1fr 1fr 1fr;gap:12px}
+@media(max-width:820px){.grid{grid-template-columns:1fr 1fr}}
+@media(max-width:520px){.grid{grid-template-columns:1fr}}
+.room{position:relative;background:var(--oled-bg);border:1px solid var(--line);border-radius:10px;
+  padding:11px;cursor:pointer;transition:box-shadow .25s,transform .08s,border-color .25s;
+  display:flex;flex-direction:column;gap:9px;isolation:isolate}
+.room:active{transform:translateY(1px)}
+.room .halo{position:absolute;inset:0;border-radius:10px;pointer-events:none;opacity:0;transition:opacity .3s;
+  background:radial-gradient(120% 90% at 50% 38%,var(--glow-soft),transparent 62%);mix-blend-mode:screen;z-index:0}
+.room.on .halo{opacity:.55}
+.room.on{border-color:color-mix(in srgb,var(--glow) 55%,transparent);
+  box-shadow:0 0 0 1px color-mix(in srgb,var(--glow) 35%,transparent),0 16px 36px -16px var(--glow-soft)}
+.room .shell{position:relative;border-radius:5px;overflow:hidden;z-index:1;
+  box-shadow:0 0 22px -6px var(--glow-soft),inset 0 0 30px rgba(0,0,0,.6)}
+.room .shell canvas{display:block;width:100%;height:auto;image-rendering:pixelated;aspect-ratio:72/40}
+.room .glassglare{position:absolute;inset:0;pointer-events:none;background:linear-gradient(115deg,rgba(255,255,255,.05),transparent 42%)}
+.rlabel{display:flex;justify-content:space-between;align-items:center;font-family:var(--mono);font-size:.72rem;color:var(--dim);position:relative;z-index:1}
+.rlabel b{color:var(--ink);font-weight:600;letter-spacing:.4px}
+.rlabel .id{font-size:.62rem;color:var(--faint)}
+.dolls{font-size:15px;letter-spacing:2px;min-height:19px;position:relative;z-index:1}
+.hint{font-family:var(--mono);color:var(--faint);font-size:.76rem;margin-top:12px;line-height:1.5}
+.hint b{color:var(--dim)}
+
+/* ---------- layout specs + gallery cards ---------- */
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:16px}
+.spec{border:1px solid var(--line);border-radius:14px;padding:16px;background:linear-gradient(180deg,var(--panel),var(--bg2));transition:.25s}
+.spec:hover{border-color:var(--glow);box-shadow:0 0 40px -22px var(--glow-soft);transform:translateY(-2px)}
+.spec .shell{position:relative;border-radius:5px;overflow:hidden;box-shadow:0 0 22px -6px var(--glow-soft),inset 0 0 30px rgba(0,0,0,.6)}
+.spec .shell canvas{display:block;width:100%;height:auto;image-rendering:pixelated;aspect-ratio:72/40}
+.spec .glassglare{position:absolute;inset:0;pointer-events:none;background:linear-gradient(115deg,rgba(255,255,255,.05),transparent 42%)}
+.spec h3{margin:13px 0 5px;font-size:1rem;font-weight:700;color:var(--ink)}
+.spec p{margin:0;color:var(--dim);font-size:.84rem}
+.tag{display:inline-block;font-family:var(--mono);font-size:.62rem;letter-spacing:.16em;text-transform:uppercase;
+  color:var(--glow);border:1px solid color-mix(in srgb,var(--glow) 42%,transparent);border-radius:20px;padding:2px 10px;margin-bottom:6px}
+.gallery{display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:14px}
+.gcell{border:1px solid var(--line);border-radius:12px;padding:12px;background:linear-gradient(180deg,var(--panel),var(--bg2));transition:.25s}
+.gcell:hover{border-color:var(--glow);box-shadow:0 0 34px -20px var(--glow-soft)}
+.gcell .shell{position:relative;border-radius:4px;overflow:hidden;box-shadow:0 0 18px -6px var(--glow-soft),inset 0 0 26px rgba(0,0,0,.6)}
+.gcell .shell canvas{display:block;width:100%;height:auto;image-rendering:pixelated;aspect-ratio:72/40}
+.gcell .cap{font-family:var(--mono);font-size:.74rem;color:var(--dim);margin-top:9px}
+.gcell .cap b{color:var(--ink)}
+.legend{display:flex;gap:20px;flex-wrap:wrap;font-family:var(--mono);font-size:.76rem;color:var(--dim);margin-top:16px}
+.legend span{display:inline-flex;align-items:center;gap:7px}
+.legend b{color:var(--glow)}
+
+/* ---------- footer ---------- */
+footer{padding:44px 0 74px;border-top:1px solid var(--line2);color:var(--faint);font-family:var(--mono);font-size:.78rem;
+  display:flex;justify-content:space-between;flex-wrap:wrap;gap:16px}
+footer a{color:var(--dim)}footer a:hover{color:var(--glow)}
+
+/* ===================== light theme ===================== */
+@media (prefers-color-scheme: light){
+  :root{
+    --bg:#e9efee; --bg2:#dde7e6; --panel:#f7fbfa; --panel2:#e8f1f0;
+    --ink:#0a1a1c; --dim:#41595d; --faint:#7f989b;
+    --line:rgba(7,104,116,.22); --line2:rgba(7,104,116,.10);
+    --glow:#06697a; --glow-soft:rgba(7,120,134,.30);
+    --amber:#a75e06; --lime:#3c860f; --red:#cc3444;
+    /* OLED phosphor stays lit-on-dark in both themes */
+    --oled-bg:#02100f; --oled-lit:#7df9ff;
+  }
+  body{background-image:
+    radial-gradient(900px 500px at 72% -8%, rgba(7,120,134,.10), transparent 60%),
+    radial-gradient(700px 600px at 8% 108%, rgba(167,94,6,.07), transparent 55%),
+    radial-gradient(circle at center, rgba(7,104,116,.06) 1px, transparent 1.4px);}
+  body::after{opacity:.028}
+  header{background:linear-gradient(to bottom,rgba(233,239,238,.92),rgba(233,239,238,.6))}
+}
+/* ===================== reduced motion (a11y) ===================== */
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.001ms!important;animation-iteration-count:1!important;transition-duration:.001ms!important;scroll-behavior:auto!important}
+}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="wrap bar">
+    <a class="brand" href="index.html">smol<span class="dot">▚</span></a>
+    <nav>
+      <a href="#house">the house</a><a href="#layouts">layouts</a><a href="#states">states</a>
+      <a href="https://github.com/jphein/smol/issues/75" target="_blank" rel="noopener">issue #75 ↗</a>
+    </nav>
+    <a class="back" href="index.html">← back to smol</a>
+  </div>
+</header>
+
+<!-- HERO -->
+<div class="hero"><div class="wrap">
+  <span class="kicker">◇ Design preview · issue #75 · vision, not built</span>
+  <h1 class="h1">The <em>dollhouse</em>.</h1>
+  <p class="lead">One ~$9 smol per room — an OLED panel, a WS2812 room light, and BLE-tag presence.
+     Every room shows who's home and what the light's doing, at a glance. Tap a room to press its button; shuffle the dolls to watch presence drive the lights.</p>
+  <div class="chips">
+    <span class="chip"><b>72×40</b> real OLED</span>
+    <span class="chip">one smol <b>per room</b></span>
+    <span class="chip">presence → <b>light</b></span>
+    <span class="chip"><b>#22</b> BLE tags</span>
+  </div>
+  <div class="disclaimer">
+    <b>This is a design preview, not a shipped feature.</b> smol #75 is scoped, not built — no firmware, no flashing.
+    Every panel below renders on the real <code>72×40</code> OLED geometry (pixel-accurate, upscaled) so the layouts are honest about what fits. The dolls are fictional; presence and lights are mocked in your browser.
+  </div>
+</div></div>
+
+<!-- THE HOUSE -->
+<section id="house"><div class="wrap">
+  <div class="sec-head reveal">
+    <span class="kicker">01 — The house</span>
+    <h2>A smol in every room.</h2>
+    <p>Each cell is the real <b>72×40</b> smol OLED (<code>DisplaySize72x40</code>, pixel-accurate, upscaled). Lit rooms glow.
+       Dolls carry $2 BLE tags — <b>nearest-node-wins</b> puts a doll "in" a room; the tag button (a tap) is the guaranteed toggle.</p>
+  </div>
+  <div class="reveal">
+    <div class="controls">
+      <button class="btn" id="shuffle">🎲 Shuffle the dolls</button>
+      <button class="btn" id="allon">💡 All lights on</button>
+      <button class="btn" id="alloff">🌙 All lights off</button>
+    </div>
+    <div class="house"><div class="grid" id="houseGrid"></div></div>
+    <div class="hint"><b>Tap a room</b> → toggles its light (the doll-button fallback, #75's guaranteed path). <b>Shuffle</b> → tags move; occupied rooms auto-warm (presence → light).</div>
+  </div>
+</div></section>
+
+<!-- PANEL LAYOUTS -->
+<section id="layouts"><div class="wrap">
+  <div class="sec-head reveal">
+    <span class="kicker">02 — Panel layouts</span>
+    <h2>Three layouts, one job each.</h2>
+    <p><b>A</b> is the daily driver; <b>B</b> reads across the room; <b>C</b> is the storybook idle screen. All fit the firmware's fonts (5×8 / 6×10 / 10×20) and primitives (Line / Rectangle).</p>
+  </div>
+  <div class="cards reveal" id="specs"></div>
+</div></section>
+
+<!-- STATE GALLERY -->
+<section id="states"><div class="wrap">
+  <div class="sec-head reveal">
+    <span class="kicker">03 — State gallery</span>
+    <h2>Every field degrades gracefully.</h2>
+    <p>Presence <b>source</b> is honest on the glass: <code>◉</code> button = confident, <code>◌</code> RSSI = estimated (the experimental #22 path). Temperature shows only when a real ambient sensor is bound — never chip-die temp dressed up as room temp.</p>
+  </div>
+  <div class="gallery reveal" id="gallery"></div>
+  <div class="legend reveal">
+    <span><b>◉</b> button presence (definite)</span>
+    <span><b>◌</b> RSSI presence (nearest-node, #22)</span>
+    <span><b>▓▓░░</b> WS2812 brightness</span>
+    <span><b>colour name</b> — mono OLED; the LED shows the real hue</span>
+  </div>
+</div></section>
+
+<footer class="wrap">
+  <span>smol · the dollhouse — a design preview for <a href="https://github.com/jphein/smol/issues/75" target="_blank" rel="noopener">issue #75 ↗</a>. Vision, not built.</span>
+  <span><a href="index.html">← back to smol</a></span>
+</footer>
+
+<script>
+/* ================================ the dollhouse — #75 design preview ================================
+   Renders the real 72×40 smol OLED (DisplaySize72x40, main.rs:241) for each room, upscaled + tinted to
+   the site's phosphor. Presence + lights are mocked. Dolls are fictional (privacy: public page).       */
+(() => {
+'use strict';
+const $  = (s, r = document) => r.querySelector(s);
+const $$ = (s, r = document) => [...r.querySelectorAll(s)];
+const SCALE = 7, W = 72, H = 40;   // the REAL smol panel: DisplaySize72x40
+
+/* ---- OLED pixel renderer: draw a 72×40 B/W buffer, then tint white→phosphor ---- */
+function px(){
+  const b = document.createElement('canvas'); b.width = W; b.height = H;
+  const c = b.getContext('2d'); c.imageSmoothingEnabled = false;
+  c.fillStyle = '#000'; c.fillRect(0, 0, W, H); c.fillStyle = '#fff'; c.strokeStyle = '#fff';
+  c.textBaseline = 'top'; return { b, c };
+}
+const F = {
+  small: 'bold 8px "DejaVu Sans Mono","Liberation Mono",monospace',
+  title: 'bold 9px "DejaVu Sans Mono","Liberation Mono",monospace',
+  hero:  'bold 18px "DejaVu Sans Mono","Liberation Mono",monospace',
+};
+function hex(h){ h = h.replace('#',''); if (h.length === 3) h = h.split('').map(x => x + x).join('');
+  return [parseInt(h.slice(0,2),16), parseInt(h.slice(2,4),16), parseInt(h.slice(4,6),16)]; }
+function paint(g, buf){
+  const root = getComputedStyle(document.documentElement);
+  const lit = (root.getPropertyValue('--oled-lit').trim() || '#7df9ff');
+  const bg  = (root.getPropertyValue('--oled-bg').trim()  || '#02100f');
+  const tmp = document.createElement('canvas'); tmp.width = W; tmp.height = H;
+  const tc = tmp.getContext('2d'); tc.drawImage(buf, 0, 0);
+  const img = tc.getImageData(0, 0, W, H), d = img.data, L = hex(lit), B = hex(bg);
+  for (let i = 0; i < d.length; i += 4){
+    const on = d[i] > 110 || d[i+1] > 110 || d[i+2] > 110;
+    const c = on ? L : B; d[i] = c[0]; d[i+1] = c[1]; d[i+2] = c[2]; d[i+3] = 255;
+  }
+  tc.putImageData(img, 0, 0);
+  g.imageSmoothingEnabled = false; g.drawImage(tmp, 0, 0, W, H, 0, 0, W*SCALE, H*SCALE);
+  g.globalAlpha = .10; g.fillStyle = '#000';
+  for (let y = 0; y < H*SCALE; y += SCALE) g.fillRect(0, y, W*SCALE, 1);
+  g.globalAlpha = 1;
+}
+
+/* ---- glyphs (drawn from Line/Rect/arc, mirroring embedded-graphics primitives) ---- */
+function bulb(c,x,y,on){ c.save(); c.translate(x,y);
+  if(on){ c.fillStyle='#fff'; c.beginPath(); c.arc(4,4,3.4,0,7); c.fill();
+    for(const a of [0,45,90,135,180,225,270,315]){ const r=a*Math.PI/180;
+      c.beginPath(); c.moveTo(4+Math.cos(r)*4.6,4+Math.sin(r)*4.6); c.lineTo(4+Math.cos(r)*6.2,4+Math.sin(r)*6.2); c.lineWidth=.9; c.stroke(); } }
+  else { c.strokeStyle='#fff'; c.lineWidth=.9; c.beginPath(); c.arc(4,4,3.4,0,7); c.stroke(); }
+  c.fillStyle='#fff'; c.fillRect(2.5,7.5,3,1.6); c.restore(); }
+function person(c,x,y,filled){ c.save(); c.translate(x,y); c.strokeStyle='#fff'; c.fillStyle='#fff'; c.lineWidth=.9;
+  c.beginPath(); c.arc(3,2,1.7,0,7); filled?c.fill():c.stroke();
+  c.beginPath(); c.moveTo(3,3.6); c.lineTo(3,7); c.moveTo(3,4.4); c.lineTo(1,6); c.moveTo(3,4.4); c.lineTo(5,6);
+  c.moveTo(3,7); c.lineTo(1.4,9.4); c.moveTo(3,7); c.lineTo(4.6,9.4); c.stroke(); c.restore(); }
+function bar(c,x,y,w,h,pct){ c.strokeStyle='#fff'; c.lineWidth=.9; c.strokeRect(x+.5,y+.5,w-1,h-1);
+  c.fillStyle='#fff'; c.fillRect(x+1.5,y+1.5,Math.max(0,(w-3)*pct/100),h-3); }
+function invbar(c,y,h,name,right){ c.fillStyle='#fff'; c.fillRect(0,y,W,h);
+  c.fillStyle='#000'; c.font=F.title; c.fillText(name,2,y+((h-9)/2));
+  if(right){ c.font=F.small; c.fillText(right,W-right.length*4.6-3,y+((h-7)/2)); } c.fillStyle='#fff'; }
+function txt(c,x,y,s,font){ c.font=font; c.fillStyle='#fff'; c.fillText(s,x,y); }
+
+/* ---- layouts (all drawn at the real 72×40 · 12-glyph wall) ---- */
+function whoStr(s){ if(!s.who||!s.who.length) return '— empty'; return s.who.join('+'); }
+function srcGlyph(c,x,y,s){ if(!s.who||!s.who.length) return; c.strokeStyle='#fff'; c.fillStyle='#fff'; c.lineWidth=.9;
+  c.beginPath(); c.arc(x+3,y+3,2.6,0,7); (s.src==='button')?c.fill():c.stroke(); }
+function fit(s,n){ return s.length>n ? s.slice(0,n) : s; }   // hard glyph clip
+function drawCard(c,s){
+  invbar(c,0,11, fit(s.name,10), '');
+  bulb(c,1,12,s.on);
+  txt(c,10,13, s.on?('ON  '+s.bri+'%'):'OFF', F.small);
+  srcGlyph(c,1,21,s);
+  txt(c,10,22, fit(whoStr(s),10), F.small);
+  if(s.on){ bar(c,1,32,44,6,s.bri); if(s.temp) txt(c,49,31,s.temp,F.small); }
+  else txt(c,1,31,'— dark —',F.small);
+}
+function drawMood(c,s){
+  txt(c,2,0, fit(s.name,11), F.small);
+  const mood = s.chime?'DING': s.on?(s.who.length?'COZY':'LIT'):(s.who.length?'HOME':'AWAY');
+  c.font=F.hero; const wpx=mood.length*11; txt(c,Math.max(1,(W-wpx)/2),11,mood,F.hero);
+  const d = (s.on?('*'+s.bri+'%'):'*off') + '  ' + (s.who.length?('o'+fit(s.who[0],5)):'o empty');
+  txt(c,2,31, fit(d,12), F.small);
+}
+function drawStory(c,s){
+  c.strokeStyle='#fff'; c.lineWidth=.9; c.strokeRect(8.5,1.5,55,10);
+  c.font=F.title; c.fillStyle='#fff'; const nm=fit(s.name,9); c.fillText(nm,36-nm.length*2.6,2);
+  bulb(c,33,14,s.on); if(s.on){ c.globalAlpha=.45; bulb(c,33,14,true); c.globalAlpha=1; }
+  const n=s.who.length; for(let i=0;i<Math.min(n,4);i++){ person(c,22+i*11,21, true); }
+  if(!n){ c.font=F.small; c.fillText('quiet',28,23); }
+  c.font=F.small; c.fillText(s.on?fit((s.color||'lit'),8):'dark',2,32);
+  if(s.temp) c.fillText(s.temp, W-s.temp.length*4.8-2,32);
+}
+const LAYOUT = { card:drawCard, mood:drawMood, story:drawStory };
+function render(canvasEl, state, layout){
+  canvasEl.width = W*SCALE; canvasEl.height = H*SCALE;
+  const g = canvasEl.getContext('2d'); const { b, c } = px();
+  (LAYOUT[layout]||drawCard)(c, state); paint(g, b);
+}
+// a room canvas lives inside a .shell (glow + glassglare), matching the site's OLED framing
+function shellCanvas(){
+  const shell = document.createElement('div'); shell.className = 'shell';
+  const cv = document.createElement('canvas');
+  const glare = document.createElement('div'); glare.className = 'glassglare';
+  shell.appendChild(cv); shell.appendChild(glare); return { shell, cv };
+}
+
+/* ================= THE HOUSE ================= */
+const rooms = [
+  {name:'Nursery', color:'warm white', bri:60, on:false, temp:'', src:'rssi'},
+  {name:'Parlor',  color:'amber',      bri:75, on:false, temp:'71°', src:'rssi'},
+  {name:'Kitchen', color:'daylight',   bri:90, on:false, temp:'', src:'rssi'},
+  {name:'Study',   color:'ocean',      bri:40, on:false, temp:'', src:'rssi'},
+  {name:'Bath',    color:'rose',       bri:55, on:false, temp:'', src:'rssi'},
+  {name:'Attic',   color:'candle',     bri:25, on:false, temp:'64°', src:'rssi'},
+];
+// fictional dolls (public page — no real names)
+const dolls = ['Ivy','Milo','Pip','Cat'];
+const DOLL_EMOJI = { Ivy:'👧', Milo:'👦', Pip:'👶', Cat:'🐈' };
+let placement = {}; // doll -> room index
+
+function occupantsOf(i){ return dolls.filter(d => placement[d] === i); }
+function syncRoomState(){ rooms.forEach((r,i) => { r.who = occupantsOf(i); }); }
+function dollEmoji(d){ return DOLL_EMOJI[d] || '🧸'; }
+
+function buildHouse(){
+  const host = $('#houseGrid'); host.innerHTML = '';
+  rooms.forEach((r,i) => {
+    const cell = document.createElement('div'); cell.className = 'room' + (r.on ? ' on' : '');
+    const halo = document.createElement('div'); halo.className = 'halo';
+    const { shell, cv } = shellCanvas();
+    const label = document.createElement('div'); label.className = 'rlabel';
+    label.innerHTML = `<b>${r.name}</b><span class="id">id ${i+7}</span>`;
+    const who = document.createElement('div'); who.className = 'dolls';
+    who.innerHTML = (r.who && r.who.length) ? r.who.map(dollEmoji).join(' ') : '<span style="opacity:.35">·</span>';
+    cell.append(halo, shell, label, who);
+    cell.addEventListener('click', () => { r.on = !r.on; buildHouse(); });
+    host.appendChild(cell);
+    render(cv, r, 'card');
+  });
+}
+function shuffle(){
+  dolls.forEach(d => placement[d] = Math.random() < 0.15 ? -1 : Math.floor(Math.random()*rooms.length));
+  syncRoomState();
+  rooms.forEach(r => { if(r.who.length){ r.on = true; r.src = 'rssi'; } }); // presence → light
+  buildHouse();
+}
+$('#shuffle').addEventListener('click', shuffle);
+$('#allon').addEventListener('click', () => { rooms.forEach(r => r.on = true); buildHouse(); });
+$('#alloff').addEventListener('click', () => { rooms.forEach(r => r.on = false); buildHouse(); });
+
+/* ================= LAYOUT SPECS ================= */
+const specStates = {
+  card:  {name:'Nursery', on:true, color:'warm white', bri:60, who:['Ivy'],       src:'button', temp:'72°'},
+  mood:  {name:'Parlor',  on:true, color:'amber',      bri:75, who:['Milo'],      src:'rssi',   temp:'71°'},
+  story: {name:'Nursery', on:true, color:'warm white', bri:60, who:['Ivy','Pip'], src:'button', temp:'72°'},
+};
+const specMeta = [
+  ['A','card','Room Card — daily driver','Nameplate + light block + who + brightness bar. Everything at a glance; "Lights ON · someone’s home" given a hierarchy.'],
+  ['B','mood','Hero mood — glanceable','One 10×20 word fusing light + occupancy: COZY / LIT / HOME / AWAY / DING. Reads from across the room.'],
+  ['C','story','Storybook — idle / attract','Drawn room-sign, a lamp that glows when on, one doll per occupant. The showpiece screensaver.'],
+];
+function buildSpecs(){
+  const host = $('#specs'); host.innerHTML = '';
+  specMeta.forEach(([tag,key,title,desc]) => {
+    const d = document.createElement('div'); d.className = 'spec';
+    const { shell, cv } = shellCanvas();
+    const meta = document.createElement('div');
+    meta.innerHTML = `<span class="tag">Layout ${tag}</span><h3>${title}</h3><p>${desc}</p>`;
+    d.append(shell, meta); host.appendChild(d);
+    render(cv, specStates[key], key);
+  });
+}
+
+/* ================= STATE GALLERY ================= */
+const gallery = [
+  [{name:'Kitchen',on:true, color:'daylight',   bri:90,who:['Milo'],           src:'rssi',  temp:''},    '<b>Occupied</b> + lit · RSSI ◌'],
+  [{name:'Study',  on:false,color:'ocean',      bri:40,who:[],                 src:'',      temp:''},    '<b>Empty</b> + dark — away'],
+  [{name:'Parlor', on:true, color:'amber',      bri:70,who:['Ivy','Pip','Cat'],src:'button',temp:'71°'}, '<b>Full house</b> · button ◉'],
+  [{name:'Bath',   on:true, color:'rose',       bri:55,who:[],                 src:'',      temp:''},    '<b>Lit, nobody home</b> (manual)'],
+  [{name:'Nursery',on:true, color:'warm white', bri:60,who:['Pip'],            src:'button',chime:true,temp:''}, '<b>Chime</b> — doorbell / lullaby (#61)'],
+  [{name:'Attic',  on:false,color:'candle',     bri:25,who:['Cat'],            src:'rssi',  temp:'64°'}, '<b>Present, light off</b> + room temp'],
+];
+function buildGallery(){
+  const host = $('#gallery'); host.innerHTML = '';
+  gallery.forEach(([st,cap]) => {
+    const d = document.createElement('div'); d.className = 'gcell';
+    const { shell, cv } = shellCanvas();
+    const c = document.createElement('div'); c.className = 'cap'; c.innerHTML = cap;
+    d.append(shell, c); host.appendChild(d);
+    render(cv, st, st.chime ? 'mood' : 'card');
+  });
+}
+
+/* ================= reveal + boot ================= */
+const io = new IntersectionObserver(es => es.forEach(e => {
+  if (e.isIntersecting){ e.target.classList.add('in'); io.unobserve(e.target); }
+}), { threshold: 0.12 });
+$$('.reveal').forEach(el => io.observe(el));
+
+placement = { Ivy:0, Milo:1, Pip:0, Cat:5 }; syncRoomState();
+rooms.forEach(r => { if(r.who.length) r.on = true; });
+buildHouse(); buildSpecs(); buildGallery();
+// re-tint on colour-scheme change (phosphor is fixed, but keeps canvases crisp)
+matchMedia('(prefers-color-scheme: dark)').addEventListener?.('change', () => { buildHouse(); buildSpecs(); buildGallery(); });
+})();
+</script>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -331,7 +331,7 @@ body.editing .toolbar{opacity:1;transform:none;pointer-events:auto}
     <div class="brand">smol<span class="dot">▚</span><span class="cursor"></span></div>
     <nav>
       <a href="#vitals">vitals</a><a href="#games">games</a><a href="#builds">apps</a>
-      <a href="#mission">mission control</a><a href="#roadmap">roadmap</a><a href="#research">research</a><a href="#board">board</a><a href="#influences">influences</a><a href="#pocketwatch">watch</a><a href="#case">case</a>
+      <a href="#mission">mission control</a><a href="#roadmap">roadmap</a><a href="#dollhouse">dollhouse</a><a href="#research">research</a><a href="#board">board</a><a href="#influences">influences</a><a href="#pocketwatch">watch</a><a href="#case">case</a>
     </nav>
     <div class="live" id="live"><span class="led"></span><span id="liveTxt">connecting…</span></div>
   </div>
@@ -620,6 +620,29 @@ body.editing .toolbar{opacity:1;transform:none;pointer-events:auto}
     <li><b>BLE PRESENCE</b>Advertise a beacon for room-level presence in Home Assistant (#22).</li>
     <li><b>COLOR TFT</b>Add an ST7789 and NES/GB emulation becomes possible.</li>
   </ul>
+</div></section>
+
+<!-- DOLLHOUSE — design preview → dollhouse.html -->
+<section id="dollhouse" class="road"><div class="wrap">
+  <div class="sec-head reveal">
+    <span class="kicker">◇ Design preview · not built</span>
+    <h2>The dollhouse.</h2>
+    <p class="body">A vision for what a fleet of smols becomes at home: <b>one ~$9 smol per room</b> — an OLED panel showing who's home and what the light's doing, presence-driven. Scoped as <a href="https://github.com/jphein/smol/issues/75" target="_blank" rel="noopener" style="color:var(--glow)">issue&nbsp;#75</a>, not yet built.</p>
+  </div>
+  <a class="spec reveal" href="dollhouse.html" style="display:block;padding:26px">
+    <div class="chips" style="margin:0 0 20px">
+      <span class="chip">🛏️ Nursery <b>· 👧 home</b></span>
+      <span class="chip">🛋️ Parlor <b>· 💡 on</b></span>
+      <span class="chip">🍳 Kitchen <b>· 🌙 dark</b></span>
+      <span class="chip">📚 Study</span>
+      <span class="chip">🛁 Bath</span>
+      <span class="chip">🏠 Attic <b>· 🐈</b></span>
+    </div>
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap">
+      <span class="mono" style="color:var(--dim);font-size:.9rem">Tap a room, shuffle the dolls, watch presence drive the lights — every panel on the real 72×40 OLED.</span>
+      <span class="mono" style="color:var(--glow);font-weight:700;white-space:nowrap">Open the interactive dollhouse&nbsp;→</span>
+    </div>
+  </a>
 </div></section>
 
 <!-- RESEARCH -->


### PR DESCRIPTION
Rolls the **#75 dollhouse** mock (JP's tap-a-room / shuffle-dolls demo) into the public site as an honestly-labeled **design preview**, per JP's request. Branches off #103's merged `site/`.

## What's here
- **`site/dollhouse.html`** — the full interactive mock, restyled to nebula's design system: Silkscreen/JetBrains/Sora, `#7df9ff` phosphor on `#02100f`, the `.bezel`/`scanlines`/`glassglare` OLED framing, film grain, dark + light via `prefers-color-scheme`. Six real-`72×40` room panels (tap to toggle, shuffle presence→light), three layout specs (Room Card / Hero mood / Storybook), a degrade-gracefully state gallery, and a prominent **"design preview · vision, not built — no firmware, no flashing"** banner. Self-contained (inline CSS/JS, no external deps bar Google Fonts, like index.html).
- **`index.html`** — a design-preview card + nav link (`#dollhouse`) after the roadmap, reusing the existing `.spec`/`.chip` pattern, linking to `dollhouse.html`.

## Public-repo hygiene ✅
- Dolls **genericized to fictional names** (`Emma/Max/Baby` → `Ivy/Milo/Pip`, quote → "someone's home") — real child names don't belong in a public room-presence demo. Flagged + defaulted with team-lead/hypnos.
- Scanned clean: no IPs, LAN hosts, MQTT topics, entity-ids, or secrets. Entity refs are generic `<room>` template patterns documenting the design.

## Verified
- Rendered headless (Playwright) in **dark + light**, both full pages QA'd — 3-col house grid, all 6 OLED panels draw (`canvasDrew: true`), layout specs + gallery render, the index card + CTA link resolve. Caught & fixed a duplicate-`id="house"` collision (section vs grid container) during QA.
- Auto-deploys to Pages on merge.

Gate: hygiene + oracle → team-lead merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)