### PR TITLE
fix(fw): #101 gateway self-reboot — persistent MQTT session + QoS1 command delivery

### DIFF
--- a/rust/clock/src/net/mqtt.rs
+++ b/rust/clock/src/net/mqtt.rs
@@ -91,7 +91,12 @@ pub fn encode_connect(out: &mut [u8], client_id: &[u8], user: &[u8], pass: &[u8]
     c.remaining_len(var + payload);
     c.str_field(b"MQTT");
     c.u8(0x04); // protocol level 4 (3.1.1)
-    c.u8(0xC2); // flags: username | password | clean session
+    // #101: clean_session=FALSE (0xC0 = username|password, clean-session bit CLEARED). A PERSISTENT
+    // session lets the broker QUEUE QoS1 command topics (cmd/reset, cmd/scan) between our per-flush
+    // connections and redeliver them on reconnect — the transient command was otherwise dropped
+    // unless it landed in the sub-second flush window (the #101 gateway self-reboot no-op). NB: 0xC0,
+    // NOT 0x82 — 0x82 would clear the PASSWORD flag (bit 0x40) → broker rejects CONNECT.
+    c.u8(0xC0); // flags: username | password (clean-session CLEARED → persistent, #101)
     c.u8(0x00); // keep-alive MSB
     c.u8(0x00); // keep-alive LSB (0 = disabled)
     c.str_field(client_id);
@@ -115,6 +120,19 @@ pub fn encode_publish(out: &mut [u8], topic: &[u8], payload: &[u8], retain: bool
 /// SUBSCRIBE (one topic filter, requested QoS 0). Byte 0 is `0x82` — the low nibble
 /// `0b0010` is mandatory for SUBSCRIBE. `packet_id` must be non-zero.
 pub fn encode_subscribe(out: &mut [u8], packet_id: u16, topic: &[u8]) -> Option<usize> {
+    encode_subscribe_qos(out, packet_id, topic, 0)
+}
+
+/// #101: SUBSCRIBE at requested QoS 1 — used ONLY for the transient COMMAND topics (cmd/reset,
+/// cmd/scan). With `clean_session=false`, a QoS1 subscription makes the broker QUEUE a one-shot
+/// command for our persistent session and redeliver it on the next flush reconnect (a QoS0 sub is
+/// never queued for an offline client). The receiver MUST PUBACK the delivered QoS1 PUBLISH (see
+/// [`encode_puback`]) or the broker redelivers it every reconnect → reboot loop.
+pub fn encode_subscribe_qos1(out: &mut [u8], packet_id: u16, topic: &[u8]) -> Option<usize> {
+    encode_subscribe_qos(out, packet_id, topic, 1)
+}
+
+fn encode_subscribe_qos(out: &mut [u8], packet_id: u16, topic: &[u8], qos: u8) -> Option<usize> {
     let remaining = 2 + (2 + topic.len()) + 1; // packet id + topic filter + requested-QoS byte
     let mut c = Cursor::new(out);
     c.u8(0x82);
@@ -122,7 +140,20 @@ pub fn encode_subscribe(out: &mut [u8], packet_id: u16, topic: &[u8]) -> Option<
     c.u8((packet_id >> 8) as u8);
     c.u8(packet_id as u8);
     c.str_field(topic);
-    c.u8(0x00); // requested QoS 0
+    c.u8(qos); // requested QoS (0 for downlinks; 1 for the #101 command topics)
+    c.done()
+}
+
+/// #101: PUBACK — acknowledge a received QoS1 PUBLISH so the broker drops it from our persistent
+/// session's outbound queue. WITHOUT this ack the broker redelivers the message on every reconnect
+/// (a queued `cmd/reset` → reboot every flush = soft-brick). Fixed 4 bytes: `0x40`, remaining-len 2,
+/// then the 2-byte packet identifier echoed back.
+pub fn encode_puback(out: &mut [u8], packet_id: u16) -> Option<usize> {
+    let mut c = Cursor::new(out);
+    c.u8(0x40); // PUBACK
+    c.u8(0x02); // remaining length = 2 (just the packet id)
+    c.u8((packet_id >> 8) as u8);
+    c.u8(packet_id as u8);
     c.done()
 }
 
@@ -142,7 +173,8 @@ pub enum Incoming<'a> {
     SubAck,
     /// An inbound PUBLISH: the retained downlink we subscribed for. `payload`
     /// borrows the accumulator; the caller copies it out before advancing.
-    Publish { topic: &'a [u8], payload: &'a [u8] },
+    /// `packet_id` is `Some` for a QoS>0 delivery (the caller MUST PUBACK it — #101); `None` at QoS0.
+    Publish { topic: &'a [u8], payload: &'a [u8], packet_id: Option<u16> },
     /// Any other packet type (PINGRESP, etc.) — skipped, but still consumed.
     Other,
 }
@@ -204,10 +236,16 @@ pub fn parse_packet(buf: &[u8]) -> Option<(Incoming<'_>, usize)> {
                 return Some((Incoming::Other, total));
             }
             let topic = &body[2..off];
-            if qos > 0 {
-                off += 2; // skip the packet identifier
-            }
-            Incoming::Publish { topic, payload: &body[off..] }
+            // #101: capture the packet id of a QoS>0 PUBLISH so the caller can PUBACK it (the bounds
+            // check above guarantees `body[off]`/`body[off+1]` exist when qos>0). QoS0 → None.
+            let packet_id = if qos > 0 {
+                let pid = ((body[off] as u16) << 8) | body[off + 1] as u16;
+                off += 2;
+                Some(pid)
+            } else {
+                None
+            };
+            Incoming::Publish { topic, payload: &body[off..], packet_id }
         }
         _ => Incoming::Other,
     };

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1603,13 +1603,13 @@ fn mqtt_session(
         // #52 remote reboot (pid 13): wildcard-subscribe the TRANSIENT `smol/+/cmd/reset` COMMAND
         // topic (retain:false → seen only while we're connected, never replayed). On receipt the
         // gateway fires a ONE-SHOT `<id>R` relay (never cached — anti-reboot-loop); own id → self.
-        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 13, b"smol/+/cmd/reset") {
+        if let Some(n) = crate::net::mqtt::encode_subscribe_qos1(&mut pkt, 13, b"smol/+/cmd/reset") {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
         // #71 on-demand scan (pid 14): wildcard-subscribe the TRANSIENT `smol/+/cmd/scan` COMMAND
         // topic (retain:false). On receipt the gateway fires a ONE-SHOT `<id>W` relay (never cached
         // — a periodic scan is the coexist hazard); own id → self-scan. Twin of the pid-13 reset arm.
-        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 14, b"smol/+/cmd/scan") {
+        if let Some(n) = crate::net::mqtt::encode_subscribe_qos1(&mut pkt, 14, b"smol/+/cmd/scan") {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
         // #45 Custom screen (pid 15): wildcard-subscribe every leaf's retained custom-screen layout
@@ -1884,9 +1884,9 @@ fn mqtt_session(
         iface.poll(smoltcp_now(), device, sockets);
         recv_into(sockets, tcp_handle, &mut acc[..], &mut acc_len);
         loop {
-            let consumed = match crate::net::mqtt::parse_packet(&acc[..acc_len]) {
+            let (consumed, puback_id) = match crate::net::mqtt::parse_packet(&acc[..acc_len]) {
                 None => break,
-                Some((crate::net::mqtt::Incoming::Publish { topic, payload }, consumed)) => {
+                Some((crate::net::mqtt::Incoming::Publish { topic, payload, packet_id }, consumed)) => {
                     // #26 cast: precompute the cast-topic match as a plain bool (avoids a
                     // block-in-`if`-condition; `false` in non-cast builds, where `cast_topic`
                     // does not exist, so the arm below is inert there).
@@ -2110,15 +2110,33 @@ fn mqtt_session(
                             log::info!("smol #40: leaf id{} OTA install command received", leaf_id);
                         }
                     }
-                    consumed
+                    // #101: a QoS1 command (cmd/reset / cmd/scan) carries a packet id → PUBACK it
+                    // below (after the acc compaction) so the broker drops the one-shot command.
+                    (consumed, packet_id)
                 }
-                Some((_, consumed)) => consumed,
+                Some((_, consumed)) => (consumed, None),
             };
             // #40 QUIET-PERIOD: a packet was parsed (the `None` arm broke above) → reset the
             // quiet timer so an in-flight retained burst keeps the drain alive.
             last_msg = Instant::now();
             acc.copy_within(consumed..acc_len, 0);
             acc_len -= consumed;
+            // #101: PUBACK a delivered QoS1 command so the broker drops it from our (now persistent)
+            // session — else it redelivers on every reconnect → reboot loop (the soft-brick the
+            // retain:false choice avoided). Sent AFTER the compaction so the `acc` borrow is
+            // released; reuses the same pkt/tcp_send/deadline/tick handles as the SUBSCRIBEs above.
+            // ACK-THEN-ACT egress guarantee (the crux): this PUBACK is pushed to the wire HERE
+            // (tcp_send + this loop's iface.poll), and the reset never fires in-handler — the only
+            // software_reset() is in main, AFTER flush_telemetry returns, i.e. AFTER the GRACEFUL
+            // DISCONNECT + `socket.close()` below (smoltcp close() = FIN with the TX buffer DRAINED,
+            // NOT abort()/RST that would discard a still-buffered PUBACK). Even an operator
+            // long-press abort BREAKS to that same clean DISCONNECT. So the ack always egresses
+            // before the post-flush reboot → the redelivery loop physically cannot occur.
+            if let Some(pid) = puback_id {
+                if let Some(n) = crate::net::mqtt::encode_puback(&mut pkt, pid) {
+                    let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+                }
+            }
         }
         // #40 QUIET-PERIOD break: exit once the 3 downlink flags are in AND no new packet has
         // arrived for DOWNLINK_SETTLE. The retained backlog (staged/install/cfg) arrives as a


### PR DESCRIPTION
Fixes #101 — the gateway self-reboot (#52 `cmd/reset` to the gateway's own id) was a no-op on hardware while the relayed-leaf reset worked.

## Root cause (the own-id branch is NOT the bug)
All three suspects in the issue are refuted by a static trace on the canary code: `parse_leaf_config_topic` doesn't filter the own id; the `reset_req.own()` drain is unconditional and `CFG_APPLY_KEYS` includes `R` (empty value still sets `have=true`); the `main` apply isn't gateway-gated and the 10 s debounce passes at 860 s uptime. **The own-reboot path is correct — the command simply never arrived.**

The gateway connects **clean_session=true** (`0xC2`), subscribes **QoS 0**, `cmd/reset` is **retain:false**, and the MQTT session is torn down **every flush** (`connect → DISCONNECT`, ~30 s). So a QoS1 `smol/<id>/cmd/reset` published while the gateway is disconnected (≈29.5 s of every 30 s) is dropped by the broker (not queued, not retained) and never redelivered — it only fires if it lands in the sub-second flush window. The leaf reset "worked" by timing luck (same constraint, no privileged path). The "boot=1 across 4+ flush cycles" observation corroborates a dropped-at-publish command.

## Fix (Fix A — make the assumed persistent-session/QoS1 contract real)
- `encode_connect` flags **`0xC2 → 0xC0`**: clean_session=false, keep username+password (NOT `0x82`, which would drop the password flag → CONNECT rejected). The broker now persists the session and queues QoS1 commands between flushes.
- Subscribe **`cmd/reset` + `cmd/scan` at QoS 1** (`encode_subscribe_qos1`); the other 13 downlink subscribes stay QoS 0 (blast radius = the 2 command topics).
- **Inbound-QoS1 PUBACK** (`parse_packet` now captures the packet id; `encode_puback`; the `mqtt_session` drain loop PUBACKs delivered QoS1 commands). This is the real one-shot guard — without the ack the broker redelivers on every reconnect (~30 s, past the 10 s boot-debounce) → reboot loop / soft-brick.

## ACK-THEN-ACT (loop physically cannot occur)
The reset is applied via the **deferred** `CfgTracker → main` path: the drain-loop handler only sets a flag; the sole `software_reset()` is in `main` **after** `flush_telemetry` returns — i.e. after the **graceful** DISCONNECT + `socket.close()` (FIN, TX drained; not `.abort()`/RST). The PUBACK egresses during the drain (and is belt-flushed by the graceful close); even an operator long-press abort breaks to that same clean close. So the ack always precedes the reboot.

## Verification
4-profile serial build (riscv32imc), all clean: `default` ✅ · `wifi` ✅ (the mqtt/wifi changes live here) · `wled` ✅; `espnow` `clippy -- -D warnings` ✅ **0 warnings**. default-build invariant holds (mqtt.rs/wifi.rs are `#[cfg(wifi)]` → absent from the default build).

⏳ **Hardware canary deferred to the morning** (gateway reset → boot counter ticks). Merge criterion: oracle-green + 4-profile compile-proof.
