### PR TITLE
feat(fw): #100 Stage 1 — runtime network switching (dual slots, CFG key N, un-brickable fallback)

### DIFF
--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -1188,7 +1188,20 @@ fn main() -> ! {
                                 commanded: slot,
                                 fallback: false,
                             });
-                            esp_hal::system::software_reset();
+                            // #100 canary lesson: VERIFY-AFTER-WRITE before the reset. If the
+                            // record didn't persist (any flash error — all swallowed above), a
+                            // reset would boot back on the old slot, re-receive the retained
+                            // command, and loop forever (~20 s reset cycle, observed on HW).
+                            // A failed readback = abort the switch this cycle; the retained
+                            // command retries next cycle, and the failure stays VISIBLE
+                            // (commanded stays != slot) instead of becoming a reboot loop.
+                            let persisted = crate::ota::read_net_cfg()
+                                .is_some_and(|c| c.commanded == slot);
+                            if persisted {
+                                esp_hal::system::software_reset();
+                            } else {
+                                log::warn!("smol #100: net record did NOT persist — switch aborted (no reset)");
+                            }
                         }
                     }
                 }

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -1167,6 +1167,33 @@ fn main() -> ! {
                 log::info!("smol #45: custom screen layout updated ({} B)", n);
             }
 
+            // #100: a network-switch config (key `N`) = the active WiFi-slot index. CONFIG/CACHED
+            // (retained), so it re-delivers every burst → EDGE-TRIGGERED on a change of the COMMANDED
+            // slot (NOT the active slot): a re-read of the same value is a no-op ⇒ never a reboot-loop
+            // (compare-to-commanded also means a latched fallback stays put — re-command to escape).
+            // A genuine change → persist {active=slot, commanded=slot, fallback=false} + reboot into
+            // the slot (the boot fallback then associates on it, self-healing if it's unreachable).
+            // Out-of-range / unparseable → ignored (keep current). software_reset() never returns.
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_NET) {
+                if let Some(slot) = core::str::from_utf8(&o.buf[..o.len])
+                    .ok()
+                    .and_then(|s| s.trim().parse::<u8>().ok())
+                {
+                    if (slot as usize) < crate::secrets::WIFI_NETWORKS.len() {
+                        let cur = crate::ota::read_net_cfg().map_or(0, |c| c.commanded);
+                        if slot != cur {
+                            log::warn!("smol #100: network slot -> {} (was commanded {}) — reboot", slot, cur);
+                            crate::ota::write_net_cfg(crate::ota::NetCfg {
+                                active: slot,
+                                commanded: slot,
+                                fallback: false,
+                            });
+                            esp_hal::system::software_reset();
+                        }
+                    }
+                }
+            }
+
             // #52: a remote reboot command (key `R`) — a COMMAND (cache-bypass, one-shot). Applied
             // once (edge — `take` clears it); the value is empty (the key IS the command). Feeds
             // BOTH a leaf (relayed `<id>R`) and the gateway's OWN reset (injected into `self.cfg`),

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -70,6 +70,10 @@ pub use wifi::CFG_KEY_REBOOT;
 // take_cfg_offer(Y); the held layout feeds the Custom plugin render).
 #[cfg(feature = "espnow")]
 pub use wifi::CFG_KEY_CUSTOM;
+// #100 network-switch key — same `main`-bridge rationale (espnow leaf-apply path via
+// take_cfg_offer(N); the apply writes the NVS net-record + reboots into the slot).
+#[cfg(feature = "espnow")]
+pub use wifi::CFG_KEY_NET;
 // #45: `main` sizes its held Custom-layout buffer to the max keyed value — bridge the const out
 // of the private `wifi` module (espnow-only: only the Custom apply path names it).
 #[cfg(feature = "espnow")]

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -180,12 +180,13 @@ const CFG_PREFIX: &[u8] = b"SMOLv1 CFG "; // + "NNN" + KEY + verbatim "<value>"
 /// (a `take_cfg_offer(key)` + apply) and a gateway fill site in `mqtt_session`. Sized `[_; N]`
 /// (not `&[u8]`) so [`CfgTracker`] can allocate exactly one `.bss` buffer slot per key.
 /// An inbound key not listed is dropped at [`CfgTracker::set`] (never buffered/applied).
-const CFG_APPLY_KEYS: [u8; 7] = [
+const CFG_APPLY_KEYS: [u8; 8] = [
     crate::net::wifi::CFG_KEY_SCREEN,
     crate::net::wifi::CFG_KEY_LED,
     crate::net::wifi::CFG_KEY_UNITS,
     crate::net::wifi::CFG_KEY_PLUGINS,
     crate::net::wifi::CFG_KEY_CUSTOM, // #45 custom-screen layout (cached + relayed like S/L/U/P)
+    crate::net::wifi::CFG_KEY_NET, // #100 active WiFi-slot index (cached + relayed; edge-triggered reboot)
     // #52 remote reboot: R IS a buffered/applied key (a leaf takes it via take_cfg_offer(R)) but
     // is NEVER put in cfg_cache/broadcast_cached_configs — the one-shot relay uses broadcast_config
     // directly. The anti-reboot-loop invariant: R rides the CFG wire + apply path, not the cache.
@@ -2374,8 +2375,16 @@ impl RadioManager {
         let tx = self.bench.tx_count;
         let e = self.diag_extra;
         let led_state = if e.led_on { "on" } else { "off" };
+        // #100: active WiFi slot + fallback state (net=<slot>:<ok|fb>). `fb` = we auto-reverted off
+        // the commanded slot (the un-brick fallback fired) — HA surfaces "the network switch failed".
+        let net = crate::ota::read_net_cfg().unwrap_or(crate::ota::NetCfg {
+            active: 0,
+            commanded: 0,
+            fallback: false,
+        });
+        let net_fb = if net.fallback { "fb" } else { "ok" };
         alloc::format!(
-            "DIAG|slot={}|rst={}|boot={}|ota={}|up={}|heap={}|hmin={}|btn={}|btnl={}|fok={}|ffl={}|vok={}|vfl={}|loss={}|rtt={}|rx={}|tx={}|led={}:{}|tage={}|tsrc={}",
+            "DIAG|slot={}|rst={}|boot={}|ota={}|up={}|heap={}|hmin={}|btn={}|btnl={}|fok={}|ffl={}|vok={}|vfl={}|loss={}|rtt={}|rx={}|tx={}|led={}:{}|tage={}|tsrc={}|net={}:{}",
             d.boot_slot,
             d.reset_reason,
             d.boot_count,
@@ -2397,6 +2406,8 @@ impl RadioManager {
             led_state,
             e.tage_s,
             e.tsrc,
+            net.active,
+            net_fb,
         )
     }
 
@@ -3487,6 +3498,10 @@ impl RadioManager {
         // #45: the gateway's OWN custom-screen layout — same self-apply path (take_cfg_offer(Y)).
         if let Some((buf, len)) = gw_own.custom {
             self.cfg.set(crate::net::wifi::CFG_KEY_CUSTOM, &buf[..len]);
+        }
+        // #100: the gateway's OWN active-slot index — same self-apply path (take_cfg_offer(N)).
+        if let Some((buf, len)) = gw_own.net {
+            self.cfg.set(crate::net::wifi::CFG_KEY_NET, &buf[..len]);
         }
         // #52 remote reboot — a COMMAND, not a config. Fire a ONE-SHOT `<id>R` frame per queued
         // leaf target via `broadcast_config` DIRECTLY (NOT `cfg_cache` / `broadcast_cached_configs`):

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -434,10 +434,8 @@ fn associate_slot(
     {
         return AssocResult::TimedOut;
     }
-    if !matches!(controller.is_started(), Ok(true)) {
-        if controller.start().is_err() {
-            return AssocResult::TimedOut;
-        }
+    if !matches!(controller.is_started(), Ok(true)) && controller.start().is_err() {
+        return AssocResult::TimedOut;
     }
     if controller.connect().is_err() {
         return AssocResult::TimedOut;
@@ -587,6 +585,7 @@ pub fn run_ntp_burst(
     // Poll the stack until DHCP yields an address. The DHCP `Event` borrows
     // the socket, so we extract the plain (Ipv4Cidr, router) data inside a
     // short scope, then apply it to the interface once the borrow is released.
+    let deadline = Instant::now() + SYNC_BUDGET; // DHCP+SNTP budget (assoc has its own per-slot budget in try_time_sync)
     loop {
         if tick() {
             return None; // #20 abort during DHCP wait

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -49,7 +49,11 @@ use smoltcp::{
 // -------------------------------------------------------------------------
 
 // Real values live in the git-ignored `crate::secrets` (repo is public).
-use crate::secrets::{WIFI_PASS as WIFI_PASSWORD, WIFI_SSID};
+// #100 Stage 1a: the single WiFi creds are now slot 0 of the dual-slot `WIFI_NETWORKS`. Kept as
+// these module consts (const-index [0]) so the assoc sites are unchanged and behaviour is identical
+// to the pre-#100 single-network build. Stage 1b threads the RUNTIME-selected slot (NVS `N`) here.
+const WIFI_SSID: &str = crate::secrets::WIFI_NETWORKS[0].ssid;
+const WIFI_PASSWORD: &str = crate::secrets::WIFI_NETWORKS[0].pass;
 
 /// NTP server IPv4. We hardcode an anycast IP so we need no DNS resolver in
 /// the smoltcp build. time.cloudflare.com's NTP anycast address:
@@ -60,15 +64,17 @@ const NTP_PORT: u16 = 123;
 /// Address/creds live in the git-ignored `crate::secrets` (retargetable one-liners —
 /// see the secrets comment for the VLAN11-leg rationale + the VLAN6 fallback). Built
 /// from the `[u8;4]` there so `secrets.rs` stays a plain imports-free consts file.
+// #100 Stage 1a: broker leg = slot 0's baked broker (const-index [0]); identical to pre-#100.
+// Stage 1b threads the runtime slot; Stage 2 adds the NVS broker override + CONNACK fallback.
 #[cfg(feature = "wifi")]
 const MQTT_BROKER_IP: Ipv4Addr = Ipv4Addr::new(
-    crate::secrets::MQTT_BROKER_IP[0],
-    crate::secrets::MQTT_BROKER_IP[1],
-    crate::secrets::MQTT_BROKER_IP[2],
-    crate::secrets::MQTT_BROKER_IP[3],
+    crate::secrets::WIFI_NETWORKS[0].broker_ip[0],
+    crate::secrets::WIFI_NETWORKS[0].broker_ip[1],
+    crate::secrets::WIFI_NETWORKS[0].broker_ip[2],
+    crate::secrets::WIFI_NETWORKS[0].broker_ip[3],
 );
 #[cfg(feature = "wifi")]
-const MQTT_BROKER_PORT: u16 = crate::secrets::MQTT_BROKER_PORT;
+const MQTT_BROKER_PORT: u16 = crate::secrets::WIFI_NETWORKS[0].broker_port;
 
 /// The retained downlink topic every node subscribes to for battery voltages, and
 /// the uplink topic template `smol/<id>/telemetry` — see `mqtt_session`.

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -929,6 +929,13 @@ pub const CFG_KEY_CUSTOM: u8 = b'Y';
 #[cfg(feature = "wifi")]
 #[allow(dead_code)]
 pub const CFG_KEY_SCAN: u8 = b'W';
+/// #100 network-switch CONFIG (key `N`) = the active WiFi-slot index (`0`/`1`). RETAINED/CACHED
+/// STATE (relayed like S/L/U/P/Y, NOT a one-shot command like R/W) — a node applies it by writing
+/// the NVS net-record + rebooting into the slot, EDGE-triggered on a change of the commanded slot
+/// (re-reading the same retained value is a no-op → never a reboot-loop). Per-node
+/// `smol/<id>/config/net` or fleet-wide `smol/config/net` (target 255). Value = one ASCII digit.
+#[cfg(feature = "wifi")]
+pub const CFG_KEY_NET: u8 = b'N';
 
 /// #48 (GwOwnCfg — approved arch): the GATEWAY's OWN per-node configs read from its own MQTT
 /// topics this burst. A leaf gets these RELAYED (→ its `CfgTracker`); the gateway reads them
@@ -955,12 +962,15 @@ pub struct GwOwnCfg {
     pub plugins: Option<([u8; CFG_VALUE_MAX], usize)>,
     /// #45 the gateway's own `smol/<id>/config/custom` value `(buf, len)`, or `None` if absent.
     pub custom: Option<([u8; CFG_VALUE_MAX], usize)>,
+    /// #100 the gateway's own `smol/<id>/config/net` (or global `smol/config/net`) active-slot
+    /// index value `(buf, len)`, or `None` if absent this burst.
+    pub net: Option<([u8; CFG_VALUE_MAX], usize)>,
 }
 
 #[cfg(feature = "wifi")]
 impl GwOwnCfg {
     pub const fn new() -> Self {
-        Self { led: None, units: None, plugins: None, custom: None }
+        Self { led: None, units: None, plugins: None, custom: None, net: None }
     }
     /// Pack a payload into the `(buf, len)` a field holds (truncated to `CFG_VALUE_MAX`), so the
     /// mqtt-drain arms stay one-liners: `gw_own.led = Some(GwOwnCfg::val(payload));`.
@@ -1691,6 +1701,16 @@ fn mqtt_session(
         if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 15, b"smol/+/config/custom") {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
+        // #100 network-switch (pid 16 per-node + pid 17 fleet-wide): the retained active-slot index.
+        // CONFIG/CACHED (key `N`, relayed like S/L/U/P/Y). Per-node `smol/<id>/config/net` + the
+        // global `smol/config/net` (→ target 255). Applying it writes the NVS net-record + reboots
+        // into the slot, edge-triggered on a commanded-slot CHANGE (a re-read is a no-op → no loop).
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 16, b"smol/+/config/net") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 17, b"smol/config/net") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
     }
 
     // --- PUBLISH telemetry (transient) + discovery config (retained) per node ---
@@ -2136,6 +2156,38 @@ fn mqtt_session(
                         } else {
                             gw_own.custom = Some(GwOwnCfg::val(payload));
                             log::info!("smol #45: gateway own custom screen captured ({} B)", payload.len());
+                        }
+                    } else if topic == b"smol/config/net" {
+                        // #100 GLOBAL network-switch (no id) → cache under the broadcast target 255
+                        // so ONE relayed `<255>N<slot>` frame reaches every leaf, + gw_own.net for the
+                        // gateway's own self-apply. Value = one ASCII slot digit; the apply validates.
+                        if let Some(cache) = cfg_cache.as_deref_mut() {
+                            let now = Instant::now().duration_since_epoch().as_millis();
+                            cache.set(CFG_TARGET_ALL, CFG_KEY_NET, payload, [0u8; 6], now);
+                        }
+                        gw_own.net = Some(GwOwnCfg::val(payload));
+                        log::info!(
+                            "smol #100: global net-slot captured ({} B) — cached (255,N) + self",
+                            payload.len()
+                        );
+                    } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/config/net") {
+                        // #100 PER-NODE network-switch: twin of the led/plugins arm. OTHER leaf →
+                        // cache under key `N` for the ESP-NOW relay; OUR OWN id → gw_own.net. The apply
+                        // (main) writes the NVS net-record + reboots into the slot, edge-triggered on a
+                        // commanded-slot CHANGE (a re-read of the same retained value is a no-op → no loop).
+                        if leaf_id != node_id {
+                            if let Some(cache) = cfg_cache.as_deref_mut() {
+                                let now = Instant::now().duration_since_epoch().as_millis();
+                                cache.set(leaf_id, CFG_KEY_NET, payload, [0u8; 6], now);
+                                log::info!(
+                                    "smol #100: cached leaf id{} net-slot for relay ({} B)",
+                                    leaf_id,
+                                    payload.len()
+                                );
+                            }
+                        } else {
+                            gw_own.net = Some(GwOwnCfg::val(payload));
+                            log::info!("smol #100: gateway own net-slot captured ({} B)", payload.len());
                         }
                     } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/cmd/reset") {
                         // #52 remote reboot — a COMMAND on a TRANSIENT topic (retain:false), so we

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -48,33 +48,18 @@ use smoltcp::{
 // Configuration (compile-time placeholders — set before flashing).
 // -------------------------------------------------------------------------
 
-// Real values live in the git-ignored `crate::secrets` (repo is public).
-// #100 Stage 1a: the single WiFi creds are now slot 0 of the dual-slot `WIFI_NETWORKS`. Kept as
-// these module consts (const-index [0]) so the assoc sites are unchanged and behaviour is identical
-// to the pre-#100 single-network build. Stage 1b threads the RUNTIME-selected slot (NVS `N`) here.
-const WIFI_SSID: &str = crate::secrets::WIFI_NETWORKS[0].ssid;
-const WIFI_PASSWORD: &str = crate::secrets::WIFI_NETWORKS[0].pass;
+// #100 Stage 1b: WiFi creds are read PER-SLOT at runtime (`WIFI_NETWORKS[active].ssid/pass`) inside
+// `associate_slot`, selected by the NVS net-record + the un-brickable fallback — no fixed SSID const.
 
 /// NTP server IPv4. We hardcode an anycast IP so we need no DNS resolver in
 /// the smoltcp build. time.cloudflare.com's NTP anycast address:
 const NTP_SERVER_IP: Ipv4Addr = Ipv4Addr::new(162, 159, 200, 123);
 const NTP_PORT: u16 = 123;
 
-/// HA Mosquitto broker (v2 MQTT-native bridge — the old LAN UDP collector is retired).
-/// Address/creds live in the git-ignored `crate::secrets` (retargetable one-liners —
-/// see the secrets comment for the VLAN11-leg rationale + the VLAN6 fallback). Built
-/// from the `[u8;4]` there so `secrets.rs` stays a plain imports-free consts file.
-// #100 Stage 1a: broker leg = slot 0's baked broker (const-index [0]); identical to pre-#100.
-// Stage 1b threads the runtime slot; Stage 2 adds the NVS broker override + CONNACK fallback.
-#[cfg(feature = "wifi")]
-const MQTT_BROKER_IP: Ipv4Addr = Ipv4Addr::new(
-    crate::secrets::WIFI_NETWORKS[0].broker_ip[0],
-    crate::secrets::WIFI_NETWORKS[0].broker_ip[1],
-    crate::secrets::WIFI_NETWORKS[0].broker_ip[2],
-    crate::secrets::WIFI_NETWORKS[0].broker_ip[3],
-);
-#[cfg(feature = "wifi")]
-const MQTT_BROKER_PORT: u16 = crate::secrets::WIFI_NETWORKS[0].broker_port;
+// #100 HA Mosquitto broker (v2 MQTT-native bridge): the leg is now the ACTIVE slot's own-VLAN
+// broker, resolved at RUNTIME in `mqtt_session` from the NVS net-record (`active_broker()`) — a
+// slot IS a (ssid, broker, ota) tuple, so the broker MUST follow the associated network (the
+// quad-homed-broker rule: a cross-VLAN leg drops CONNACK). Not a compile-time const any more.
 
 /// The retained downlink topic every node subscribes to for battery voltages, and
 /// the uplink topic template `smol/<id>/telemetry` — see `mqtt_session`.
@@ -413,10 +398,82 @@ pub fn try_time_sync(
     synced
 }
 
+/// #100: outcome of ONE association attempt — drives the slot-fallback loop. Only `TimedOut`
+/// counts toward a revert; `Aborted` (a #20 long-press) unwinds the burst without touching NVS.
+#[cfg(feature = "wifi")]
+enum AssocResult {
+    Associated,
+    TimedOut,
+    Aborted,
+}
+
+/// #100: one association attempt on `WIFI_NETWORKS[slot]`. Disconnect-then-(re)configure so a
+/// slot SWITCH (different SSID) re-associates cleanly, then wait for `is_connected` within
+/// `SYNC_BUDGET`. Extracted from `run_ntp_burst` so the fallback loop can retry PER-SLOT and
+/// revert on `TimedOut` ONLY (never on a long-press abort or a later DHCP/SNTP failure).
+#[cfg(feature = "wifi")]
+fn associate_slot(
+    controller: &mut esp_wifi::wifi::WifiController<'static>,
+    slot: u8,
+    tick: &mut dyn FnMut() -> bool,
+) -> AssocResult {
+    let net = &crate::secrets::WIFI_NETWORKS[slot as usize];
+    // Drop any prior association before reconfiguring (harmless if not connected) so switching
+    // SSIDs between slots doesn't leave a stale config. Errors are non-fatal → treated as a miss.
+    let _ = controller.disconnect();
+    if controller
+        .set_configuration(&Configuration::Client(ClientConfiguration {
+            ssid: net.ssid.into(),
+            password: net.pass.into(),
+            // COEXIST SOAK (#23 PART 1): pin association to ch1 (see the pre-#100 note).
+            #[cfg(feature = "coexist-soak")]
+            channel: Some(1),
+            ..Default::default()
+        }))
+        .is_err()
+    {
+        return AssocResult::TimedOut;
+    }
+    if !matches!(controller.is_started(), Ok(true)) {
+        if controller.start().is_err() {
+            return AssocResult::TimedOut;
+        }
+    }
+    if controller.connect().is_err() {
+        return AssocResult::TimedOut;
+    }
+    let deadline = Instant::now() + SYNC_BUDGET;
+    while !matches!(controller.is_connected(), Ok(true)) {
+        if tick() {
+            return AssocResult::Aborted; // #20 long-press mid-sync
+        }
+        if Instant::now() > deadline {
+            log::warn!("smol #100: assoc timed out on slot {} ('{}')", slot, net.ssid);
+            return AssocResult::TimedOut;
+        }
+    }
+    log::info!("smol #100: associated to slot {} ('{}')", slot, net.ssid);
+    AssocResult::Associated
+}
+
+/// #100: the ACTIVE slot's broker leg (IPv4, port), resolved at RUNTIME from the NVS net-record
+/// (default slot 0 if erased/corrupt). The broker MUST follow the associated network — own-VLAN
+/// leg rule, a cross-VLAN leg drops CONNACK. Stage 2 layers an NVS broker OVERRIDE + CONNACK
+/// fallback on top of this. Panic-free slot index (clamped to the array).
+#[cfg(feature = "wifi")]
+fn active_broker() -> (Ipv4Addr, u16) {
+    let active = crate::ota::read_net_cfg().map_or(0usize, |c| c.active as usize);
+    let net = &crate::secrets::WIFI_NETWORKS[active.min(crate::secrets::WIFI_NETWORKS.len() - 1)];
+    (
+        Ipv4Addr::new(net.broker_ip[0], net.broker_ip[1], net.broker_ip[2], net.broker_ip[3]),
+        net.broker_port,
+    )
+}
+
 /// Shared WiFi -> DHCP -> SNTP burst, reused by both the Phase-2 `wifi`-only
-/// build and the Phase-3 `espnow` build. Associates using the `crate::secrets`
-/// credentials, drives a `smoltcp` DHCP+UDP stack over `device`, runs one SNTP
-/// exchange, and returns the Unix time (seconds) or `None` on any timeout.
+/// build and the Phase-3 `espnow` build. #100: associates on the NVS-selected slot with the
+/// un-brickable fallback (see the assoc loop below), drives a `smoltcp` DHCP+UDP stack over
+/// `device`, runs one SNTP exchange, and returns the Unix time (seconds) or `None` on any timeout.
 ///
 /// `tick` is invoked frequently inside every busy-wait loop; the `espnow` build
 /// passes a closure that fast-blinks the blue LED so "WiFi/NTP in progress" is
@@ -486,38 +543,46 @@ pub fn run_ntp_burst(
     );
     let tcp_handle = sockets.add(tcp_socket);
 
-    // --- WiFi connect ----------------------------------------------------
-    controller
-        .set_configuration(&Configuration::Client(ClientConfiguration {
-            ssid: WIFI_SSID.into(),
-            password: WIFI_PASSWORD.into(),
-            // COEXIST SOAK (#23 PART 1): pin association to ch1 so the gateway lands
-            // on the same channel the leaf pins to (mesh ch == AP ch). The `roam`
-            // SSID spans 1/6/11; this restricts the STA to the ch1 AP (north-bedroom).
-            #[cfg(feature = "coexist-soak")]
-            channel: Some(1),
-            ..Default::default()
-        }))
-        .ok()?;
-    if !matches!(controller.is_started(), Ok(true)) {
-        controller.start().ok()?;
-    }
-    controller.connect().ok()?;
-
-    let deadline = Instant::now() + SYNC_BUDGET;
-
-    // Wait for association.
-    while !matches!(controller.is_connected(), Ok(true)) {
-        // #20 abort: a long-press mid-sync bails the burst (tick latches true).
-        if tick() {
+    // --- #100 WiFi connect with the UN-BRICKABLE slot fallback -----------
+    // Associate on the NVS-selected slot (default 0 if the record is erased/corrupt). A wrong or
+    // unreachable selection SELF-HEALS without USB: up to ASSOC_ATTEMPTS × SYNC_BUDGET on the
+    // active slot; all TimedOut → the ONE revert to the other slot (write NVS {active=other,
+    // fallback=1}) → retry it. BOTH slots fail → STAY PUT (return None; the boot free-runs and the
+    // next burst/boot retries). The NVS `fallback` flag GATES the cross-reboot revert: an
+    // already-reverted boot never reverts again → provably ONE revert-write per commanded
+    // selection, ZERO flash wear during a sustained total outage. Only a `TimedOut` counts toward a
+    // revert — a `#20 long-press Aborted` unwinds without ever touching NVS.
+    const ASSOC_ATTEMPTS: u8 = 3;
+    let mut sel = crate::ota::read_net_cfg().unwrap_or(crate::ota::NetCfg {
+        active: 0,
+        commanded: 0,
+        fallback: false,
+    });
+    'assoc: loop {
+        let mut attempt = 0u8;
+        loop {
+            match associate_slot(controller, sel.active, tick) {
+                AssocResult::Associated => break 'assoc,
+                AssocResult::Aborted => return None, // long-press → never a revert
+                AssocResult::TimedOut => {
+                    attempt += 1;
+                    if attempt >= ASSOC_ATTEMPTS {
+                        break; // active slot exhausted → revert or stay-put
+                    }
+                }
+            }
+        }
+        if sel.fallback {
+            // Already reverted (this boot, or a prior one — the NVS flag) and the fallback slot ALSO
+            // failed → STAY PUT. No revert, no NVS write (the anti-ping-pong / zero-wear guarantee).
+            log::warn!("smol #100: both slots unreachable (fallback latched) — staying put, no NVS write");
             return None;
         }
-        if Instant::now() > deadline {
-            log::warn!("smol: WiFi connect timed out");
-            return None;
-        }
+        let other = 1 - sel.active;
+        sel = crate::ota::NetCfg { active: other, commanded: sel.commanded, fallback: true };
+        crate::ota::write_net_cfg(sel); // the ONE revert-write
+        log::warn!("smol #100: selected slot unreachable — reverted to slot {} (fallback), retrying", other);
     }
-    log::info!("smol: WiFi associated to '{}'", WIFI_SSID);
 
     // Poll the stack until DHCP yields an address. The DHCP `Event` borrows
     // the socket, so we extract the plain (Ipv4Cidr, router) data inside a
@@ -1432,7 +1497,9 @@ fn mqtt_session(
     deadline: Instant,
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
-    let broker = (IpAddress::Ipv4(MQTT_BROKER_IP), MQTT_BROKER_PORT);
+    // #100: broker = the ACTIVE slot's own-VLAN leg (runtime, from the NVS net-record).
+    let (broker_ip, broker_port) = active_broker();
+    let broker = (IpAddress::Ipv4(broker_ip), broker_port);
     // #21 per-board node-manager config topic (retained default-screen command).
     let mut cfg_topic = MqttScratch::new();
     let _ = write!(cfg_topic, "smol/{}/config/default_screen", node_id);

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -53,9 +53,10 @@ pub const OTA_AUTO_INSTALL: bool = false;
 
 /// Image-host allowlist (spec §4b-5): an announce whose URL host is not one of these
 /// is refused BEFORE any socket opens. The real LAN host(s) live in the GIT-IGNORED
-/// `crate::secrets` (this repo is PUBLIC — never commit a LAN IP), mirroring how
-/// `MQTT_BROKER_IP` is sourced. Rebuild to change the host. Gate logic is unchanged.
-pub const IMAGE_HOST_ALLOWLIST: &[&str] = crate::secrets::OTA_IMAGE_HOSTS;
+/// `crate::secrets` (this repo is PUBLIC — never commit a LAN IP). #100 Stage 1a: sourced
+/// from slot 0 of the dual-slot `WIFI_NETWORKS` (const-index [0]); identical to pre-#100.
+/// Stage 3 makes it the runtime-active slot's allowlist + an NVS CFG-`O` override.
+pub const IMAGE_HOST_ALLOWLIST: &[&str] = crate::secrets::WIFI_NETWORKS[0].ota_hosts;
 
 /// Max image = one app slot (`ota_0`/`ota_1` size from `partitions-ota.csv`). An
 /// announce larger than this is refused before any flash op; also cross-checked vs

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -1587,12 +1587,18 @@ pub fn write_net_cfg(c: NetCfg) {
     let Ok(Some(nvs)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Nvs)) else {
         return;
     };
-    let mut region = nvs.as_embedded_storage(&mut flash);
+    // Sector 5 is the LAST nvs sector: the FlashRegion erase API bounds-checks its EXCLUSIVE
+    // end with `contains(addr_to)` (strict `<`), so `erase(0x5000, 0x6000)` — ending exactly at
+    // the partition boundary — is structurally impossible through the region (OutOfBounds).
+    // Found on hardware (#100 canary reset-loop): the swallowed erase error meant the record
+    // never persisted. Erase+write RAW at absolute addresses instead — same 4 KB, same
+    // segregation (identity/floor/boot-count live in sectors 0-4, untouched).
+    let base = nvs.offset(); // absolute flash address of the nvs partition
     let sector = <FlashStorage as NorFlash>::ERASE_SIZE as u32; // 4096
-    if region.erase(NET_REC_OFF, NET_REC_OFF + sector).is_err() {
+    if flash.erase(base + NET_REC_OFF, base + NET_REC_OFF + sector).is_err() {
         return;
     }
-    let _ = region.write(NET_REC_OFF, &encode_net_cfg(c));
+    let _ = flash.write(base + NET_REC_OFF, &encode_net_cfg(c));
 }
 
 /// The running app slot as 0 (`ota_0`) / 1 (`ota_1`); 255 on a non-OTA board or any read

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -1488,6 +1488,120 @@ pub fn reset_reason_token() -> &'static str {
     }
 }
 
+// =========================================================================
+// #100 network-switcher: persisted network selection (nvs SECTOR 5, offset 0x5000).
+// =========================================================================
+//
+// The runtime WiFi-slot selection lives in its OWN nvs sector, SEGREGATED from identity
+// (sector 0), the freshness-floor (sectors 1-2 @ 4096/8192) and the boot-count (sectors 3-4 @
+// 12288/16384) — verified the ONLY free sector in the 0x6000 (6-sector) nvs partition. A write
+// erases the whole sector, so own-sector segregation is the #40/#70 brick-class discipline: this
+// record can NEVER wipe identity/floor/boot-count, and they can never wipe it. Corrupt / erased /
+// out-of-range → `None` → the caller defaults to slot 0 (the boot-default network — SAFE: a
+// garbage record never strands the node on a phantom slot). Brick-safe: never panics, best-effort.
+#[cfg(feature = "wifi")]
+const NET_MAGIC: [u8; 4] = *b"SMn1";
+#[cfg(feature = "wifi")]
+const NET_VERSION: u8 = 1;
+/// nvs sector 5 = 0x5000 = 20480 (the one free sector; see the segregation note above).
+#[cfg(feature = "wifi")]
+const NET_REC_OFF: u32 = 5 * 4096;
+#[cfg(feature = "wifi")]
+const NET_REC_LEN: usize = 16;
+
+/// The persisted network selection. `active` = the slot we associate on NOW; `commanded` = the
+/// last slot HA asked for via CFG-`N` — it differs from `active` iff we auto-reverted; `fallback`
+/// = we're running on a reverted slot, not the commanded one (surfaced as `net=<slot>:fb` in DIAG).
+#[cfg(feature = "wifi")]
+#[derive(Clone, Copy)]
+// #100 Stage 1b WIP: the record + its read/write are wired by the assoc-fallback + CFG-N apply in
+// the NEXT commit; this `allow(dead_code)` comes OFF then (the whole net-record becomes live).
+#[allow(dead_code)]
+pub struct NetCfg {
+    pub active: u8,
+    pub commanded: u8,
+    pub fallback: bool,
+}
+
+/// Decode a stored net record. `Some` iff magic + version + both redundancy guards pass AND every
+/// slot index is in range (0/1 — `WIFI_NETWORKS.len() == 2`). Erased flash (0xFF) / corruption /
+/// an out-of-range slot all fail → `None` → caller uses slot 0.
+#[cfg(feature = "wifi")]
+#[allow(dead_code)] // #100 Stage 1b WIP — wired next commit (see NetCfg note).
+fn parse_net_cfg(rec: &[u8]) -> Option<NetCfg> {
+    if rec.len() < 10 || rec[0..4] != NET_MAGIC || rec[4] != NET_VERSION {
+        return None;
+    }
+    let (active, commanded, fb) = (rec[5], rec[6], rec[7]);
+    // complement + checksum guards (mirror the identity record).
+    if rec[8] != active ^ 0xFF || rec[9] != (active ^ commanded ^ fb).wrapping_add(0x5A) {
+        return None;
+    }
+    // Slot indices MUST be valid (< 2) and fallback a clean bool — else treat as corrupt.
+    if active > 1 || commanded > 1 || fb > 1 {
+        return None;
+    }
+    Some(NetCfg { active, commanded, fallback: fb != 0 })
+}
+
+/// Encode the 16-byte net record.
+#[cfg(feature = "wifi")]
+#[allow(dead_code)] // #100 Stage 1b WIP — wired next commit (see NetCfg note).
+fn encode_net_cfg(c: NetCfg) -> [u8; NET_REC_LEN] {
+    let mut r = [0u8; NET_REC_LEN];
+    r[0..4].copy_from_slice(&NET_MAGIC);
+    r[4] = NET_VERSION;
+    r[5] = c.active;
+    r[6] = c.commanded;
+    r[7] = c.fallback as u8;
+    r[8] = c.active ^ 0xFF;
+    r[9] = (c.active ^ c.commanded ^ c.fallback as u8).wrapping_add(0x5A);
+    r
+}
+
+/// Read the persisted net selection. `None` on any flash/partition error, erased, or corrupt →
+/// the caller defaults to slot 0 (boot-default network — SAFE). Brick-safe (never panics).
+#[cfg(feature = "wifi")]
+#[allow(dead_code)] // #100 Stage 1b WIP — called by the boot slot-select + fallback next commit.
+pub fn read_net_cfg() -> Option<NetCfg> {
+    use embedded_storage::nor_flash::ReadNorFlash;
+    let mut flash = FlashStorage::new();
+    let mut buf = [0u8; PT_SCRATCH];
+    let pt = read_partition_table(&mut flash, &mut buf).ok()?;
+    let nvs = pt
+        .find_partition(PartitionType::Data(DataPartitionSubType::Nvs))
+        .ok()??;
+    let mut region = nvs.as_embedded_storage(&mut flash);
+    let mut rec = [0u8; NET_REC_LEN];
+    region.read(NET_REC_OFF, &mut rec).ok()?;
+    parse_net_cfg(&rec)
+}
+
+/// Persist the net selection (erase + write nvs sector 5). Best-effort — any error is swallowed
+/// (the in-RAM selection still governs THIS boot; the next boot retries). Sector 5 is the net
+/// record's OWN sector (segregated), so the erase+write can never touch identity/floor/boot-count.
+/// Called ONLY on a genuine change (CFG-`N` apply, or the ONE-per-boot fallback revert) — never in
+/// a retry loop, so no flash wear / NVS ping-pong even during a total-outage stay-put.
+#[cfg(feature = "wifi")]
+#[allow(dead_code)] // #100 Stage 1b WIP — called by the one-per-boot fallback revert next commit.
+pub fn write_net_cfg(c: NetCfg) {
+    use embedded_storage::nor_flash::NorFlash;
+    let mut flash = FlashStorage::new();
+    let mut buf = [0u8; PT_SCRATCH];
+    let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
+        return;
+    };
+    let Ok(Some(nvs)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Nvs)) else {
+        return;
+    };
+    let mut region = nvs.as_embedded_storage(&mut flash);
+    let sector = <FlashStorage as NorFlash>::ERASE_SIZE as u32; // 4096
+    if region.erase(NET_REC_OFF, NET_REC_OFF + sector).is_err() {
+        return;
+    }
+    let _ = region.write(NET_REC_OFF, &encode_net_cfg(c));
+}
+
 /// The running app slot as 0 (`ota_0`) / 1 (`ota_1`); 255 on a non-OTA board or any read
 /// error. A silent rollback flips this vs the pushed slot — the headline #70 signal.
 #[cfg(feature = "espnow")]

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -1514,9 +1514,6 @@ const NET_REC_LEN: usize = 16;
 /// = we're running on a reverted slot, not the commanded one (surfaced as `net=<slot>:fb` in DIAG).
 #[cfg(feature = "wifi")]
 #[derive(Clone, Copy)]
-// #100 Stage 1b WIP: the record + its read/write are wired by the assoc-fallback + CFG-N apply in
-// the NEXT commit; this `allow(dead_code)` comes OFF then (the whole net-record becomes live).
-#[allow(dead_code)]
 pub struct NetCfg {
     pub active: u8,
     pub commanded: u8,
@@ -1527,7 +1524,6 @@ pub struct NetCfg {
 /// slot index is in range (0/1 — `WIFI_NETWORKS.len() == 2`). Erased flash (0xFF) / corruption /
 /// an out-of-range slot all fail → `None` → caller uses slot 0.
 #[cfg(feature = "wifi")]
-#[allow(dead_code)] // #100 Stage 1b WIP — wired next commit (see NetCfg note).
 fn parse_net_cfg(rec: &[u8]) -> Option<NetCfg> {
     if rec.len() < 10 || rec[0..4] != NET_MAGIC || rec[4] != NET_VERSION {
         return None;
@@ -1546,7 +1542,6 @@ fn parse_net_cfg(rec: &[u8]) -> Option<NetCfg> {
 
 /// Encode the 16-byte net record.
 #[cfg(feature = "wifi")]
-#[allow(dead_code)] // #100 Stage 1b WIP — wired next commit (see NetCfg note).
 fn encode_net_cfg(c: NetCfg) -> [u8; NET_REC_LEN] {
     let mut r = [0u8; NET_REC_LEN];
     r[0..4].copy_from_slice(&NET_MAGIC);
@@ -1562,7 +1557,6 @@ fn encode_net_cfg(c: NetCfg) -> [u8; NET_REC_LEN] {
 /// Read the persisted net selection. `None` on any flash/partition error, erased, or corrupt →
 /// the caller defaults to slot 0 (boot-default network — SAFE). Brick-safe (never panics).
 #[cfg(feature = "wifi")]
-#[allow(dead_code)] // #100 Stage 1b WIP — called by the boot slot-select + fallback next commit.
 pub fn read_net_cfg() -> Option<NetCfg> {
     use embedded_storage::nor_flash::ReadNorFlash;
     let mut flash = FlashStorage::new();
@@ -1583,7 +1577,6 @@ pub fn read_net_cfg() -> Option<NetCfg> {
 /// Called ONLY on a genuine change (CFG-`N` apply, or the ONE-per-boot fallback revert) — never in
 /// a retry loop, so no flash wear / NVS ping-pong even during a total-outage stay-put.
 #[cfg(feature = "wifi")]
-#[allow(dead_code)] // #100 Stage 1b WIP — called by the one-per-boot fallback revert next commit.
 pub fn write_net_cfg(c: NetCfg) {
     use embedded_storage::nor_flash::NorFlash;
     let mut flash = FlashStorage::new();

--- a/rust/clock/src/secrets.rs.example
+++ b/rust/clock/src/secrets.rs.example
@@ -4,46 +4,65 @@
 //!
 //! ```bash
 //! cp src/secrets.rs.example src/secrets.rs
-//! # then edit src/secrets.rs with your real SSID/password
+//! # then edit src/secrets.rs with your real SSID/password(s)
 //! ```
 //!
 //! `src/secrets.rs` is git-ignored (`.gitignore`: `**/secrets.rs`) because the
 //! repo is PUBLIC — real credentials must never be committed. Only the `wifi`
 //! and `espnow` feature builds read these (Phase 1 needs no WiFi).
 
-/// WiFi SSID for the NTP-sync burst.
-pub const WIFI_SSID: &str = "YOUR_WIFI_SSID";
+// --- #100 dual network slots (dashboard-switchable, un-brickable fallback) ----
+// Each slot is a full network identity: WiFi creds + the MQTT broker leg + the OTA
+// image-host allowlist. The ACTIVE slot is selected at RUNTIME (CFG key `N`, persisted
+// in NVS) and a failed association auto-reverts to the other slot (the un-brickable
+// fallback — a wrong selection self-heals without USB). Secrets NEVER cross MQTT; only
+// the slot INDEX is relayed. Slot 0 is the boot default.
 
-/// WiFi password for `WIFI_SSID`.
-pub const WIFI_PASS: &str = "YOUR_WIFI_PASSWORD";
+/// One bakeable network slot. `broker_ip` MUST be the broker leg that is SAME-SUBNET as
+/// this network's DHCP lease (the quad-homed-broker rule — a cross-VLAN leg drops CONNACK).
+/// `ota_hosts` is the OTA fetch allowlist for this network (defense-in-depth; the image is
+/// itself ed25519-gated). Plain-TCP Mosquitto (no TLS in no_std).
+pub struct NetSlot {
+    pub ssid: &'static str,
+    pub pass: &'static str,
+    /// Broker IPv4 as four octets (own-VLAN leg for THIS network).
+    pub broker_ip: [u8; 4],
+    /// Broker TCP port (Mosquitto default 1883, plain).
+    pub broker_port: u16,
+    /// OTA image-host allowlist for this network (issue #6 §4b-5).
+    pub ota_hosts: &'static [&'static str],
+}
 
-// --- Home Assistant MQTT broker (v2 MQTT-native batt/telemetry bridge) --------
-// Plain-TCP Mosquitto (no TLS). Point this at the broker leg that is SAME-SUBNET
-// as the board's DHCP lease (no inter-VLAN routing / no firewall in path). The
-// `espnow` gateway publishes telemetry + retained discovery here and receives the
-// retained `smol/display/batt` payload; the `wifi`-only build receives it at boot.
+/// The two baked network slots. Slot 0 = boot default; slot 1 = the alternate (e.g. the
+/// migration target). Real values live ONLY in the git-ignored `secrets.rs` — never commit them.
+pub const WIFI_NETWORKS: [NetSlot; 2] = [
+    NetSlot {
+        ssid: "YOUR_WIFI_SSID_0",
+        pass: "YOUR_WIFI_PASSWORD_0",
+        broker_ip: [10, 0, 0, 0],
+        broker_port: 1883,
+        ota_hosts: &["10.0.0.0"],
+    },
+    NetSlot {
+        ssid: "YOUR_WIFI_SSID_1",
+        pass: "YOUR_WIFI_PASSWORD_1",
+        broker_ip: [10, 0, 0, 0],
+        broker_port: 1883,
+        ota_hosts: &["10.0.0.0"],
+    },
+];
 
-/// Broker IPv4 as four octets (kept as a plain array so this file has no imports).
-pub const MQTT_BROKER_IP: [u8; 4] = [10, 0, 0, 0];
-
-/// Broker TCP port (Mosquitto default 1883, plain — no TLS in no_std).
-pub const MQTT_BROKER_PORT: u16 = 1883;
-
+// --- MQTT broker auth (shared across slots — same Mosquitto, same credentials) ----
 /// Broker username (anonymous auth is expected OFF → username + password required).
 pub const MQTT_USER: &str = "YOUR_MQTT_USER";
 
 /// Broker password. NEVER commit the real value — `secrets.rs` is git-ignored.
 pub const MQTT_PASS: &str = "YOUR_MQTT_PASSWORD";
 
-// --- OTA image-host allowlist (issue #6) --------------------------------------
-/// URL hosts the OTA fetch will accept an image from (spec §4b-5). Real LAN IP(s)
-/// live only in the git-ignored `secrets.rs` — never commit them (repo is PUBLIC).
-pub const OTA_IMAGE_HOSTS: &[&str] = &["10.0.0.0"]; // your OTA image host(s)
-
 // --- #26 smol Cast → WLED matrix (realtime UDP pixel stream) ------------------
 // The gateway mirrors its OLED image onto a network LED matrix running WLED, over
 // UDP :21324 (DNRGB). The matrix's LAN IP lives ONLY here (git-ignored) — never
-// commit it (repo is PUBLIC), same discipline as WIFI_SSID / OTA_IMAGE_HOSTS. Only a
+// commit it (repo is PUBLIC), same discipline as the WiFi slots. Only a
 // `--features cast` build reads these; each is `#[cfg(feature = "cast")]` so a
 // non-cast build never warns on the unused const.
 


### PR DESCRIPTION
JP's #100, Stage 1 (WiFi core). Built by morpheus-quartet2 (design + implementation through code-complete; hit the weekly quota pre-build), finished by team-lead (orphaned-deadline fix + clippy).

**What ships:**
- **Dual baked NetSlot slots** in git-ignored secrets (`(ssid, pass, broker_ip, broker_port, ota_hosts)` per slot; secrets.rs.example templates the shape).
- **CFG key N** — retained per-node/fleet network selection; NVS-persisted (**sector 5**, own-sector per the #40 brick discipline; corrupt/unseeded → slot 0).
- **The un-brickable fallback** (the load-bearing safety): assoc-timeout-only revert after 3×30s attempts; **two-level revert gating** (NVS cross-reboot flag + in-RAM per-boot) = ≤1 revert-write per selection, **provably zero flash wear in total outage** (STAY-PUT: both-slots-fail → keep retrying active at slow cadence, no further writes); `net=`/`fallback` surfaced in DIAG.
- Runtime broker per slot (IP-only v1; hostname deferred pending DNS-from-DHCP verification).

**Verify:** 4 profiles compile + espnow clippy -D warnings = 0. Default-build invariant via cfg-gating.
**HW canary (team-lead, before/at merge):** select a bogus slot → fallback reverts + DIAG shows net=fallback → then a REAL both-way switch (slot0 jplovescl ↔ slot1 roam) → clean migrations. The bench proof IS the feature's acceptance test.

Stage 2 (CFG broker override) + Stage 3 (OTA-host override) follow per the signed-off staging.