### PR TITLE
feat(fw+ha): #74 stage-2 — config-drift detection + display-mirror

### DIFF
--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -410,6 +410,37 @@ input_button:
 # --- Dashboard mirror: subscribe the retained topic so a card shows exactly ---
 # what the boards fetch (the payload is <=96 chars, well under the 255 state cap).
 mqtt:
+  # --- #74 item 5 (stage-2) DISPLAY MIRROR — the gateway's live OLED as an image ---
+  # The gateway publishes its glass as a base64 64×32 1-bit BMP to retained smol/<id>/screen
+  # (fw reuses the #26 Cast framebuffer tee — no new draw-path tap; GATEWAY-only v1, a leaf's
+  # screen needs a mesh-frame follow-on). HA decodes b64 → BMP and serves it as an image the
+  # dashboard renders (the node-box "mini-OLED" idiom made real). Downsampled to 64×32 so the
+  # 1-bit BMP (~424 B base64) fits the gateway's 512 B MQTT packet. Only the elected gateway
+  # publishes a live image; the other ids stay 'unknown' until they take the gateway role.
+  # NOTE: supersedes luna's staged TEXT `smol/<id>/display` (DISP|line;…) mirror — that HELD
+  # approach needed an invasive per-plugin text tap; this bitmap path is non-invasive + faithful.
+  image:
+    - name: "smol 7 screen"
+      unique_id: smol_7_screen_mirror
+      image_topic: "smol/7/screen"
+      image_encoding: b64
+      content_type: image/bmp
+      entity_category: diagnostic
+      icon: "mdi:monitor-screenshot"
+    - name: "smol 8 screen"
+      unique_id: smol_8_screen_mirror
+      image_topic: "smol/8/screen"
+      image_encoding: b64
+      content_type: image/bmp
+      entity_category: diagnostic
+      icon: "mdi:monitor-screenshot"
+    - name: "smol 9 screen"
+      unique_id: smol_9_screen_mirror
+      image_topic: "smol/9/screen"
+      image_encoding: b64
+      content_type: image/bmp
+      entity_category: diagnostic
+      icon: "mdi:monitor-screenshot"
   sensor:
     - name: "smol display batt"
       unique_id: smol_display_batt_mirror

--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -1225,8 +1225,10 @@ mqtt:
         {% if f | length >= 4 %}{% set ns.rows = ns.rows + [{'builds': f[0], 'outcome': f[1], 'dur_s': f[2] | int(0), 'at_up': f[3] | int(0)}] %}{% endif %}{% endfor %}
         {{ {'entries': ns.rows} | tojson }}
     # --- #74 config-drift DEVICE ECHO (item 3) — applied-config string the node reports.
-    # HA-side _expected reconstruction + drift binary_sensor are HELD pending the cfg= canonical
-    # contract with the #70/#74 fw (luna-74-ha-staging.md §3) — they'd false-alarm until pinned.
+    # CONTRACT PINNED (fw #74 stage-2): the DIAG record now carries `cfg=<screen>:<page>,<led>,
+    # <mask4hexU>,<units>` (e.g. `Grid:1,status,0000,F24`; screen = the LIVE rendered screen, mask
+    # = #55's %04X hex, units = temp+clock e.g. F24). The `_expected` reconstruction + `config_drift`
+    # binary_sensor live in the template: section below (search "config-drift COMPARATOR").
     - name: "smol 7 config applied"
       unique_id: smol_7_cfg_applied_mirror
       state_topic: "smol/7/diag"
@@ -1643,6 +1645,128 @@ template:
               {% endfor %}
             {% endfor %}
             {{ ns.e }}
+
+  # =====================================================================================
+  # #74 item 3 — config-drift COMPARATOR (fw contract PINNED in #74 stage-2).
+  # `_expected` rebuilds the SAME canonical string the fw emits in `cfg=`, from the retained
+  # COMMAND topics HA published. `config_drift` does a ROBUST FIELD-BY-FIELD compare (not a
+  # brittle whole-string equality): a field is only judged when HA has actually commanded it
+  # (a still-unknown command topic = "no opinion" = never drift), and the screen field
+  # tolerates a commanded default that omits the `:page`. So a half-configured node does NOT
+  # false-alarm; drift lights only on a genuine live≠desired (dropped CFG relay / stale NVS /
+  # manual nav off the commanded default). Attributes surface applied-vs-expected for debug.
+  # NOTE: logic host-validated (jinja mocks, 10 scenarios); confirm on the id7 canary that the
+  # live cfg= string parses as expected before trusting the dashboard drift chip.
+  - sensor:
+      - name: "smol 7 config expected"
+        unique_id: smol_7_config_expected
+        icon: "mdi:cog-outline"
+        state: >-
+          {% set scr = states('sensor.smol_7_config') %}
+          {% set led = states('sensor.smol_7_led') %}
+          {% set mask = states('sensor.smol_7_plugins') %}
+          {% set units = (state_attr('sensor.smol_units','temp') or 'F') ~ (state_attr('sensor.smol_units','clock') or '24') %}
+          {{ scr }},{{ led }},{{ mask }},{{ units }}
+      - name: "smol 8 config expected"
+        unique_id: smol_8_config_expected
+        icon: "mdi:cog-outline"
+        state: >-
+          {% set scr = states('sensor.smol_8_config') %}
+          {% set led = states('sensor.smol_8_led') %}
+          {% set mask = states('sensor.smol_8_plugins') %}
+          {% set units = (state_attr('sensor.smol_units','temp') or 'F') ~ (state_attr('sensor.smol_units','clock') or '24') %}
+          {{ scr }},{{ led }},{{ mask }},{{ units }}
+      - name: "smol 9 config expected"
+        unique_id: smol_9_config_expected
+        icon: "mdi:cog-outline"
+        state: >-
+          {% set scr = states('sensor.smol_9_config') %}
+          {% set led = states('sensor.smol_9_led') %}
+          {% set mask = states('sensor.smol_9_plugins') %}
+          {% set units = (state_attr('sensor.smol_units','temp') or 'F') ~ (state_attr('sensor.smol_units','clock') or '24') %}
+          {{ scr }},{{ led }},{{ mask }},{{ units }}
+  - binary_sensor:
+      - name: "smol 7 config drift"
+        unique_id: smol_7_config_drift
+        device_class: problem
+        icon: "mdi:cog-sync"
+        state: >-
+          {% set ap = states('sensor.smol_7_config_applied') %}
+          {% set ns = namespace(drift=false) %}
+          {% if ap not in ['unknown','unavailable','none',''] %}
+            {% set f = ap.split(',') %}
+            {% if f | length >= 4 %}
+              {% set e_scr = states('sensor.smol_7_config') %}
+              {% set e_led = states('sensor.smol_7_led') %}
+              {% set e_mask = states('sensor.smol_7_plugins') %}
+              {% set e_units = (state_attr('sensor.smol_units','temp') or '') ~ (state_attr('sensor.smol_units','clock') or '') %}
+              {% if e_scr not in ['unknown','unavailable','none',''] %}
+                {% set a_cmp = f[0] if ':' in e_scr else f[0].split(':')[0] %}
+                {% if a_cmp != e_scr %}{% set ns.drift = true %}{% endif %}
+              {% endif %}
+              {% if e_led not in ['unknown','unavailable','none',''] and f[1] != e_led %}{% set ns.drift = true %}{% endif %}
+              {% if e_mask not in ['unknown','unavailable','none',''] and f[2] != e_mask %}{% set ns.drift = true %}{% endif %}
+              {% if e_units | length == 3 and f[3] != e_units %}{% set ns.drift = true %}{% endif %}
+            {% endif %}
+          {% endif %}
+          {{ ns.drift }}
+        attributes:
+          applied: "{{ states('sensor.smol_7_config_applied') }}"
+          expected: "{{ states('sensor.smol_7_config_expected') }}"
+      - name: "smol 8 config drift"
+        unique_id: smol_8_config_drift
+        device_class: problem
+        icon: "mdi:cog-sync"
+        state: >-
+          {% set ap = states('sensor.smol_8_config_applied') %}
+          {% set ns = namespace(drift=false) %}
+          {% if ap not in ['unknown','unavailable','none',''] %}
+            {% set f = ap.split(',') %}
+            {% if f | length >= 4 %}
+              {% set e_scr = states('sensor.smol_8_config') %}
+              {% set e_led = states('sensor.smol_8_led') %}
+              {% set e_mask = states('sensor.smol_8_plugins') %}
+              {% set e_units = (state_attr('sensor.smol_units','temp') or '') ~ (state_attr('sensor.smol_units','clock') or '') %}
+              {% if e_scr not in ['unknown','unavailable','none',''] %}
+                {% set a_cmp = f[0] if ':' in e_scr else f[0].split(':')[0] %}
+                {% if a_cmp != e_scr %}{% set ns.drift = true %}{% endif %}
+              {% endif %}
+              {% if e_led not in ['unknown','unavailable','none',''] and f[1] != e_led %}{% set ns.drift = true %}{% endif %}
+              {% if e_mask not in ['unknown','unavailable','none',''] and f[2] != e_mask %}{% set ns.drift = true %}{% endif %}
+              {% if e_units | length == 3 and f[3] != e_units %}{% set ns.drift = true %}{% endif %}
+            {% endif %}
+          {% endif %}
+          {{ ns.drift }}
+        attributes:
+          applied: "{{ states('sensor.smol_8_config_applied') }}"
+          expected: "{{ states('sensor.smol_8_config_expected') }}"
+      - name: "smol 9 config drift"
+        unique_id: smol_9_config_drift
+        device_class: problem
+        icon: "mdi:cog-sync"
+        state: >-
+          {% set ap = states('sensor.smol_9_config_applied') %}
+          {% set ns = namespace(drift=false) %}
+          {% if ap not in ['unknown','unavailable','none',''] %}
+            {% set f = ap.split(',') %}
+            {% if f | length >= 4 %}
+              {% set e_scr = states('sensor.smol_9_config') %}
+              {% set e_led = states('sensor.smol_9_led') %}
+              {% set e_mask = states('sensor.smol_9_plugins') %}
+              {% set e_units = (state_attr('sensor.smol_units','temp') or '') ~ (state_attr('sensor.smol_units','clock') or '') %}
+              {% if e_scr not in ['unknown','unavailable','none',''] %}
+                {% set a_cmp = f[0] if ':' in e_scr else f[0].split(':')[0] %}
+                {% if a_cmp != e_scr %}{% set ns.drift = true %}{% endif %}
+              {% endif %}
+              {% if e_led not in ['unknown','unavailable','none',''] and f[1] != e_led %}{% set ns.drift = true %}{% endif %}
+              {% if e_mask not in ['unknown','unavailable','none',''] and f[2] != e_mask %}{% set ns.drift = true %}{% endif %}
+              {% if e_units | length == 3 and f[3] != e_units %}{% set ns.drift = true %}{% endif %}
+            {% endif %}
+          {% endif %}
+          {{ ns.drift }}
+        attributes:
+          applied: "{{ states('sensor.smol_9_config_applied') }}"
+          expected: "{{ states('sensor.smol_9_config_expected') }}"
 
 automation:
   - id: smol_publish_batt_display

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -920,7 +920,24 @@ fn main() -> ! {
                     app::TimeSource::Adopted(_) => "mesh",
                     app::TimeSource::None => "none",
                 };
-                r.set_diag_extra(led_mode.to_wire(), led_on, tage_s, tsrc);
+                // #74 item 3 (stage-2): build this node's APPLIED-config string for HA config-drift.
+                // Canonical wire form `<screen>:<page>,<led>,<mask4hexU>,<units>` (e.g.
+                // `Grid:1,status,0000,F24`) — sub-seps `,`/`:`, NEVER `|` (the DIAG separator). screen
+                // = the LIVE rendered screen (captures manual BOOT-nav, same source as #50 STAT, the
+                // "what's actually running" truth JP wants — not the commanded default). mask = #55's
+                // hex form (`parse_plugin_mask` reads hex). units = temp+clock, no sep. HA rebuilds the
+                // same string from its command topics + plain-string-compares → the drift sensor.
+                let (cfg_kind, cfg_page) = app.live_screen();
+                let cfg = alloc::format!(
+                    "{}:{},{},{:04X},{}{}",
+                    cfg_kind.as_wire(),
+                    cfg_page,
+                    led_mode.to_wire(),
+                    plugin_mask,
+                    if units.temp_f { "F" } else { "C" },
+                    if units.clk_24h { "24" } else { "12" },
+                );
+                r.set_diag_extra(led_mode.to_wire(), led_on, tage_s, tsrc, cfg.as_bytes());
             }
             // #70/#49: a LEAF broadcasts its compact DIAG record on a SLOW ~60 s cadence (diag is
             // slow-moving — keep mesh airtime low), expedited by a BOOT-button press (rate-limited

--- a/rust/clock/src/net/cast.rs
+++ b/rust/clock/src/net/cast.rs
@@ -275,3 +275,140 @@ pub fn is_enabled() -> bool {
     // SAFETY: single-caller (flush/main path, never an ISR); no reference is formed.
     unsafe { core::ptr::addr_of!(CAST_ENABLED).read() }
 }
+
+// =========================================================================
+// #74 stage-2 — display mirror: the SAME shadow glass, encoded as a tiny 1-bit
+// BMP for HA to render as an `mqtt image`. Reuses the Cast tee (no new draw-path
+// tap — the invasive per-plugin text approach was deliberately NOT taken), so a
+// `cast` build gets the HA screen mirror for free alongside the WLED stream.
+// =========================================================================
+//
+// Why a DOWNSAMPLED BMP (not the full 72×40, not raw bits):
+//   * The gateway MQTT publish path is bounded to a 512 B packet buffer (`pkt` in
+//     net/wifi.rs) — a full 72×40 1-bit BMP is 542 B raw / 724 B base64, too big.
+//     A 64×32 BMP is 318 B raw / 424 B base64 → fits the packet with margin.
+//   * BMP (not PBM/XBM) because browsers render `image/bmp` inline — HA serves the
+//     bytes through its image proxy and a `<img>` in the dashboard shows it.
+//   * base64 (not raw binary) keeps `smol/<id>/screen` a text topic (greppable via
+//     mosquitto_sub, no binary-payload edge cases) — HA decodes with `image_encoding: b64`.
+// The down-sample + 180° flip reuse [`cell_on`] (the WLED path's box-sampler), so the
+// mirror matches the glass a viewer reads (the panel is mounted `Rotate180`).
+
+/// Mirror image geometry — chosen so the 1-bit BMP fits the 512 B MQTT packet.
+pub const SCREEN_W: usize = 64;
+pub const SCREEN_H: usize = 32;
+/// A target cell lights when ≥ this % of its (near-1:1) source block is lit. Low so
+/// thin OLED text survives the mild 72×40→64×32 down-sample.
+const SCREEN_THRESH_PCT: u32 = 25;
+/// 1-bit BMP: 14 (file hdr) + 40 (info hdr) + 8 (2-colour palette) + rows. Each row is
+/// `SCREEN_W` bits padded to a 4-byte boundary = 8 B for 64 px; 32 rows = 256 B.
+const SCREEN_ROW_BYTES: usize = SCREEN_W.div_ceil(32) * 4; // 8
+const SCREEN_BMP_LEN: usize = 62 + SCREEN_ROW_BYTES * SCREEN_H; // 318
+/// base64 of the BMP: ceil(318/3)*4 = 424.
+pub const SCREEN_B64_LEN: usize = SCREEN_BMP_LEN.div_ceil(3) * 4; // 424
+
+/// Encode the shadow glass as a 64×32 1-bit BMP into `out` (must be ≥ [`SCREEN_BMP_LEN`]),
+/// returning the byte length. PURE (no HAL / heap) — host-testable like [`pack_dnrgb`].
+/// Bottom-up rows (positive `biHeight`) + `flip180` reproduce what a viewer reads off the
+/// `Rotate180`-mounted glass. Down-sample via [`cell_on`] (shared with the WLED path).
+pub fn pack_bmp1(m: &Mirror, out: &mut [u8]) -> usize {
+    if out.len() < SCREEN_BMP_LEN {
+        return 0;
+    }
+    for b in out[..SCREEN_BMP_LEN].iter_mut() {
+        *b = 0;
+    }
+    // --- BITMAPFILEHEADER (14) ---
+    out[0] = b'B';
+    out[1] = b'M';
+    out[2..6].copy_from_slice(&(SCREEN_BMP_LEN as u32).to_le_bytes());
+    out[10..14].copy_from_slice(&62u32.to_le_bytes()); // pixel data offset
+    // --- BITMAPINFOHEADER (40) ---
+    out[14..18].copy_from_slice(&40u32.to_le_bytes());
+    out[18..22].copy_from_slice(&(SCREEN_W as i32).to_le_bytes());
+    out[22..26].copy_from_slice(&(SCREEN_H as i32).to_le_bytes()); // +H = bottom-up
+    out[26..28].copy_from_slice(&1u16.to_le_bytes()); // planes
+    out[28..30].copy_from_slice(&1u16.to_le_bytes()); // 1 bpp
+    out[34..38].copy_from_slice(&((SCREEN_ROW_BYTES * SCREEN_H) as u32).to_le_bytes()); // biSizeImage
+    out[46..50].copy_from_slice(&2u32.to_le_bytes()); // biClrUsed
+    out[50..54].copy_from_slice(&2u32.to_le_bytes()); // biClrImportant
+    // --- palette (8): idx0 = black (off), idx1 = white (lit). BMP order is B,G,R,0. ---
+    out[58] = 0xFF;
+    out[59] = 0xFF;
+    out[60] = 0xFF;
+    // --- pixels: 1 = lit. Bottom-up: file row r ↔ image row (H-1-r); MSB = leftmost px. ---
+    let cfg = MatrixCfg {
+        w: SCREEN_W,
+        h: SCREEN_H,
+        serpentine: false,
+        flip180: true,
+        thresh_pct: SCREEN_THRESH_PCT,
+        on: [0, 0, 0],
+        off: [0, 0, 0],
+        timeout_s: 0,
+    };
+    for r in 0..SCREEN_H {
+        let img_y = SCREEN_H - 1 - r;
+        let row0 = 62 + r * SCREEN_ROW_BYTES;
+        for x in 0..SCREEN_W {
+            if cell_on(m, x, img_y, &cfg) {
+                out[row0 + x / 8] |= 0x80u8 >> (x % 8);
+            }
+        }
+    }
+    SCREEN_BMP_LEN
+}
+
+/// Standard base64 (RFC 4648, `+`/`/`, `=` padded) of `src` into `out`, returning the
+/// byte length written. PURE + panic-free (writes at most `out.len()` bytes; stops if
+/// `out` is too small). Host-testable.
+pub fn base64_into(src: &[u8], out: &mut [u8]) -> usize {
+    const A: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut o = 0;
+    let mut i = 0;
+    while i < src.len() {
+        if o + 4 > out.len() {
+            break;
+        }
+        let b0 = src[i];
+        let b1 = if i + 1 < src.len() { src[i + 1] } else { 0 };
+        let b2 = if i + 2 < src.len() { src[i + 2] } else { 0 };
+        out[o] = A[(b0 >> 2) as usize];
+        out[o + 1] = A[(((b0 & 0x03) << 4) | (b1 >> 4)) as usize];
+        out[o + 2] = if i + 1 < src.len() {
+            A[(((b1 & 0x0F) << 2) | (b2 >> 6)) as usize]
+        } else {
+            b'='
+        };
+        out[o + 3] = if i + 2 < src.len() {
+            A[(b2 & 0x3F) as usize]
+        } else {
+            b'='
+        };
+        o += 4;
+        i += 3;
+    }
+    o
+}
+
+/// Fixed scratch for the mirror BMP + its base64, kept off the (bounded) MQTT-flush stack
+/// in `.bss` — the same single-threaded main-path discipline as [`CAST_MIRROR`] (written
+/// and read only from the flush, never an ISR; `addr_of[_mut]!` keeps `static_mut_refs` quiet).
+static mut SCREEN_BMP: [u8; SCREEN_BMP_LEN] = [0; SCREEN_BMP_LEN];
+static mut SCREEN_B64: [u8; SCREEN_B64_LEN] = [0; SCREEN_B64_LEN];
+
+/// Gateway flush: build the current glass into a base64 BMP and hand it to `f` as a byte
+/// slice (the retained `smol/<id>/screen` payload). Closure form so no `&'static mut`
+/// escapes (`static_mut_refs`-clean), mirroring [`with_frame`].
+pub fn with_screen_b64<R>(f: impl FnOnce(&[u8]) -> R) -> R {
+    // SAFETY: single-caller (gateway flush on the main path, never an ISR); the three
+    // statics are distinct (no aliasing) and no reference to them outlives this call.
+    unsafe {
+        let m = &*core::ptr::addr_of!(CAST_MIRROR);
+        let bmp = &mut *core::ptr::addr_of_mut!(SCREEN_BMP);
+        let blen = pack_bmp1(m, bmp);
+        let b64 = &mut *core::ptr::addr_of_mut!(SCREEN_B64);
+        let n = base64_into(&bmp[..blen], b64);
+        f(&b64[..n])
+    }
+}

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -480,11 +480,29 @@ struct DiagExtra {
     tage_s: u32,
     /// #74 item 8: time source token ("ntp"/"mesh"/"none") — maps `TimeSource`.
     tsrc: &'static str,
+    /// #74 item 3 (stage-2): the node's APPLIED-config string for HA config-drift — the compact
+    /// `<screen>:<page>,<led>,<mask4hexU>,<units>` (e.g. `Grid:1,status,0000,F24`), built in `main`
+    /// from live_screen/led/plugin_mask/units and mirrored here. Fixed buffer (Copy-safe, no heap);
+    /// `cfg_len == 0` = not populated (wifi-only build: `main` only sets it on the espnow path) →
+    /// `diag_record` OMITS the `cfg=` field rather than emit a misleading default.
+    cfg: [u8; DIAG_CFG_MAX],
+    cfg_len: u8,
 }
+
+/// Max bytes of the DIAG `cfg=` applied-config string (Copy buffer in [`DiagExtra`]). Worst real
+/// content is `WledRemote:255,status,FFFF,C12` ≈ 30 B; 40 leaves headroom for any future field.
+const DIAG_CFG_MAX: usize = 40;
 
 impl DiagExtra {
     const fn new() -> Self {
-        Self { led_mode: "status", led_on: false, tage_s: 0, tsrc: "none" }
+        Self {
+            led_mode: "status",
+            led_on: false,
+            tage_s: 0,
+            tsrc: "none",
+            cfg: [0; DIAG_CFG_MAX],
+            cfg_len: 0,
+        }
     }
 }
 
@@ -2342,8 +2360,27 @@ impl RadioManager {
     /// #74: mirror `main`-owned node state (LED mode + its lit state, time-sync age + source) into
     /// the RadioManager so the DIAG record can fold in `led`/`tage`/`tsrc`. `main` calls this on the
     /// ~10 s diag-sample tick; both diag builders (leaf broadcast + gateway flush) read the copy.
-    pub fn set_diag_extra(&mut self, led_mode: &'static str, led_on: bool, tage_s: u32, tsrc: &'static str) {
-        self.diag_extra = DiagExtra { led_mode, led_on, tage_s, tsrc };
+    pub fn set_diag_extra(
+        &mut self,
+        led_mode: &'static str,
+        led_on: bool,
+        tage_s: u32,
+        tsrc: &'static str,
+        cfg: &[u8],
+    ) {
+        // #74 stage-2: copy the applied-config string into the fixed Copy buffer (clamped). An empty
+        // `cfg` (never set by `main`) keeps `cfg_len == 0`, so `diag_record` omits the `cfg=` field.
+        let n = cfg.len().min(DIAG_CFG_MAX);
+        let mut buf = [0u8; DIAG_CFG_MAX];
+        buf[..n].copy_from_slice(&cfg[..n]);
+        self.diag_extra = DiagExtra {
+            led_mode,
+            led_on,
+            tage_s,
+            tsrc,
+            cfg: buf,
+            cfg_len: n as u8,
+        };
     }
 
     /// #70/#49: build this node's compact DIAG record for retained `smol/<id>/diag`. Format matches
@@ -2383,7 +2420,7 @@ impl RadioManager {
             fallback: false,
         });
         let net_fb = if net.fallback { "fb" } else { "ok" };
-        alloc::format!(
+        let mut rec = alloc::format!(
             "DIAG|slot={}|rst={}|boot={}|ota={}|up={}|heap={}|hmin={}|btn={}|btnl={}|fok={}|ffl={}|vok={}|vfl={}|loss={}|rtt={}|rx={}|tx={}|led={}:{}|tage={}|tsrc={}|net={}:{}",
             d.boot_slot,
             d.reset_reason,
@@ -2408,7 +2445,18 @@ impl RadioManager {
             e.tsrc,
             net.active,
             net_fb,
-        )
+        );
+        // #74 item 3 (stage-2): fold in the APPLIED-config string for HA config-drift, ONLY when
+        // `main` populated it (espnow build). ASCII by construction (as_wire/to_wire/hex/F24). HA
+        // reconstructs the same string from its command topics + plain-string-compares (luna's
+        // `sensor.smol_<id>_config_applied` + drift binary_sensor) — no hash primitive needed.
+        if e.cfg_len > 0 {
+            if let Ok(cfg) = core::str::from_utf8(&e.cfg[..e.cfg_len as usize]) {
+                rec.push_str("|cfg=");
+                rec.push_str(cfg);
+            }
+        }
+        rec
     }
 
     /// #40 #3: broadcast this LEAF's OTA RX-diag beacon (`LDBG` = id + heard/verdict/sent) so a

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1934,6 +1934,25 @@ fn mqtt_session(
         }
     }
 
+    // #74 stage-2 display mirror: publish the gateway's OWN glass as a 64×32 1-bit BMP (base64) to
+    // RETAINED `smol/<id>/screen` for HA to render as an `mqtt image`. `cast`-only — it reuses the
+    // #26 Cast tee's live `Mirror` (the tee already snapshots the glass every render tick, so there
+    // is NO new draw-path tap; the invasive per-plugin text approach was deliberately not taken).
+    // GATEWAY-only v1: leaves have no MQTT (Cast is a gateway-role activity) — a leaf-screen mirror
+    // is a mesh-frame follow-on. The b64 BMP is ~424 B → fits the 512 B `pkt` packet with margin.
+    #[cfg(feature = "cast")]
+    {
+        let mut sctopic = MqttScratch::new();
+        let _ = write!(sctopic, "smol/{}/screen", node_id);
+        crate::net::cast::with_screen_b64(|b64| {
+            if let Some(n) =
+                crate::net::mqtt::encode_publish(&mut pkt, sctopic.as_bytes(), b64, true)
+            {
+                let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+            }
+        });
+    }
+
     // --- Receive the retained battery + grid payloads (both SUBSCRIBEs above) ---
     // Wait until BOTH retained downlinks land (they arrive back-to-back after the
     // subscribes) or the deadline — whichever first. A topic with no retained message

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1266,10 +1266,12 @@ impl CfgCache {
 /// `CFG_VALUE_MAX` (16, sized for a screen string) because a diag/scan record is a multi-field
 /// line (~130 B) — but still well under the ~250 B ESP-NOW frame budget once the 12 B frame
 /// prefix + 3 B id are added. #74 wave-2 folds ~7 more keys onto the DIAG record (led/rtt/rx/tx/
-/// tage/tsrc/loss), so 224 — the ESP-NOW frame is then 12 (prefix) + 3 (id) + 224 = 239 B, still
-/// under the ~250 B ESP-NOW ceiling with margin.
+/// tage/tsrc/loss); stage-2 adds the ~24 B `cfg=` applied-config string (config-drift). 232 — the
+/// ESP-NOW frame is then 12 (prefix) + 3 (id) + 232 = 247 B, still under the ~250 B ceiling. This
+/// bounds ONLY relayed LEAF records (the gateway self-publishes its own full record via MQTT); the
+/// ~24 B headroom absorbs long-uptime counter growth (up/rx/tx) so `cfg=` (record tail) survives.
 #[cfg(feature = "wifi")]
-pub const RELAY_VALUE_MAX: usize = 224;
+pub const RELAY_VALUE_MAX: usize = 232;
 
 #[cfg(feature = "wifi")]
 const RELAY_CACHE_CAP: usize = 12;


### PR DESCRIPTION
## #74 obs wave-2 — the deferred remainder (stage-2)

Finishes issue #74 after stage-1 (DIAG link-quality/time-sync/LED fold-ins, PR #97). Two
commits, staged A then B.

### A — config-drift detection (`cfg=`)  [commit 1]
Each node folds a compact **applied-config** string onto the retained `smol/<id>/diag` record:

```
cfg=<screen>:<page>,<led>,<mask4hexU>,<units>     e.g.  cfg=Grid:1,status,0000,F24
```

**Canonical contract (fw is the producer — this is the ONE thing to pin, per luna's staging note):**
- `screen:page` = the **LIVE** rendered screen (`app.live_screen()`, same source as the #50 STAT
  readback — captures manual BOOT-nav, i.e. what's *actually running*, not the commanded default)
- `led` = `LedMode::to_wire()` (`status`/`on`/`off`)
- `mask` = `plugin_mask` as `{:04X}` (matches #55's `%04X` hex)
- `units` = temp+clock, no separator (`F24` / `C12`)

Cheap on the fw side — every value is already in RAM. Built in `main` and mirrored into the
RadioManager via a fixed **Copy** buffer on `DiagExtra`; `diag_record` appends `|cfg=` **only when
populated**, so a wifi-only build (no espnow config path) omits the key rather than emit a misleading
default. `RELAY_VALUE_MAX` 224→232 for the longer record (ESP-NOW frame 247 B < 250 ceiling; bounds
only relayed *leaf* records — the gateway self-publishes its full record via MQTT).

**HA half** (`ha/packages/smol_mesh.yaml`): `sensor.smol_<id>_config_expected` rebuilds the SAME
canonical string from the retained command topics, and `binary_sensor.smol_<id>_config_drift` does a
**robust field-by-field compare** — a field is judged only when HA has actually commanded it
(still-`unknown` = no opinion = **no false alarm**), and the screen field tolerates a commanded default
that omits `:page`. Drift lights only on a genuine live≠desired (dropped CFG relay / stale NVS / manual
nav off the default). Logic host-validated with jinja mocks across 10 scenarios (match, per-field
drift, un-commanded fields, page-optional screen, unknown-applied).

### B — display-mirror  [commit 2]
Publish the gateway's live glass as a base64 **64×32 1-bit BMP** to retained `smol/<id>/screen`; HA
renders it as an `mqtt image` (the node-box mini-OLED made real).

- **Reuses the #26 Cast framebuffer tee** — the `Mirror` already snapshots the glass every render
  tick, so there is **no new draw-path tap**. This deliberately **supersedes** the deferred
  per-plugin `text_lines()` mirror (`smol/<id>/display`, `DISP|…`), which was invasive / brick-adjacent
  — the exact reason it was scoped out. luna's staged text-`display` sensors are left in place but are
  now superseded by the bitmap path (flagged in the yaml).
- **Fit to the 512 B gateway MQTT packet:** a full 72×40 BMP is 724 B base64 (too big), so downsample
  to 64×32 via the existing `cell_on` box-sampler (180° flip matches the `Rotate180` mount) → 318 B raw
  / 424 B base64. `pack_bmp1` + `base64_into` are pure + host-validated (PIL opens the BMP with correct
  dimensions/orientation; base64 byte-matches std). Scratch kept off the bounded flush stack in `.bss`
  via a `with_screen_b64` closure (the `CAST_MIRROR` static-mut discipline, `static_mut_refs`-clean).
- **GATEWAY-only v1** (as flagged in the task): leaves have no MQTT and Cast is a gateway-role
  activity, so only the elected gateway publishes a live image; a leaf screen mirror is a mesh-frame
  follow-on. `cast`-only — default/wifi/espnow/wled builds are byte-free of it.

### Design choices proposed (per the task)
- **Cadence:** publish on the existing gateway-flush telemetry cadence (no new subscription/enable
  plumbing). An on-demand enable (mirroring the `smol/<id>/cast` idiom) is a trivial follow-on if MQTT
  load ever matters — noted, not built, to keep v1 lean.
- **Bitmap over text:** chosen per the framebuffer-reuse steer; it's non-invasive and faithful.

### Verification
- All 5 build profiles (default/wifi/espnow/wled/cast) `cargo check` + `clippy -D warnings` clean.
- **Default-build invariant** held by cfg-gating (every fw change is behind `wifi`/`espnow`/`cast`),
  not ELF byte-equality.
- Pure encoders + HA drift logic host-validated (see commit bodies).
- **HW pending** (team-lead canary): a full release build (hypnos-gated) + on the id7 canary confirm
  (1) the live `cfg=` string parses as the drift comparator expects before trusting the dashboard chip,
  and (2) the `smol/<gw>/screen` BMP renders in HA.

Refs #74, #97 (stage-1), #26 (Cast tee), #56 (CFG channel), #55/#48/#43 (config sources).
