### PR TITLE
feat(#100): Stage 2/3 — runtime broker + OTA-host overrides (dashboard-managed, un-brickable)

### DIFF
--- a/ha/dashboard/smol_network_card.yaml
+++ b/ha/dashboard/smol_network_card.yaml
@@ -1,0 +1,111 @@
+# smol network identity — dashboard-managed WiFi slot + broker + OTA host (#100)
+# ---------------------------------------------------------------------------
+# HA PUBLISH/GUI half of the #100 runtime network switcher. Per node you set:
+#   • Network  → retained smol/<id>/config/net = 0/1 (WiFi slot; edge-triggered reboot)
+#   • Broker   → retained smol/<id>/config/broker = ip[:port] (reboot; CONNACK fallback)
+#   • OTA host → retained smol/<id>/config/ota_host = ip (no reboot; extra allowlist host)
+# The board applies each on its next burst (no reflash) and self-heals a bad WiFi slot or
+# broker WITHOUT USB (the un-brickable fallback — surfaced live below as net=/brk= state).
+#
+# ⚠️ NETWORK MAPPING: "iot (jplovescl)" = slot 0, "roam" = slot 1 — this MUST match the
+# local secrets.rs WIFI_NETWORKS order. A wrong pick self-heals (net shows "<slot>:fb") but
+# the label would mislead; verify against secrets.rs at canary. NEVER switch a power-only
+# board's WiFi to a network you can't reach it on without confirming the fallback slot works.
+#
+# Broker/OTA-host overrides are RFC1918-validated on the board; an empty value CLEARS the
+# override (back to the active slot's baked broker / allowlist). A broker override that fails
+# to CONNACK 3× auto-disables (brk=fb) and reverts to the baked broker — re-type a NEW value
+# to retry. A bad OTA host can only refuse a fetch (the image stays signed/monotonicity-gated).
+#
+# Install at DEPLOY time via the WS lovelace/config/save API — do NOT hand-edit
+# .storage/lovelace* (HA caches + overwrites). See ha/README.md. (Deployment HELD for JP.)
+type: vertical-stack
+cards:
+  - type: markdown
+    content: >
+      ## smol · network identity
+
+      Switch each node's **WiFi network**, **MQTT broker**, and **OTA host** from the
+      dashboard — published as retained MQTT, applied on the node's next burst, no reflash.
+      A wrong WiFi slot or broker **self-heals without USB** (the un-brickable fallback);
+      the live state below shows `:fb` when a fallback has fired.
+
+  - type: entities
+    title: Set all nodes
+    show_header_toggle: false
+    entities:
+      - entity: input_select.smol_all_network
+        name: Network (all)
+        icon: mdi:wifi-sync
+
+  - type: entities
+    title: id7 · Dominion (gateway)
+    show_header_toggle: false
+    entities:
+      - type: section
+        label: Network
+      - entity: input_select.smol_7_network
+        name: WiFi network
+      - entity: sensor.smol_7_network
+        name: Active (net=slot:state)
+        icon: mdi:wifi-check
+      - type: section
+        label: Broker override
+      - entity: input_text.smol_7_broker
+        name: Broker ip[:port] (empty = baked)
+      - entity: sensor.smol_7_broker_state
+        name: Broker state
+      - type: section
+        label: OTA host override
+      - entity: input_text.smol_7_ota_host
+        name: Extra OTA host ip (empty = slot)
+      - entity: sensor.smol_7_ota_host_state
+        name: OTA host state
+
+  - type: entities
+    title: id8 · Nexus
+    show_header_toggle: false
+    entities:
+      - type: section
+        label: Network
+      - entity: input_select.smol_8_network
+        name: WiFi network
+      - entity: sensor.smol_8_network
+        name: Active (net=slot:state)
+        icon: mdi:wifi-check
+      - type: section
+        label: Broker override
+      - entity: input_text.smol_8_broker
+        name: Broker ip[:port] (empty = baked)
+      - entity: sensor.smol_8_broker_state
+        name: Broker state
+      - type: section
+        label: OTA host override
+      - entity: input_text.smol_8_ota_host
+        name: Extra OTA host ip (empty = slot)
+      - entity: sensor.smol_8_ota_host_state
+        name: OTA host state
+
+  - type: entities
+    title: id9 · Herald
+    show_header_toggle: false
+    entities:
+      - type: section
+        label: Network
+      - entity: input_select.smol_9_network
+        name: WiFi network
+      - entity: sensor.smol_9_network
+        name: Active (net=slot:state)
+        icon: mdi:wifi-check
+      - type: section
+        label: Broker override
+      - entity: input_text.smol_9_broker
+        name: Broker ip[:port] (empty = baked)
+      - entity: sensor.smol_9_broker_state
+        name: Broker state
+      - type: section
+        label: OTA host override
+      - entity: input_text.smol_9_ota_host
+        name: Extra OTA host ip (empty = slot)
+      - entity: sensor.smol_9_ota_host_state
+        name: OTA host state

--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -139,6 +139,35 @@ input_text:
     name: "smol 9 Custom screen (author)"
     max: 120
     initial: ""
+  # --- #100 Stage 2/3 per-node network overrides (dashboard-managed, un-brickable). BROKER =
+  # MQTT leg "ip" or "ip:port" (RFC1918; empty = the slot's baked broker). OTA HOST = one extra
+  # RFC1918 image host appended to the fetch allowlist (empty = slot default). The board
+  # RFC1918-validates before applying and self-heals a wrong broker via the CONNACK fallback
+  # (surfaced as brk=fb in smol/<id>/diag); a wrong OTA host can only refuse a fetch (never a brick).
+  smol_7_broker:
+    name: "smol 7 broker override (ip[:port])"
+    max: 21
+    initial: ""
+  smol_8_broker:
+    name: "smol 8 broker override (ip[:port])"
+    max: 21
+    initial: ""
+  smol_9_broker:
+    name: "smol 9 broker override (ip[:port])"
+    max: 21
+    initial: ""
+  smol_7_ota_host:
+    name: "smol 7 OTA host override (ip)"
+    max: 15
+    initial: ""
+  smol_8_ota_host:
+    name: "smol 8 OTA host override (ip)"
+    max: 15
+    initial: ""
+  smol_9_ota_host:
+    name: "smol 9 OTA host override (ip)"
+    max: 15
+    initial: ""
 
 input_boolean:
   smol_display_override:
@@ -257,6 +286,9 @@ input_boolean:
 #     smol/<id>/config/led             → L   (blue-LED mode, #48)
 #     smol/config/units                → U   (display units, GLOBAL/#43)
 #     smol/<id>/config/plugins         → P   (plugin-enable mask, #55; topic TBD)
+#     smol/<id>/config/net             → N   (WiFi slot 0/1, #100 Stage 1; edge-triggered reboot)
+#     smol/<id>/config/broker          → B   (MQTT broker ip[:port], #100 Stage 2; reboot + fallback)
+#     smol/<id>/config/ota_host        → O   (extra OTA host ip, #100 Stage 3; no reboot)
 # #56 is FOUNDATION ONLY: the firmware relays the S channel (default_screen) exactly
 # as before — this file's default_screen PUBLISH half is UNCHANGED, and a leaf keeps
 # converging on its dashboard-set screen. The L/U/(P) topics + GUI below already exist
@@ -360,6 +392,31 @@ input_select:
     options: [status, "on", "off"]
     initial: status
     icon: mdi:led-on
+  # --- #100 network switch (per-node: iot/roam → slot 0/1) → retained smol/<id>/config/net (qos 1).
+  # ⚠️ MAPPING: option "iot (jplovescl)" = slot 0, "roam" = slot 1 — this MUST match the local
+  # secrets.rs WIFI_NETWORKS order. A wrong pick self-heals via the fw assoc fallback (visible as
+  # net=<slot>:fb in smol/<id>/diag) so it never bricks, but the label would mislead — verify against
+  # secrets.rs at canary. Set-all fans out to every per-node select (no broadcast topic).
+  smol_all_network:
+    name: "smol all · network"
+    options: ["iot (jplovescl)", "roam"]
+    initial: "iot (jplovescl)"
+    icon: mdi:wifi-sync
+  smol_7_network:
+    name: "smol id7 · network"
+    options: ["iot (jplovescl)", "roam"]
+    initial: "iot (jplovescl)"
+    icon: mdi:wifi
+  smol_8_network:
+    name: "smol id8 · network"
+    options: ["iot (jplovescl)", "roam"]
+    initial: "iot (jplovescl)"
+    icon: mdi:wifi
+  smol_9_network:
+    name: "smol id9 · network"
+    options: ["iot (jplovescl)", "roam"]
+    initial: "iot (jplovescl)"
+    icon: mdi:wifi
 
 input_button:
   smol_all_apply:
@@ -976,6 +1033,74 @@ mqtt:
       icon: "mdi:memory"
       value_template: >-
         {% set ns = namespace(v='0') %}{% for kv in value.split('|') %}{% if kv.startswith('hmin=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}{{ ns.v | int(0) }}
+    # --- #100 network identity (parsed from smol/<id>/diag; #100 Stage 1/2/3) ---
+    # net=<slot>:<ok|fb>  (fb = the WiFi assoc fallback fired — the commanded slot was unreachable)
+    # brk=<baked|ovr|fb>  (broker: baked slot leg | override active | override auto-disabled by CONNACK)
+    # otah=<slot|ovr>     (OTA fetch host: slot default | an override is appended to the allowlist)
+    # Degrades safe: 'unknown' until the Stage-2/3 firmware ships the keys.
+    - name: "smol 7 network"
+      unique_id: smol_7_network_mirror
+      state_topic: "smol/7/diag"
+      entity_category: diagnostic
+      icon: "mdi:wifi"
+      value_template: >-
+        {% set ns = namespace(v='unknown') %}{% for kv in value.split('|') %}{% if kv.startswith('net=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}{{ ns.v }}
+    - name: "smol 7 broker state"
+      unique_id: smol_7_broker_state_mirror
+      state_topic: "smol/7/diag"
+      entity_category: diagnostic
+      icon: "mdi:server-network"
+      value_template: >-
+        {% set ns = namespace(v='unknown') %}{% for kv in value.split('|') %}{% if kv.startswith('brk=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}{{ ns.v }}
+    - name: "smol 7 ota host state"
+      unique_id: smol_7_ota_host_state_mirror
+      state_topic: "smol/7/diag"
+      entity_category: diagnostic
+      icon: "mdi:cloud-download-outline"
+      value_template: >-
+        {% set ns = namespace(v='unknown') %}{% for kv in value.split('|') %}{% if kv.startswith('otah=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}{{ ns.v }}
+    - name: "smol 8 network"
+      unique_id: smol_8_network_mirror
+      state_topic: "smol/8/diag"
+      entity_category: diagnostic
+      icon: "mdi:wifi"
+      value_template: >-
+        {% set ns = namespace(v='unknown') %}{% for kv in value.split('|') %}{% if kv.startswith('net=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}{{ ns.v }}
+    - name: "smol 8 broker state"
+      unique_id: smol_8_broker_state_mirror
+      state_topic: "smol/8/diag"
+      entity_category: diagnostic
+      icon: "mdi:server-network"
+      value_template: >-
+        {% set ns = namespace(v='unknown') %}{% for kv in value.split('|') %}{% if kv.startswith('brk=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}{{ ns.v }}
+    - name: "smol 8 ota host state"
+      unique_id: smol_8_ota_host_state_mirror
+      state_topic: "smol/8/diag"
+      entity_category: diagnostic
+      icon: "mdi:cloud-download-outline"
+      value_template: >-
+        {% set ns = namespace(v='unknown') %}{% for kv in value.split('|') %}{% if kv.startswith('otah=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}{{ ns.v }}
+    - name: "smol 9 network"
+      unique_id: smol_9_network_mirror
+      state_topic: "smol/9/diag"
+      entity_category: diagnostic
+      icon: "mdi:wifi"
+      value_template: >-
+        {% set ns = namespace(v='unknown') %}{% for kv in value.split('|') %}{% if kv.startswith('net=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}{{ ns.v }}
+    - name: "smol 9 broker state"
+      unique_id: smol_9_broker_state_mirror
+      state_topic: "smol/9/diag"
+      entity_category: diagnostic
+      icon: "mdi:server-network"
+      value_template: >-
+        {% set ns = namespace(v='unknown') %}{% for kv in value.split('|') %}{% if kv.startswith('brk=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}{{ ns.v }}
+    - name: "smol 9 ota host state"
+      unique_id: smol_9_ota_host_state_mirror
+      state_topic: "smol/9/diag"
+      entity_category: diagnostic
+      icon: "mdi:cloud-download-outline"
+      value_template: >-
+        {% set ns = namespace(v='unknown') %}{% for kv in value.split('|') %}{% if kv.startswith('otah=') %}{% set ns.v = kv.split('=',1)[1] %}{% endif %}{% endfor %}{{ ns.v }}
     # --- id7 mesh-health + time-sync (#74 fold-ins) ---
     - name: "smol 7 led state"
       unique_id: smol_7_led_state_mirror
@@ -2039,6 +2164,113 @@ automation:
             - input_select.smol_9_led
         data:
           option: "{{ trigger.to_state.state }}"
+
+  # =====================================================================
+  # #100 network switch — per-node select → RETAINED smol/<id>/config/net = 0/1 (qos 1). Slot 0 =
+  # "iot (jplovescl)", slot 1 = "roam" (MUST match secrets.rs WIFI_NETWORKS order). qos 1 so the
+  # switch is delivered even through a flaky link (transient-command lesson). RETAINED = the gateway
+  # reads it on its burst + relays it to leaves; a wrong pick self-heals (fw fallback → net=<slot>:fb).
+  # =====================================================================
+  - id: smol_net_publish
+    alias: "smol #100: publish per-node network slot"
+    description: >-
+      On any per-node network select changing, publish retained smol/<id>/config/net = 0|1.
+    mode: parallel
+    max: 10
+    trigger:
+      - platform: state
+        entity_id:
+          - input_select.smol_7_network
+          - input_select.smol_8_network
+          - input_select.smol_9_network
+    condition:
+      - condition: template
+        value_template: "{{ trigger.from_state is not none and trigger.from_state.state not in ['unavailable', 'unknown'] }}"
+    action:
+      - service: mqtt.publish
+        data:
+          topic: "smol/{{ trigger.entity_id.split('.')[1].split('_')[1] }}/config/net"
+          retain: true
+          qos: 1
+          payload: "{{ '0' if trigger.to_state.state == 'iot (jplovescl)' else '1' }}"
+
+  - id: smol_all_net_fanout
+    alias: "smol #100: set-all network → per-node selects"
+    description: >-
+      On the ALL network select changing, fan out to every per-node network select (each then
+      publishes its retained smol/<id>/config/net). No broadcast topic (mirrors the LED fanout).
+    mode: single
+    trigger:
+      - platform: state
+        entity_id: input_select.smol_all_network
+    condition:
+      - condition: template
+        value_template: "{{ trigger.from_state is not none and trigger.from_state.state not in ['unavailable', 'unknown'] }}"
+    action:
+      - service: input_select.select_option
+        target:
+          entity_id:
+            - input_select.smol_7_network
+            - input_select.smol_8_network
+            - input_select.smol_9_network
+        data:
+          option: "{{ trigger.to_state.state }}"
+
+  # =====================================================================
+  # #100 Stage 2 broker override — per-node input_text → RETAINED smol/<id>/config/broker (qos 1).
+  # Value = "ip" or "ip:port" (empty = clear → the slot's baked broker). The board RFC1918-validates
+  # + self-heals a wrong value via the CONNACK fallback. RETAINED so the gateway relays to leaves.
+  # =====================================================================
+  - id: smol_broker_publish
+    alias: "smol #100: publish per-node broker override"
+    description: >-
+      On any per-node broker input_text changing, publish retained smol/<id>/config/broker (raw).
+    mode: parallel
+    max: 10
+    trigger:
+      - platform: state
+        entity_id:
+          - input_text.smol_7_broker
+          - input_text.smol_8_broker
+          - input_text.smol_9_broker
+    condition:
+      - condition: template
+        value_template: "{{ trigger.from_state is not none and trigger.from_state.state not in ['unavailable', 'unknown'] }}"
+    action:
+      - service: mqtt.publish
+        data:
+          topic: "smol/{{ trigger.entity_id.split('.')[1].split('_')[1] }}/config/broker"
+          retain: true
+          qos: 1
+          payload: "{{ trigger.to_state.state }}"
+
+  # =====================================================================
+  # #100 Stage 3 OTA-host override — per-node input_text → RETAINED smol/<id>/config/ota_host (qos 1).
+  # Value = one extra RFC1918 image host (empty = clear → slot default). Applied WITHOUT a reboot;
+  # the board RFC1918-validates. RETAINED so the gateway relays to leaves.
+  # =====================================================================
+  - id: smol_ota_host_publish
+    alias: "smol #100: publish per-node OTA-host override"
+    description: >-
+      On any per-node OTA-host input_text changing, publish retained smol/<id>/config/ota_host (raw).
+    mode: parallel
+    max: 10
+    trigger:
+      - platform: state
+        entity_id:
+          - input_text.smol_7_ota_host
+          - input_text.smol_8_ota_host
+          - input_text.smol_9_ota_host
+    condition:
+      - condition: template
+        value_template: "{{ trigger.from_state is not none and trigger.from_state.state not in ['unavailable', 'unknown'] }}"
+    action:
+      - service: mqtt.publish
+        data:
+          topic: "smol/{{ trigger.entity_id.split('.')[1].split('_')[1] }}/config/ota_host"
+          retain: true
+          qos: 1
+          payload: "{{ trigger.to_state.state }}"
 
   # =====================================================================
   # #52 remote REBOOT — per-node button → TRANSIENT smol/<id>/cmd/reset (retain:FALSE).

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -1200,10 +1200,18 @@ fn main() -> ! {
                         let cur = crate::ota::read_net_cfg().map_or(0, |c| c.commanded);
                         if slot != cur {
                             log::warn!("smol #100: network slot -> {} (was commanded {}) — reboot", slot, cur);
+                            // A WiFi-slot switch resets to the new network's BAKED identity: the
+                            // broker + OTA-host overrides are cleared (they were set for the OLD
+                            // network's VLAN and would drop CONNACK cross-VLAN / point OTA off-net).
+                            // The slot IS the full network identity — re-apply an override after the
+                            // switch if still wanted.
                             crate::ota::write_net_cfg(crate::ota::NetCfg {
                                 active: slot,
                                 commanded: slot,
                                 fallback: false,
+                                broker: None,
+                                broker_fallback: false,
+                                ota_host: None,
                             });
                             // #100 canary lesson: VERIFY-AFTER-WRITE before the reset. If the
                             // record didn't persist (any flash error — all swallowed above), a
@@ -1219,6 +1227,73 @@ fn main() -> ! {
                             } else {
                                 log::warn!("smol #100: net record did NOT persist — switch aborted (no reset)");
                             }
+                        }
+                    }
+                }
+            }
+
+            // #100 Stage 2: a broker-override config (key `B`) = the MQTT broker leg (`ip` or
+            // `ip:port`). CONFIG/CACHED (retained) — EDGE-TRIGGERED on a change of the COMMANDED
+            // broker (`c.broker`), NOT the runtime one: a re-read is a no-op, and a CONNACK-fallback
+            // that DISABLED the override (broker_fallback=true, broker kept) does NOT re-fire the
+            // retained value → never the reboot-loop the #100 canary forbids. Escape a fallen-back
+            // override by commanding a NEW value (or empty = clear). Empty = CLEAR (baked broker). A
+            // non-empty value that isn't an RFC1918 ip[:port] is IGNORED (keep current). A genuine
+            // change → persist {broker=new, broker_fallback=false, ..cur} + VERIFY-AFTER-WRITE +
+            // reboot onto it (a wrong broker then self-heals via the CONNACK fallback). Never returns.
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_BROKER) {
+                let raw = core::str::from_utf8(&o.buf[..o.len]).unwrap_or("").trim();
+                let new_broker = if raw.is_empty() {
+                    None
+                } else {
+                    crate::ota::parse_broker_override(raw)
+                };
+                // Apply only a VALID command: an explicit clear (empty) OR a parsed override. A
+                // non-empty unparseable value is dropped (keep current) — never write garbage.
+                if raw.is_empty() || new_broker.is_some() {
+                    let cur = crate::ota::read_net_cfg();
+                    if new_broker != cur.and_then(|c| c.broker) {
+                        log::warn!("smol #100: broker override changed (set={}) — reboot", new_broker.is_some());
+                        crate::ota::write_net_cfg(crate::ota::NetCfg {
+                            broker: new_broker,
+                            broker_fallback: false,
+                            ..cur.unwrap_or_default()
+                        });
+                        let persisted = crate::ota::read_net_cfg()
+                            .is_some_and(|c| c.broker == new_broker && !c.broker_fallback);
+                        if persisted {
+                            esp_hal::system::software_reset();
+                        } else {
+                            log::warn!("smol #100: broker record did NOT persist — change aborted (no reset)");
+                        }
+                    }
+                }
+            }
+
+            // #100 Stage 3: an OTA-host-override config (key `O`) = one extra RFC1918 image host
+            // appended to the fetch allowlist. CONFIG/CACHED (retained) — EDGE-TRIGGERED on a change.
+            // Empty = CLEAR; a non-empty non-RFC1918 value is IGNORED. Applied WITHOUT a reboot: the
+            // allowlist is read at fetch/gate time, so the next OTA simply sees the new host. A bad
+            // value can only REFUSE a fetch (the image is still monotonicity-gated) — never a brick,
+            // so no fallback machinery is needed. VERIFY-AFTER-WRITE keeps a persist failure visible.
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_OTA) {
+                let raw = core::str::from_utf8(&o.buf[..o.len]).unwrap_or("").trim();
+                let new_host = if raw.is_empty() {
+                    None
+                } else {
+                    crate::ota::parse_ota_host_override(raw)
+                };
+                if raw.is_empty() || new_host.is_some() {
+                    let cur = crate::ota::read_net_cfg();
+                    if new_host != cur.and_then(|c| c.ota_host) {
+                        crate::ota::write_net_cfg(crate::ota::NetCfg {
+                            ota_host: new_host,
+                            ..cur.unwrap_or_default()
+                        });
+                        if crate::ota::read_net_cfg().is_some_and(|c| c.ota_host == new_host) {
+                            log::warn!("smol #100: OTA-host override changed (set={}) — no reboot", new_host.is_some());
+                        } else {
+                            log::warn!("smol #100: OTA-host record did NOT persist");
                         }
                     }
                 }

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -74,6 +74,12 @@ pub use wifi::CFG_KEY_CUSTOM;
 // take_cfg_offer(N); the apply writes the NVS net-record + reboots into the slot).
 #[cfg(feature = "espnow")]
 pub use wifi::CFG_KEY_NET;
+// #100 Stage 2/3 broker + OTA-host override keys — same `main`-bridge rationale (espnow apply path
+// via take_cfg_offer(B)/(O); B writes the NVS record + reboots, O writes it WITHOUT a reboot).
+#[cfg(feature = "espnow")]
+pub use wifi::CFG_KEY_BROKER;
+#[cfg(feature = "espnow")]
+pub use wifi::CFG_KEY_OTA;
 // #45: `main` sizes its held Custom-layout buffer to the max keyed value — bridge the const out
 // of the private `wifi` module (espnow-only: only the Custom apply path names it).
 #[cfg(feature = "espnow")]

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -180,13 +180,15 @@ const CFG_PREFIX: &[u8] = b"SMOLv1 CFG "; // + "NNN" + KEY + verbatim "<value>"
 /// (a `take_cfg_offer(key)` + apply) and a gateway fill site in `mqtt_session`. Sized `[_; N]`
 /// (not `&[u8]`) so [`CfgTracker`] can allocate exactly one `.bss` buffer slot per key.
 /// An inbound key not listed is dropped at [`CfgTracker::set`] (never buffered/applied).
-const CFG_APPLY_KEYS: [u8; 8] = [
+const CFG_APPLY_KEYS: [u8; 10] = [
     crate::net::wifi::CFG_KEY_SCREEN,
     crate::net::wifi::CFG_KEY_LED,
     crate::net::wifi::CFG_KEY_UNITS,
     crate::net::wifi::CFG_KEY_PLUGINS,
     crate::net::wifi::CFG_KEY_CUSTOM, // #45 custom-screen layout (cached + relayed like S/L/U/P)
     crate::net::wifi::CFG_KEY_NET, // #100 active WiFi-slot index (cached + relayed; edge-triggered reboot)
+    crate::net::wifi::CFG_KEY_BROKER, // #100 Stage 2 broker-leg override (cached + relayed; edge-triggered reboot)
+    crate::net::wifi::CFG_KEY_OTA, // #100 Stage 3 OTA-host override (cached + relayed; applied WITHOUT reboot)
     // #52 remote reboot: R IS a buffered/applied key (a leaf takes it via take_cfg_offer(R)) but
     // is NEVER put in cfg_cache/broadcast_cached_configs — the one-shot relay uses broadcast_config
     // directly. The anti-reboot-loop invariant: R rides the CFG wire + apply path, not the cache.
@@ -2414,14 +2416,26 @@ impl RadioManager {
         let led_state = if e.led_on { "on" } else { "off" };
         // #100: active WiFi slot + fallback state (net=<slot>:<ok|fb>). `fb` = we auto-reverted off
         // the commanded slot (the un-brick fallback fired) — HA surfaces "the network switch failed".
+        // Stage 2/3: brk=<baked|ovr|fb> (broker override state — `fb` = the override was auto-disabled
+        // after repeated CONNACK failures, running the baked broker) + otah=<slot|ovr> (an OTA-host
+        // override is appended to the allowlist). All read live from the one NVS net-record.
         let net = crate::ota::read_net_cfg().unwrap_or(crate::ota::NetCfg {
             active: 0,
             commanded: 0,
             fallback: false,
+            broker: None,
+            broker_fallback: false,
+            ota_host: None,
         });
         let net_fb = if net.fallback { "fb" } else { "ok" };
+        let brk = match (net.broker.is_some(), net.broker_fallback) {
+            (true, false) => "ovr",
+            (true, true) => "fb",
+            _ => "baked",
+        };
+        let otah = if net.ota_host.is_some() { "ovr" } else { "slot" };
         let mut rec = alloc::format!(
-            "DIAG|slot={}|rst={}|boot={}|ota={}|up={}|heap={}|hmin={}|btn={}|btnl={}|fok={}|ffl={}|vok={}|vfl={}|loss={}|rtt={}|rx={}|tx={}|led={}:{}|tage={}|tsrc={}|net={}:{}",
+            "DIAG|slot={}|rst={}|boot={}|ota={}|up={}|heap={}|hmin={}|btn={}|btnl={}|fok={}|ffl={}|vok={}|vfl={}|loss={}|rtt={}|rx={}|tx={}|led={}:{}|tage={}|tsrc={}|net={}:{}|brk={}|otah={}",
             d.boot_slot,
             d.reset_reason,
             d.boot_count,
@@ -2445,6 +2459,8 @@ impl RadioManager {
             e.tsrc,
             net.active,
             net_fb,
+            brk,
+            otah,
         );
         // #74 item 3 (stage-2): fold in the APPLIED-config string for HA config-drift, ONLY when
         // `main` populated it (espnow build). ASCII by construction (as_wire/to_wire/hex/F24). HA
@@ -3550,6 +3566,14 @@ impl RadioManager {
         // #100: the gateway's OWN active-slot index — same self-apply path (take_cfg_offer(N)).
         if let Some((buf, len)) = gw_own.net {
             self.cfg.set(crate::net::wifi::CFG_KEY_NET, &buf[..len]);
+        }
+        // #100 Stage 2: the gateway's OWN broker override — same self-apply path (take_cfg_offer(B)).
+        if let Some((buf, len)) = gw_own.broker {
+            self.cfg.set(crate::net::wifi::CFG_KEY_BROKER, &buf[..len]);
+        }
+        // #100 Stage 3: the gateway's OWN OTA-host override — same self-apply path (take_cfg_offer(O)).
+        if let Some((buf, len)) = gw_own.ota {
+            self.cfg.set(crate::net::wifi::CFG_KEY_OTA, &buf[..len]);
         }
         // #52 remote reboot — a COMMAND, not a config. Fire a ONE-SHOT `<id>R` frame per queued
         // leaf target via `broadcast_config` DIRECTLY (NOT `cfg_cache` / `broadcast_cached_configs`):

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1695,22 +1695,18 @@ fn mqtt_session(
         }
     }
 
-    // --- SUBSCRIBE smol/display/batt + smol/display/grid FIRST ---
-    // Subscribe before publishing so the broker queues the RETAINED downlink payloads
-    // to us immediately — the downlinks (which every node needs) are prioritized over
-    // the loss-tolerant telemetry uplink, and the retained replies stream in while we
-    // publish. Both are drained into their caches after the publishes, below. GRID
-    // (issue #16) is one extra SUBSCRIBE on the already-open connection (packet-id 2).
-    if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 1, BATT_TOPIC) {
-        let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
-    }
-    if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 2, GRID_TOPIC) {
-        let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
-    }
-    // #23 election: subscribe the retained single-gateway topic (packet-id 3).
-    if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 3, MESH_CHANNEL_TOPIC) {
-        let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
-    }
+    // --- SUBSCRIBE order (subscribe before publishing so the broker queues the RETAINED
+    // downlink payloads while we publish; all drained after the publishes, below) ---
+    // #100 DRAIN-ORDER FIX (HW canary #110): the batt/grid/mc primary-downlink SUBSCRIBEs
+    // (pids 1/2/3) are deferred to the END of the subscribe sequence — see the block just
+    // before the PUBLISH loop. The retained-drain loop breaks on `got_batt && got_grid &&
+    // got_mc && <400ms quiet>`; a broker delivers retained in SUBSCRIBE order, so subscribing
+    // these three FIRST completed the break-gate before the later config retained (net/broker/
+    // ota, pids 16-21) arrived in a subsequent TCP-window chunk >400ms later → the drain exited
+    // and CFG-B/O never applied (deterministic miss, HW-observed). Subscribing them LAST makes
+    // the gate structurally unable to trip until the whole config backlog is drained — order-
+    // and buffer-size-independent. (The "subscribe before publish" priority is preserved: all
+    // subscribes, batt/grid/mc included, still precede the telemetry PUBLISH.)
     // #33 Model-A: subscribe the ONE retained fleet STAGING topic (packet-id 4) as the
     // latest_version source + fetch target. No per-id announce-act topic exists (dropped
     // — the #32 closure): staging only advertises "update available"; it never fetches.
@@ -1816,6 +1812,25 @@ fn mqtt_session(
         if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 21, b"smol/config/ota_host") {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
+    }
+
+    // #100 DRAIN-ORDER FIX (HW canary #110): the batt/grid/mc primary downlinks are the
+    // retained-drain break-gate (`got_batt && got_grid && got_mc && <quiet>`), so they MUST be
+    // the LAST retained to arrive — subscribe them AFTER every config topic above. A broker sends
+    // retained in SUBSCRIBE order, so the gate now cannot complete until the whole config backlog
+    // (screen/led/…/net/broker/ota, pids 6-21) has been delivered and drained → CFG-B/O reliably
+    // apply. (Boot burst: cfg_cache=None skips the gateway block, so these are effectively first,
+    // as before — mc is usually absent at boot, so that path still drains to the deadline.) Pids
+    // stay 1/2/3 (identifiers, not order); only the SEND order moved. Still before the PUBLISH loop.
+    if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 1, BATT_TOPIC) {
+        let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+    }
+    if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 2, GRID_TOPIC) {
+        let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+    }
+    // #23 election: subscribe the retained single-gateway topic (packet-id 3).
+    if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 3, MESH_CHANNEL_TOPIC) {
+        let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
     }
 
     // --- PUBLISH telemetry (transient) + discovery config (retained) per node ---

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -454,18 +454,81 @@ fn associate_slot(
     AssocResult::Associated
 }
 
-/// #100: the ACTIVE slot's broker leg (IPv4, port), resolved at RUNTIME from the NVS net-record
-/// (default slot 0 if erased/corrupt). The broker MUST follow the associated network — own-VLAN
-/// leg rule, a cross-VLAN leg drops CONNACK. Stage 2 layers an NVS broker OVERRIDE + CONNACK
-/// fallback on top of this. Panic-free slot index (clamped to the array).
+/// #100: the broker leg (IPv4, port) to connect THIS burst, resolved at RUNTIME from the NVS
+/// net-record (default slot 0 if erased/corrupt). Precedence: a Stage-2 CFG-`B` OVERRIDE wins
+/// UNLESS it has been auto-disabled (`broker_fallback`, after repeated CONNACK failures) — then, or
+/// when there is no override, the ACTIVE slot's baked broker is used. The baked broker is the
+/// un-brickable FLOOR: it follows the associated network (own-VLAN leg rule, a cross-VLAN leg drops
+/// CONNACK), so a wrong override always self-heals back to a reachable broker. Panic-free slot index.
 #[cfg(feature = "wifi")]
 fn active_broker() -> (Ipv4Addr, u16) {
-    let active = crate::ota::read_net_cfg().map_or(0usize, |c| c.active as usize);
+    let cfg = crate::ota::read_net_cfg();
+    // A CFG-`B` override wins UNLESS it has been auto-disabled (`broker_fallback`).
+    if let Some((ip, port)) = cfg.and_then(|c| c.broker.filter(|_| !c.broker_fallback)) {
+        return (Ipv4Addr::new(ip[0], ip[1], ip[2], ip[3]), port);
+    }
+    let active = cfg.map_or(0usize, |c| c.active as usize);
     let net = &crate::secrets::WIFI_NETWORKS[active.min(crate::secrets::WIFI_NETWORKS.len() - 1)];
     (
         Ipv4Addr::new(net.broker_ip[0], net.broker_ip[1], net.broker_ip[2], net.broker_ip[3]),
         net.broker_port,
     )
+}
+
+/// #100 Stage 2: consecutive broker-connect failures WHILE a CFG-`B` override is active, counted
+/// IN-RAM across bursts (resets on reboot — a fresh boot re-tries the override from scratch). At
+/// [`BROKER_FAIL_LIMIT`] the override is auto-disabled (see [`note_broker_connect`]). Single-core,
+/// main-thread-only (the flush path), so a plain `static mut` matches the OTA-outcome idiom here.
+#[cfg(feature = "espnow")]
+static mut BROKER_FAIL_STREAK: u8 = 0;
+
+/// #100 Stage 2: how many consecutive failed CONNACKs on an override broker trigger the self-heal.
+#[cfg(feature = "espnow")]
+const BROKER_FAIL_LIMIT: u8 = 3;
+
+/// #100 Stage 2 un-brickable broker fallback. Called after each gateway MQTT flush with whether the
+/// broker CONNACK'd. It only acts when a CFG-`B` override is ACTIVE (set AND not already fallen
+/// back) — the baked broker is the floor, so a baked-broker miss never counts. Called ONLY after the
+/// WiFi association already succeeded (see the call site), so a failure here is genuinely a
+/// broker/TCP problem, not a WiFi flap. On [`BROKER_FAIL_LIMIT`] consecutive misses it disables the
+/// override with ONE NVS write (`broker_fallback = true`, keeping `broker` for DIAG + the CFG-`B`
+/// edge-trigger); the next flush uses the slot's baked broker. A success resets the streak. Once
+/// fallen back it early-returns (zero further writes — the anti-ping-pong / zero-wear guarantee,
+/// mirroring the WiFi assoc fallback). The escape is a NEW CFG-`B` value (which clears the flag).
+#[cfg(feature = "espnow")]
+pub fn note_broker_connect(connected: bool) {
+    let Some(cfg) = crate::ota::read_net_cfg() else {
+        return;
+    };
+    // No ACTIVE override (none set, or already fallen back to baked) → nothing to self-heal from.
+    if cfg.broker.is_none() || cfg.broker_fallback {
+        unsafe {
+            *core::ptr::addr_of_mut!(BROKER_FAIL_STREAK) = 0;
+        }
+        return;
+    }
+    if connected {
+        unsafe {
+            *core::ptr::addr_of_mut!(BROKER_FAIL_STREAK) = 0;
+        }
+        return;
+    }
+    let streak = unsafe {
+        let p = core::ptr::addr_of_mut!(BROKER_FAIL_STREAK);
+        *p = (*p).saturating_add(1);
+        *p
+    };
+    if streak >= BROKER_FAIL_LIMIT {
+        // ONE NVS write: disable the override (keep `broker` for DIAG + edge-trigger) → baked broker.
+        crate::ota::write_net_cfg(crate::ota::NetCfg { broker_fallback: true, ..cfg });
+        unsafe {
+            *core::ptr::addr_of_mut!(BROKER_FAIL_STREAK) = 0;
+        }
+        log::warn!(
+            "smol #100: broker override unreachable x{} — disabled, reverting to the slot's baked broker",
+            streak
+        );
+    }
 }
 
 /// Shared WiFi -> DHCP -> SNTP burst, reused by both the Phase-2 `wifi`-only
@@ -555,6 +618,9 @@ pub fn run_ntp_burst(
         active: 0,
         commanded: 0,
         fallback: false,
+        broker: None,
+        broker_fallback: false,
+        ota_host: None,
     });
     'assoc: loop {
         let mut attempt = 0u8;
@@ -577,7 +643,9 @@ pub fn run_ntp_burst(
             return None;
         }
         let other = 1 - sel.active;
-        sel = crate::ota::NetCfg { active: other, commanded: sel.commanded, fallback: true };
+        // Preserve commanded + the broker/OTA overrides (`..sel`) — the WiFi revert only flips the
+        // active slot; a broker/OTA override survives a slot fallback (and CFG-`N` clears them).
+        sel = crate::ota::NetCfg { active: other, fallback: true, ..sel };
         crate::ota::write_net_cfg(sel); // the ONE revert-write
         log::warn!("smol #100: selected slot unreachable — reverted to slot {} (fallback), retrying", other);
     }
@@ -935,6 +1003,19 @@ pub const CFG_KEY_SCAN: u8 = b'W';
 /// `smol/<id>/config/net` or fleet-wide `smol/config/net` (target 255). Value = one ASCII digit.
 #[cfg(feature = "wifi")]
 pub const CFG_KEY_NET: u8 = b'N';
+/// #100 Stage 2 broker-override CONFIG (key `B`) = the MQTT broker leg `"a.b.c.d"` or `"a.b.c.d:port"`
+/// (RFC1918-gated, IP-only v1; empty = clear back to the slot's baked broker). RETAINED/CACHED STATE
+/// (relayed like `N`). A node applies it by writing the NVS net-record + rebooting; EDGE-triggered on
+/// a change of the COMMANDED broker (a re-read is a no-op → never a reboot-loop, even after the CONNACK
+/// fallback disables the override). Per-node `smol/<id>/config/broker` or fleet-wide `smol/config/broker`.
+#[cfg(feature = "wifi")]
+pub const CFG_KEY_BROKER: u8 = b'B';
+/// #100 Stage 3 OTA-host-override CONFIG (key `O`) = one extra RFC1918 image host `"a.b.c.d"` appended
+/// to the fetch allowlist (empty = clear). RETAINED/CACHED STATE (relayed like `N`). Applied by writing
+/// the NVS net-record — NO reboot (the allowlist is read at fetch/gate time). EDGE-triggered on a change.
+/// Per-node `smol/<id>/config/ota_host` or fleet-wide `smol/config/ota_host`.
+#[cfg(feature = "wifi")]
+pub const CFG_KEY_OTA: u8 = b'O';
 
 /// #48 (GwOwnCfg — approved arch): the GATEWAY's OWN per-node configs read from its own MQTT
 /// topics this burst. A leaf gets these RELAYED (→ its `CfgTracker`); the gateway reads them
@@ -964,12 +1045,18 @@ pub struct GwOwnCfg {
     /// #100 the gateway's own `smol/<id>/config/net` (or global `smol/config/net`) active-slot
     /// index value `(buf, len)`, or `None` if absent this burst.
     pub net: Option<([u8; CFG_VALUE_MAX], usize)>,
+    /// #100 Stage 2 the gateway's own `smol/<id>/config/broker` (or global `smol/config/broker`)
+    /// broker-leg override value `(buf, len)`, or `None` if absent this burst.
+    pub broker: Option<([u8; CFG_VALUE_MAX], usize)>,
+    /// #100 Stage 3 the gateway's own `smol/<id>/config/ota_host` (or global `smol/config/ota_host`)
+    /// OTA-host override value `(buf, len)`, or `None` if absent this burst.
+    pub ota: Option<([u8; CFG_VALUE_MAX], usize)>,
 }
 
 #[cfg(feature = "wifi")]
 impl GwOwnCfg {
     pub const fn new() -> Self {
-        Self { led: None, units: None, plugins: None, custom: None, net: None }
+        Self { led: None, units: None, plugins: None, custom: None, net: None, broker: None, ota: None }
     }
     /// Pack a payload into the `(buf, len)` a field holds (truncated to `CFG_VALUE_MAX`), so the
     /// mqtt-drain arms stay one-liners: `gw_own.led = Some(GwOwnCfg::val(payload));`.
@@ -1712,6 +1799,23 @@ fn mqtt_session(
         if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 17, b"smol/config/net") {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
+        // #100 Stage 2 broker override (pid 18 per-node + pid 19 fleet-wide): the retained broker leg.
+        // Twin of net (key `B`, relayed + cached + edge-triggered reboot). Applying it writes the NVS
+        // net-record + reboots onto the new broker; a wrong value self-heals via the CONNACK fallback.
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 18, b"smol/+/config/broker") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 19, b"smol/config/broker") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
+        // #100 Stage 3 OTA-host override (pid 20 per-node + pid 21 fleet-wide): one extra RFC1918 image
+        // host (key `O`, relayed + cached). Applied WITHOUT reboot — the allowlist is read at fetch time.
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 20, b"smol/+/config/ota_host") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 21, b"smol/config/ota_host") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
     }
 
     // --- PUBLISH telemetry (transient) + discovery config (retained) per node ---
@@ -2208,6 +2312,64 @@ fn mqtt_session(
                         } else {
                             gw_own.net = Some(GwOwnCfg::val(payload));
                             log::info!("smol #100: gateway own net-slot captured ({} B)", payload.len());
+                        }
+                    } else if topic == b"smol/config/broker" {
+                        // #100 Stage 2 GLOBAL broker override (no id) → cache under target 255 + gw_own.
+                        // Twin of the global-net arm. Opaque bytes; the apply (main) RFC1918-validates.
+                        if let Some(cache) = cfg_cache.as_deref_mut() {
+                            let now = Instant::now().duration_since_epoch().as_millis();
+                            cache.set(CFG_TARGET_ALL, CFG_KEY_BROKER, payload, [0u8; 6], now);
+                        }
+                        gw_own.broker = Some(GwOwnCfg::val(payload));
+                        log::info!(
+                            "smol #100: global broker override captured ({} B) — cached (255,B) + self",
+                            payload.len()
+                        );
+                    } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/config/broker") {
+                        // #100 Stage 2 PER-NODE broker override: twin of the per-node net arm. OTHER
+                        // leaf → cache under key `B` for the ESP-NOW relay; OUR OWN id → gw_own.broker.
+                        if leaf_id != node_id {
+                            if let Some(cache) = cfg_cache.as_deref_mut() {
+                                let now = Instant::now().duration_since_epoch().as_millis();
+                                cache.set(leaf_id, CFG_KEY_BROKER, payload, [0u8; 6], now);
+                                log::info!(
+                                    "smol #100: cached leaf id{} broker override for relay ({} B)",
+                                    leaf_id,
+                                    payload.len()
+                                );
+                            }
+                        } else {
+                            gw_own.broker = Some(GwOwnCfg::val(payload));
+                            log::info!("smol #100: gateway own broker override captured ({} B)", payload.len());
+                        }
+                    } else if topic == b"smol/config/ota_host" {
+                        // #100 Stage 3 GLOBAL OTA-host override (no id) → cache under target 255 + gw_own.
+                        // Twin of the global-net arm. Opaque bytes; the apply (main) RFC1918-validates.
+                        if let Some(cache) = cfg_cache.as_deref_mut() {
+                            let now = Instant::now().duration_since_epoch().as_millis();
+                            cache.set(CFG_TARGET_ALL, CFG_KEY_OTA, payload, [0u8; 6], now);
+                        }
+                        gw_own.ota = Some(GwOwnCfg::val(payload));
+                        log::info!(
+                            "smol #100: global OTA-host override captured ({} B) — cached (255,O) + self",
+                            payload.len()
+                        );
+                    } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/config/ota_host") {
+                        // #100 Stage 3 PER-NODE OTA-host override: twin of the per-node net arm. OTHER
+                        // leaf → cache under key `O` for the ESP-NOW relay; OUR OWN id → gw_own.ota.
+                        if leaf_id != node_id {
+                            if let Some(cache) = cfg_cache.as_deref_mut() {
+                                let now = Instant::now().duration_since_epoch().as_millis();
+                                cache.set(leaf_id, CFG_KEY_OTA, payload, [0u8; 6], now);
+                                log::info!(
+                                    "smol #100: cached leaf id{} OTA-host override for relay ({} B)",
+                                    leaf_id,
+                                    payload.len()
+                                );
+                            }
+                        } else {
+                            gw_own.ota = Some(GwOwnCfg::val(payload));
+                            log::info!("smol #100: gateway own OTA-host override captured ({} B)", payload.len());
                         }
                     } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/cmd/reset") {
                         // #52 remote reboot — a COMMAND on a TRANSIENT topic (retain:false), so we
@@ -2956,6 +3118,11 @@ pub fn run_mqtt_burst(
         deadline,
         tick,
     );
+
+    // #100 Stage 2: feed the broker-override fallback. We only reach here AFTER the WiFi
+    // association succeeded (the assoc wait above returns early on failure), so `session_ok`
+    // reflects the broker CONNACK, not a WiFi flap. A no-op unless a CFG-`B` override is active.
+    note_broker_connect(session_ok);
 
     // #26 cast: if HA enabled it (learned via the retained `smol/<id>/cast` topic during
     // the session above), stream the mirrored glass image to the WLED matrix over the

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -1705,7 +1705,9 @@ pub fn parse_ipv4(s: &str) -> Option<[u8; 4]> {
 
 /// RFC1918 private-range test (`10/8`, `172.16/12`, `192.168/16`). CFG-`B`/`O` overrides MUST pass
 /// this so a dashboard typo can never point a board off-LAN (the on-LAN guard JP named in #100).
-#[cfg(feature = "wifi")]
+/// `espnow`-gated: reached only through the two override parsers below, which the espnow-only CFG
+/// apply path calls (a wifi-only build has no `RadioManager`/apply, so it would be dead code there).
+#[cfg(feature = "espnow")]
 pub fn is_rfc1918(ip: [u8; 4]) -> bool {
     matches!(ip,
         [10, ..]
@@ -1716,7 +1718,8 @@ pub fn is_rfc1918(ip: [u8; 4]) -> bool {
 /// Parse a CFG-`B` broker override value `"a.b.c.d"` or `"a.b.c.d:port"` (port defaults to 1883,
 /// the plain-Mosquitto port). `None` unless the IP is RFC1918 and the port is non-zero — the apply
 /// path treats `None` as "invalid, keep current" and an empty string as an explicit CLEAR.
-#[cfg(feature = "wifi")]
+/// `espnow`-gated: called only from the espnow-only CFG-`B` apply path (see `is_rfc1918`).
+#[cfg(feature = "espnow")]
 pub fn parse_broker_override(s: &str) -> Option<([u8; 4], u16)> {
     let s = s.trim();
     let (ip_str, port) = match s.rsplit_once(':') {
@@ -1732,7 +1735,8 @@ pub fn parse_broker_override(s: &str) -> Option<([u8; 4], u16)> {
 
 /// Parse a CFG-`O` OTA-host override value `"a.b.c.d"`. `None` unless the IP is RFC1918 (keeps OTA
 /// fetches on-LAN; the image is still ed25519/monotonicity-gated regardless — belt-and-suspenders).
-#[cfg(feature = "wifi")]
+/// `espnow`-gated: called only from the espnow-only CFG-`O` apply path (see `is_rfc1918`).
+#[cfg(feature = "espnow")]
 pub fn parse_ota_host_override(s: &str) -> Option<[u8; 4]> {
     let ip = parse_ipv4(s.trim())?;
     if !is_rfc1918(ip) {

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -1525,10 +1525,15 @@ const NET_VERSION: u8 = 2;
 const NET_REC_OFF: u32 = 5 * 4096;
 /// v2 record length. The v1 core is 10 B (magic..guard2); the v2 ext ([10..25]) adds the broker
 /// override (present + fallback flags, 4-B IP, 2-B port), the OTA-host override (present + 4-B IP),
-/// and a sum-checksum + complement guard. Read fixed-width: a stored v1 record leaves [16..25]
-/// erased (0xFF), which the v1 parse path never inspects.
+/// and a sum-checksum + complement guard at [23]/[24]. Read fixed-width: a stored v1 record leaves
+/// [16..] erased (0xFF), which the v1 parse path never inspects.
+///
+/// 28, NOT 25: esp-storage's `NorFlash::WRITE_SIZE == WORD_SIZE == 4` — a write whose length isn't
+/// word-aligned returns `NotAligned`, which `write_net_cfg`'s swallowed error turned into "record
+/// never persists" (HW-canary find, 2026-07-12: capture + edge-trigger fired, then verify-after-write
+/// aborted EVERY apply). [25..28] is zero pad outside the checksum; the guards stay at [23]/[24].
 #[cfg(feature = "wifi")]
-const NET_REC_LEN: usize = 25;
+const NET_REC_LEN: usize = 28;
 
 /// The persisted network identity. `active` = the WiFi slot we associate on NOW; `commanded` = the
 /// last slot HA asked for via CFG-`N` (differs from `active` iff we auto-reverted); `fallback` = the

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -22,7 +22,7 @@
 //! The announced SHA-256 proves "not corrupted in transit"; it does **NOT** prove
 //! "from a trusted source." Whoever can publish to the broker controls both the URL
 //! and the hash. v1 posture: **OTA authority == MQTT broker write access**, acceptable
-//! only because the broker sits on a trusted VLAN. The URL-host allowlist ([`IMAGE_HOST_ALLOWLIST`])
+//! only because the broker sits on a trusted VLAN. The URL-host allowlist (`host_allowed`)
 //! is defence-in-depth, not authentication. Do NOT let any code imply sha256 == trust.
 
 use esp_bootloader_esp_idf::ota::{Ota, OtaImageState};
@@ -51,12 +51,24 @@ pub const BUILD_NUMBER: u32 = parse_u32(env!("BUILD_NUMBER"));
 #[allow(dead_code)]
 pub const OTA_AUTO_INSTALL: bool = false;
 
-/// Image-host allowlist (spec §4b-5): an announce whose URL host is not one of these
-/// is refused BEFORE any socket opens. The real LAN host(s) live in the GIT-IGNORED
-/// `crate::secrets` (this repo is PUBLIC — never commit a LAN IP). #100 Stage 1a: sourced
-/// from slot 0 of the dual-slot `WIFI_NETWORKS` (const-index [0]); identical to pre-#100.
-/// Stage 3 makes it the runtime-active slot's allowlist + an NVS CFG-`O` override.
-pub const IMAGE_HOST_ALLOWLIST: &[&str] = crate::secrets::WIFI_NETWORKS[0].ota_hosts;
+/// Image-host allowlist test (spec §4b-5): an announce whose URL host is not allowed is refused
+/// BEFORE any socket opens. The real LAN host(s) live in the GIT-IGNORED `crate::secrets` (this repo
+/// is PUBLIC — never commit a LAN IP). #100 Stage 3: the base allowlist is the RUNTIME-active slot's
+/// baked `ota_hosts` (was a slot-0 const), PLUS the NVS CFG-`O` override (one extra RFC1918 host,
+/// dashboard-set). Read at gate time — no reboot. A bad override can only ever REFUSE a fetch (it is
+/// merely an additional allowed host); the image itself stays monotonicity-gated, so this is
+/// defense-in-depth, never a brick surface.
+#[cfg(feature = "wifi")]
+fn host_allowed(host: &str) -> bool {
+    let cfg = read_net_cfg();
+    let active = cfg.map_or(0usize, |c| c.active as usize);
+    let slot = &crate::secrets::WIFI_NETWORKS[active.min(crate::secrets::WIFI_NETWORKS.len() - 1)];
+    if slot.ota_hosts.contains(&host) {
+        return true;
+    }
+    // Stage 3: the CFG-`O` override — one extra RFC1918 host, matched by parsing the URL host.
+    matches!(cfg.and_then(|c| c.ota_host), Some(ovr) if parse_ipv4(host) == Some(ovr))
+}
 
 /// Max image = one app slot (`ota_0`/`ota_1` size from `partitions-ota.csv`). An
 /// announce larger than this is refused before any flash op; also cross-checked vs
@@ -269,7 +281,7 @@ pub fn split_url(url: &str) -> Option<(&str, u16, &str)> {
 pub enum Reject {
     /// `build <= BUILD_NUMBER` — downgrade or stale-retained replay (§4b-1).
     NotNewer,
-    /// URL host not on [`IMAGE_HOST_ALLOWLIST`] (§4b-5).
+    /// URL host not allowed by `host_allowed` (§4b-5).
     HostNotAllowed,
     /// `size` is 0 or larger than a slot (§4b-2 bound).
     BadSize,
@@ -285,7 +297,7 @@ pub fn gate(a: &Announce) -> Result<(), Reject> {
         return Err(Reject::NotNewer);
     }
     let (host, _port, _path) = split_url(a.url()).ok_or(Reject::BadUrl)?;
-    if !IMAGE_HOST_ALLOWLIST.contains(&host) {
+    if !host_allowed(host) {
         return Err(Reject::HostNotAllowed);
     }
     if a.size == 0 || a.size > MAX_IMAGE_SIZE {
@@ -1501,35 +1513,70 @@ pub fn reset_reason_token() -> &'static str {
 // garbage record never strands the node on a phantom slot). Brick-safe: never panics, best-effort.
 #[cfg(feature = "wifi")]
 const NET_MAGIC: [u8; 4] = *b"SMn1";
+/// Record version WRITTEN by this firmware. v1 (Stage 1) = the 10-byte core (slot selection only);
+/// v2 (Stage 2/3) appends the broker + OTA-host overrides. `parse_net_cfg` accepts BOTH: a v2 fw
+/// reading a Stage-1 v1 record treats it as "no overrides"; a v1 fw reading a v2 record rejects it
+/// (version mismatch) → slot 0 (a SAFE rollback default). No forced migration — the first v2 write
+/// (CFG-`N`/`B`/`O` apply or a fallback) upgrades the record in place.
 #[cfg(feature = "wifi")]
-const NET_VERSION: u8 = 1;
+const NET_VERSION: u8 = 2;
 /// nvs sector 5 = 0x5000 = 20480 (the one free sector; see the segregation note above).
 #[cfg(feature = "wifi")]
 const NET_REC_OFF: u32 = 5 * 4096;
+/// v2 record length. The v1 core is 10 B (magic..guard2); the v2 ext ([10..25]) adds the broker
+/// override (present + fallback flags, 4-B IP, 2-B port), the OTA-host override (present + 4-B IP),
+/// and a sum-checksum + complement guard. Read fixed-width: a stored v1 record leaves [16..25]
+/// erased (0xFF), which the v1 parse path never inspects.
 #[cfg(feature = "wifi")]
-const NET_REC_LEN: usize = 16;
+const NET_REC_LEN: usize = 25;
 
-/// The persisted network selection. `active` = the slot we associate on NOW; `commanded` = the
-/// last slot HA asked for via CFG-`N` — it differs from `active` iff we auto-reverted; `fallback`
-/// = we're running on a reverted slot, not the commanded one (surfaced as `net=<slot>:fb` in DIAG).
+/// The persisted network identity. `active` = the WiFi slot we associate on NOW; `commanded` = the
+/// last slot HA asked for via CFG-`N` (differs from `active` iff we auto-reverted); `fallback` = the
+/// WiFi assoc fallback fired (surfaced as `net=<slot>:fb`). #100 Stage 2/3 overrides (all runtime,
+/// NVS-persisted, RFC1918-gated at the CFG apply): `broker` = the COMMANDED broker leg override (the
+/// slot's baked broker is used when `None`); `broker_fallback` = the override was auto-disabled after
+/// repeated CONNACK failures — `broker` is KEPT (for DIAG + the edge-trigger) but ignored at runtime,
+/// mirroring the WiFi `fallback`; `ota_host` = one extra RFC1918 host appended to the OTA allowlist.
 #[cfg(feature = "wifi")]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct NetCfg {
     pub active: u8,
     pub commanded: u8,
     pub fallback: bool,
+    /// Stage 2: broker leg override (IPv4 octets + port). `None` = use the active slot's baked broker.
+    pub broker: Option<([u8; 4], u16)>,
+    /// Stage 2: the `broker` override was auto-disabled (N failed CONNACKs). Runtime uses the baked
+    /// broker; `broker` is retained so DIAG shows `brk=fb` and CFG-`B` edge-triggers correctly.
+    pub broker_fallback: bool,
+    /// Stage 3: one extra OTA image-host (RFC1918) appended to the fetch allowlist. `None` = none.
+    pub ota_host: Option<[u8; 4]>,
 }
 
-/// Decode a stored net record. `Some` iff magic + version + both redundancy guards pass AND every
-/// slot index is in range (0/1 — `WIFI_NETWORKS.len() == 2`). Erased flash (0xFF) / corruption /
-/// an out-of-range slot all fail → `None` → caller uses slot 0.
+/// The v2 extension checksum over `rec[10..23]` (the override bytes). A wrapping sum + `0x5A` bias,
+/// stored at `[23]` with its complement at `[24]` — the same two-guard scheme as the v1 core.
+#[cfg(feature = "wifi")]
+fn net_ext_checksum(rec: &[u8]) -> u8 {
+    rec[10..23]
+        .iter()
+        .fold(0u8, |a, &b| a.wrapping_add(b))
+        .wrapping_add(0x5A)
+}
+
+/// Decode a stored net record. `Some` iff magic + a known version + the core redundancy guards pass
+/// AND the slot indices are in range (< 2). A v1 record yields no overrides; a v2 record must ALSO
+/// pass the ext checksum + complement (else the overrides are corrupt → the whole record is rejected
+/// → caller uses slot 0, no override). Erased flash (0xFF) / corruption all fail → `None`.
 #[cfg(feature = "wifi")]
 fn parse_net_cfg(rec: &[u8]) -> Option<NetCfg> {
-    if rec.len() < 10 || rec[0..4] != NET_MAGIC || rec[4] != NET_VERSION {
+    if rec.len() < 10 || rec[0..4] != NET_MAGIC {
+        return None;
+    }
+    let ver = rec[4];
+    if ver != 1 && ver != 2 {
         return None;
     }
     let (active, commanded, fb) = (rec[5], rec[6], rec[7]);
-    // complement + checksum guards (mirror the identity record).
+    // Core complement + checksum guards (mirror the identity record) — present in v1 AND v2.
     if rec[8] != active ^ 0xFF || rec[9] != (active ^ commanded ^ fb).wrapping_add(0x5A) {
         return None;
     }
@@ -1537,10 +1584,38 @@ fn parse_net_cfg(rec: &[u8]) -> Option<NetCfg> {
     if active > 1 || commanded > 1 || fb > 1 {
         return None;
     }
-    Some(NetCfg { active, commanded, fallback: fb != 0 })
+    let core = NetCfg {
+        active,
+        commanded,
+        fallback: fb != 0,
+        broker: None,
+        broker_fallback: false,
+        ota_host: None,
+    };
+    if ver == 1 {
+        return Some(core); // Stage-1 record: no overrides.
+    }
+    // v2 ext: require the full record + a matching checksum/complement before trusting the overrides.
+    if rec.len() < NET_REC_LEN || rec[23] != net_ext_checksum(rec) || rec[24] != rec[23] ^ 0xFF {
+        return None;
+    }
+    let broker = (rec[10] == 1).then(|| {
+        (
+            [rec[12], rec[13], rec[14], rec[15]],
+            u16::from_le_bytes([rec[16], rec[17]]),
+        )
+    });
+    let ota_host = (rec[18] == 1).then_some([rec[19], rec[20], rec[21], rec[22]]);
+    Some(NetCfg {
+        broker,
+        broker_fallback: rec[11] == 1,
+        ota_host,
+        ..core
+    })
 }
 
-/// Encode the 16-byte net record.
+/// Encode the v2 net record (always written at [`NET_VERSION`] = 2). Absent overrides zero their
+/// present-flag + bytes so the record is deterministic; the ext checksum + complement close it.
 #[cfg(feature = "wifi")]
 fn encode_net_cfg(c: NetCfg) -> [u8; NET_REC_LEN] {
     let mut r = [0u8; NET_REC_LEN];
@@ -1551,6 +1626,18 @@ fn encode_net_cfg(c: NetCfg) -> [u8; NET_REC_LEN] {
     r[7] = c.fallback as u8;
     r[8] = c.active ^ 0xFF;
     r[9] = (c.active ^ c.commanded ^ c.fallback as u8).wrapping_add(0x5A);
+    if let Some((ip, port)) = c.broker {
+        r[10] = 1;
+        r[12..16].copy_from_slice(&ip);
+        r[16..18].copy_from_slice(&port.to_le_bytes());
+    }
+    r[11] = c.broker_fallback as u8;
+    if let Some(ip) = c.ota_host {
+        r[18] = 1;
+        r[19..23].copy_from_slice(&ip);
+    }
+    r[23] = net_ext_checksum(&r);
+    r[24] = r[23] ^ 0xFF;
     r
 }
 
@@ -1599,6 +1686,59 @@ pub fn write_net_cfg(c: NetCfg) {
         return;
     }
     let _ = flash.write(base + NET_REC_OFF, &encode_net_cfg(c));
+}
+
+/// Parse a dotted-quad IPv4 (`"10.0.8.111"`) into four octets. Panic-free, `no_std`: rejects any
+/// part that isn't a 0..=255 decimal and anything other than exactly four parts. `None` on garbage.
+#[cfg(feature = "wifi")]
+pub fn parse_ipv4(s: &str) -> Option<[u8; 4]> {
+    let mut octets = [0u8; 4];
+    let mut it = s.split('.');
+    for o in octets.iter_mut() {
+        *o = it.next()?.parse::<u8>().ok()?;
+    }
+    if it.next().is_some() {
+        return None; // more than four parts
+    }
+    Some(octets)
+}
+
+/// RFC1918 private-range test (`10/8`, `172.16/12`, `192.168/16`). CFG-`B`/`O` overrides MUST pass
+/// this so a dashboard typo can never point a board off-LAN (the on-LAN guard JP named in #100).
+#[cfg(feature = "wifi")]
+pub fn is_rfc1918(ip: [u8; 4]) -> bool {
+    matches!(ip,
+        [10, ..]
+        | [172, 16..=31, ..]
+        | [192, 168, ..])
+}
+
+/// Parse a CFG-`B` broker override value `"a.b.c.d"` or `"a.b.c.d:port"` (port defaults to 1883,
+/// the plain-Mosquitto port). `None` unless the IP is RFC1918 and the port is non-zero — the apply
+/// path treats `None` as "invalid, keep current" and an empty string as an explicit CLEAR.
+#[cfg(feature = "wifi")]
+pub fn parse_broker_override(s: &str) -> Option<([u8; 4], u16)> {
+    let s = s.trim();
+    let (ip_str, port) = match s.rsplit_once(':') {
+        Some((ip, p)) => (ip, p.parse::<u16>().ok()?),
+        None => (s, 1883u16),
+    };
+    let ip = parse_ipv4(ip_str)?;
+    if !is_rfc1918(ip) || port == 0 {
+        return None;
+    }
+    Some((ip, port))
+}
+
+/// Parse a CFG-`O` OTA-host override value `"a.b.c.d"`. `None` unless the IP is RFC1918 (keeps OTA
+/// fetches on-LAN; the image is still ed25519/monotonicity-gated regardless — belt-and-suspenders).
+#[cfg(feature = "wifi")]
+pub fn parse_ota_host_override(s: &str) -> Option<[u8; 4]> {
+    let ip = parse_ipv4(s.trim())?;
+    if !is_rfc1918(ip) {
+        return None;
+    }
+    Some(ip)
 }
 
 /// The running app slot as 0 (`ota_0`) / 1 (`ota_1`); 255 on a non-OTA board or any read


### PR DESCRIPTION
Builds on the merged Stage-1 slot switcher (#108). Layers the two remaining runtime overrides JP scoped in #100 — the **MQTT broker leg** and the **OTA-host allowlist** — both dashboard-managed, fallback-protected, sharing the one sector-5 NVS record. Closes the rest of #100.

## What ships
- **Stage 2 — broker override (CFG key `B`, retained `smol/<id>/config/broker`)**: value `ip` or `ip:port` (RFC1918-gated, IP-only v1, port default 1883; empty = clear). Apply = edge-triggered + verify-after-write + reboot. `active_broker()` prefers the override unless it has been auto-disabled.
- **Stage 3 — OTA-host override (CFG key `O`, retained `smol/<id>/config/ota_host`)**: one extra RFC1918 host appended to the fetch allowlist (base is now the **active slot's** `ota_hosts`, was a slot-0 const). Read at gate time — **no reboot**, no fallback (a bad host can only refuse a fetch; the image stays monotonicity-gated).
- **HA** (`ha/packages/smol_mesh.yaml` + new `ha/dashboard/smol_network_card.yaml`): per-node network `input_select` + broker/OTA-host `input_text` + publish automations (retained, **qos 1**, guarded against unavailable/unknown) + `net`/`brk`/`otah` DIAG mirror sensors. Repo copy only — team-lead deploys to live HA.

## NVS record v1 → v2 (back-compatible)
One sector-5 record (25 B). A v2 firmware reading a Stage-1 **v1** record treats it as "no overrides" (slot selection preserved — no data loss on OTA upgrade). A v1 firmware reading a v2 record rejects it → slot 0 (a safe rollback). No forced migration; the first v2 write upgrades in place. `NetCfg` gains `broker: Option<([u8;4],u16)>`, `broker_fallback: bool`, `ota_host: Option<[u8;4]>`; ext fields carry their own checksum + complement guard.

## Invariants (identical discipline to the Stage-1 WiFi fallback)
- **Un-brickable**: the active slot's *baked* broker is the floor. A wrong broker override self-heals without USB — 3 consecutive failed CONNACKs (in-RAM streak across bursts, counted only *after* WiFi association succeeds, so a WiFi flap never counts) → ONE NVS write disables the override (`broker_fallback=true`) → baked broker next flush.
- **Never-loop**: CFG-`B` edge-triggers on the *commanded* broker, not the runtime one. A fallback-disable keeps the commanded value (for DIAG + the edge-trigger), so the retained command never re-fires → no reboot/flush loop (the exact class the #100 canary caught for CFG-N). Escape a fallen-back override with a *new* value.
- **Never-wear**: `broker_fallback` persists in NVS and gates further writes → provably ONE revert-write per commanded broker, zero across reboots during a sustained outage.
- **CFG-`N` resets identity**: a WiFi-slot switch clears both overrides (they were set for the old network's VLAN; a stale broker would drop CONNACK cross-VLAN).
- **Default build byte-free**: `ota.rs` + `secrets.rs` are `#[cfg(feature="wifi")]` modules — not compiled without a radio. Proven by cfg-gating (not ELF equality — build.rs embeds a git stamp) AND a green default-profile clippy.

## Verification
All 5 profiles clippy `-D warnings` = 0: **default / wifi / espnow / wled / cast**. Parse-checked (rustfmt). Not yet hardware-run — team-lead canaries before merge.

## Canary asks (HW, before merge)
1. Bogus broker via CFG-`B` → 3 CONNACK fails → `brk=fb` in DIAG + baked broker reached, telemetry resumes, **no reboot loop**.
2. Real broker override round-trip: CFG-`B` → reboot → `brk=ovr` → reachable.
3. CFG-`O` host → OTA fetch from the override host succeeds (gate accepts).
4. CFG-`N` slot switch clears a prior broker override (`brk=baked` after).
5. v1→v2 upgrade: a Stage-1 board OTA'd to this fw keeps its slot selection.

## ⚠️ One thing to verify at canary
The HA network `input_select` maps **"iot (jplovescl)" = slot 0, "roam" = slot 1** — this MUST match the local `secrets.rs` `WIFI_NETWORKS` order. A wrong pick self-heals (fallback → `net=<slot>:fb`) so it never bricks, but the dashboard label would mislead. Commented in `smol_mesh.yaml` + the card.

## Record migration (review note a)
`encode_net_cfg` **always writes v2** (`NET_VERSION=2`), so the record is **upgraded in place on the first write** — where "first write" = the first CFG-`N`/`B`/`O` apply *or* a WiFi assoc fallback after the upgrade. Until such a write happens a Stage-1 **v1** record is left untouched on flash and read as "no overrides" (slot selection intact). There is no separate migration pass and no "preserve-v1-until-override-set" special case: the very next thing that changes the record (including a plain slot switch or a fallback) rewrites the whole record as v2.

## CONNACK counter isolation across CFG-N (review note b)
Confirmed safe by two independent mechanisms: (1) `BROKER_FAIL_STREAK` is a plain in-RAM `static mut` (not `rtc_fast`/persistent), and every commanded change — CFG-`N` and CFG-`B` alike — ends in `software_reset()`, which clears RAM → the streak is 0 after any switch. (2) CFG-`N` also clears the broker override (`broker=None`), and `note_broker_connect` early-returns whenever `broker.is_none()`, so even a hypothetical surviving counter could not act on the new slot's baked broker. A slot change never inherits the other broker's strikes.

## Design note — self-referential gateway demotion (HW-observed)
A gateway whose broker override is unreachable can't reach the broker to confirm its own mesh-channel (MC) ownership, so it demotes itself to "leaf scanning for gateway <self>" — a self-reference (it's looking for the gateway it *is*). The Stage-2 3-strike CONNACK latch is what breaks the loop: after 3 failed CONNACKs it clears the override → the baked broker is reachable → MC ownership re-confirms → it re-crowns. Same self-heal guarantee as the WiFi fallback, one layer up.

## Post-canary fixes (see PR comments for detail)
1. `652f9f2` — drain-order: batt/grid/mc subscribe last so the retained-drain break-gate can't fire before the config backlog drains (fixed CFG-B/O never applying).
2. `1b52456` — word-align the v2 NVS record 25→28 (esp-storage NorFlash WRITE_SIZE=4; a non-aligned write returned NotAligned → silent non-persist → verify-after-write aborted every apply). HW-proven on id8: apply→persist→reboot→3-strike fallback→brk=fb.
