### PR TITLE
feat(fw): #72 IO/component registry v1 — runtime pin-binding, config + control + input, over keyed CFG

### DIFF
--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -123,6 +123,17 @@ ed25519-compact = { version = "2", default-features = false, optional = true }
 # --release` with no flags exercises the guaranteed-green baseline.
 default = []
 
+# #72 IO/component registry (ESPHome inverted, "fat image / thin runtime config").
+# Compiles the digital-`Flex` driver menu into ONE image; a runtime pin-map relayed
+# over the #56 keyed-CFG `G` channel selects which driver binds each free GPIO at
+# boot — no recompile. Default-OFF so the default/wifi/espnow builds stay BYTE-FREE
+# of it (#44): `src/io.rs` is `#![cfg(feature = "io")]` and every hook is cfg-gated.
+# Implies `espnow`: the pin-map's transport (the CfgTracker relay + `take_cfg_offer`
+# apply) lives in the ESP-NOW radio manager, and the fleet runs espnow end-to-end.
+# v1 = digital in/out only (the provably-feasible `Flex` case); ADC/PWM/WS2812-RMT
+# are deferred to v1.5/v2 behind the §2.4 bind-time spike.
+io = ["espnow"]
+
 # Phase 2: WiFi STA + SNTP time sync (+ optional weather).
 # Also carries OTA (issue #6): the flash/otadata crates + esp-backtrace's
 # `custom-halt` (panic→software_reset, MF-2) are pulled in HERE, not on the base

--- a/rust/clock/src/io.rs
+++ b/rust/clock/src/io.rs
@@ -1,0 +1,428 @@
+//! #72 IO/component registry — runtime pin-binding core (v1: digital `Flex`).
+//!
+//! ## The model: ESPHome inverted
+//!
+//! ESPHome generates C++ from YAML and **recompiles per config**. smol wants **no
+//! recompile**, so we invert it: every driver is compiled into ONE image (a driver
+//! menu), and a runtime pin-map — relayed over the #56 keyed-CFG `G` channel, NOT
+//! rebuilt — selects which driver binds to which GPIO at boot. Same trade smol
+//! already made for app plugins (#7), one level down: this `PinMap` is to GPIOs
+//! what the `Plugin` trait is to screens.
+//!
+//! ## What this module is (the de-risked foundation)
+//!
+//! Issue #72 §2.4 flagged ONE real unknown: esp-hal moves *typed* GPIO singletons
+//! at construction, so runtime binding needs the free pins held type-erased and
+//! **re-typed between input and output at runtime**. This module proves that for
+//! the digital case: the 5 free pins are held as [`Flex`] (which is just an erased
+//! `AnyPin` inside), and [`PinMap::bind_input`] / [`PinMap::bind_output`] flip a
+//! pin's direction live by toggling its input/output buffers — no recompile, no
+//! peripheral re-take. [`boot_selftest`] exercises exactly that transition on real
+//! silicon so the hardware canary can confirm it.
+//!
+//! **Digital only in v1.** `Flex` re-types digital in/out cleanly; ADC and RMT/WS2812
+//! do NOT — attenuation/calibration and the RMT channel are fixed at bind — so they
+//! are deferred to v1.5/v2 behind their own bind-time spike.
+//!
+//! ## Persistence: none (relay-only, by design)
+//!
+//! The pin-map is NOT persisted in NVS — the `G` key writes ZERO flash (no wear, no
+//! sector risk; the nvs partition is already full, sectors 0-5 all owned). It rides
+//! purely on the gateway's retained-config relay: `broadcast_cached_configs`
+//! (main.rs) re-relays every cached `(id, key)` config on the ~10 s flush cadence,
+//! so a rebooted leaf re-arms its pins within ~10 s of the gateway being up — the
+//! exact mechanism the S/L/U/P/Y config keys already rely on. Trade-off: a leaf that
+//! reboots *while the gateway is down* has no IO config until the gateway returns.
+
+use esp_hal::gpio::{Flex, InputConfig, Level, OutputConfig, Pull};
+
+/// The GPIOs free for runtime binding on the ESP32-C3 SuperMini. Everything else on
+/// the exposed header is already claimed by an on-board peripheral or is a boot
+/// strapping / USB-serial pin — see [`RESERVED_PINS`]. Slot `i` of a [`PinMap`] owns
+/// the physical pin `FREE_PINS[i]`.
+pub const FREE_PINS: [u8; 5] = [0, 1, 3, 7, 10];
+
+/// GPIOs that MUST NEVER be bound: a `G`-key descriptor naming one is rejected and
+/// surfaced in DIAG, never applied. Cited against their real claim sites (NOT
+/// `board.rs`, which is the per-board *identity* template — `NODE_ID`/`DEFAULT_APP`
+/// only — and holds no pin map):
+///   * `4`     — battery ADC        (`main.rs` `sensors::Sensors::new(.. GPIO4)`; `sensors::BATT_ADC_GPIO`)
+///   * `5`,`6` — OLED I²C SDA/SCL   (`main.rs` `.with_sda(GPIO5)` / `.with_scl(GPIO6)`; `main.rs` header)
+///   * `8`     — blue status LED    (`main.rs` `led::Led::new(Output::new(GPIO8 ..))`; `led.rs`, strapping)
+///   * `9`     — BOOT button        (`main.rs` `Button::new(GPIO9)`; `input.rs`, strapping)
+///   * `2`     — boot strapping pin (C3 boot-mode select; #72 pin-budget note)
+///   * `20`,`21` — USB-serial UART  (log console; #72 pin-budget note)
+pub const RESERVED_PINS: [u8; 8] = [2, 4, 5, 6, 8, 9, 20, 21];
+
+/// Number of runtime-bindable slots (= free pins). Fixed capacity → no alloc.
+pub const NPIN: usize = FREE_PINS.len();
+
+/// The role a slot is currently bound to. v1 is digital only — the provably-feasible
+/// `Flex` case. (v2 adds analog/PWM/bus kinds behind the §2.4 bind-time spike.)
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PinDir {
+    /// Digital input with the internal pull-up (active-low convention, as the BOOT
+    /// button uses): a button/contact reads `Low` when pressed/closed.
+    Input,
+    /// Digital push-pull output: drives a relay coil or a plain single-color LED
+    /// (the #75 dollhouse room lamp).
+    Output,
+}
+
+/// A configured component's kind — the semantic role HA sees, layered over the
+/// electrical [`PinDir`]. v1 is digital only. The wire char is the single byte after
+/// the pin number in a `G`-key binding (e.g. `7B` = GPIO7 is a Button).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ComponentKind {
+    /// Momentary button / contact (`B`) → HA `binary_sensor` / press events. Digital
+    /// input, pull-up (reads `Low` when pressed, like the BOOT button).
+    Button,
+    /// Latching binary sensor (`S`) — reed / PIR / float → HA `binary_sensor`. Digital
+    /// input, pull-up.
+    BinarySensor,
+    /// Relay / GPIO switch (`R`) → HA `switch`. Digital push-pull output.
+    Relay,
+    /// Plain single-color LED (`L`) → HA `light` — the #75 dollhouse room lamp. Digital
+    /// push-pull output (drive High = on for a header-wired LED-to-GND).
+    Led,
+}
+
+impl ComponentKind {
+    /// Decode the wire char. Unknown → `None` (forward-compat drop, #56 / #46 clamp).
+    pub fn from_wire(c: u8) -> Option<Self> {
+        match c {
+            b'B' => Some(Self::Button),
+            b'S' => Some(Self::BinarySensor),
+            b'R' => Some(Self::Relay),
+            b'L' => Some(Self::Led),
+            _ => None,
+        }
+    }
+
+    /// The electrical direction this kind binds the pin to.
+    pub fn dir(self) -> PinDir {
+        match self {
+            Self::Button | Self::BinarySensor => PinDir::Input,
+            Self::Relay | Self::Led => PinDir::Output,
+        }
+    }
+}
+
+/// A raw input level must be stable this long (ms) before a committed edge counts —
+/// same 25 ms debounce the BOOT button uses (`input.rs`), rejecting tact-switch bounce.
+const INPUT_DEBOUNCE_MS: u64 = 25;
+
+/// Per-slot debounced input state (meaningful only for a bound INPUT slot). Active-low
+/// convention (pull-up): a press pulls the pin LOW, so a HIGH→LOW committed edge is a
+/// "press" and bumps `count`. Reset when the slot is (re)bound as an input.
+#[derive(Clone, Copy)]
+struct InState {
+    /// Last COMMITTED (debounced) level — `true` = high = released.
+    level: bool,
+    /// The raw candidate level currently being debounced.
+    cand: bool,
+    /// When the current candidate was first seen (monotonic ms).
+    cand_since: u64,
+    /// Falling-edge (press) count — monotonic, wraps. HA reads it as a press event source.
+    count: u16,
+}
+
+impl InState {
+    const fn new() -> Self {
+        // Released (high) at rest — the pull-up idles high until something pulls it low.
+        Self { level: true, cand: true, cand_since: 0, count: 0 }
+    }
+}
+
+/// Fixed-capacity runtime pin-map: one optional `Flex` slot per [`FREE_PINS`] entry,
+/// no alloc. Every free pin is held as a `Flex` for the whole run (claimed once at
+/// boot); [`PinDir`] tracks whether a slot is currently bound as input, output, or
+/// unbound (Hi-Z). Binding is a runtime buffer-direction flip — the #72 §2.4 spike.
+pub struct PinMap {
+    /// Slot `i` owns physical pin `FREE_PINS[i]`, type-erased as a `Flex`.
+    flex: [Flex<'static>; NPIN],
+    /// Slot `i`'s current electrical role, or `None` if unbound (both buffers off → Hi-Z).
+    dir: [Option<PinDir>; NPIN],
+    /// Slot `i`'s debounced input state (press counter + level). Only advanced for a
+    /// bound INPUT slot by [`PinMap::poll_inputs`]; reset when (re)bound as an input.
+    inputs: [InState; NPIN],
+}
+
+impl PinMap {
+    /// Adopt the free GPIOs (already wrapped as `Flex` by the caller, which owns the
+    /// peripheral singletons). Every slot starts UNBOUND / Hi-Z — `Flex::new` resets
+    /// each pin to a known state with no buffer enabled, so nothing is driven until a
+    /// binding selects it.
+    pub fn new(flex: [Flex<'static>; NPIN]) -> Self {
+        Self {
+            flex,
+            dir: [None; NPIN],
+            inputs: [InState::new(); NPIN],
+        }
+    }
+
+    /// Slot index owning physical pin `gpio`, or `None` if `gpio` is not a free pin.
+    pub fn slot_of(gpio: u8) -> Option<usize> {
+        FREE_PINS.iter().position(|&p| p == gpio)
+    }
+
+    /// Is `gpio` on the never-bind reject list ([`RESERVED_PINS`])?
+    pub fn is_reserved(gpio: u8) -> bool {
+        RESERVED_PINS.contains(&gpio)
+    }
+
+    /// Bind slot `slot` as a digital input with the internal pull-up. Runtime re-type:
+    /// disable the output driver, apply the pull, enable the input buffer.
+    pub fn bind_input(&mut self, slot: usize) {
+        let f = &mut self.flex[slot];
+        f.set_output_enable(false);
+        f.apply_input_config(&InputConfig::default().with_pull(Pull::Up));
+        f.set_input_enable(true);
+        self.dir[slot] = Some(PinDir::Input);
+        self.inputs[slot] = InState::new(); // fresh debounce + zeroed press counter
+    }
+
+    /// Bind slot `slot` as a digital push-pull output at `level`. Runtime re-type:
+    /// disable the input buffer, set the initial level BEFORE enabling the driver
+    /// (so the pin never glitches through the opposite level), enable the output.
+    pub fn bind_output(&mut self, slot: usize, level: Level) {
+        let f = &mut self.flex[slot];
+        f.set_input_enable(false);
+        f.apply_output_config(&OutputConfig::default());
+        f.set_level(level);
+        f.set_output_enable(true);
+        self.dir[slot] = Some(PinDir::Output);
+    }
+
+    /// Bind slot `slot` to a component `kind`: applies the kind's electrical direction
+    /// (inputs → pull-up; outputs → OFF = `Level::Low`, so a freshly-configured relay/LED
+    /// starts de-energised until commanded on). The semantic kind is re-derived from the
+    /// `G` wire each apply; per-slot kind storage lands in a later stage (uplink/discovery).
+    pub fn bind_component(&mut self, slot: usize, kind: ComponentKind) {
+        match kind.dir() {
+            PinDir::Input => self.bind_input(slot),
+            PinDir::Output => self.bind_output(slot, Level::Low),
+        }
+    }
+
+    /// Release slot `slot` back to unbound / Hi-Z (both buffers off). Used when a `G`
+    /// descriptor clears a pin, or to leave pins safe after the self-test.
+    pub fn clear(&mut self, slot: usize) {
+        let f = &mut self.flex[slot];
+        f.set_output_enable(false);
+        f.set_input_enable(false);
+        self.dir[slot] = None;
+    }
+
+    /// Read a bound-input slot's live level. `None` if the slot is not an input.
+    pub fn read(&self, slot: usize) -> Option<Level> {
+        match self.dir[slot] {
+            Some(PinDir::Input) => Some(self.flex[slot].level()),
+            _ => None,
+        }
+    }
+
+    /// Drive a bound-output slot to `level`. No-op if the slot is not an output.
+    pub fn write(&mut self, slot: usize, level: Level) {
+        if self.dir[slot] == Some(PinDir::Output) {
+            self.flex[slot].set_level(level);
+        }
+    }
+
+    /// The role slot `slot` is currently bound to (`None` = unbound).
+    pub fn dir(&self, slot: usize) -> Option<PinDir> {
+        self.dir[slot]
+    }
+
+    /// Poll every bound INPUT slot at monotonic `now_ms`: debounce the raw level and
+    /// count a "press" on each committed HIGH→LOW edge (active-low, pull-up). Cheap —
+    /// call every subtick. Output / unbound slots are skipped.
+    pub fn poll_inputs(&mut self, now_ms: u64) {
+        for slot in 0..NPIN {
+            if self.dir[slot] != Some(PinDir::Input) {
+                continue;
+            }
+            let raw = self.flex[slot].is_high();
+            let st = &mut self.inputs[slot];
+            if raw != st.cand {
+                // new raw candidate — restart its debounce window
+                st.cand = raw;
+                st.cand_since = now_ms;
+            } else if raw != st.level && now_ms.saturating_sub(st.cand_since) >= INPUT_DEBOUNCE_MS {
+                // candidate held stable past the debounce window → commit it
+                st.level = raw;
+                if !raw {
+                    st.count = st.count.wrapping_add(1); // fell to LOW = a press
+                }
+            }
+        }
+    }
+
+    /// The debounced press count for a bound INPUT slot, or `None` if the slot is not a
+    /// bound input. Folded into the DIAG record (`io=<pin>:<count>,…`) so HA sees presses.
+    pub fn input_count(&self, slot: usize) -> Option<u16> {
+        match self.dir[slot] {
+            Some(PinDir::Input) => Some(self.inputs[slot].count),
+            _ => None,
+        }
+    }
+}
+
+/// #72 spike (canary-observable): prove runtime direction re-typing works on real
+/// silicon. For each free pin, at RUNTIME with no recompile: bind it as OUTPUT and
+/// latch Low then High (reading the driver latch back each time), then RE-TYPE the
+/// SAME pin to INPUT-pull-up and read its live level — the exact `Flex` typed-
+/// singleton transition issue #72 §2.4 called the one real unknown. Each step is
+/// logged to serial so the hardware canary can confirm it. Every pin is left
+/// CLEARED (Hi-Z) on exit, so the probe is safe even if something is wired. Called
+/// ONCE at boot under the `io` feature.
+pub fn boot_selftest(map: &mut PinMap) {
+    for (slot, &gpio) in FREE_PINS.iter().enumerate() {
+        map.bind_output(slot, Level::Low);
+        let latched_low = map.flex[slot].output_level();
+        map.write(slot, Level::High);
+        let latched_high = map.flex[slot].output_level();
+        let as_out = map.dir(slot);
+
+        map.bind_input(slot); // <-- the runtime re-type: output -> input, same pin
+        let read_level = map.read(slot);
+        let as_in = map.dir(slot);
+
+        log::info!(
+            "smol #72 io-spike: GPIO{} {:?}->latch(lo={:?} hi={:?}) then {:?}->level={:?} [runtime rebind OK]",
+            gpio,
+            as_out,
+            latched_low,
+            latched_high,
+            as_in,
+            read_level,
+        );
+
+        map.clear(slot); // leave Hi-Z / unbound — safe default
+    }
+    // Exercise the bind-time validation helpers (stage 2's `G`-parser gates on these):
+    // a free pin resolves to a slot; a reserved pin is reject-listed and slot-less.
+    log::info!(
+        "smol #72 io-spike: {} free pins {:?} rebindable (GPIO{} -> slot {:?}); reserved {:?} reject-listed (GPIO4 reserved? {})",
+        NPIN,
+        FREE_PINS,
+        FREE_PINS[0],
+        PinMap::slot_of(FREE_PINS[0]),
+        RESERVED_PINS,
+        PinMap::is_reserved(4),
+    );
+}
+
+/// Apply a whole `G`-key pin-map wire to `map`, panic-free. Format: `;`-separated
+/// tokens `<pin><kind>` where pin is decimal (0/1/3/7/10) and kind is one of
+/// `B`(button) `S`(sensor) `R`(relay) `L`(led) — e.g. `0L;7B;10R`. Every slot is
+/// CLEARED first (so a binding removed from the new map releases its pin), then each
+/// valid token binds its slot. Invalid tokens — unparsable pin, reserved / non-free
+/// pin, unknown or missing kind — are SKIPPED with a log and never applied (#46 clamp
+/// / #56 forward-compat drop). An empty wire clears every pin. Returns the count bound.
+///
+/// The whole map rides ONE `G` value because `CfgCache` upserts on `(id, key)` — one
+/// value per key per node (there is no per-pin sub-key). A 5-pin map is ~15 B, well
+/// inside `CFG_VALUE_MAX` (64).
+pub fn apply_wire(map: &mut PinMap, wire: &[u8]) -> usize {
+    // Release every slot first — a binding dropped from the new map frees its pin.
+    for slot in 0..NPIN {
+        map.clear(slot);
+    }
+    let mut bound = 0;
+    for tok in wire.split(|&b| b == b';') {
+        let tok = tok.trim_ascii();
+        if tok.is_empty() {
+            continue;
+        }
+        // Leading decimal run = the pin; the first non-digit begins the kind + params.
+        let split = tok.iter().position(|b| !b.is_ascii_digit()).unwrap_or(tok.len());
+        let (pin_bytes, rest) = tok.split_at(split);
+        let Some(pin) = parse_pin(pin_bytes) else {
+            log::warn!("smol #72 io: token without a pin number — skipped");
+            continue;
+        };
+        let Some(&kc) = rest.first() else {
+            log::warn!("smol #72 io: GPIO{} has no type char — skipped", pin);
+            continue;
+        };
+        let Some(kind) = ComponentKind::from_wire(kc) else {
+            log::warn!("smol #72 io: GPIO{} unknown type '{}' — skipped", pin, kc as char);
+            continue;
+        };
+        if PinMap::is_reserved(pin) {
+            log::warn!("smol #72 io: GPIO{} is reserved — rejected", pin);
+            continue;
+        }
+        let Some(slot) = PinMap::slot_of(pin) else {
+            log::warn!("smol #72 io: GPIO{} is not a bindable pin — rejected", pin);
+            continue;
+        };
+        map.bind_component(slot, kind);
+        bound += 1;
+        log::info!("smol #72 io: GPIO{} bound as {:?}", pin, kind);
+    }
+    bound
+}
+
+/// Apply a `g`-key output-states wire to `map`, panic-free. Format: `;`-separated
+/// `<pin>=<0|1>` tokens (e.g. `0=1;10=0`) — `1`/`0` drives the pin's bound OUTPUT
+/// High/Low (a room LED / relay on / off). No-op for a pin that is unbound or bound as
+/// an INPUT (a control frame can arrive before its config `G`; both are retained +
+/// relayed, so they converge, and `main` re-asserts the states after a `G` re-bind).
+/// Unparsable tokens are SKIPPED with a log. Returns the count of outputs driven.
+pub fn apply_set(map: &mut PinMap, wire: &[u8]) -> usize {
+    let mut driven = 0;
+    for tok in wire.split(|&b| b == b';') {
+        let tok = tok.trim_ascii();
+        if tok.is_empty() {
+            continue;
+        }
+        let Some(eq) = tok.iter().position(|&b| b == b'=') else {
+            log::warn!("smol #72 io: io-set token without '=' — skipped");
+            continue;
+        };
+        let (pin_bytes, val_bytes) = tok.split_at(eq);
+        let Some(pin) = parse_pin(pin_bytes.trim_ascii()) else {
+            log::warn!("smol #72 io: io-set token without a pin number — skipped");
+            continue;
+        };
+        // val_bytes starts with the '=' — skip it, then trim.
+        let v = val_bytes[1..].trim_ascii();
+        let level = if v == b"1" {
+            Level::High
+        } else if v == b"0" {
+            Level::Low
+        } else {
+            log::warn!("smol #72 io: GPIO{} io-set value not 0/1 — skipped", pin);
+            continue;
+        };
+        let Some(slot) = PinMap::slot_of(pin) else {
+            log::warn!("smol #72 io: GPIO{} not a bindable pin — io-set skipped", pin);
+            continue;
+        };
+        if map.dir(slot) == Some(PinDir::Output) {
+            map.write(slot, level);
+            driven += 1;
+        } else {
+            log::warn!("smol #72 io: GPIO{} not a bound output — io-set ignored", pin);
+        }
+    }
+    driven
+}
+
+/// Parse 1-2 decimal digits as a pin number, panic-free. `None` if empty, > 2 digits,
+/// or non-numeric (no exposed GPIO is > 21, so 2 digits is ample and keeps it bounded).
+fn parse_pin(bytes: &[u8]) -> Option<u8> {
+    if bytes.is_empty() || bytes.len() > 2 {
+        return None;
+    }
+    let mut n: u8 = 0;
+    for &b in bytes {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        n = n.checked_mul(10)?.checked_add(b - b'0')?;
+    }
+    Some(n)
+}

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -136,6 +136,12 @@ mod hunt;
 mod familiar;
 // On-board sensors: chip die-temp (tsens) + battery ADC on GPIO4. Always on.
 mod sensors;
+// #72 IO/component registry (ESPHome inverted): the digital-`Flex` driver menu +
+// runtime pin-map for the free GPIOs (0/1/3/7/10), configured live over the #56
+// keyed-CFG `G` channel — no recompile. Default-OFF (`io` feature, implies `espnow`)
+// so the default/wifi/espnow builds are BYTE-FREE of it (#44). v1 = digital in/out.
+#[cfg(feature = "io")]
+mod io;
 // #43 display units (°F/°C · 12h/24h): the fleet-global `Units` config + wire parse.
 // Always compiled — the CLOCK screen (universal) renders through it; only espnow nodes
 // receive a config (the relay/apply path is radio-only, like the screen/LED channels).
@@ -412,6 +418,40 @@ fn main() -> ! {
         sensors::BATT_ADC_GPIO,
         sensors::BATT_DIVIDER as u32,
     );
+
+    // --- #72 IO registry: claim the free GPIOs as runtime-bindable Flex pins --
+    // Hold GPIO0/1/3/7/10 as type-erased `Flex` so a runtime pin-map (relayed over
+    // the #56 keyed-CFG `G` channel) can bind each as a digital input/output at
+    // boot — no recompile. The boot self-test proves the runtime out<->in re-type
+    // (issue #72 §2.4, the one real unknown) on real silicon, then leaves every pin
+    // Hi-Z. Held for the whole run; the CFG `G` apply (below) re-binds slots live.
+    // Default-OFF (`io` feature) → the default/wifi/espnow builds never link this.
+    #[cfg(feature = "io")]
+    let mut io_pins = {
+        use esp_hal::gpio::Flex;
+        let mut m = io::PinMap::new([
+            Flex::new(peripherals.GPIO0),
+            Flex::new(peripherals.GPIO1),
+            Flex::new(peripherals.GPIO3),
+            Flex::new(peripherals.GPIO7),
+            Flex::new(peripherals.GPIO10),
+        ]);
+        io::boot_selftest(&mut m);
+        m
+    };
+    // #72: last-applied `G` pin-map wire — edge-triggers the re-bind. The retained config
+    // re-delivers every ~10 s; re-binding every burst would stomp output (relay/LED) state,
+    // so `apply_wire` runs only when the wire CHANGES.
+    #[cfg(feature = "io")]
+    let mut io_wire = [0u8; crate::net::CFG_VALUE_MAX];
+    #[cfg(feature = "io")]
+    let mut io_wire_len: usize = 0;
+    // #72: last-applied `g` output-states wire — held so it can be RE-ASSERTED after a `G`
+    // re-bind (apply_wire binds every output OFF), restoring the commanded lamp/relay levels.
+    #[cfg(feature = "io")]
+    let mut io_set_wire = [0u8; crate::net::CFG_VALUE_MAX];
+    #[cfg(feature = "io")]
+    let mut io_set_len: usize = 0;
 
     // --- HA battery-voltage cache (Batt screen) ------------------------------
     // Owned by `main`, borrowed read-only to the Batt plugin via `Ctx::batt`. Filled
@@ -938,6 +978,21 @@ fn main() -> ! {
                     if units.clk_24h { "24" } else { "12" },
                 );
                 r.set_diag_extra(led_mode.to_wire(), led_on, tage_s, tsrc, cfg.as_bytes());
+                // #72: fold the bound-input press counters into the DIAG record (io=<pin>:<count>,…).
+                #[cfg(feature = "io")]
+                {
+                    use core::fmt::Write as _;
+                    let mut io_field = alloc::string::String::new();
+                    for slot in 0..io::NPIN {
+                        if let Some(c) = io_pins.input_count(slot) {
+                            if !io_field.is_empty() {
+                                io_field.push(',');
+                            }
+                            let _ = write!(io_field, "{}:{}", io::FREE_PINS[slot], c);
+                        }
+                    }
+                    r.set_diag_io(io_field.as_bytes());
+                }
             }
             // #70/#49: a LEAF broadcasts its compact DIAG record on a SLOW ~60 s cadence (diag is
             // slow-moving — keep mesh airtime low), expedited by a BOOT-button press (rate-limited
@@ -1298,6 +1353,36 @@ fn main() -> ! {
                     }
                 }
             }
+            // #72: the relayed / gateway-own IO pin-map (key `G`). EDGE-triggered on a CHANGE of
+            // the wire (the retained value re-delivers every ~10 s; re-binding every burst would
+            // reset outputs). On change: re-bind the free GPIOs via io::apply_wire (validates +
+            // rejects reserved/unknown pins). No NVS — survives reboot via the gateway's re-relay.
+            #[cfg(feature = "io")]
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_IO) {
+                if o.len != io_wire_len || io_wire[..o.len] != o.buf[..o.len] {
+                    io_wire[..o.len].copy_from_slice(&o.buf[..o.len]);
+                    io_wire_len = o.len;
+                    let n = io::apply_wire(&mut io_pins, &o.buf[..o.len]);
+                    // apply_wire bound every output OFF — re-assert the last commanded output
+                    // states so a lamp/relay stays at its level across a config edit.
+                    if io_set_len > 0 {
+                        io::apply_set(&mut io_pins, &io_set_wire[..io_set_len]);
+                    }
+                    log::info!("smol #72 io: pin-map applied ({} B, {} pins bound)", o.len, n);
+                }
+            }
+            // #72: the relayed / gateway-own output states (key `g`). EDGE-triggered on a CHANGE;
+            // drives each bound OUTPUT to its commanded level (io::apply_set no-ops on unbound /
+            // input slots). Held in io_set_wire so a later `G` re-bind re-asserts it.
+            #[cfg(feature = "io")]
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_IO_SET) {
+                if o.len != io_set_len || io_set_wire[..o.len] != o.buf[..o.len] {
+                    io_set_wire[..o.len].copy_from_slice(&o.buf[..o.len]);
+                    io_set_len = o.len;
+                    let n = io::apply_set(&mut io_pins, &o.buf[..o.len]);
+                    log::info!("smol #72 io: output states set ({} B, {} driven)", o.len, n);
+                }
+            }
 
             // #52: a remote reboot command (key `R`) — a COMMAND (cache-bypass, one-shot). Applied
             // once (edge — `take` clears it); the value is empty (the key IS the command). Feeds
@@ -1465,6 +1550,9 @@ fn main() -> ! {
         // the plugin performs its app-specific action and returns Stay/Switch. A
         // long press universally maps to `Switch(Menu)` (the global gesture grammar
         // is enforced centrally: `main` acts only on the returned `Transition`).
+        // #72: advance the bound-input debouncers every subtick (press-edge counting for DIAG).
+        #[cfg(feature = "io")]
+        io_pins.poll_inputs(now);
         if let Some(press) = button.poll(now) {
             ctx.redraw = true;
             // #20 (1a): any press marks activity so the next recurring flush defers.

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -80,6 +80,14 @@ pub use wifi::CFG_KEY_NET;
 pub use wifi::CFG_KEY_BROKER;
 #[cfg(feature = "espnow")]
 pub use wifi::CFG_KEY_OTA;
+// #72 IO-registry key — the leaf/own apply path (take_cfg_offer(G) → io::apply_wire re-binds
+// the free GPIOs). `io`-gated (⊃ espnow): only the io apply path names it here.
+#[cfg(feature = "io")]
+pub use wifi::CFG_KEY_IO;
+// #72 IO output-control key — the leaf/own apply path (take_cfg_offer(g) → io::apply_set drives
+// the bound OUTPUT slots). `io`-gated, same rationale.
+#[cfg(feature = "io")]
+pub use wifi::CFG_KEY_IO_SET;
 // #45: `main` sizes its held Custom-layout buffer to the max keyed value — bridge the const out
 // of the private `wifi` module (espnow-only: only the Custom apply path names it).
 #[cfg(feature = "espnow")]

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -180,7 +180,7 @@ const CFG_PREFIX: &[u8] = b"SMOLv1 CFG "; // + "NNN" + KEY + verbatim "<value>"
 /// (a `take_cfg_offer(key)` + apply) and a gateway fill site in `mqtt_session`. Sized `[_; N]`
 /// (not `&[u8]`) so [`CfgTracker`] can allocate exactly one `.bss` buffer slot per key.
 /// An inbound key not listed is dropped at [`CfgTracker::set`] (never buffered/applied).
-const CFG_APPLY_KEYS: [u8; 10] = [
+const CFG_APPLY_KEYS: [u8; 12] = [
     crate::net::wifi::CFG_KEY_SCREEN,
     crate::net::wifi::CFG_KEY_LED,
     crate::net::wifi::CFG_KEY_UNITS,
@@ -196,6 +196,14 @@ const CFG_APPLY_KEYS: [u8; 10] = [
     // #71 on-demand WiFi scan: W — same COMMAND discipline as R (buffered/applied via take_cfg_offer(W),
     // NEVER cached — a cached scan = periodic off-channel excursion, the coexist hazard). One-shot relay.
     crate::net::wifi::CFG_KEY_SCAN,
+    // #72 IO registry pin-map: G — cached + relayed like S/L/U/P/Y/N. Present UNCONDITIONALLY (not
+    // `io`-gated) so the leaf-apply slot + relay path exist without splitting this array per-feature;
+    // the config PLUMBING (subscribe/fill/apply) is `io`-gated, so a non-io build never feeds it →
+    // the slot is inert (one CfgTracker slot, ~66 B .bss). A leaf takes it via take_cfg_offer(G).
+    crate::net::wifi::CFG_KEY_IO,
+    // #72 IO output states: g — same unconditional-slot rationale as G above (the config
+    // PLUMBING is `io`-gated; a non-io build's slot is inert). Leaf takes it via take_cfg_offer(g).
+    crate::net::wifi::CFG_KEY_IO_SET,
 ];
 /// #50b leaf-status UPLINK tag: `"SMOLv1 STAT "` (12 B, trailing space) then `"NNN"`
 /// (3-ASCII zero-padded SENDER leaf id) then the verbatim live `<AppKind>:<page>` value
@@ -507,6 +515,10 @@ impl DiagExtra {
         }
     }
 }
+
+/// #72 io registry: max bytes of the `io=` DIAG field (≤ 5 inputs × `<pin>:<count>,` ≈ 45 B).
+#[cfg(feature = "io")]
+const IO_DIAG_MAX: usize = 48;
 
 /// Tracks the two timestamps that define the peer link state. Monotonic ms
 /// (`Instant::now().duration_since_epoch().as_millis()`); 0 = "never seen".
@@ -1573,6 +1585,12 @@ pub struct RadioManager {
     diag: DiagCounters,
     /// #74 obs wave-2: node state mirrored from `main` (LED mode + time-sync) for the DIAG record.
     diag_extra: DiagExtra,
+    /// #72 io registry: this node's compact `io=<pin>:<count>,…` DIAG field (bound-input press
+    /// counters), pushed from `main` via `set_diag_io` each diag-sample tick. Fixed buffer, no heap.
+    #[cfg(feature = "io")]
+    diag_io: [u8; IO_DIAG_MAX],
+    #[cfg(feature = "io")]
+    diag_io_len: usize,
     /// #40 leaf-mesh-OTA: the LEAF receive state machine (verify-sig → signed-bounds →
     /// window reassembly → readback verify → activate). Idle except during a transfer.
     /// Unused on a gateway (which drives the RELAY side via `run_leaf_ota_relay`).
@@ -1739,6 +1757,10 @@ impl RadioManager {
             own_scan: None,
             diag: DiagCounters::new(),
             diag_extra: DiagExtra::new(),
+            #[cfg(feature = "io")]
+            diag_io: [0u8; IO_DIAG_MAX],
+            #[cfg(feature = "io")]
+            diag_io_len: 0,
             ota_leaf: crate::ota_mesh::OtaLeafSession::new(),
             #[cfg(feature = "wled")]
             wled_seq: 0,
@@ -2385,6 +2407,16 @@ impl RadioManager {
         };
     }
 
+    /// #72: mirror `main`-built `io=` DIAG field (bound-input press counters `<pin>:<count>,…`)
+    /// into the RadioManager so BOTH diag builders (leaf broadcast + gateway flush) fold it in.
+    /// `main` calls this on the ~10 s diag-sample tick. Truncated to [`IO_DIAG_MAX`].
+    #[cfg(feature = "io")]
+    pub fn set_diag_io(&mut self, s: &[u8]) {
+        let n = s.len().min(IO_DIAG_MAX);
+        self.diag_io[..n].copy_from_slice(&s[..n]);
+        self.diag_io_len = n;
+    }
+
     /// #70/#49: build this node's compact DIAG record for retained `smol/<id>/diag`. Format matches
     /// luna's DEPLOYED HA parser (PR #81): literal `DIAG` first field, then `key=value` pairs
     /// PIPE-separated, order-independent, forward-compatible (HA picks by key, unknown keys ignored,
@@ -2470,6 +2502,15 @@ impl RadioManager {
             if let Ok(cfg) = core::str::from_utf8(&e.cfg[..e.cfg_len as usize]) {
                 rec.push_str("|cfg=");
                 rec.push_str(cfg);
+            }
+        }
+        // #72: append the io registry's bound-input press counters (io=<pin>:<count>,…) AFTER cfg=.
+        // `io`-gated + only when populated → the DIAG string is byte-identical on a non-io build.
+        #[cfg(feature = "io")]
+        if self.diag_io_len > 0 {
+            if let Ok(io) = core::str::from_utf8(&self.diag_io[..self.diag_io_len]) {
+                rec.push_str("|io=");
+                rec.push_str(io);
             }
         }
         rec
@@ -3574,6 +3615,16 @@ impl RadioManager {
         // #100 Stage 3: the gateway's OWN OTA-host override — same self-apply path (take_cfg_offer(O)).
         if let Some((buf, len)) = gw_own.ota {
             self.cfg.set(crate::net::wifi::CFG_KEY_OTA, &buf[..len]);
+        }
+        // #72: the gateway's OWN io pin-map — same self-apply path (take_cfg_offer(G)).
+        #[cfg(feature = "io")]
+        if let Some((buf, len)) = gw_own.io {
+            self.cfg.set(crate::net::wifi::CFG_KEY_IO, &buf[..len]);
+        }
+        // #72: the gateway's OWN io output-states — same self-apply path (take_cfg_offer(g)).
+        #[cfg(feature = "io")]
+        if let Some((buf, len)) = gw_own.io_set {
+            self.cfg.set(crate::net::wifi::CFG_KEY_IO_SET, &buf[..len]);
         }
         // #52 remote reboot — a COMMAND, not a config. Fire a ONE-SHOT `<id>R` frame per queued
         // leaf target via `broadcast_config` DIRECTLY (NOT `cfg_cache` / `broadcast_cached_configs`):

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1017,6 +1017,31 @@ pub const CFG_KEY_BROKER: u8 = b'B';
 #[cfg(feature = "wifi")]
 pub const CFG_KEY_OTA: u8 = b'O';
 
+/// #72 IO/component registry CONFIG (key `G`) = the node's whole pin-map descriptor:
+/// `;`-separated `<pin><kind>` tokens (e.g. `0L;7B;10R`), ≤ `CFG_VALUE_MAX`. RETAINED /
+/// CACHED (relayed like S/L/U/P/Y/N, not a one-shot command). Per-node
+/// `smol/<id>/config/io`. Applied by (re)binding the free GPIOs via
+/// `crate::io::apply_wire`, EDGE-triggered on a CHANGE of the map (a re-read of the same
+/// retained value is a no-op). Writes NO NVS (zero flash wear / sector risk — the nvs
+/// partition is full); survives reboot purely via the gateway's ~10 s config re-relay.
+// allow(dead_code): named in `CFG_APPLY_KEYS` (espnow) unconditionally so a G slot exists
+// for the relay, and in the `io`-gated fill/apply plumbing — but NOT in any wifi-tier fill
+// arm, so a wifi-only (no-espnow, no-io) build sees it unused. Same rationale as R/W.
+#[cfg(feature = "wifi")]
+#[allow(dead_code)]
+pub const CFG_KEY_IO: u8 = b'G';
+
+/// #72 IO output CONTROL (key `g`, lowercase — distinct from the `G` config map) = the
+/// node's output STATES: `;`-separated `<pin>=<0|1>` (e.g. `0=1;10=0`), ≤ `CFG_VALUE_MAX`.
+/// RETAINED / CACHED (relayed like G), NOT a command — a lamp/relay holds its commanded
+/// level across reboot / relay-loss (re-asserted from the retained value after a re-relay
+/// or a `G` re-bind). Applied by driving each named OUTPUT slot via `crate::io::apply_set`
+/// (no-op on an unbound / input slot). Per-node `smol/<id>/io/set`. Writes NO NVS.
+/// Same allow(dead_code) rationale as `G` (unused in a wifi-only build).
+#[cfg(feature = "wifi")]
+#[allow(dead_code)]
+pub const CFG_KEY_IO_SET: u8 = b'g';
+
 /// #48 (GwOwnCfg — approved arch): the GATEWAY's OWN per-node configs read from its own MQTT
 /// topics this burst. A leaf gets these RELAYED (→ its `CfgTracker`); the gateway reads them
 /// DIRECTLY. Bundled into ONE `run_mqtt_burst`/`mqtt_session` out-param (net +1, not +N) — after
@@ -1051,12 +1076,31 @@ pub struct GwOwnCfg {
     /// #100 Stage 3 the gateway's own `smol/<id>/config/ota_host` (or global `smol/config/ota_host`)
     /// OTA-host override value `(buf, len)`, or `None` if absent this burst.
     pub ota: Option<([u8; CFG_VALUE_MAX], usize)>,
+    /// #72 the gateway's own `smol/<id>/config/io` pin-map value `(buf, len)`, or `None` if
+    /// absent this burst. `io`-gated so a non-io build's struct is byte-unchanged.
+    #[cfg(feature = "io")]
+    pub io: Option<([u8; CFG_VALUE_MAX], usize)>,
+    /// #72 the gateway's own `smol/<id>/io/set` output-states value `(buf, len)`, or `None`.
+    #[cfg(feature = "io")]
+    pub io_set: Option<([u8; CFG_VALUE_MAX], usize)>,
 }
 
 #[cfg(feature = "wifi")]
 impl GwOwnCfg {
     pub const fn new() -> Self {
-        Self { led: None, units: None, plugins: None, custom: None, net: None, broker: None, ota: None }
+        Self {
+            led: None,
+            units: None,
+            plugins: None,
+            custom: None,
+            net: None,
+            broker: None,
+            ota: None,
+            #[cfg(feature = "io")]
+            io: None,
+            #[cfg(feature = "io")]
+            io_set: None,
+        }
     }
     /// Pack a payload into the `(buf, len)` a field holds (truncated to `CFG_VALUE_MAX`), so the
     /// mqtt-drain arms stay one-liners: `gw_own.led = Some(GwOwnCfg::val(payload));`.
@@ -1812,14 +1856,28 @@ fn mqtt_session(
         if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 21, b"smol/config/ota_host") {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
+        // #72 IO registry (pid 22): wildcard-subscribe every node's retained pin-map so the
+        // gateway caches + relays it (key `G`) over ESP-NOW, twin of the custom/led wildcard.
+        // `io`-gated (⊃ espnow) → non-io builds emit no SUBSCRIBE. (pids 18-21 are #100/#110's
+        // broker/ota_host per-node+global — #72 is last on the merge ladder, so it takes 22/23.)
+        // Kept BEFORE the batt/grid/mc drain-gate below (that ordering is load-bearing — see #110).
+        #[cfg(feature = "io")]
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 22, b"smol/+/config/io") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
+        // #72 IO output control (pid 23): every node's retained output-states topic (key `g`).
+        #[cfg(feature = "io")]
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 23, b"smol/+/io/set") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
     }
 
     // #100 DRAIN-ORDER FIX (HW canary #110): the batt/grid/mc primary downlinks are the
     // retained-drain break-gate (`got_batt && got_grid && got_mc && <quiet>`), so they MUST be
     // the LAST retained to arrive — subscribe them AFTER every config topic above. A broker sends
     // retained in SUBSCRIBE order, so the gate now cannot complete until the whole config backlog
-    // (screen/led/…/net/broker/ota, pids 6-21) has been delivered and drained → CFG-B/O reliably
-    // apply. (Boot burst: cfg_cache=None skips the gateway block, so these are effectively first,
+    // (screen/led/…/net/broker/ota/io, pids 6-23) has been delivered and drained → CFG reliably
+    // applies. (Boot burst: cfg_cache=None skips the gateway block, so these are effectively first,
     // as before — mc is usually absent at boot, so that path still drains to the deadline.) Pids
     // stay 1/2/3 (identifiers, not order); only the SEND order moved. Still before the PUBLISH loop.
     if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 1, BATT_TOPIC) {
@@ -2385,6 +2443,54 @@ fn mqtt_session(
                         } else {
                             gw_own.ota = Some(GwOwnCfg::val(payload));
                             log::info!("smol #100: gateway own OTA-host override captured ({} B)", payload.len());
+                        }
+                    } else if let Some(_leaf_id) = parse_leaf_config_topic(topic, b"/config/io") {
+                        // #72 IO registry pin-map: twin of the custom/net arms. OTHER node →
+                        // cache under key `G` for the ESP-NOW relay; OUR OWN id → gw_own.io for
+                        // self-apply. Verbatim bytes; the node's `io::apply_wire` validates + binds
+                        // (unknown type / reserved pin rejected, #46 clamp). Body is `io`-gated
+                        // (the arm CONDITION matches the cast-arm precedent above — a feature's
+                        // topic string in the always-compiled match, io-specific work cfg-gated).
+                        #[cfg(feature = "io")]
+                        {
+                            let leaf_id = _leaf_id;
+                            if leaf_id != node_id {
+                                if let Some(cache) = cfg_cache.as_deref_mut() {
+                                    let now = Instant::now().duration_since_epoch().as_millis();
+                                    cache.set(leaf_id, CFG_KEY_IO, payload, [0u8; 6], now);
+                                    log::info!(
+                                        "smol #72: cached leaf id{} io-map for relay ({} B)",
+                                        leaf_id,
+                                        payload.len()
+                                    );
+                                }
+                            } else {
+                                gw_own.io = Some(GwOwnCfg::val(payload));
+                                log::info!("smol #72: gateway own io-map captured ({} B)", payload.len());
+                            }
+                        }
+                    } else if let Some(_leaf_id) = parse_leaf_config_topic(topic, b"/io/set") {
+                        // #72 IO output states: twin of the config/io arm. OTHER node → cache under
+                        // key `g` for the ESP-NOW relay; OUR OWN id → gw_own.io_set for self-apply.
+                        // Verbatim bytes; `io::apply_set` drives the named OUTPUT slots (no-op on an
+                        // unbound / input slot). Body `io`-gated (arm matches the cast-arm precedent).
+                        #[cfg(feature = "io")]
+                        {
+                            let leaf_id = _leaf_id;
+                            if leaf_id != node_id {
+                                if let Some(cache) = cfg_cache.as_deref_mut() {
+                                    let now = Instant::now().duration_since_epoch().as_millis();
+                                    cache.set(leaf_id, CFG_KEY_IO_SET, payload, [0u8; 6], now);
+                                    log::info!(
+                                        "smol #72: cached leaf id{} io-set for relay ({} B)",
+                                        leaf_id,
+                                        payload.len()
+                                    );
+                                }
+                            } else {
+                                gw_own.io_set = Some(GwOwnCfg::val(payload));
+                                log::info!("smol #72: gateway own io-set captured ({} B)", payload.len());
+                            }
                         }
                     } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/cmd/reset") {
                         // #52 remote reboot — a COMMAND on a TRANSIENT topic (retain:false), so we


### PR DESCRIPTION
## #72 IO/component registry — v1 (digital: runtime pin-binding, config + control + input, over keyed CFG)

ESPHome inverted: one fat image, thin runtime config. Every driver is compiled in; a runtime
pin-map — relayed over the #56 keyed-CFG channel, no recompile — selects which driver binds each
free GPIO at boot. Flash once, reconfigure from HA forever. The #7 plugin pattern one level down.

Closes the v1 slice of #72. Foundation for the #75 dollhouse (per-room smols driving their own
LEDs + buttons). **Rebased onto #110 (main @ 8456977); merge-ladder tail.**

### What v1 does (signed off)
Digital IO you wire from HA — button, reed/PIR contact, relay, LED — on any of the 5 free GPIOs
(0/1/3/7/10), **configured** live from HA (key `G`), **driven** on/off from HA (key `g`, the #75
room-lamp first-light path), and its **inputs' press counts published** to HA (DIAG `io=` field).
Relay-only (no NVS). Proves the whole runtime-pin-bind pipeline on the digital `Flex` case.

### Contents (one squashed commit)
- **io.rs**: `PinMap` over `[Flex;5]` — `bind_input`/`bind_output`/`clear` flip a pin's direction at
  RUNTIME (issue §2.4's unknown, resolved for digital); `boot_selftest` proves the out↔in re-type on
  silicon. `ComponentKind{Button,BinarySensor,Relay,Led}` (wire B/S/R/L). `apply_wire` (whole map,
  `0L;7B;10R`), `apply_set` (outputs, `0=1;10=0`), `poll_inputs` (debounced press-edge counting).
  Panic-free; reserved/non-free/unknown tokens rejected + logged.
- **CFG channel** (mirrors #45's `Y`): `G` (config map, retained `smol/<id>/config/io`), `g` (output
  states, retained `smol/<id>/io/set`) — cached + relayed + gateway-own, edge-triggered; `g`
  re-asserted after a `G` re-bind so a lamp stays lit across a config edit. Press counts fold into
  DIAG as `io=<pin>:<count>,…` (after `cfg=`), on both the leaf-broadcast + gateway-flush builders.

### Design (all signed off)
- **Digital only.** ADC/PWM/WS2812-RMT deferred to v1.5/v2 behind the §2.4 bind spike.
- **Relay-only — NO NVS.** `G`/`g` write zero flash (partition full). Map + output states survive
  reboot via the gateway's ~10 s config re-relay. **Trade-off:** a leaf rebooting while the gateway
  is down has no IO config until the gateway returns (~10 s).
- **`io` implies `espnow`.** `CFG_APPLY_KEYS` gains `G`+`g` unconditionally (approved) → ~132 B inert
  `.bss` in espnow-without-io; the DEFAULT build is unaffected (#44 invariant intact).

### Reserved-pin reject list (compile + runtime)
`2,4,5,6,8,9,20,21` rejected, cited to their `main.rs` claim sites (OLED I²C GPIO5/6, BOOT GPIO9,
batt ADC GPIO4, LED GPIO8; 2 strapping; 20/21 USB-serial) — `board.rs` is identity-only.

### Merge-ladder / rebase
Rebased onto #110 (broker/ota_host). Subscribe pids **22/23** (clear #110's 18-21), placed with the
config subs **before** the batt/grid/mc drain-gate (#110's load-bearing order). Reconciled:
`CFG_APPLY_KEYS` → 12 (B,O,G,g), `GwOwnCfg` (+io/io_set), net.rs re-exports, mqtt_session fill-arm
chain, DIAG tail (`io=` after `cfg=`).

### Build
`clippy -D warnings = 0` across default/wifi/espnow/wled/cast + espnow,io (post-rebase). Release
builds green; default ELF byte-free of io (symbol + string absence). No new deps.

Deferred follow-ups: WS2812/RMT driver (v1.5, RMT-bind spike); HA MQTT discovery-emit (HA lane).

### HW canary
`--features espnow,io` on a board (GPIO0/1/3/7/10 unwired): boot serial prints the per-pin runtime
rebind. On a gateway: publish retained `smol/<id>/config/io` = `0L;7B;10R` → serial logs bindings +
rejects `5L` as reserved; `smol/<id>/io/set` = `0=1` → GPIO0 drives High (a wired room LED lights);
a bound button's press count appears in `smol/<id>/diag` as `io=7:N`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)