### PR TITLE
fix(fw): #114 Stage 1 — election heal (H1 crown-handover standoff + H2 seq-race)

### DIFF
--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1591,6 +1591,15 @@ pub struct RadioManager {
     scan_idx: usize,
     last_scan_hop_ms: u64,
     last_owner_heard_ms: u64,
+    /// #114 H1: has this leaf heard a HELLO from its CURRENT `elected_owner` since adopting it?
+    /// Reset on every owner change, set in the HELLO arm. Distinguishes a NEVER-heard dead owner
+    /// (a forged / phantom retained `MC` — the #114 crown-handover standoff) from a heard-then-died
+    /// owner. A never-heard dead owner has no live board to stagger against, so recovery takes it
+    /// over PROMPTLY (id-only tiebreak, skipping the RSSI backoff meant for a possibly-live vacated
+    /// owner); a heard-then-died owner keeps the RSSI-weighted stagger. Best-effort: the HARD safety
+    /// gate is still the FROZEN-seq test (a live owner's seq advances every ≤30 s flush), so a stale
+    /// value only changes WHICH backoff is used — never causes a false takeover of a live owner.
+    owner_hello_seen: bool,
     /// #29: the gateway's operating ESP-NOW channel, LEARNED from the `rx_control` of received
     /// frames (in `service`) — 0 until the first frame is heard. Published in the retained
     /// `MC|owner|<ch>|seq` election record (via `current_channel`) so a re-electing / roaming leaf
@@ -1749,6 +1758,7 @@ impl RadioManager {
 
             last_scan_hop_ms: 0,
             last_owner_heard_ms: 0,
+            owner_hello_seen: false,
             mc_seen_owner: 0,
             mc_seen_seq: 0,
             mc_seen_ms: 0,
@@ -1879,6 +1889,10 @@ impl RadioManager {
         elect.seen_owner = self.mc_seen_owner;
         elect.seen_seq = self.mc_seen_seq;
         elect.seen_ms = self.mc_seen_ms;
+        // #114 H1: tell the resolver whether we've EVER heard this owner's HELLO. A dead owner we
+        // never heard (a forged/phantom retained MC — the standoff) is taken over promptly instead
+        // of waiting the RSSI backoff (which exists to stagger takeover of a possibly-live owner).
+        elect.owner_never_heard = !self.owner_hello_seen;
         // #6 OTA / #21 config / #33 install: a leaf's recovery burst can also surface these.
         let mut ota_offer: Option<crate::ota::Announce> = None;
         let mut config_offer: Option<crate::app::DefaultScreen> = None;
@@ -1948,6 +1962,10 @@ impl RadioManager {
         self.mc_seen_owner = elect.seen_owner;
         self.mc_seen_seq = elect.seen_seq;
         self.mc_seen_ms = elect.seen_ms;
+        // #114 H1: a CHANGED owner must re-prove itself by HELLO before we trust it as heard.
+        if elect.owner_id != self.elected_owner {
+            self.owner_hello_seen = false;
+        }
         self.elected_owner = elect.owner_id;
         self.scan_locked = false;
         if elect.i_am_owner {
@@ -3636,6 +3654,10 @@ impl RadioManager {
             self.mc_seen_owner = elect.seen_owner;
             self.mc_seen_seq = elect.seen_seq;
             self.mc_seen_ms = elect.seen_ms;
+            // #114 H1: a CHANGED owner must re-prove itself by HELLO before we trust it as heard.
+            if elect.owner_id != self.elected_owner {
+                self.owner_hello_seen = false;
+            }
             self.elected_owner = elect.owner_id;
             if !elect.i_am_owner {
                 self.relay.is_gateway = false;
@@ -3820,6 +3842,9 @@ impl RadioManager {
                     if !self.relay.is_gateway && peer_id == self.elected_owner {
                         self.scan_locked = true;
                         self.last_owner_heard_ms = now;
+                        // #114 H1: our elected owner is provably ALIVE on the mesh (heard its
+                        // HELLO) — so it is NOT a phantom; recovery keeps the RSSI stagger for it.
+                        self.owner_hello_seen = true;
                         // #51 A1: re-locked a valid owner's HELLO → resume normal HELLO
                         // (we are a healthy leaf again, no longer an abdicated ghost).
                         self.silent_until_relock = false;

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -2742,6 +2742,72 @@ fn mqtt_session(
             elect.i_am_owner = false; // couldn't prove uplink → stay leaf, retry next burst
             log::warn!("smol: mesh election — MC publish FAILED, not claiming ownership");
         }
+        // #114 H2: seq-claim RACE tie-break. Two candidates that hit an EMPTY MC simultaneously both
+        // claim seq=1 (last-write-wins on the broker) and both would burst as gateway — a split-brain
+        // that today only reconverges via the lowest-id flush resolver (~1–2 flushes). After OUR claim
+        // publish, briefly re-read the retained MC: a DIFFERENT owner appearing means a concurrent
+        // claim landed → resolve DETERMINISTICALLY by lowest id (the HIGHER id always YIELDS; a lower
+        // id re-asserts seq+1 so the retained record names it). Bounded (≤400 ms, tick-abortable) +
+        // FAIL-SAFE: a timeout / parse-miss keeps our original verdict (never a regression), and we
+        // never yield to — nor claim over — an owner we haven't out-ranked by id.
+        if elect.i_am_owner && published {
+            let reread_deadline = Instant::now() + Duration::from_millis(400);
+            let mut competitor: Option<(u8, u8, u32)> = None;
+            while Instant::now() < reread_deadline {
+                if tick() {
+                    break;
+                }
+                iface.poll(smoltcp_now(), device, sockets);
+                recv_into(sockets, tcp_handle, &mut acc[..], &mut acc_len);
+                loop {
+                    match crate::net::mqtt::parse_packet(&acc[..acc_len]) {
+                        Some((crate::net::mqtt::Incoming::Publish { topic, payload, .. }, consumed)) => {
+                            if topic == MESH_CHANNEL_TOPIC {
+                                if let Some(mc2) = parse_mesh_channel(payload) {
+                                    competitor = Some(mc2);
+                                }
+                            }
+                            acc.copy_within(consumed..acc_len, 0);
+                            acc_len -= consumed;
+                        }
+                        Some((_, consumed)) => {
+                            acc.copy_within(consumed..acc_len, 0);
+                            acc_len -= consumed;
+                        }
+                        None => break,
+                    }
+                }
+                // Stop as soon as we've seen a competing owner (a concurrent claim landed).
+                if competitor.map(|(o, _, _)| o != node_id).unwrap_or(false) {
+                    break;
+                }
+            }
+            if let Some((owner2, _ch2, seq2)) = competitor {
+                if owner2 > node_id {
+                    // A HIGHER id overwrote our claim, but we out-rank it → re-assert with seq+1 so
+                    // the retained record names us (the lowest); it yields when it re-reads.
+                    let reseq = seq2.wrapping_add(1);
+                    let mut mcp2 = MqttScratch::new();
+                    let _ = write!(mcp2, "MC|{}|{}|{}", node_id, elect.my_channel, reseq);
+                    if let Some(n) =
+                        crate::net::mqtt::encode_publish(&mut pkt, MESH_CHANNEL_TOPIC, mcp2.as_bytes(), true)
+                    {
+                        if tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick) {
+                            elect.seen_seq = reseq;
+                            log::info!("smol: #114 H2 — re-asserted claim over higher-id {} (seq {})", owner2, reseq);
+                        }
+                    }
+                } else if owner2 < node_id {
+                    // A LOWER id also claimed and holds the slot → YIELD (no duplicate gateway).
+                    elect.i_am_owner = false;
+                    elect.owner_id = owner2;
+                    elect.seen_owner = owner2;
+                    elect.seen_seq = seq2;
+                    elect.seen_ms = elect.now_ms;
+                    log::info!("smol: #114 H2 — yielding to lower-id owner {} (claim race)", owner2);
+                }
+            }
+        }
     }
     log::info!(
         "smol: mesh election -> {} (owner id{}, seen seq {})",

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -114,6 +114,13 @@ pub struct MeshElect {
     /// gateway-flush this is false → the original, hardware-validated lowest-id
     /// election runs UNCHANGED (preserves #2 split-brain + fast cold-start).
     pub recovery: bool,
+    /// #114 H1: (recovery only) true iff this leaf has NEVER heard a HELLO from the owner it is
+    /// following. A DEAD owner (frozen seq) that was never heard is a forged / phantom retained MC
+    /// (the crown-handover standoff) — there is no live board to stagger against, so the resolver
+    /// takes it over PROMPTLY (id-only tiebreak) instead of waiting the full RSSI backoff. Never
+    /// overrides the FROZEN-seq safety gate: an owner whose seq still advances is alive and is never
+    /// taken over regardless of this flag (RF-dead-zone protection intact).
+    pub owner_never_heard: bool,
     /// #51 return-flap fix: true ONLY on the one-shot BOOT election. A freshly-booted board
     /// must NEVER claim over a DIFFERENT owner already present in the retained MC — it comes
     /// up as a leaf and lets leaf-scan (fast HELLO lock) + the recovery election decide (live
@@ -144,6 +151,7 @@ impl MeshElect {
             my_rssi: -99, // weak default until the first association captures it
             my_channel: 0, // #29: advisory 0 until a frame's rx_control is learned
             recovery: false,
+            owner_never_heard: false,
             boot: false,
             i_am_owner: false,
             owner_id: my_id,
@@ -2676,7 +2684,15 @@ fn mqtt_session(
                 // #51 recovery: owner is DEAD. Take over once past RECOVERY_STALE_MS PLUS our
                 // RSSI-weighted backoff — the strongest-uplink survivor crosses first.
                 elect.owner_alive = false;
-                let backoff = reelect_backoff_ms(elect.my_rssi, node_id);
+                // #114 H1: a dead owner this leaf NEVER heard a HELLO from is a forged / phantom
+                // retained MC (the standoff) — there is no live board to stagger against, so skip
+                // the RSSI backoff and take over promptly on an id-only tiebreak (lowest id first).
+                // A heard-then-died owner keeps the RSSI-weighted stagger (pick the best survivor).
+                let backoff = if elect.owner_never_heard {
+                    (node_id as u64) * 200
+                } else {
+                    reelect_backoff_ms(elect.my_rssi, node_id)
+                };
                 if elect.now_ms.saturating_sub(elect.seen_ms)
                     >= RECOVERY_STALE_MS.saturating_add(backoff)
                 {


### PR DESCRIPTION
## #114 Stage 1 — heal correctness

Branch off `main@49382b1` (post-#74). Scope-proposal signed off by team-lead; full survey in
`scratch/smol-dreamteam/114-latency-scope.md`.

### H1 — crown-handover standoff (this commit) ✅
**Bug (live repro today):** a leaf that adopted a retained `MC` owner it had **never heard a HELLO
from** could defer to it forever. A forged / one-shot retained `MC|<id>` looks "alive" by its seq,
and the dead-owner takeover then waited the **full RSSI backoff** (bucket-2 = 30 s, and an
unassociated leaf defaults `my_rssi = -99` → the slowest bucket) → takeover dragged to ~65 s+, i.e.
the standoff that needed a manual MC reset.

**Fix:** track `owner_hello_seen` per leaf (set when the elected owner's HELLO is heard, reset on
owner change), plumb `owner_never_heard` into the recovery election. A **dead owner (frozen seq) the
leaf never heard** is a phantom — no live board to stagger against — so it's taken over promptly on
an id-only tiebreak (lowest id first) instead of the RSSI backoff. A **heard-then-died** owner keeps
the RSSI-weighted stagger (best survivor wins). Expected: phantom-owner heal **minutes/manual → ~35 s**.

**Safety (unchanged invariant):** takeover still requires the MC seq **frozen** past
`RECOVERY_STALE_MS` (35 s). A healthy gateway republishes its MC every ≤30 s flush, so its seq never
freezes → a live owner (even one a leaf can't hear) is **never** taken over — RF-dead-zone protection
intact. Per team-lead's constraint, 35 s sits comfortably above the **15 s `RELAY_FLUSH_BUDGET`**
mesh-deaf window, so a normal flush can't trigger a false takeover.

### H2 — double `seq=1` claim race (second commit) ✅
**Bug:** two candidates that hit an **empty MC** simultaneously each claim `seq=1` (owner=self); the
broker keeps whichever write landed last, so **both** believe they won and burst as gateway — a
split-brain that today only reconverges via the lowest-id flush resolver (~1–2 flushes / 30–60 s).

**Fix:** after a claim publish, briefly (≤400 ms, tick-abortable) re-read the retained MC. If a
different owner appears (a concurrent claim landed), resolve **deterministically by lowest id**: the
higher id **yields** immediately (no duplicate gateway); a lower id re-asserts `seq+1` so the retained
record names it. **Fail-safe:** a timeout / parse-miss keeps the original verdict (never a
regression), and a board never yields to — nor claims over — an owner it hasn't out-ranked by id. Runs
only on a claim (cold-start / takeover), never in steady state; bounded within `RELAY_FLUSH_BUDGET`.

Kept as a **separate commit** (8791dbb) so the canary can bisect the two election-path changes.

### Verification
- `cargo check` + `clippy -D warnings` clean on default/wifi/espnow/wled.
- Default build unaffected — every change is in `wifi`/`espnow`-gated election code (cfg-gating, not
  ELF equality).
- **HW pending (team-lead canary):** (H1) re-run the forged-`MC` repro — a leaf should now self-heal
  (take over) in ~35 s instead of needing a manual reset; confirm a healthy gateway is never falsely
  taken over across its normal flushes. (H2) on a cold-start with the MC empty, confirm the fleet
  converges to a single lowest-id owner without a lingering dual-gateway window.

### Merge-ladder
`net/mode.rs` is a multi-writer surface this wave (#110 broker/OTA, #112 role-enum pending). My
election/RSSI region is expected disjoint; I'll rebase #114 onto them when they land (hypnos brokering).

Refs #114. Out of scope (per sign-off): B1 flush-shorten (held behind #22 soak), finding #3
config-apply (subsumed by #110).
