### PR TITLE
feat(fw): #114 Stage 2 — event-driven DIAG expedite on config-apply (UI freshness)

### DIFF
--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -1197,6 +1197,10 @@ fn main() -> ! {
                 if let Some(m) = led::LedMode::from_wire(core::str::from_utf8(&o.buf[..o.len]).unwrap_or("")) {
                     if m != led_mode {
                         log::info!("smol #48: LED mode -> {:?}", m);
+                        // #114 U2: an APPLIED config change rides the DIAG record's cfg= field —
+                        // expedite the next DIAG so HA's config-applied/drift updates in ~3 s
+                        // (DIAG_EXPEDITE_MIN_MS) instead of waiting up to the 60 s steady cadence.
+                        diag_dirty = true;
                     }
                     led_mode = m;
                 }
@@ -1210,6 +1214,7 @@ fn main() -> ! {
                 if let Some(u) = units::Units::from_wire(core::str::from_utf8(&o.buf[..o.len]).unwrap_or("")) {
                     if u != units {
                         log::info!("smol #43: display units -> {:?}", u);
+                        diag_dirty = true; // #114 U2: expedite DIAG (units ride cfg=) — see LED above
                     }
                     units = u;
                 }
@@ -1223,6 +1228,7 @@ fn main() -> ! {
                 if let Some(m) = menu::parse_plugin_mask(core::str::from_utf8(&o.buf[..o.len]).unwrap_or("")) {
                     if m != plugin_mask {
                         log::info!("smol #55: plugin mask -> {:#06x}", m);
+                        diag_dirty = true; // #114 U2: expedite DIAG (mask rides cfg=) — see LED above
                     }
                     plugin_mask = m;
                 }

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -236,10 +236,14 @@ pub(crate) const SUBTICK_MS: u32 = 20;
 /// signals are slow-moving, so a 60 s beat keeps mesh airtime negligible.
 #[cfg(feature = "espnow")]
 const DIAG_CADENCE_MS: u64 = 60_000;
-/// #70/#49: minimum spacing between BUTTON-expedited diag broadcasts (ms) — bounds a press-mash
-/// so it can't flood the mesh with off-cadence diags.
+/// #70/#49 + #114 U2: minimum spacing between EXPEDITED diag broadcasts (ms) — the per-node rate
+/// cap on off-cadence diags. Bounds BOTH a BOOT-button press-mash (#70) and a #114 config-apply
+/// flap (a misbehaving HA automation toggling LED/units/plugins) so neither can flood the mesh.
+/// COALESCED: `diag_dirty` is a single latch, so any number of changes between broadcasts collapse
+/// into ONE expedited diag carrying the latest state. 5 s (team-lead #114 cap "≤1 per ~5 s"); the
+/// steady-state cadence (`DIAG_CADENCE_MS`) is unchanged.
 #[cfg(feature = "espnow")]
-const DIAG_EXPEDITE_MIN_MS: u64 = 3_000;
+const DIAG_EXPEDITE_MIN_MS: u64 = 5_000;
 
 /// Minimum time the boot splash (node name + firmware version) stays on screen,
 /// even when radio bring-up was instant (default build). The espnow/wifi NTP burst

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -1007,6 +1007,12 @@ fn main() -> ! {
                 let due = (now / DIAG_CADENCE_MS) != ((now.saturating_sub(SUBTICK_MS as u64)) / DIAG_CADENCE_MS);
                 let expedite = diag_dirty && now.saturating_sub(last_diag_ms) >= DIAG_EXPEDITE_MIN_MS;
                 if due || expedite {
+                    // #114 U2 canary observability: distinguish an EXPEDITED broadcast (config-apply
+                    // triggered) from the steady 60 s cadence — the serial proof the leaf-side
+                    // mechanism fired, independent of the crown's republish quantization.
+                    if expedite && !due {
+                        log::info!("smol #114: diag expedited (config change, {} ms since last)", now.saturating_sub(last_diag_ms));
+                    }
                     let rec = r.diag_record();
                     r.broadcast_diag(rec.as_bytes());
                     last_diag_ms = now;


### PR DESCRIPTION
## #114 Stage 2 — UI freshness (event-driven DIAG expedite)

Independent of Stage 1 (PR #115, election-heal) — this touches only `main.rs` (disjoint files), off
`main@49382b1`. Scope signed off; survey in `scratch/smol-dreamteam/114-latency-scope.md`.

**Bug:** a leaf's applied config (LED / units / plugin-mask) rides the DIAG record's `cfg=` field
(#74), but DIAG only broadcasts on the slow 60 s steady cadence. So an HA-pushed config change took
up to ~60 s to show as *applied* and to clear `binary_sensor.smol_<id>_config_drift`.

**Fix (U2):** set the existing `diag_dirty` flag when an applied LED/units/plugin-mask value actually
**changes**, so the already-present expedite path broadcasts an updated DIAG within
`DIAG_EXPEDITE_MIN_MS` (~3 s). Leaf freshness after a change: **~60 s → ~3 s**.

- Scoped to the `cfg=`-carried fields; **edge-triggered** on a real change (re-applying the same
  value is a no-op).
- **Rate cap (team-lead constraint): ≤1 expedited diag per ~5 s per node.** `DIAG_EXPEDITE_MIN_MS`
  raised 3 s → **5 s** (commit eba19cf) — this floor bounds BOTH the #70 BOOT-button expedite and the
  #114 config-apply expedite, so a flapping input (e.g. a misbehaving HA automation) can't flood the
  mesh. **Coalesced:** `diag_dirty` is a single latch, so any burst of changes between broadcasts
  collapses into ONE expedited diag carrying the latest state. **Steady-state cadence
  (`DIAG_CADENCE_MS` = 60 s) is unchanged.**
- Manual screen-nav is deliberately **not** hooked (already covered by the 10 s STAT cadence; avoids
  nav-spam). The adaptive multi-cycle fast-follow window (U1) is a possible follow-on — this single
  expedite delivers the bulk of the win.

**Verification:** `cargo check` + `clippy -D warnings` clean on default/wifi/espnow/wled; default
build unaffected (change is in the espnow config-apply path — cfg-gated). HW: after landing, a config
push should reflect in HA (applied + drift-clear) within a few seconds instead of up to a minute.

Refs #114. Pairs with #74 (`cfg=` producer) and #115 (Stage 1 election-heal). Out of scope: B1
flush-shorten (held behind #22).
