### PR TITLE
fix(fw): #114 H3 — booting board never seizes the crown from a live owner

### DIFF
--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -2736,7 +2736,27 @@ fn mqtt_session(
             }
             elect.seen_owner = owner;
             elect.seen_seq = seq;
-            let stale_limit = if elect.recovery { RECOVERY_STALE_MS } else { MC_STALE_MS };
+            // #114 H3 (stale-self-reclaim fix): choose the dead-owner window by CORROBORATION.
+            // `owner_never_heard` was introduced by H1 to mean "a forged/phantom retained MC no
+            // board ever heard — take it over promptly". But it is ALSO true for EVERY freshly
+            // booted (or freshly roamed) leaf in its first seconds of life: it hasn't had a chance
+            // to hear the LIVE owner's HELLO yet. So a short window here let a just-booted board
+            // seize the crown from a healthy, actively-flushing owner it simply hadn't heard —
+            // the H3 sighting (`MC|<self>|0|seq+N` over a live foreign owner). The seq is the only
+            // signal that disambiguates a phantom from a not-yet-heard live owner: a live gateway
+            // flushes MC every <=RELAY_FLUSH_INTERVAL_MS (30s) so its seq advances (→ our anchor
+            // resets → `alive`), while a phantom's seq is frozen forever. So require the CONSERVATIVE
+            // MC_STALE_MS (90s = 3 missed flushes) freeze before taking over an owner we've NEVER
+            // heard: a live owner provably bumps its seq ~3x inside that window and is adopted, and
+            // only a genuinely-dead phantom survives to be taken over (still heals the H1 standoff,
+            // just at 90s instead of 35s — election stability > speed). A HEARD-then-lost owner keeps
+            // the fast RECOVERY_STALE_MS (35s): the owner-HELLO silence that opened this recovery is
+            // independent corroboration of death, so no live board can be misjudged there.
+            let stale_limit = if elect.recovery {
+                if elect.owner_never_heard { MC_STALE_MS } else { RECOVERY_STALE_MS }
+            } else {
+                MC_STALE_MS
+            };
             let alive = elect.now_ms.saturating_sub(elect.seen_ms) < stale_limit;
             if elect.boot && owner != node_id {
                 // #51 return-flap fix: a FRESH-booting board never displaces a DIFFERENT owner
@@ -2787,20 +2807,26 @@ fn mqtt_session(
                 elect.owner_id = owner;
                 None
             } else {
-                // #51 recovery: owner is DEAD. Take over once past RECOVERY_STALE_MS PLUS our
-                // RSSI-weighted backoff — the strongest-uplink survivor crosses first.
+                // #51 recovery: owner is DEAD (its seq stayed frozen past `stale_limit` — 35s if
+                // we HEARD-then-lost it, 90s if we NEVER heard it; see the H3 note above). Take
+                // over once past that window PLUS our stagger backoff — the best survivor crosses
+                // first; the others read its fresh MC and adopt it.
                 elect.owner_alive = false;
                 // #114 H1: a dead owner this leaf NEVER heard a HELLO from is a forged / phantom
-                // retained MC (the standoff) — there is no live board to stagger against, so skip
-                // the RSSI backoff and take over promptly on an id-only tiebreak (lowest id first).
-                // A heard-then-died owner keeps the RSSI-weighted stagger (pick the best survivor).
+                // retained MC (the standoff) confirmed dead by the conservative 90s freeze above —
+                // there is no live board to RSSI-stagger against, so use a small id-only tiebreak
+                // (lowest id first) rather than the RSSI ladder. A heard-then-died owner keeps the
+                // RSSI-weighted stagger (pick the best survivor).
                 let backoff = if elect.owner_never_heard {
                     (node_id as u64) * 200
                 } else {
                     reelect_backoff_ms(elect.my_rssi, node_id)
                 };
+                // #114 H3: gate on `stale_limit` (not a hardcoded RECOVERY_STALE_MS) so the
+                // never-heard takeover honours the SAME conservative 90s window used for `alive`
+                // above — otherwise a never-heard owner could re-enter here and claim at 35s.
                 if elect.now_ms.saturating_sub(elect.seen_ms)
-                    >= RECOVERY_STALE_MS.saturating_add(backoff)
+                    >= stale_limit.saturating_add(backoff)
                 {
                     elect.i_am_owner = true;
                     elect.owner_id = node_id;


### PR DESCRIPTION
## #114 H3 — stale-self-reclaim: a booting board never seizes the crown from a live owner

Branch off `origin/main@14868c2`. Closes the third election hole from #114 (live sightings
2026-07-13 08:36 and 2026-07-14 07:34).

### The bug
A freshly-booted board (USB reset while another board held the crown) took over a **different,
live, actively-flushing** retained owner within its first recovery burst — publishing
`MC|<self>|0|seq+2` (advisory ch=0, pre-frame). "Reproduces on demand."

### Root cause — the reporter's guess was REFUTED (verified by an independent read-only trace)
The reporter guessed the #51 boot guard was bypassed / compared a persisted self-slot. It is not:
the boot guard (`wifi.rs` `if elect.boot && owner != node_id`) **is** wired (`elect.boot=true` in
`start()`) and **is** correct — a booting board reading a foreign owner comes up **LEAF**. The boot
drain also reliably reads the retained MC (`got_mc` gates the drain break).

The claim came from the **recovery dead-owner takeover**, the *only* path by which a freshly-booted
leaf can claim over a different present owner:

- `owner_never_heard` (added by #114 **H1**) was meant to flag "a forged/phantom retained MC no board
  ever heard → take it over promptly." But it is **also true for every freshly-booted / roamed leaf**
  that simply hasn't locked the LIVE owner's HELLO yet — H1 conflates "phantom" with "just booted."
- With only the fast **35s** `RECOVERY_STALE_MS` window (a ~5s margin over the **30s** flush interval,
  and `last_flush_ms` is stamped even on a *failed* flush → a failed/slow flush leaves the seq
  un-advanced for ~60s), a not-yet-heard leaf misjudged a **live** owner as dead and claimed the crown.
- Becoming gateway, its first flush re-claimed (`owner==self`) → `seq+2`, `ch=0` = the exact sighting.

### The fix (net/wifi.rs — recovery `stale_limit` + dead-branch threshold)
Disambiguate a phantom from a not-yet-heard live owner by the **only reliable signal, the MC seq**: a
live gateway flushes (`seq++`) every ≤30s; a phantom's seq is frozen forever.

- **NEVER-heard owner in recovery → require the conservative `MC_STALE_MS` (90s = 3 missed flushes)**
  freeze before takeover. A live owner provably bumps its seq ~3× inside 90s → **adopted (leaf)**;
  only a genuinely-dead phantom survives → taken over (still heals the H1 standoff, at 90s vs 35s).
- **HEARD-then-lost owner keeps the fast 35s window** — the owner-HELLO silence that opened recovery
  is independent corroboration of death, so no live board can be misjudged there (H1's real case).
- The dead-branch takeover threshold now gates on the same `stale_limit` (was a hardcoded
  `RECOVERY_STALE_MS`), so the never-heard path can't re-enter and claim at 35s.

### Decision table (retained-owner × self/other × liveness → role) — after this fix
| Context | retained owner | liveness | → role |
|---|---|---|---|
| Boot (`boot=true`) | empty (None) | — | CLAIM (cold-start) |
| Boot | == self | — | CLAIM (own-slot reclaim) |
| Boot | != self | alive OR frozen | **LEAF** (#51: never displace at boot) |
| Gateway-flush | == self | — | CLAIM (reclaim) |
| Gateway-flush | < self | alive | adopt (demote) |
| Gateway-flush | < self | frozen | CLAIM (take over dead lower) |
| Gateway-flush | > self | any | CLAIM (lowest-id re-assert) |
| Recovery | == self | — | CLAIM (reclaim) |
| Recovery | != self | alive | ADOPT (sticky live owner) |
| Recovery | != self, **HEARD**-then-lost | frozen ≥ **35s** + RSSI-backoff | take over (best survivor) |
| Recovery | != self, **NEVER**-heard | frozen ≥ **90s** + id-tiebreak | take over (**phantom only**) |

### Preserves
#51 boot-leaf · own-slot reclaim (`owner==self`) · cold-start empty-MC claim · H1 heard-then-died
fast heal · H2 seq-race resolver. **Blast radius: the recovery adopt/takeover decision only.**

### Verification
- Full profile bar — `clippy -D warnings` clean on **default / wifi / espnow / cast / io / wled /
  espnow,cast,io** (the canonical #119 fleet image).
- Default build unaffected (change is inside `wifi`/`espnow`-gated election code).
- Root cause + sole claim site independently confirmed by a read-only adversarial trace (refuted the
  boot-guard-bypass guess; confirmed recovery-DEAD @ the takeover claim as the only fresh-leaf path).
- **HW pending (team-lead canary):** the exact H3 repro — USB-reset a board while another holds the
  crown. Expect: the rebooted board stays **LEAF** and **adopts** the live owner (its seq keeps
  advancing) instead of claiming `MC|self|…`. Also confirm a genuinely-dead phantom (a forged/frozen
  retained MC no board hears) is still taken over — now at ~90s.

### Known residual (out of scope — follow-up candidate, NOT a wrong-crown bug after this fix)
A leaf whose recovery **re-adopts the SAME** live owner sets `owner_alive=false`, so the caller does
not reset `last_owner_heard_ms` (mode.rs ~2010) → it re-elects every 10s (extra off-channel bursts)
until it hears the owner's HELLO directly. With this fix that loop is **harmless** (it always adopts,
never takes over a live owner). Left untouched to avoid perturbing the load-bearing "dead-deferred
owner gets no reset → failover on cadence" logic; a safe future fix (reset the silence clock when the
observed seq freshly advanced, after the first burst) deserves its own canary.

Refs #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
