### PR TITLE
feat(fw): #13 routed multi-hop mesh — uplink (A) + downlink freshness (B) + rig (C)

### DIFF
--- a/experiments/flood_verify/Cargo.toml
+++ b/experiments/flood_verify/Cargo.toml
@@ -1,0 +1,13 @@
+# #13 host-test harness for the PURE managed-flood core (net/flood.rs). Runs OFF-target
+# on the host (std) via `cargo run` — the firmware crate is no_std/riscv32imc and can't
+# host-test, so this #[path]-includes the real flood.rs (no drift) and exercises it.
+[package]
+name = "flood_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "flood_verify"
+path = "src/main.rs"
+[profile.dev]
+opt-level = 0

--- a/experiments/flood_verify/src/main.rs
+++ b/experiments/flood_verify/src/main.rs
@@ -1,0 +1,96 @@
+//! Host verification of the PURE #13 managed-flood core. Includes the real
+//! `net/flood.rs` verbatim (#[path], no drift) and exercises the seen-set, the
+//! forward decision, and the hop-latch hysteresis. Run: `cargo run` — panics on failure.
+
+#[path = "../../../rust/clock/src/net/flood.rs"]
+mod flood;
+
+use flood::{
+    forward_decision, ForwardAction, HopLatch, SeenSet, MAX_HOP, PROBE_EVERY, SEEN_RING,
+    UNLATCH_STREAK,
+};
+
+fn main() {
+    // --- SeenSet ----------------------------------------------------------
+    let mut s = SeenSet::new();
+    assert!(!s.contains(7, 100), "empty");
+    assert!(!s.seen_or_insert(7, 100), "first sight is new");
+    assert!(s.contains(7, 100), "recorded");
+    assert!(s.seen_or_insert(7, 100), "second sight is a dup");
+    assert!(!s.seen_or_insert(7, 101), "diff msgid is new");
+    assert!(!s.seen_or_insert(8, 100), "diff origin is new");
+    // idempotent insert doesn't consume extra ring slots
+    s.insert(7, 100);
+    s.insert(7, 100);
+    // drop-oldest overflow: fill past capacity, the earliest ages out.
+    let mut r = SeenSet::new();
+    for m in 0..(SEEN_RING as u16 + 5) {
+        assert!(!r.seen_or_insert(1, m), "each new msgid is new on insert");
+    }
+    assert!(!r.contains(1, 0), "oldest (msgid 0) aged out after overflow");
+    assert!(r.contains(1, SEEN_RING as u16 + 4), "newest retained");
+
+    // --- forward_decision -------------------------------------------------
+    // already-seen → DedupDrop regardless of role/hop.
+    assert_eq!(forward_decision(false, 2, true), ForwardAction::DedupDrop);
+    assert_eq!(forward_decision(true, 2, true), ForwardAction::DedupDrop);
+    // gateway (sink) → Reassemble, never forward.
+    assert_eq!(forward_decision(true, 2, false), ForwardAction::Reassemble);
+    assert_eq!(forward_decision(true, 1, false), ForwardAction::Reassemble);
+    // relay with hops left → Forward at hop-1.
+    assert_eq!(forward_decision(false, 2, false), ForwardAction::Forward { hop: 1 });
+    assert_eq!(forward_decision(false, 3, false), ForwardAction::Forward { hop: 2 });
+    // relay, hop exhausted (<=1) → TtlDrop (a RELAY2 that decremented to 1 at a
+    // non-gateway means it never reached the sink → drop, count ttl_drops).
+    assert_eq!(forward_decision(false, 1, false), ForwardAction::TtlDrop);
+    assert_eq!(forward_decision(false, 0, false), ForwardAction::TtlDrop);
+
+    // --- HopLatch: escalation ---------------------------------------------
+    let mut l = HopLatch::new();
+    assert!(!l.latched());
+    assert_eq!(l.origin_hop(false), 1, "single-hop by default (plain RELAY)");
+    // a partially-acked exhaust does NOT latch (gateway heard us, just lossy).
+    l.on_relay_exhausted(true);
+    assert!(!l.latched(), "partial ack ⇒ not stranded");
+    // a fully-unacked exhaust latches multi-hop.
+    l.on_relay_exhausted(false);
+    assert!(l.latched(), "zero ack ⇒ stranded ⇒ latch");
+    assert_eq!(l.origin_hop(false), MAX_HOP, "latched non-probe emits at MAX_HOP (RELAY2)");
+    assert_eq!(l.origin_hop(true), 1, "a probe always emits H=1 (plain RELAY)");
+
+    // --- HopLatch: probe gating (Gate A = downlink_up) --------------------
+    let mut l2 = HopLatch::new();
+    l2.on_relay_exhausted(false); // latch
+    // while downlink is DOWN, never probe (don't waste airtime — definitely stranded).
+    for _ in 0..(PROBE_EVERY * 3) {
+        assert!(!l2.should_probe(false), "no probe while downlink down");
+    }
+    // with downlink UP, probe fires on the 1-in-PROBE_EVERY tick.
+    let mut probes = 0;
+    for _ in 0..(PROBE_EVERY * 2) {
+        if l2.should_probe(true) {
+            probes += 1;
+        }
+    }
+    assert_eq!(probes, 2, "exactly 2 probes across 2×PROBE_EVERY ticks");
+
+    // --- HopLatch: un-latch hysteresis (no flap) --------------------------
+    let mut l3 = HopLatch::new();
+    l3.on_relay_exhausted(false);
+    assert!(l3.latched());
+    l3.on_direct_ack(); // streak 1 of UNLATCH_STREAK
+    assert!(l3.latched(), "one direct ack is not enough (hysteresis)");
+    l3.on_probe_miss(); // marginal RF: a miss resets the streak
+    assert!(l3.latched(), "still latched after a miss");
+    // now K consecutive good probes → unlatch.
+    for _ in 0..UNLATCH_STREAK {
+        l3.on_direct_ack();
+    }
+    assert!(!l3.latched(), "UNLATCH_STREAK consecutive direct acks drop the latch");
+    assert_eq!(l3.origin_hop(false), 1, "back to single-hop");
+    // a not-latched direct ack is a harmless no-op.
+    l3.on_direct_ack();
+    assert!(!l3.latched());
+
+    println!("flood_verify: ALL CHECKS PASSED (SeenSet + forward_decision + HopLatch)");
+}

--- a/experiments/flood_verify/src/main.rs
+++ b/experiments/flood_verify/src/main.rs
@@ -11,24 +11,30 @@ use flood::{
 };
 
 fn main() {
-    // --- SeenSet ----------------------------------------------------------
+    // --- SeenSet (keyed per-FRAGMENT: origin, msgid, frag) ----------------
     let mut s = SeenSet::new();
-    assert!(!s.contains(7, 100), "empty");
-    assert!(!s.seen_or_insert(7, 100), "first sight is new");
-    assert!(s.contains(7, 100), "recorded");
-    assert!(s.seen_or_insert(7, 100), "second sight is a dup");
-    assert!(!s.seen_or_insert(7, 101), "diff msgid is new");
-    assert!(!s.seen_or_insert(8, 100), "diff origin is new");
+    assert!(!s.contains(7, 100, 0), "empty");
+    assert!(!s.seen_or_insert(7, 100, 0), "first sight is new");
+    assert!(s.contains(7, 100, 0), "recorded");
+    assert!(s.seen_or_insert(7, 100, 0), "second sight is a dup");
+    assert!(!s.seen_or_insert(7, 101, 0), "diff msgid is new");
+    assert!(!s.seen_or_insert(8, 100, 0), "diff origin is new");
+    // REGRESSION (the multi-fragment bug): a DIFFERENT fragment of the SAME message is
+    // NOT a dup — else a relay drops frags 1..N and the gateway never reassembles a
+    // multi-fragment message. Each fragment must be independently forward-once.
+    assert!(!s.seen_or_insert(7, 100, 1), "frag 1 of a seen message is NEW (multi-frag)");
+    assert!(!s.seen_or_insert(7, 100, 2), "frag 2 of a seen message is NEW (multi-frag)");
+    assert!(s.seen_or_insert(7, 100, 1), "re-heard frag 1 is a dup");
     // idempotent insert doesn't consume extra ring slots
-    s.insert(7, 100);
-    s.insert(7, 100);
+    s.insert(7, 100, 0);
+    s.insert(7, 100, 0);
     // drop-oldest overflow: fill past capacity, the earliest ages out.
     let mut r = SeenSet::new();
     for m in 0..(SEEN_RING as u16 + 5) {
-        assert!(!r.seen_or_insert(1, m), "each new msgid is new on insert");
+        assert!(!r.seen_or_insert(1, m, 0), "each new msgid is new on insert");
     }
-    assert!(!r.contains(1, 0), "oldest (msgid 0) aged out after overflow");
-    assert!(r.contains(1, SEEN_RING as u16 + 4), "newest retained");
+    assert!(!r.contains(1, 0, 0), "oldest (msgid 0) aged out after overflow");
+    assert!(r.contains(1, SEEN_RING as u16 + 4, 0), "newest retained");
 
     // --- forward_decision -------------------------------------------------
     // already-seen → DedupDrop regardless of role/hop.

--- a/experiments/flood_verify/src/main.rs
+++ b/experiments/flood_verify/src/main.rs
@@ -6,9 +6,17 @@
 mod flood;
 
 use flood::{
-    forward_decision, ForwardAction, HopLatch, SeenSet, MAX_HOP, PROBE_EVERY, SEEN_RING,
-    UNLATCH_STREAK,
+    forward_decision, ForwardAction, HopLatch, SeenSet, ESCALATE_STREAK, MAX_HOP, PROBE_EVERY,
+    SEEN_RING, UNLATCH_STREAK,
 };
+
+/// Drive a fresh latch into multi-hop the way a genuinely-stranded leaf does: ESCALATE_STREAK
+/// consecutive fully-un-ACKed messages.
+fn latch_via_stranding(l: &mut HopLatch) {
+    for _ in 0..ESCALATE_STREAK {
+        l.on_relay_exhausted(false);
+    }
+}
 
 fn main() {
     // --- SeenSet (keyed per-FRAGMENT: origin, msgid, frag) ----------------
@@ -51,22 +59,36 @@ fn main() {
     assert_eq!(forward_decision(false, 1, false), ForwardAction::TtlDrop);
     assert_eq!(forward_decision(false, 0, false), ForwardAction::TtlDrop);
 
-    // --- HopLatch: escalation ---------------------------------------------
+    // --- HopLatch: escalation (CONSECUTIVE-un-ACK hysteresis) -------------
     let mut l = HopLatch::new();
     assert!(!l.latched());
     assert_eq!(l.origin_hop(false), 1, "single-hop by default (plain RELAY)");
     // a partially-acked exhaust does NOT latch (gateway heard us, just lossy).
     l.on_relay_exhausted(true);
     assert!(!l.latched(), "partial ack ⇒ not stranded");
-    // a fully-unacked exhaust latches multi-hop.
-    l.on_relay_exhausted(false);
-    assert!(l.latched(), "zero ack ⇒ stranded ⇒ latch");
+    // REGRESSION (C0 canary): fewer than ESCALATE_STREAK CONSECUTIVE full-un-ACKs must NOT latch —
+    // a single transient full-loss in a healthy all-hear mesh can't be allowed to escalate (that
+    // was the bug the bench caught: one dropped msg → hop=2 → forward-swarm → fwd!=0).
+    for i in 1..ESCALATE_STREAK {
+        l.on_relay_exhausted(false);
+        assert!(!l.latched(), "{i} consecutive full-un-ACKs (< ESCALATE_STREAK) ⇒ no latch");
+    }
+    // any ACK RESETS the streak — so losses must be CONSECUTIVE, not merely cumulative.
+    l.on_uplink_progress();
+    for _ in 1..ESCALATE_STREAK {
+        l.on_relay_exhausted(false);
+    }
+    assert!(!l.latched(), "progress reset the streak ⇒ still no latch");
+    // ESCALATE_STREAK consecutive full-un-ACKs (genuine stranding) DO latch.
+    l.on_uplink_progress();
+    latch_via_stranding(&mut l);
+    assert!(l.latched(), "ESCALATE_STREAK consecutive full-un-ACKs ⇒ stranded ⇒ latch");
     assert_eq!(l.origin_hop(false), MAX_HOP, "latched non-probe emits at MAX_HOP (RELAY2)");
     assert_eq!(l.origin_hop(true), 1, "a probe always emits H=1 (plain RELAY)");
 
     // --- HopLatch: probe gating (Gate A = downlink_up) --------------------
     let mut l2 = HopLatch::new();
-    l2.on_relay_exhausted(false); // latch
+    latch_via_stranding(&mut l2); // latch
     // while downlink is DOWN, never probe (don't waste airtime — definitely stranded).
     for _ in 0..(PROBE_EVERY * 3) {
         assert!(!l2.should_probe(false), "no probe while downlink down");
@@ -82,7 +104,7 @@ fn main() {
 
     // --- HopLatch: un-latch hysteresis (no flap) --------------------------
     let mut l3 = HopLatch::new();
-    l3.on_relay_exhausted(false);
+    latch_via_stranding(&mut l3);
     assert!(l3.latched());
     l3.on_direct_ack(); // streak 1 of UNLATCH_STREAK
     assert!(l3.latched(), "one direct ack is not enough (hysteresis)");

--- a/experiments/relay_compat/Cargo.toml
+++ b/experiments/relay_compat/Cargo.toml
@@ -1,0 +1,14 @@
+# #13 host byte-compat guard for the SMOLv1 relay wire codec (net/wire.rs). Runs OFF-target
+# on the host (std) via `cargo run` — the firmware crate is no_std/riscv32imc and can't host-test,
+# so this #[path]-includes the REAL wire.rs (no drift) and asserts the mixed-fleet byte contract
+# both directions + the exact golden wire layout. The permanent guard for the #124 UP2 migration.
+[package]
+name = "relay_compat"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "relay_compat"
+path = "src/main.rs"
+[profile.dev]
+opt-level = 0

--- a/experiments/relay_compat/src/main.rs
+++ b/experiments/relay_compat/src/main.rs
@@ -1,0 +1,118 @@
+//! #13 host byte-compat guard for the SMOLv1 relay wire codec. `#[path]`-includes the REAL
+//! `net/wire.rs` (no drift) and asserts the mixed-fleet / rolling-upgrade contract BOTH directions:
+//!   (1) a NEW-code frame parses under a VENDORED pre-#13 parser (new leaf -> old gateway), and
+//!   (2) an old-format RELAYACK parses under the NEW matcher (old gateway -> new leaf).
+//! Plus GOLDEN-BYTE assertions pinning the exact wire layout, and the #13 tag round-trips +
+//! disambiguation (a plain RELAY must never classify as RELAY2, and vice-versa). This is the
+//! regression the bench-cornered C0 investigation asked for + the guard for the #124 UP2 migration.
+//! Run: `cargo run` — panics on any mismatch.
+
+#[path = "../../../rust/clock/src/net/wire.rs"]
+mod wire;
+
+// --- VENDORED pre-#13 RELAY parser (frozen copy of mode.rs @ 14868c2, the byte-compat baseline).
+// If the REAL `wire::encode_relay` ever drifts from the pre-#13 wire, direction (1) fails loudly. ---
+const OLD_RELAY_PREFIX: &[u8] = b"SMOLv1 RELAY ";
+
+fn old_parse_id(rest: &[u8]) -> Option<u8> {
+    if rest.len() < 3 {
+        return None;
+    }
+    let mut val: u16 = 0;
+    for &b in &rest[..3] {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        val = val * 10 + (b - b'0') as u16;
+    }
+    (val <= 255).then_some(val as u8)
+}
+
+fn old_parse_u5(rest: &[u8]) -> Option<u32> {
+    if rest.len() < 5 {
+        return None;
+    }
+    let mut val: u32 = 0;
+    for &b in &rest[..5] {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        val = val * 10 + (b - b'0') as u32;
+    }
+    Some(val)
+}
+
+fn old_parse_relay(data: &[u8]) -> Option<(u8, u16, u8, u8, &[u8])> {
+    let rest = data.strip_prefix(OLD_RELAY_PREFIX)?;
+    if rest.len() < 14 {
+        return None;
+    }
+    let src_id = old_parse_id(&rest[0..3])?;
+    let msgid = u16::try_from(old_parse_u5(&rest[4..9])?).ok()?;
+    if !rest[10].is_ascii_digit() || !rest[12].is_ascii_digit() {
+        return None;
+    }
+    Some((src_id, msgid, rest[10] - b'0', rest[12] - b'0', &rest[14..]))
+}
+
+fn main() {
+    // (1) NEW frame -> OLD parser (a #13 leaf's H=1 RELAY on an old gateway) -----------------
+    let mut fb = [0u8; 128];
+    let chunk = b"cpu=42 rssi=-70 Grid:1"; // realistic short telemetry
+    let n = wire::encode_relay(7, 12345, 0, 2, chunk, &mut fb);
+    // GOLDEN bytes — the exact documented RELAY wire layout. This is the #124 migration checkpoint.
+    let golden: &[u8] = b"SMOLv1 RELAY 007 12345 0 2 cpu=42 rssi=-70 Grid:1";
+    assert_eq!(&fb[..n], golden, "encode_relay H=1 golden wire bytes");
+    let (id, mid, frag, cnt, ch) =
+        old_parse_relay(&fb[..n]).expect("pre-#13 parser MUST accept a new leaf's H=1 RELAY");
+    assert_eq!((id, mid, frag, cnt), (7, 12345, 0, 2), "old parser fields");
+    assert_eq!(ch, chunk, "old parser chunk");
+    // a max-realistic fragment (RELAY_CHUNK bytes) still round-trips through the old parser.
+    let big = [b'x'; wire::RELAY_CHUNK];
+    let n2 = wire::encode_relay(255, 65000, 3, 4, &big, &mut fb);
+    let (_, _, _, _, ch2) = old_parse_relay(&fb[..n2]).expect("old parser accepts a max fragment");
+    assert_eq!(ch2, &big[..], "old parser max chunk");
+
+    // (2) OLD-format RELAYACK -> NEW matcher (an old gateway's ACK on a #13 leaf) --------------
+    // The bug the bench chased was "the #13 leaf doesn't recognise the plain RELAYACK". It does —
+    // this asserts it against a hand-built old-format frame.
+    let old_ack: &[u8] = b"SMOLv1 RELAYACK 12345 003"; // msgid 12345, bitmap 0b011
+    let (mid_a, bm) = wire::parse_relayack(old_ack).expect("new matcher MUST accept an old RELAYACK");
+    assert_eq!((mid_a, bm), (12345, 3), "new matcher parses old RELAYACK fields");
+    // and the new encoder reproduces that exact frame (golden).
+    let mut ab = [0u8; 32];
+    let an = wire::encode_relayack(12345, 3, &mut ab);
+    assert_eq!(&ab[..an], old_ack, "encode_relayack golden wire bytes");
+
+    // #13 tag round-trips + DISAMBIGUATION (the no-flag-day guarantee) ------------------------
+    // A RELAY2 frame must NEVER classify as a plain RELAY (old fw would mis-read it), and a plain
+    // RELAY must never classify as RELAY2. Same for RELAYACK/RELAYACK2.
+    let mut r2 = [0u8; 128];
+    let r2n = wire::encode_relay2(9, 42, 2, 1, 2, b"hi", &mut r2);
+    assert!(wire::parse_relay(&r2[..r2n]).is_none(), "RELAY2 must NOT parse as plain RELAY");
+    assert_eq!(
+        wire::parse_relay2(&r2[..r2n]).unwrap(),
+        (9, 42, 2, 1, 2, &b"hi"[..]),
+        "RELAY2 round-trip"
+    );
+    assert!(wire::parse_relay2(&fb[..n2]).is_none(), "plain RELAY must NOT parse as RELAY2");
+    // the gateway's origin-keyed reassembly MAC (never aliases a real Espressif MAC).
+    assert_eq!(wire::synth_origin_mac(9), [0, 0, 0, 0, 0, 9], "synth_origin_mac layout");
+
+    let mut a2 = [0u8; 40];
+    let a2n = wire::encode_relayack2(9, 42, 3, 2, &mut a2);
+    assert!(wire::parse_relayack(&a2[..a2n]).is_none(), "RELAYACK2 must NOT parse as plain RELAYACK");
+    assert_eq!(wire::parse_relayack2(&a2[..a2n]).unwrap(), (9, 42, 3, 2), "RELAYACK2 round-trip");
+    assert!(wire::parse_relayack2(old_ack).is_none(), "plain RELAYACK must NOT parse as RELAYACK2");
+
+    // Stage B downlink freshness (BATT2/GRID2) round-trip + the seq survives verbatim.
+    let mut dl = [0u8; 128];
+    let dln = wire::encode_dl(wire::BATT2_PREFIX, 1_700_000_000, b"BATT|48V 52.8V", &mut dl);
+    let (seq, pl) = wire::parse_dl(wire::BATT2_PREFIX, &dl[..dln]).expect("BATT2 round-trip");
+    assert_eq!(seq, 1_700_000_000, "dl_seq survives verbatim");
+    assert_eq!(pl, b"BATT|48V 52.8V", "BATT2 payload verbatim");
+    // a BATT2 frame must not parse under the GRID2 prefix (tag isolation).
+    assert!(wire::parse_dl(wire::GRID2_PREFIX, &dl[..dln]).is_none(), "BATT2 is not a GRID2");
+
+    println!("relay_compat: ALL CHECKS PASSED (bidirectional byte-compat + golden bytes + #13 tag round-trips + disambiguation)");
+}

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -180,6 +180,14 @@ cast = ["espnow"]
 # serial. Builds on espnow. Everything it changes is `cfg(feature = "coexist-soak")`.
 coexist-soak = ["espnow"]
 
+# #13 MESH-TEST rig (NOT for production). A debug-only MAC deaf-list: a node silently
+# drops inbound frames whose source MAC is in the per-board `board::DEAF_MACS`, so the
+# 3-board fleet can be forced into a 2-hop topology (G→R→F) to validate routed multi-hop
+# (scratch/smol-dreamteam/13-rig-design.md). Builds on espnow. Default-OFF so a production
+# build is BYTE-FREE of it AND structurally CANNOT be made deaf (no field, no hook) — the
+# strongest guard against a "won't-rejoin" leftover-deaf ghost. DIAG surfaces deaf=/ddrops=.
+mesh-test = ["espnow"]
+
 [profile.release]
 # esp-wifi strongly recommends opt-level "s"/2/3 and LTO; the radio blobs are
 # timing-sensitive and misbehave when built at opt-level 0.

--- a/rust/clock/src/board.rs.example
+++ b/rust/clock/src/board.rs.example
@@ -69,3 +69,25 @@ pub const DEFAULT_APP: AppKind = AppKind::Menu;
 ///   * Grid: 0 = breakdown (total / L1 / L2); 1 = BIG total power (full window).
 ///   * Clock / Snake / Bench / MeshSnake / About / Menu: no pages → ignored.
 pub const DEFAULT_PAGE: u8 = 0;
+
+/// #13 MESH-TEST rig (`--features mesh-test` ONLY): the MACs this board pretends it
+/// CANNOT hear. Inbound frames whose source MAC is in this list are silently dropped at
+/// the very top of `RadioManager::service()` — faithfully simulating "out of RF range" so
+/// the 3-board fleet forces a 2-hop topology (G→R→F) to validate routed multi-hop without
+/// physical RF attenuation (see `scratch/smol-dreamteam/13-rig-design.md`). Empty = normal.
+///
+/// TEST SCAFFOLDING, per-board (like `NODE_ID`): to force `F` deaf to gateway `G`, set this
+/// on board `F`'s git-ignored `board.rs` to `[Some(<G's MAC>), None, None, None]`, and the
+/// reciprocal on `G`. Read each board's MAC off its Bench screen / serial. DIAG surfaces
+/// `deaf=<n>` / `ddrops=<n>` so a leftover entry is visible in HA — clear it by re-flashing
+/// with an empty list. A production (non-`mesh-test`) build has NO deaf field or hook at all,
+/// so it can never be made deaf. NEVER commit real MACs — `board.rs` is git-ignored; this
+/// tracked template stays empty.
+///
+/// Example (board F deaf to gateway G at 24:6f:28:aa:bb:cc):
+/// ```ignore
+/// pub const DEAF_MACS: [Option<[u8; 6]>; 4] =
+///     [Some([0x24, 0x6f, 0x28, 0xaa, 0xbb, 0xcc]), None, None, None];
+/// ```
+#[cfg(feature = "mesh-test")]
+pub const DEAF_MACS: [Option<[u8; 6]>; 4] = [None; 4];

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -906,7 +906,10 @@ fn main() -> ! {
                 && !batt_cache.is_empty()
                 && (now / 10_000) != ((now.saturating_sub(SUBTICK_MS as u64)) / 10_000)
             {
-                r.broadcast_batt(batt_cache.bytes());
+                // #13 Stage B: pass the gateway's current unix so BATT2 stamps a freshness dl_seq
+                // (bumped only on a value change) — relays re-flood strictly-newer to stranded leaves.
+                let unix_now = base_unix + (now.saturating_sub(anchor_ms) / 1000) as u32;
+                r.broadcast_batt(batt_cache.bytes(), unix_now);
             }
             // Twin GRID re-broadcast (issue #16): same ~10 s gateway-only cadence
             // and single-hop rationale as BATT (grid power also moves slowly).
@@ -914,7 +917,8 @@ fn main() -> ! {
                 && !grid_cache.is_empty()
                 && (now / 10_000) != ((now.saturating_sub(SUBTICK_MS as u64)) / 10_000)
             {
-                r.broadcast_grid(grid_cache.bytes());
+                let unix_now = base_unix + (now.saturating_sub(anchor_ms) / 1000) as u32;
+                r.broadcast_grid(grid_cache.bytes(), unix_now);
             }
             // #21 leaf-relay: a GATEWAY re-broadcasts each cached leaf's dashboard-set
             // default screen as a SMOLv1 CFG frame on the SAME ~10 s cadence as

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -19,10 +19,16 @@ pub mod mode;
 
 // #13 routed multi-hop mesh: the PURE managed-flood decision core (SeenSet + forward
 // decision + HopLatch escalation state machine), host-testable, no HAL deps. Driven by
-// the relay path in `mode`, so espnow-gated. (wip: host-tested but not yet wired — see
-// the module-level allow(dead_code) in flood.rs, dropped once mode.rs uses it.)
+// the relay path in `mode`, so espnow-gated.
 #[cfg(feature = "espnow")]
 pub mod flood;
+
+// #13: the PURE SMOLv1 relay-family wire codec (RELAY/RELAYACK/RELAY2/RELAYACK2/BATT2/GRID2 +
+// the fixed-width ASCII field helpers), extracted from `mode` so the frame formats are
+// host-unit-testable off-target (see `experiments/relay_compat`) — the mixed-fleet / #124
+// byte-compat guard. `mode` re-exports it via `use crate::net::wire::*`.
+#[cfg(feature = "espnow")]
+pub mod wire;
 
 // #25 WLED WiZmote-emit (smol as a WLED "linked remote"). `wled = ["espnow"]`, so
 // this is present only in a wled build; the default/wifi/espnow builds are byte-free

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -17,6 +17,13 @@ mod mqtt;
 #[cfg(feature = "espnow")]
 pub mod mode;
 
+// #13 routed multi-hop mesh: the PURE managed-flood decision core (SeenSet + forward
+// decision + HopLatch escalation state machine), host-testable, no HAL deps. Driven by
+// the relay path in `mode`, so espnow-gated. (wip: host-tested but not yet wired — see
+// the module-level allow(dead_code) in flood.rs, dropped once mode.rs uses it.)
+#[cfg(feature = "espnow")]
+pub mod flood;
+
 // #25 WLED WiZmote-emit (smol as a WLED "linked remote"). `wled = ["espnow"]`, so
 // this is present only in a wled build; the default/wifi/espnow builds are byte-free
 // of it (the module is `#![cfg(feature = "wled")]`). Referenced by `app` (the

--- a/rust/clock/src/net/flood.rs
+++ b/rust/clock/src/net/flood.rs
@@ -21,27 +21,34 @@
 //! byte-identical to today (the canary proves it: `fwd=0` on every node). Multi-hop
 //! only engages for a genuinely-stranded leaf (see [`HopLatch`]).
 
-// wip: this module is committed host-tested but UNWIRED (the mode.rs wiring lands in the
-// next commit). Until then its items are unused in-crate → suppress dead_code so the wip
-// build is clean. DROP THIS ATTR in the wiring commit (the -D warnings PR gate then applies).
-#![allow(dead_code)]
-
 /// v1 hop ceiling: a stranded leaf originates `RELAY2` at this `H`; one relay hop
 /// decrements it to 1 and delivers to the gateway. 3-hop (`>2`) is a follow-up.
 pub const MAX_HOP: u8 = 2;
 
-/// Capacity of the `(origin, msgid)` seen-set ring. Sized to comfortably cover the
-/// in-flight window across the small fleet (a few origins × their recent msgids);
-/// drop-oldest on overflow. Small fixed `.bss`, no alloc.
+/// Capacity of the `(origin, msgid, frag)` seen-set ring. Sized to comfortably cover
+/// the in-flight window across the small fleet (a few origins × their recent msgids ×
+/// up to `RELAY_MAX_FRAGS` fragments each); drop-oldest on overflow. Small fixed `.bss`,
+/// no alloc. 16 slots ≈ 4 fully-fragmented messages in flight — ample for the stranded
+/// single-leaf case #13 v1 targets.
 pub const SEEN_RING: usize = 16;
 
-/// A bounded ring of recently-seen `(origin_id, msgid)` — the loop/dup guard that
-/// makes the flood terminate. DISTINCT from `mode.rs`'s `DONE_RING` (keyed on
+/// A bounded ring of recently-seen `(origin_id, msgid, frag)` — the loop/dup guard
+/// that makes the flood terminate. DISTINCT from `mode.rs`'s `DONE_RING` (keyed on
 /// `(src_mac, msgid)` for post-completion re-ACK dedup): `src_mac` changes at every
 /// hop, but `origin_id` is stamped by the true source and survives forwarding, so
-/// only an `(origin, msgid)` key can recognise "I already forwarded this message".
+/// only an origin-anchored key can recognise "I already forwarded this frame".
+///
+/// KEYED PER-FRAGMENT (`frag` included): a RELAY message is FRAGMENTED — every
+/// fragment rides its own frame sharing the message `msgid` (telemetry > `RELAY_CHUNK`
+/// spans 2+ frames). A per-`(origin, msgid)` key would mark the whole message "seen"
+/// on fragment 0 and a relay would then DROP fragments 1..N → the gateway could never
+/// reassemble a multi-fragment message. `frag` in the key makes each fragment
+/// independently forward-once. (A relay's per-frame forward mirrors the leaf's
+/// per-frame broadcast; the gateway reassembles from the forwarded frames + dedups
+/// late retransmits via its own `DONE_RING`, so the gateway never consults this set —
+/// see the RELAY2 service arm.)
 pub struct SeenSet {
-    ring: [Option<(u8, u16)>; SEEN_RING],
+    ring: [Option<(u8, u16, u8)>; SEEN_RING],
     cursor: usize,
 }
 
@@ -50,28 +57,29 @@ impl SeenSet {
         Self { ring: [None; SEEN_RING], cursor: 0 }
     }
 
-    /// True if `(origin, msgid)` is already in the ring.
-    pub fn contains(&self, origin: u8, msgid: u16) -> bool {
-        self.ring.contains(&Some((origin, msgid)))
+    /// True if `(origin, msgid, frag)` is already in the ring.
+    pub fn contains(&self, origin: u8, msgid: u16, frag: u8) -> bool {
+        self.ring.contains(&Some((origin, msgid, frag)))
     }
 
-    /// Record `(origin, msgid)` (drop-oldest on overflow). Idempotent — recording an
-    /// already-present key is a no-op (keeps the ring from filling with dups).
-    pub fn insert(&mut self, origin: u8, msgid: u16) {
-        if self.contains(origin, msgid) {
+    /// Record `(origin, msgid, frag)` (drop-oldest on overflow). Idempotent — recording
+    /// an already-present key is a no-op (keeps the ring from filling with dups).
+    pub fn insert(&mut self, origin: u8, msgid: u16, frag: u8) {
+        if self.contains(origin, msgid, frag) {
             return;
         }
-        self.ring[self.cursor] = Some((origin, msgid));
+        self.ring[self.cursor] = Some((origin, msgid, frag));
         self.cursor = (self.cursor + 1) % SEEN_RING;
     }
 
-    /// Atomic "have I seen this?" + record. Returns true if it was ALREADY seen
-    /// (caller drops as a dup); false if it's new (caller processes + it's now recorded).
-    pub fn seen_or_insert(&mut self, origin: u8, msgid: u16) -> bool {
-        if self.contains(origin, msgid) {
+    /// Atomic "have I seen this fragment?" + record. Returns true if it was ALREADY
+    /// seen (caller drops as a dup); false if it's new (caller processes + it's now
+    /// recorded).
+    pub fn seen_or_insert(&mut self, origin: u8, msgid: u16, frag: u8) -> bool {
+        if self.contains(origin, msgid, frag) {
             return true;
         }
-        self.insert(origin, msgid);
+        self.insert(origin, msgid, frag);
         false
     }
 }

--- a/rust/clock/src/net/flood.rs
+++ b/rust/clock/src/net/flood.rs
@@ -131,6 +131,15 @@ pub fn forward_decision(is_gateway: bool, hop: u8, already_seen: bool) -> Forwar
 /// flapping a leaf between single- and multi-hop.
 pub const UNLATCH_STREAK: u8 = 2;
 
+/// Number of CONSECUTIVE fully-un-ACKed messages required to escalate INTO multi-hop.
+/// The down→up hysteresis (mirror of [`UNLATCH_STREAK`]): a genuinely-stranded leaf has
+/// EVERY message fully un-ACKed and latches in `ESCALATE_STREAK × emit-interval` (~45 s at
+/// 15 s), while a single transient full-loss in an otherwise-healthy all-hear mesh does NOT
+/// escalate — any ACKed message resets the streak. This is what keeps the byte-identical
+/// invariant (`fwd=0`) intact under normal packet loss: without it, ONE dropped message would
+/// latch a leaf to `RELAY2` and start a bounded forward-swarm that the C0 canary reads as failure.
+pub const ESCALATE_STREAK: u8 = 3;
+
 /// Send 1-in-N emits as an `H=1` direct probe while latched + downlink-present, so a
 /// leaf that moved back into range re-tests its uplink cheaply (~N × emit-interval).
 pub const PROBE_EVERY: u32 = 8;
@@ -138,8 +147,10 @@ pub const PROBE_EVERY: u32 = 8;
 /// The leaf's single-hop ⇄ multi-hop escalation state machine (pure).
 ///
 /// - Starts single-hop (`H=1`, plain `RELAY`).
-/// - [`on_relay_exhausted`] latches multi-hop when a message goes fully un-ACKed
-///   (the gateway heard NOTHING directly) → subsequent emits use `RELAY2` at [`MAX_HOP`].
+/// - [`on_relay_exhausted`] latches multi-hop only after [`ESCALATE_STREAK`] CONSECUTIVE
+///   fully-un-ACKed messages (genuine stranding, not a transient loss) → subsequent emits use
+///   `RELAY2` at [`MAX_HOP`]. [`on_uplink_progress`] resets that streak the moment the gateway
+///   ACKs anything — so normal packet loss never escalates (preserves the `fwd=0` invariant).
 /// - While latched, [`should_probe`] fires a 1-in-[`PROBE_EVERY`] plain-`RELAY` (`H=1`)
 ///   probe, but ONLY when the caller reports the owner's HELLO is heard directly
 ///   (`downlink_up` — else the leaf is definitely still stranded; don't waste airtime).
@@ -150,11 +161,14 @@ pub struct HopLatch {
     latched: bool,
     emit_count: u32,
     ack_streak: u8,
+    /// Consecutive fully-un-ACKed messages since the last ACK — the escalation (down→up)
+    /// hysteresis counter. Reaches [`ESCALATE_STREAK`] ⇒ latch; any ACK resets it to 0.
+    unack_streak: u8,
 }
 
 impl HopLatch {
     pub const fn new() -> Self {
-        Self { latched: false, emit_count: 0, ack_streak: 0 }
+        Self { latched: false, emit_count: 0, ack_streak: 0, unack_streak: 0 }
     }
 
     /// Are we currently in multi-hop mode?
@@ -184,13 +198,29 @@ impl HopLatch {
         downlink_up && self.emit_count.is_multiple_of(PROBE_EVERY)
     }
 
-    /// A message exhausted `RELAY_MAX_TRIES` with ZERO fragments ACKed → the gateway
-    /// can't hear us directly. Latch multi-hop (idempotent).
+    /// A message exhausted `RELAY_MAX_TRIES`. `any_frag_acked` = the gateway confirmed ≥1
+    /// fragment (directly, or via the flooded RELAYACK2 once already multi-hop) → it can hear
+    /// us, so reset the escalation streak. ZERO acks = a fully-lost message; latch multi-hop
+    /// ONLY after [`ESCALATE_STREAK`] such messages IN A ROW, so a single transient full-loss
+    /// in a healthy all-hear mesh does NOT escalate (that would break the `fwd=0` invariant).
     pub fn on_relay_exhausted(&mut self, any_frag_acked: bool) {
-        if !any_frag_acked {
+        if any_frag_acked {
+            self.unack_streak = 0;
+            return;
+        }
+        self.unack_streak = self.unack_streak.saturating_add(1);
+        if self.unack_streak >= ESCALATE_STREAK {
             self.latched = true;
             self.ack_streak = 0;
         }
+    }
+
+    /// Our uplink made progress — a message was fully ACKed (or any fragment ACKed): proof the
+    /// gateway hears us, so reset the escalation streak. Does NOT un-latch (that needs the
+    /// direct-ACK probe streak — a latched leaf whose `RELAY2` is ACKed via the flood is still
+    /// stranded on the DIRECT path). Called from the leaf's per-message complete path.
+    pub fn on_uplink_progress(&mut self) {
+        self.unack_streak = 0;
     }
 
     /// A DIRECT RELAYACK arrived (the gateway heard an `H=1` frame from us). While

--- a/rust/clock/src/net/flood.rs
+++ b/rust/clock/src/net/flood.rs
@@ -1,0 +1,215 @@
+//! #13 routed multi-hop mesh — the PURE managed-flood decision core.
+//!
+//! ## What this is
+//! smol's uplink relay is single-hop today: a leaf out of direct ESP-NOW range of
+//! the elected gateway is stranded. #13 adds Meshtastic-lineage **managed flood**:
+//! a hop-limit (`H`) + an `(origin, msgid)` seen-set + a forward path, rooted at the
+//! #76-elected owner, table-free (rides roam/re-election for free).
+//!
+//! This module is the **pure** brain — no esp-hal / esp-wifi deps, host-unit-testable
+//! (see `scratch/13-multihop/flood_verify`), mirroring the `cast`/`ble` pure split.
+//! It owns three decision pieces the live relay path in `net/mode.rs` drives:
+//!   1. [`SeenSet`] — the bounded `(origin, msgid)` loop/dup guard.
+//!   2. [`forward_decision`] — what a node does with an inbound multi-hop RELAY2 frame.
+//!   3. [`HopLatch`] — the leaf's single-hop⇄multi-hop escalation state machine with
+//!      un-latch hysteresis (so a leaf that moves back into range stops flooding).
+//!
+//! ## The byte-identical invariant (team-lead's gate)
+//! A non-escalated leaf sends plain `SMOLv1 RELAY` with an implicit `H=1`; nodes
+//! forward ONLY `H>1` frames (a new `RELAY2` tag). So when every node hears the
+//! gateway directly, no `RELAY2` ever exists → no node ever forwards → behaviour is
+//! byte-identical to today (the canary proves it: `fwd=0` on every node). Multi-hop
+//! only engages for a genuinely-stranded leaf (see [`HopLatch`]).
+
+// wip: this module is committed host-tested but UNWIRED (the mode.rs wiring lands in the
+// next commit). Until then its items are unused in-crate → suppress dead_code so the wip
+// build is clean. DROP THIS ATTR in the wiring commit (the -D warnings PR gate then applies).
+#![allow(dead_code)]
+
+/// v1 hop ceiling: a stranded leaf originates `RELAY2` at this `H`; one relay hop
+/// decrements it to 1 and delivers to the gateway. 3-hop (`>2`) is a follow-up.
+pub const MAX_HOP: u8 = 2;
+
+/// Capacity of the `(origin, msgid)` seen-set ring. Sized to comfortably cover the
+/// in-flight window across the small fleet (a few origins × their recent msgids);
+/// drop-oldest on overflow. Small fixed `.bss`, no alloc.
+pub const SEEN_RING: usize = 16;
+
+/// A bounded ring of recently-seen `(origin_id, msgid)` — the loop/dup guard that
+/// makes the flood terminate. DISTINCT from `mode.rs`'s `DONE_RING` (keyed on
+/// `(src_mac, msgid)` for post-completion re-ACK dedup): `src_mac` changes at every
+/// hop, but `origin_id` is stamped by the true source and survives forwarding, so
+/// only an `(origin, msgid)` key can recognise "I already forwarded this message".
+pub struct SeenSet {
+    ring: [Option<(u8, u16)>; SEEN_RING],
+    cursor: usize,
+}
+
+impl SeenSet {
+    pub const fn new() -> Self {
+        Self { ring: [None; SEEN_RING], cursor: 0 }
+    }
+
+    /// True if `(origin, msgid)` is already in the ring.
+    pub fn contains(&self, origin: u8, msgid: u16) -> bool {
+        self.ring.contains(&Some((origin, msgid)))
+    }
+
+    /// Record `(origin, msgid)` (drop-oldest on overflow). Idempotent — recording an
+    /// already-present key is a no-op (keeps the ring from filling with dups).
+    pub fn insert(&mut self, origin: u8, msgid: u16) {
+        if self.contains(origin, msgid) {
+            return;
+        }
+        self.ring[self.cursor] = Some((origin, msgid));
+        self.cursor = (self.cursor + 1) % SEEN_RING;
+    }
+
+    /// Atomic "have I seen this?" + record. Returns true if it was ALREADY seen
+    /// (caller drops as a dup); false if it's new (caller processes + it's now recorded).
+    pub fn seen_or_insert(&mut self, origin: u8, msgid: u16) -> bool {
+        if self.contains(origin, msgid) {
+            return true;
+        }
+        self.insert(origin, msgid);
+        false
+    }
+}
+
+impl Default for SeenSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// What a node should do with an inbound multi-hop `RELAY2` frame, decided purely
+/// from `(is_gateway, hop, already_seen)`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ForwardAction {
+    /// Already in the seen-set — drop, bump `dedup_hits`. (Bounds the flood.)
+    DedupDrop,
+    /// This node is the elected gateway (the flood's sink) — reassemble the fragment
+    /// keyed by `origin`, and (on completion) flood a `RELAYACK2` back. Never re-forward.
+    Reassemble,
+    /// A relay node with hops left — re-broadcast as `RELAY2` at `hop - 1`, bump
+    /// `fwd_count`/`fwd_ok`, record in the seen-set.
+    Forward { hop: u8 },
+    /// Hop budget exhausted (`hop <= 1` at a non-gateway) — drop, bump `ttl_drops`.
+    TtlDrop,
+}
+
+/// Decide the fate of an inbound `RELAY2` (multi-hop uplink) fragment. Pure: the
+/// caller supplies liveness (`is_gateway`) + the already-seen result, and applies
+/// the returned action (forwarding, reassembling, or dropping) + the matching counter.
+///
+/// `hop` is the frame's current hop-limit (as received, before decrement). A gateway
+/// always reassembles (it's the sink); a relay forwards while `hop > 1`, else `TtlDrop`.
+pub fn forward_decision(is_gateway: bool, hop: u8, already_seen: bool) -> ForwardAction {
+    if already_seen {
+        return ForwardAction::DedupDrop;
+    }
+    if is_gateway {
+        return ForwardAction::Reassemble;
+    }
+    if hop > 1 {
+        ForwardAction::Forward { hop: hop - 1 }
+    } else {
+        ForwardAction::TtlDrop
+    }
+}
+
+/// Number of consecutive successful direct-uplink probes required to drop the
+/// multi-hop latch — the hysteresis that stops a marginal/asymmetric link from
+/// flapping a leaf between single- and multi-hop.
+pub const UNLATCH_STREAK: u8 = 2;
+
+/// Send 1-in-N emits as an `H=1` direct probe while latched + downlink-present, so a
+/// leaf that moved back into range re-tests its uplink cheaply (~N × emit-interval).
+pub const PROBE_EVERY: u32 = 8;
+
+/// The leaf's single-hop ⇄ multi-hop escalation state machine (pure).
+///
+/// - Starts single-hop (`H=1`, plain `RELAY`).
+/// - [`on_relay_exhausted`] latches multi-hop when a message goes fully un-ACKed
+///   (the gateway heard NOTHING directly) → subsequent emits use `RELAY2` at [`MAX_HOP`].
+/// - While latched, [`should_probe`] fires a 1-in-[`PROBE_EVERY`] plain-`RELAY` (`H=1`)
+///   probe, but ONLY when the caller reports the owner's HELLO is heard directly
+///   (`downlink_up` — else the leaf is definitely still stranded; don't waste airtime).
+/// - [`on_direct_ack`] counts a successful probe; after [`UNLATCH_STREAK`] consecutive,
+///   the latch drops back to single-hop. Any miss ([`on_probe_miss`]) resets the streak.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HopLatch {
+    latched: bool,
+    emit_count: u32,
+    ack_streak: u8,
+}
+
+impl HopLatch {
+    pub const fn new() -> Self {
+        Self { latched: false, emit_count: 0, ack_streak: 0 }
+    }
+
+    /// Are we currently in multi-hop mode?
+    pub fn latched(&self) -> bool {
+        self.latched
+    }
+
+    /// The hop-limit to originate the NEXT emit with, given whether this emit is a
+    /// probe. Single-hop (latch off) or a probe → `1` (plain `RELAY`); latched
+    /// non-probe → [`MAX_HOP`] (`RELAY2`).
+    pub fn origin_hop(&self, is_probe: bool) -> u8 {
+        if self.latched && !is_probe {
+            MAX_HOP
+        } else {
+            1
+        }
+    }
+
+    /// Call once per relay emit (before choosing the frame). Advances the probe
+    /// counter and returns whether THIS emit should be a direct `H=1` probe: only
+    /// while latched AND `downlink_up` (owner HELLO heard directly), on the 1-in-N tick.
+    pub fn should_probe(&mut self, downlink_up: bool) -> bool {
+        if !self.latched {
+            return false;
+        }
+        self.emit_count = self.emit_count.wrapping_add(1);
+        downlink_up && self.emit_count.is_multiple_of(PROBE_EVERY)
+    }
+
+    /// A message exhausted `RELAY_MAX_TRIES` with ZERO fragments ACKed → the gateway
+    /// can't hear us directly. Latch multi-hop (idempotent).
+    pub fn on_relay_exhausted(&mut self, any_frag_acked: bool) {
+        if !any_frag_acked {
+            self.latched = true;
+            self.ack_streak = 0;
+        }
+    }
+
+    /// A DIRECT RELAYACK arrived (the gateway heard an `H=1` frame from us). While
+    /// latched, count it toward un-latching; after [`UNLATCH_STREAK`] consecutive,
+    /// drop the latch. When not latched this just (re)confirms single-hop health.
+    pub fn on_direct_ack(&mut self) {
+        if !self.latched {
+            return;
+        }
+        self.ack_streak = self.ack_streak.saturating_add(1);
+        if self.ack_streak >= UNLATCH_STREAK {
+            self.latched = false;
+            self.ack_streak = 0;
+            self.emit_count = 0;
+        }
+    }
+
+    /// A probe went un-ACKed (uplink still down) — reset the streak, stay latched.
+    pub fn on_probe_miss(&mut self) {
+        if self.latched {
+            self.ack_streak = 0;
+        }
+    }
+}
+
+impl Default for HopLatch {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -504,14 +504,20 @@ struct DiagCounters {
     /// (OTA verify ok/fail is read live from `OtaLeafSession`, not mirrored here.)
     flush_ok: u32,
     flush_fail: u32,
-    /// #13 multi-hop mesh counters (surfaced as `fwd=`/`dedup=`/`ttl=` in the DIAG record; the
-    /// rig scores P2/P3 off them, and the C0 byte-identical canary is exactly `fwd == 0` on every
-    /// node across a normal all-hear window). `fwd` = inbound `RELAY2` frames this node re-broadcast;
-    /// `dedup` = `RELAY2` frames dropped as already-seen `(origin,msgid,frag)`; `ttl` = `RELAY2`
-    /// frames dropped for an exhausted hop budget. All stay 0 in the single-hop / all-hear case.
+    /// #13 multi-hop mesh counters (surfaced in the DIAG record; the rig scores P2/P3 off them).
+    /// `fwd` = inbound UPLINK `RELAY2` frames this node re-broadcast — this is the C0 byte-identical
+    /// invariant: `fwd == 0` on every node across a normal all-hear window (a non-stranded leaf never
+    /// emits RELAY2, so nobody forwards). `dedup` = `RELAY2` frames dropped as already-seen
+    /// `(origin,msgid,frag)`; `ttl` = `RELAY2` frames dropped for an exhausted hop budget. All stay 0
+    /// in the single-hop / all-hear case.
+    ///
+    /// `dfwd` (SEPARATE) = DOWNLINK `BATT2`/`GRID2` re-floods — nonzero BY DESIGN (Stage B's
+    /// strictly-newer downlink flood re-broadcasts each new value once, like `TIME`). Kept distinct
+    /// from `fwd` so the uplink invariant stays machine-checkable — do NOT fold it into `fwd`.
     fwd: u32,
     dedup: u32,
     ttl: u32,
+    dfwd: u32,
     /// #13 MESH-TEST rig ONLY: count of inbound frames dropped by the deaf-list (surfaced as
     /// `ddrops=` in DIAG). A production build has no deaf-list, so this field doesn't exist.
     #[cfg(feature = "mesh-test")]
@@ -529,6 +535,7 @@ impl DiagCounters {
             fwd: 0,
             dedup: 0,
             ttl: 0,
+            dfwd: 0,
             #[cfg(feature = "mesh-test")]
             ddrops: 0,
         }
@@ -2644,7 +2651,7 @@ impl RadioManager {
         // score P2/P3; `fwd == 0` fleet-wide is the C0 all-hear byte-identical canary).
         let mesh_hop = if self.relay.latch.latched() { crate::net::flood::MAX_HOP } else { 1 };
         let mut rec = alloc::format!(
-            "DIAG|slot={}|rst={}|boot={}|ota={}|up={}|heap={}|hmin={}|btn={}|btnl={}|fok={}|ffl={}|vok={}|vfl={}|loss={}|rtt={}|rx={}|tx={}|led={}:{}|tage={}|tsrc={}|net={}:{}|brk={}|otah={}|fwd={}|dedup={}|ttl={}|hop={}|dlseq={}",
+            "DIAG|slot={}|rst={}|boot={}|ota={}|up={}|heap={}|hmin={}|btn={}|btnl={}|fok={}|ffl={}|vok={}|vfl={}|loss={}|rtt={}|rx={}|tx={}|led={}:{}|tage={}|tsrc={}|net={}:{}|brk={}|otah={}|fwd={}|dedup={}|ttl={}|hop={}|dlseq={}|dfwd={}",
             d.boot_slot,
             d.reset_reason,
             d.boot_count,
@@ -2678,6 +2685,7 @@ impl RadioManager {
             // stay unchanged when an older/replayed dl_seq is dropped). 0 on a gateway (source) or
             // a v1-only leaf. Representative of the downlink channel; GRID2 uses the same mechanism.
             self.batt.dl_seq,
+            self.diag.dfwd,
         );
         // #74 item 3 (stage-2): fold in the APPLIED-config string for HA config-drift, ONLY when
         // `main` populated it (espnow build). ASCII by construction (as_wire/to_wire/hex/F24). HA
@@ -4407,7 +4415,10 @@ impl RadioManager {
                         let mut fb = [0u8; DL_FRAME_MAX];
                         let len = encode_dl(BATT2_PREFIX, seq, payload, &mut fb);
                         self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
-                        log::info!("smol: BATT2 seq {} adopted + reflooded", seq);
+                        // DOWNLINK re-flood (Stage B, nonzero by design) — counted SEPARATELY from the
+                        // uplink `fwd` invariant so C0's `fwd==0` stays machine-checkable.
+                        self.diag.dfwd = self.diag.dfwd.saturating_add(1);
+                        log::info!("smol: BATT2 seq {} adopted + reflooded (dfwd)", seq);
                     }
                     label = Some(alloc::format!("batt2 {}", seq));
                 }
@@ -4423,7 +4434,8 @@ impl RadioManager {
                         let mut fb = [0u8; DL_FRAME_MAX];
                         let len = encode_dl(GRID2_PREFIX, seq, payload, &mut fb);
                         self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
-                        log::info!("smol: GRID2 seq {} adopted + reflooded", seq);
+                        self.diag.dfwd = self.diag.dfwd.saturating_add(1); // downlink re-flood (see BATT2)
+                        log::info!("smol: GRID2 seq {} adopted + reflooded (dfwd)", seq);
                     }
                     label = Some(alloc::format!("grid2 {}", seq));
                 }

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -4275,11 +4275,17 @@ impl RadioManager {
                     // Leaf: the gateway confirmed these fragments — stop resending
                     // them. On a gateway (no outstanding tx) this is a no-op.
                     self.relay.apply_ack(msgid, bitmap);
-                    // #13: a DIRECT (unicast) RELAYACK proves the gateway heard an H=1 frame
+                    // #13: the gateway ACKed a fragment directly → it hears us → reset the
+                    // escalation streak so a LATER transient full-loss starts counting fresh
+                    // (escalation is CONSECUTIVE-only; this is what keeps fwd=0 under normal loss).
+                    if bitmap != 0 {
+                        self.relay.latch.on_uplink_progress();
+                    }
+                    // #13: a DIRECT (unicast) RELAYACK also proves the gateway heard an H=1 frame
                     // from us directly → the uplink is back. While latched, count it toward
-                    // un-latching (UNLATCH_STREAK consecutive drops the latch back to
-                    // single-hop). A no-op when not latched. NOTE: the flooded RELAYACK2 does
-                    // NOT call this — it proves only the multi-hop path, not direct reach.
+                    // un-latching (UNLATCH_STREAK consecutive drops the latch back to single-hop).
+                    // A no-op when not latched. NOTE: the flooded RELAYACK2 does NOT call this —
+                    // it proves only the multi-hop path, not direct reach.
                     self.relay.latch.on_direct_ack();
                     label = Some(alloc::format!("ack {:05}", msgid));
                 }
@@ -4323,6 +4329,14 @@ impl RadioManager {
                                 let len =
                                     encode_relay2(origin, msgid, next_hop, frag, count, chunk, &mut fb);
                                 self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
+                                // Rate-limited serial trace (the forward path was previously OLED-only —
+                                // a rig watching serial saw the fwd counter climb with no log). Every 8th.
+                                if self.diag.fwd.is_multiple_of(8) {
+                                    log::info!(
+                                        "smol #13: fwd {} (origin {:03} msgid {} frag {} -> h{})",
+                                        self.diag.fwd, origin, msgid, frag, next_hop
+                                    );
+                                }
                                 label = Some(alloc::format!("fwd {:03} h{} f{}", origin, next_hop, frag));
                             }
                             crate::net::flood::ForwardAction::DedupDrop => {
@@ -4349,6 +4363,11 @@ impl RadioManager {
                         // works, NOT that the gateway can hear us DIRECTLY (only an H=1 probe drawing a
                         // direct RELAYACK un-latches us). Never re-forward an ACK addressed to us.
                         self.relay.apply_ack(msgid, bitmap);
+                        // Multi-hop delivery worked → the gateway hears us (via the relay) → reset
+                        // the escalation streak (does NOT un-latch — that still needs a direct probe).
+                        if bitmap != 0 {
+                            self.relay.latch.on_uplink_progress();
+                        }
                         label = Some(alloc::format!("ack2 {:05}", msgid));
                     } else if hop > 1 {
                         // Not for us + hops left: flood it one hop further toward the target. Loop

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -55,6 +55,11 @@ use esp_wifi::{
 
 use crate::led::LedState;
 use crate::net::WifiPeripherals;
+// #13: the relay-family wire codec + ASCII field helpers live in the PURE, host-testable
+// `net::wire` module (extracted from here, byte-identical). Glob-imported so every call site
+// below (encode_relay, parse_relay[2], *relayack*, encode_dl, write_u5/u10, parse_id/u5/u10,
+// the *_PREFIX / RELAY_CHUNK / BATT_PAYLOAD_MAX consts, …) stays unqualified.
+use crate::net::wire::*;
 
 /// Fixed ESP-NOW channel used in TIME-SHARE mode. All smol units must agree on
 /// this value (1..=13). 6 is a common, low-congestion default.
@@ -123,28 +128,11 @@ const BEACON_PREFIX: &[u8] = b"SMOLv1 BEACON "; // + "NNN SSSSS EEEEE"
 /// on a private fixed channel; harden with a signed payload or an ESP-NOW LMK
 /// if it ever matters. Documented, not defended.
 const TIME_PREFIX: &[u8] = b"SMOLv1 TIME "; // + "NNN UUUUUUUUUU SSSSSSSSSS"
-/// Relay-bridge tags (see the "Relay bridge" section below). RELAY carries a
-/// fragment of a leaf's telemetry uplink; RELAYACK is the gateway's per-message
-/// received-fragment bitmap so the leaf can retransmit gaps. Distinct tags to
-/// keep the SMOLv1 namespace clean for the in-flight MMO-snake frames (issue #5).
-/// The trailing space on RELAY disambiguates it from RELAYACK at parse time
-/// (`"SMOLv1 RELAY "[12]` is ' ' where RELAYACK has 'A'), so match order is moot.
-const RELAY_PREFIX: &[u8] = b"SMOLv1 RELAY "; // + "NNN MMMMM F C " + chunk
-const RELAYACK_PREFIX: &[u8] = b"SMOLv1 RELAYACK "; // + "MMMMM BBB"
-/// #13 multi-hop uplink tags (see the "#13 routed multi-hop mesh" section below +
-/// `net/flood.rs`). A frame is byte-identical to today UNLESS a leaf is genuinely
-/// stranded (can't reach the gateway directly), so these tags appear ONLY when a hop
-/// count ≥ 2 is actually needed. Both are NEW tags (not an append to RELAY/RELAYACK,
-/// whose headers are fixed-offset): a stranded leaf emits `RELAY2` (hop-limited,
-/// origin-stamped) and a relay re-broadcasts it; the gateway floods `RELAYACK2` back
-/// (R1 table-free ACK). An OLD firmware `classify()`s both to `None` (harmless text) —
-/// it can't relay anyway — so no flag-day flash and no rolling-upgrade regression:
-/// a leaf that needs hop ≥ 2 was, by definition, out of direct gateway range, i.e.
-/// already stranded pre-#13. `RELAY2` diverges from `RELAY` at byte 12 (`'2'` vs `' '`)
-/// and `RELAYACK2` from `RELAYACK` at byte 15 (`'2'` vs `' '`), so `strip_prefix` never
-/// confuses the base tag with its multi-hop variant regardless of match order.
-const RELAY2_PREFIX: &[u8] = b"SMOLv1 RELAY2 "; // + "OOO MMMMM H F C " + chunk
-const RELAYACK2_PREFIX: &[u8] = b"SMOLv1 RELAYACK2 "; // + "TTT MMMMM BBB H"
+// #13: the RELAY / RELAYACK / RELAY2 / RELAYACK2 wire TAGS + their whole codec live in the
+// pure, host-testable `net::wire` module (glob-imported above — RELAY carries a leaf-telemetry
+// fragment; RELAYACK the gateway's fragment-bitmap; RELAY2/RELAYACK2 the #13 multi-hop variants,
+// NEW tags an old firmware classifies to None → no flag-day). The `*_FRAME_MAX` buffer-size
+// consts stay here — they size call-site stack buffers in this module, not the codec.
 /// Max RELAY2 frame length on the wire (30-byte header + full chunk); sizes stack buffers.
 /// Header = 14-byte prefix + "OOO MMMMM H F C " (16) = 30, vs RELAY's 27 (the extra 3 =
 /// the origin↔src split's `H ` hop field; `OOO` is the ORIGIN id, distinct from the
@@ -177,18 +165,11 @@ const GRID_PREFIX: &[u8] = b"SMOLv1 GRID "; // + verbatim "GRID|l1|l2|l3"
 /// Max GRID payload retained/echoed — matches `GridCache` (LOCKED ≤ 96 B).
 const GRID_PAYLOAD_MAX: usize = 96;
 
-/// #13 Stage B — downlink FRESHNESS tags. The v1 `BATT`/`GRID` frames carry NO freshness
-/// field (a locked no-length-byte memcpy — a header can't be inserted), so a relay can't tell
-/// new data from a replay and downlink stays single-hop. `BATT2`/`GRID2` prepend a 10-digit
-/// monotonic `dl_seq` (the gateway's unix-second of the last VALUE CHANGE — survives a gateway
-/// reboot + never wraps, exactly like `TIME`'s `synced_at`): a node adopts + RE-FLOODS only a
-/// STRICTLY-NEWER `dl_seq` (the `TIME` strict-newer template), so downlink reaches a stranded
-/// leaf via a relay AND an older/replayed frame is dropped (no loop). `BATT2` diverges from
-/// `BATT` at byte 11 (`'2'` vs `' '`) and from `GRID2` at byte 7, so `strip_prefix` never
-/// confuses them. NEW tags: an old node `classify()`s them to `None` (harmless) — the same
-/// fleet-flash / no-flag-day discipline as `RELAY2`.
-const BATT2_PREFIX: &[u8] = b"SMOLv1 BATT2 "; // + "SSSSSSSSSS " + verbatim "BATT|…"
-const GRID2_PREFIX: &[u8] = b"SMOLv1 GRID2 "; // + "SSSSSSSSSS " + verbatim "GRID|…"
+// #13 Stage B: the BATT2 / GRID2 downlink-freshness TAGS + their `encode_dl`/`parse_dl` codec
+// live in `net::wire` (glob-imported) — a 10-digit monotonic `dl_seq` (gateway unix-of-last-
+// value-change, TIME `synced_at`-style strict-newer) prepended to the verbatim BATT|/GRID|
+// payload so a relay re-floods only strictly-newer data. v1 `BATT`/`GRID` (above) stay here for
+// the back-compat receive path. `DL_FRAME_MAX` (this module's emit-buffer size) stays here.
 /// Max BATT2/GRID2 frame on the wire: 13-B prefix + 10-digit `dl_seq` + space + ≤96-B payload
 /// = ≤120; 128 leaves headroom. Sizes the emit stack buffer.
 const DL_FRAME_MAX: usize = 128;
@@ -4771,15 +4752,7 @@ fn encode_beacon(id: u8, seq: u32, echo: u32, out: &mut [u8]) -> usize {
     n
 }
 
-/// Write a 5-digit zero-padded decimal (value mod 100000) into `out[..5]`.
-fn write_u5(v: u32, out: &mut [u8]) {
-    let v = v % 100_000;
-    out[0] = b'0' + ((v / 10_000) % 10) as u8;
-    out[1] = b'0' + ((v / 1_000) % 10) as u8;
-    out[2] = b'0' + ((v / 100) % 10) as u8;
-    out[3] = b'0' + ((v / 10) % 10) as u8;
-    out[4] = b'0' + (v % 10) as u8;
-}
+// (write_u5 / write_u10 / parse_id / parse_u5 / parse_u10 moved to `net::wire`, glob-imported.)
 
 /// Encode a TIME frame `"SMOLv1 TIME NNN UUUUUUUUUU SSSSSSSSSS"` into `out`;
 /// returns length (37). `unix`/`synced_at` are 10-digit zero-padded decimals —
@@ -4803,16 +4776,6 @@ fn encode_time(id: u8, unix: u32, synced_at: u32, out: &mut [u8]) -> usize {
     write_u10(synced_at, &mut out[n..]);
     n += 10;
     n
-}
-
-/// Write a 10-digit zero-padded decimal into `out[..10]`. 10 digits holds every
-/// u32 (max 4_294_967_295), so no clamp is needed — the full value round-trips
-/// through [`parse_u10`]. Filled least-significant-digit first.
-fn write_u10(mut v: u32, out: &mut [u8]) {
-    for i in (0..10).rev() {
-        out[i] = b'0' + (v % 10) as u8;
-        v /= 10;
-    }
 }
 
 /// Parse an inbound payload into a [`Frame`], or `None` if it isn't ours.
@@ -4923,284 +4886,6 @@ fn parse_frame(data: &[u8]) -> Option<Frame<'_>> {
         return Some(Frame::Scan { src, value: &rest[3..] });
     }
     None
-}
-
-/// Parse a 3-digit ASCII id (`b"007"` -> 7). Rejects non-digits / short input.
-fn parse_id(rest: &[u8]) -> Option<u8> {
-    if rest.len() < 3 {
-        return None;
-    }
-    let mut val: u16 = 0;
-    for &b in &rest[..3] {
-        if !b.is_ascii_digit() {
-            return None;
-        }
-        val = val * 10 + (b - b'0') as u16;
-    }
-    (val <= 255).then_some(val as u8)
-}
-
-/// Parse exactly 5 ASCII digits into a u32. Rejects short/non-digit input.
-fn parse_u5(rest: &[u8]) -> Option<u32> {
-    if rest.len() < 5 {
-        return None;
-    }
-    let mut val: u32 = 0;
-    for &b in &rest[..5] {
-        if !b.is_ascii_digit() {
-            return None;
-        }
-        val = val * 10 + (b - b'0') as u32;
-    }
-    Some(val)
-}
-
-/// Parse exactly 10 ASCII digits into a u32. Accumulates in u64 and range-checks
-/// on the way out, so a garbled/hostile 10-digit field that exceeds u32::MAX
-/// (e.g. "9999999999") is rejected as `None` rather than silently wrapping —
-/// stricter than [`parse_u5`], where 5 digits always fit in u32.
-fn parse_u10(rest: &[u8]) -> Option<u32> {
-    if rest.len() < 10 {
-        return None;
-    }
-    let mut val: u64 = 0;
-    for &b in &rest[..10] {
-        if !b.is_ascii_digit() {
-            return None;
-        }
-        val = val * 10 + (b - b'0') as u64;
-    }
-    u32::try_from(val).ok()
-}
-
-// --- Relay wire codec (pure + fixed-width; host-unit-testable) --------------
-
-/// Encode a RELAY fragment `"SMOLv1 RELAY NNN MMMMM F C " + <chunk>` into `out`;
-/// returns total length (27-byte header + chunk). `NNN` = src id, `MMMMM` = msgid
-/// (5-digit u16), `F`/`C` = single-digit frag index / count (count <=
-/// RELAY_MAX_FRAGS <= 9). `chunk` is truncated to `RELAY_CHUNK`. Mirrors
-/// [`encode_beacon`]'s discipline.
-fn encode_relay(src_id: u8, msgid: u16, frag: u8, count: u8, chunk: &[u8], out: &mut [u8]) -> usize {
-    let mut n = 0;
-    out[..RELAY_PREFIX.len()].copy_from_slice(RELAY_PREFIX);
-    n += RELAY_PREFIX.len();
-    out[n] = b'0' + (src_id / 100) % 10;
-    out[n + 1] = b'0' + (src_id / 10) % 10;
-    out[n + 2] = b'0' + src_id % 10;
-    n += 3;
-    out[n] = b' ';
-    n += 1;
-    write_u5(msgid as u32, &mut out[n..]);
-    n += 5;
-    out[n] = b' ';
-    n += 1;
-    out[n] = b'0' + frag;
-    n += 1;
-    out[n] = b' ';
-    n += 1;
-    out[n] = b'0' + count;
-    n += 1;
-    out[n] = b' ';
-    n += 1;
-    let len = chunk.len().min(RELAY_CHUNK);
-    out[n..n + len].copy_from_slice(&chunk[..len]);
-    n + len
-}
-
-/// Parse a RELAY frame into `(src_id, msgid, frag, count, chunk)`, or `None` if it
-/// isn't a well-formed RELAY. `chunk` borrows `data`. The caller
-/// ([`Relay::accept`]) re-validates `count`/`frag`/`chunk.len()` against its caps.
-fn parse_relay(data: &[u8]) -> Option<(u8, u16, u8, u8, &[u8])> {
-    let rest = data.strip_prefix(RELAY_PREFIX)?;
-    if rest.len() < 14 {
-        return None;
-    }
-    let src_id = parse_id(&rest[0..3])?;
-    let msgid = u16::try_from(parse_u5(&rest[4..9])?).ok()?;
-    if !rest[10].is_ascii_digit() || !rest[12].is_ascii_digit() {
-        return None;
-    }
-    let frag = rest[10] - b'0';
-    let count = rest[12] - b'0';
-    Some((src_id, msgid, frag, count, &rest[14..]))
-}
-
-/// Encode a `"SMOLv1 RELAYACK MMMMM BBB"` frame into `out`; returns length (25).
-/// `MMMMM` = msgid (5-digit), `BBB` = the 3-digit received-fragment bitmap (0..255).
-fn encode_relayack(msgid: u16, bitmap: u8, out: &mut [u8]) -> usize {
-    let mut n = 0;
-    out[..RELAYACK_PREFIX.len()].copy_from_slice(RELAYACK_PREFIX);
-    n += RELAYACK_PREFIX.len();
-    write_u5(msgid as u32, &mut out[n..]);
-    n += 5;
-    out[n] = b' ';
-    n += 1;
-    out[n] = b'0' + (bitmap / 100) % 10;
-    out[n + 1] = b'0' + (bitmap / 10) % 10;
-    out[n + 2] = b'0' + bitmap % 10;
-    n += 3;
-    n
-}
-
-/// Parse a RELAYACK frame into `(msgid, bitmap)`, or `None`. The 3-digit bitmap
-/// reuses [`parse_id`] (both are a 3-ASCII-digit `u8` in 0..=255).
-fn parse_relayack(data: &[u8]) -> Option<(u16, u8)> {
-    let rest = data.strip_prefix(RELAYACK_PREFIX)?;
-    if rest.len() < 9 {
-        return None;
-    }
-    let msgid = u16::try_from(parse_u5(&rest[0..5])?).ok()?;
-    let bitmap = parse_id(&rest[6..9])?;
-    Some((msgid, bitmap))
-}
-
-// --- #13 multi-hop wire codec (RELAY2 / RELAYACK2) --------------------------
-
-/// Encode a RELAY2 fragment `"SMOLv1 RELAY2 " + "OOO MMMMM H F C " + <chunk>` into
-/// `out`; returns total length (30-byte header + chunk). `OOO` = ORIGIN id (the true
-/// source, distinct from the re-broadcasting relay's MAC), `MMMMM` = msgid, `H` = 1-digit
-/// hop-limit (1..=`MAX_HOP`), `F`/`C` = frag index / count. Twin of [`encode_relay`] with
-/// the origin + hop fields; `chunk` truncated to `RELAY_CHUNK`.
-fn encode_relay2(origin: u8, msgid: u16, hop: u8, frag: u8, count: u8, chunk: &[u8], out: &mut [u8]) -> usize {
-    let mut n = 0;
-    out[..RELAY2_PREFIX.len()].copy_from_slice(RELAY2_PREFIX);
-    n += RELAY2_PREFIX.len();
-    out[n] = b'0' + (origin / 100) % 10;
-    out[n + 1] = b'0' + (origin / 10) % 10;
-    out[n + 2] = b'0' + origin % 10;
-    n += 3;
-    out[n] = b' ';
-    n += 1;
-    write_u5(msgid as u32, &mut out[n..]);
-    n += 5;
-    out[n] = b' ';
-    n += 1;
-    out[n] = b'0' + hop; // hop is 1..=MAX_HOP (single digit)
-    n += 1;
-    out[n] = b' ';
-    n += 1;
-    out[n] = b'0' + frag;
-    n += 1;
-    out[n] = b' ';
-    n += 1;
-    out[n] = b'0' + count;
-    n += 1;
-    out[n] = b' ';
-    n += 1;
-    let len = chunk.len().min(RELAY_CHUNK);
-    out[n..n + len].copy_from_slice(&chunk[..len]);
-    n + len
-}
-
-/// Parse a RELAY2 frame into `(origin, msgid, hop, frag, count, chunk)`, or `None`.
-/// `chunk` borrows `data`. The caller re-validates `count`/`frag`/`chunk.len()`.
-// The return mirrors `parse_relay`'s tuple shape + the one `hop` field (6 = just over the
-// complexity heuristic); `parse_frame` immediately destructures it into `Frame::Relay2`, so
-// a named struct would add a type for no call-site clarity. (Codebase precedent: the
-// `#[allow(clippy::too_many_arguments)]` on the relay-offer service fn.)
-#[allow(clippy::type_complexity)]
-fn parse_relay2(data: &[u8]) -> Option<(u8, u16, u8, u8, u8, &[u8])> {
-    let rest = data.strip_prefix(RELAY2_PREFIX)?;
-    // "OOO MMMMM H F C " = 16 header bytes (origin 3, sp, msgid 5, sp, hop 1, sp, frag 1,
-    // sp, count 1, sp), then the chunk.
-    if rest.len() < 16 {
-        return None;
-    }
-    let origin = parse_id(&rest[0..3])?;
-    let msgid = u16::try_from(parse_u5(&rest[4..9])?).ok()?;
-    if !rest[10].is_ascii_digit() || !rest[12].is_ascii_digit() || !rest[14].is_ascii_digit() {
-        return None;
-    }
-    let hop = rest[10] - b'0';
-    let frag = rest[12] - b'0';
-    let count = rest[14] - b'0';
-    Some((origin, msgid, hop, frag, count, &rest[16..]))
-}
-
-/// Encode a `"SMOLv1 RELAYACK2 " + "TTT MMMMM BBB H"` frame into `out`; returns length (32).
-/// `TTT` = TARGET origin id being ACKed, `MMMMM` = msgid, `BBB` = 3-digit bitmap, `H` = hop.
-fn encode_relayack2(target: u8, msgid: u16, bitmap: u8, hop: u8, out: &mut [u8]) -> usize {
-    let mut n = 0;
-    out[..RELAYACK2_PREFIX.len()].copy_from_slice(RELAYACK2_PREFIX);
-    n += RELAYACK2_PREFIX.len();
-    out[n] = b'0' + (target / 100) % 10;
-    out[n + 1] = b'0' + (target / 10) % 10;
-    out[n + 2] = b'0' + target % 10;
-    n += 3;
-    out[n] = b' ';
-    n += 1;
-    write_u5(msgid as u32, &mut out[n..]);
-    n += 5;
-    out[n] = b' ';
-    n += 1;
-    out[n] = b'0' + (bitmap / 100) % 10;
-    out[n + 1] = b'0' + (bitmap / 10) % 10;
-    out[n + 2] = b'0' + bitmap % 10;
-    n += 3;
-    out[n] = b' ';
-    n += 1;
-    out[n] = b'0' + hop;
-    n += 1;
-    n
-}
-
-/// Parse a RELAYACK2 frame into `(target, msgid, bitmap, hop)`, or `None`.
-fn parse_relayack2(data: &[u8]) -> Option<(u8, u16, u8, u8)> {
-    let rest = data.strip_prefix(RELAYACK2_PREFIX)?;
-    // "TTT MMMMM BBB H" = 15 bytes (target 3, sp, msgid 5, sp, bitmap 3, sp, hop 1).
-    if rest.len() < 15 {
-        return None;
-    }
-    let target = parse_id(&rest[0..3])?;
-    let msgid = u16::try_from(parse_u5(&rest[4..9])?).ok()?;
-    let bitmap = parse_id(&rest[10..13])?;
-    if !rest[14].is_ascii_digit() {
-        return None;
-    }
-    let hop = rest[14] - b'0';
-    Some((target, msgid, bitmap, hop))
-}
-
-/// #13: the synthetic MAC a gateway keys a RELAY2 reassembly by — `00:00:00:00:00:<origin>`.
-/// Reassembly + late-retransmit dedup must key on the true SOURCE, but a RELAY2's `src_mac` is
-/// the LAST RELAY's MAC (changes per hop). The `origin` id (u8, stamped by the source, survives
-/// forwarding) maps into the existing `(src_mac, msgid)`-keyed `ReasmSlot`/`DONE_RING` tables
-/// WITHOUT collision: a real ESP32 STA MAC carries an Espressif OUI in its top bytes, never
-/// all-zero, so this synthetic key can never alias a single-hop leaf's real MAC.
-fn synth_origin_mac(origin: u8) -> [u8; 6] {
-    [0, 0, 0, 0, 0, origin]
-}
-
-// --- #13 Stage B downlink freshness codec (BATT2 / GRID2) ------------------
-
-/// Encode a downlink freshness frame `<prefix> + "SSSSSSSSSS " + <payload>` into `out`; returns
-/// length. `prefix` is `BATT2_PREFIX`/`GRID2_PREFIX`; `seq` is the 10-digit freshness (full u32,
-/// like TIME's `synced_at` — see [`write_u10`]); `payload` is the verbatim `BATT|…`/`GRID|…` bytes
-/// (truncated to `BATT_PAYLOAD_MAX`). Mirrors [`encode_time`]'s fixed-width discipline.
-fn encode_dl(prefix: &[u8], seq: u32, payload: &[u8], out: &mut [u8]) -> usize {
-    let mut n = 0;
-    out[..prefix.len()].copy_from_slice(prefix);
-    n += prefix.len();
-    write_u10(seq, &mut out[n..]);
-    n += 10;
-    out[n] = b' ';
-    n += 1;
-    let len = payload.len().min(BATT_PAYLOAD_MAX);
-    out[n..n + len].copy_from_slice(&payload[..len]);
-    n + len
-}
-
-/// Parse a downlink freshness frame with `prefix` into `(seq, payload)`, or `None`. `payload`
-/// borrows `data` (the verbatim `BATT|…`/`GRID|…` bytes after the 10-digit seq + its space). The
-/// caller validates the `BATT|`/`GRID|` marker (a stray frame can't wipe a good reading).
-fn parse_dl<'a>(prefix: &[u8], data: &'a [u8]) -> Option<(u32, &'a [u8])> {
-    let rest = data.strip_prefix(prefix)?;
-    // "SSSSSSSSSS " = 10 seq digits + a space, then the payload.
-    if rest.len() < 11 {
-        return None;
-    }
-    let seq = parse_u10(&rest[0..10])?;
-    Some((seq, &rest[11..]))
 }
 
 // -------------------------------------------------------------------------

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -152,8 +152,8 @@ const RELAYACK2_FRAME_MAX: usize = 40;
 /// propagate a stale payload or loop; single-hop gateway → neighbour leaves is
 /// the safe, intended shape. Same threat model as every SMOLv1 frame (unauthed).
 const BATT_PREFIX: &[u8] = b"SMOLv1 BATT "; // + verbatim "BATT|l1|l2|l3"
-/// Max BATT payload retained/echoed — matches `BattCache` (LOCKED ≤ 96 B).
-const BATT_PAYLOAD_MAX: usize = 96;
+// `BATT_PAYLOAD_MAX` (≤ 96 B, matches BattCache/GridCache) lives in `net::wire` (glob-imported) —
+// the codec's `encode_dl` truncates to it, and this module's trackers/buffers size to it.
 
 /// Grid-downlink tag (issue #16): the exact TWIN of [`BATT_PREFIX`] — the 12-B
 /// `"SMOLv1 GRID "` (trailing space) then the VERBATIM `smol/display/grid` payload
@@ -1268,9 +1268,8 @@ pub struct BenchStats {
 //     header + a loop-prevention seen-set + a shared-channel invariant across
 //     every node (+200-400 LOC). This is single-hop uplink only.
 
-/// Max telemetry payload per RELAY fragment (bytes). On the wire a frame is the
-/// fixed 27-byte ASCII header + this, comfortably under the 250 B ESP-NOW limit.
-const RELAY_CHUNK: usize = 64;
+// `RELAY_CHUNK` (64 B max telemetry payload per fragment) lives in `net::wire` (glob-imported) —
+// the codec truncates chunks to it, and this module's reassembly/tx offsets index by it.
 /// Max fragments per message. Kept <= 8 so the received-fragment bitmap is a
 /// single `u8`; => max reassembled telemetry = CHUNK * FRAGS bytes.
 const RELAY_MAX_FRAGS: usize = 4;

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -509,6 +509,10 @@ struct DiagCounters {
     fwd: u32,
     dedup: u32,
     ttl: u32,
+    /// #13 MESH-TEST rig ONLY: count of inbound frames dropped by the deaf-list (surfaced as
+    /// `ddrops=` in DIAG). A production build has no deaf-list, so this field doesn't exist.
+    #[cfg(feature = "mesh-test")]
+    ddrops: u32,
 }
 
 impl DiagCounters {
@@ -522,6 +526,8 @@ impl DiagCounters {
             fwd: 0,
             dedup: 0,
             ttl: 0,
+            #[cfg(feature = "mesh-test")]
+            ddrops: 0,
         }
     }
 }
@@ -1696,6 +1702,13 @@ pub struct RadioManager {
     /// still HELLO-scans when it is 0/stale/absent (the proven fallback). Sourced from `rx_control`,
     /// NOT the deliberately-sidestepped `esp_wifi_get_channel`.
     learned_channel: u8,
+    /// #13 MESH-TEST rig ONLY: MACs this board pretends it cannot hear. `service()` drops any
+    /// inbound frame from a listed source before it touches the roster/parse — a deterministic,
+    /// reproducible stand-in for physical RF attenuation that forces a 2-hop topology. Seeded
+    /// once from the per-board `board::DEAF_MACS`. Empty = normal. A production build has neither
+    /// this field nor the hook, so it can never be made deaf. See the `mesh-test` cargo feature.
+    #[cfg(feature = "mesh-test")]
+    deaf: [Option<[u8; 6]>; 4],
     /// #23 fix (oracle #1/#2): persistent staleness observation of the retained `MC`
     /// record — the last owner id + seq seen and when that pair was FIRST seen. A seq
     /// frozen past `MC_STALE_MS` marks the owner DEAD (takeover-able). Seeded into the
@@ -1848,6 +1861,8 @@ impl RadioManager {
             scan_locked: false,
             scan_idx: 0,
             learned_channel: 0, // #29: unknown until the first frame is heard
+            #[cfg(feature = "mesh-test")]
+            deaf: crate::board::DEAF_MACS, // #13 rig: baked per-board deaf-list (empty in prod)
 
             last_scan_hop_ms: 0,
             last_owner_heard_ms: 0,
@@ -2610,6 +2625,14 @@ impl RadioManager {
                 rec.push_str("|io=");
                 rec.push_str(io);
             }
+        }
+        // #13 MESH-TEST rig: surface the deaf-list state so a leftover entry is visible in HA at a
+        // glance (the anti-"won't-rejoin-ghost" guard) — `deaf` = active entries, `ddrops` = frames
+        // dropped by it. `mesh-test`-gated → the DIAG string is byte-identical on a production build.
+        #[cfg(feature = "mesh-test")]
+        {
+            let deaf_n = self.deaf.iter().flatten().count();
+            rec.push_str(&alloc::format!("|deaf={}|ddrops={}", deaf_n, self.diag.ddrops));
         }
         rec
     }
@@ -3961,6 +3984,15 @@ impl RadioManager {
             // eviction-immune and permanently burns a 16-slot LRU slot — the #28 ceiling too).
             // Drop our own frames before ANY handler (OTA dispatch + generic Frame parse below).
             if src == self.self_mac {
+                continue;
+            }
+            // #13 MESH-TEST rig: drop frames from a deaf-listed source BEFORE any handler
+            // (OTA dispatch, roster, parse) — a deterministic stand-in for "out of RF range"
+            // that forces a 2-hop topology. `ddrops` counts these so a leftover entry is
+            // visible in DIAG. Compiled out entirely in a production build (no `mesh-test`).
+            #[cfg(feature = "mesh-test")]
+            if self.deaf.iter().flatten().any(|m| *m == src) {
+                self.diag.ddrops = self.diag.ddrops.saturating_add(1);
                 continue;
             }
             // RSSI of this frame (dBm) from the ESP-NOW RX control info; used by

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -177,6 +177,22 @@ const GRID_PREFIX: &[u8] = b"SMOLv1 GRID "; // + verbatim "GRID|l1|l2|l3"
 /// Max GRID payload retained/echoed — matches `GridCache` (LOCKED ≤ 96 B).
 const GRID_PAYLOAD_MAX: usize = 96;
 
+/// #13 Stage B — downlink FRESHNESS tags. The v1 `BATT`/`GRID` frames carry NO freshness
+/// field (a locked no-length-byte memcpy — a header can't be inserted), so a relay can't tell
+/// new data from a replay and downlink stays single-hop. `BATT2`/`GRID2` prepend a 10-digit
+/// monotonic `dl_seq` (the gateway's unix-second of the last VALUE CHANGE — survives a gateway
+/// reboot + never wraps, exactly like `TIME`'s `synced_at`): a node adopts + RE-FLOODS only a
+/// STRICTLY-NEWER `dl_seq` (the `TIME` strict-newer template), so downlink reaches a stranded
+/// leaf via a relay AND an older/replayed frame is dropped (no loop). `BATT2` diverges from
+/// `BATT` at byte 11 (`'2'` vs `' '`) and from `GRID2` at byte 7, so `strip_prefix` never
+/// confuses them. NEW tags: an old node `classify()`s them to `None` (harmless) — the same
+/// fleet-flash / no-flag-day discipline as `RELAY2`.
+const BATT2_PREFIX: &[u8] = b"SMOLv1 BATT2 "; // + "SSSSSSSSSS " + verbatim "BATT|…"
+const GRID2_PREFIX: &[u8] = b"SMOLv1 GRID2 "; // + "SSSSSSSSSS " + verbatim "GRID|…"
+/// Max BATT2/GRID2 frame on the wire: 13-B prefix + 10-digit `dl_seq` + space + ≤96-B payload
+/// = ≤120; 128 leaves headroom. Sizes the emit stack buffer.
+const DL_FRAME_MAX: usize = 128;
+
 /// #21/#56 leaf-relay config-downlink tag: `"SMOLv1 CFG "` (11 B, trailing space) then
 /// `"NNN"` (3-ASCII zero-padded TARGET leaf id), then a 1-byte config `KEY` (#56), then
 /// the VERBATIM value for that channel (empty = clear). Diverges from HELLO/BATT/GRID/
@@ -462,6 +478,12 @@ enum Frame<'a> {
     /// A grid-downlink payload from a gateway (issue #16): the verbatim `GRID|…`
     /// bytes (twin of `Batt`; copied into `GridTracker` in `service`).
     Grid(&'a [u8]),
+    /// #13 Stage B: a battery downlink carrying a monotonic freshness `seq` (the gateway's
+    /// unix-second of the last value change). A node adopts + re-floods only a STRICTLY-NEWER
+    /// `seq`; `payload` is the verbatim `BATT|…` bytes (borrows the RX buffer).
+    Batt2 { seq: u32, payload: &'a [u8] },
+    /// #13 Stage B: the grid twin of [`Frame::Batt2`].
+    Grid2 { seq: u32, payload: &'a [u8] },
     /// #21/#56 leaf-relay: a gateway's keyed CONFIG downlink — `target` leaf id, the config
     /// channel `key` (`S`=screen/…), + the verbatim `value` bytes (`value` borrows the RX
     /// buffer; the leaf buffers it per-key in `CfgTracker` in `service` IFF `target ==
@@ -671,11 +693,14 @@ struct BattTracker {
     buf: [u8; BATT_PAYLOAD_MAX],
     len: usize,
     have: bool,
+    /// #13 Stage B: the freshness `seq` of the last-adopted BATT2 (0 = none / v1 BATT only). A
+    /// higher `seq` is strictly newer; drives the strict-newer adopt + relay re-flood decision.
+    dl_seq: u32,
 }
 
 impl BattTracker {
     const fn new() -> Self {
-        Self { buf: [0; BATT_PAYLOAD_MAX], len: 0, have: false }
+        Self { buf: [0; BATT_PAYLOAD_MAX], len: 0, have: false, dl_seq: 0 }
     }
 
     /// Buffer a freshly-received payload (truncated to capacity; ≤ 96 B by spec).
@@ -684,6 +709,19 @@ impl BattTracker {
         self.buf[..n].copy_from_slice(&payload[..n]);
         self.len = n;
         self.have = true;
+    }
+
+    /// #13 Stage B: adopt a BATT2 payload IFF its `seq` is STRICTLY NEWER than the last adopted
+    /// (the `TIME` strict-newer template). Returns true if adopted → the caller re-floods it.
+    /// A first sight always adopts (so a stranded leaf catches up); a same/older `seq` is a
+    /// replay/echo → dropped (bounds the flood, no loop).
+    fn set_fresh(&mut self, payload: &[u8], seq: u32) -> bool {
+        if self.have && seq <= self.dl_seq {
+            return false;
+        }
+        self.set(payload);
+        self.dl_seq = seq;
+        true
     }
 }
 
@@ -703,11 +741,13 @@ struct GridTracker {
     buf: [u8; GRID_PAYLOAD_MAX],
     len: usize,
     have: bool,
+    /// #13 Stage B: freshness `seq` of the last-adopted GRID2 (twin of `BattTracker::dl_seq`).
+    dl_seq: u32,
 }
 
 impl GridTracker {
     const fn new() -> Self {
-        Self { buf: [0; GRID_PAYLOAD_MAX], len: 0, have: false }
+        Self { buf: [0; GRID_PAYLOAD_MAX], len: 0, have: false, dl_seq: 0 }
     }
 
     /// Buffer a freshly-received payload (truncated to capacity; ≤ 96 B by spec).
@@ -717,6 +757,16 @@ impl GridTracker {
         self.len = n;
         self.have = true;
     }
+
+    /// #13 Stage B: strict-newer adopt + re-flood decision (twin of `BattTracker::set_fresh`).
+    fn set_fresh(&mut self, payload: &[u8], seq: u32) -> bool {
+        if self.have && seq <= self.dl_seq {
+            return false;
+        }
+        self.set(payload);
+        self.dl_seq = seq;
+        true
+    }
 }
 
 /// A `Copy` snapshot of a buffered GRID payload handed to `main` by
@@ -725,6 +775,38 @@ impl GridTracker {
 pub struct GridOffer {
     pub buf: [u8; GRID_PAYLOAD_MAX],
     pub len: usize,
+}
+
+/// #13 Stage B GATEWAY-origin state for ONE downlink channel (BATT2 or GRID2): the last payload
+/// broadcast + the freshness `seq` assigned to it. `broadcast_batt`/`broadcast_grid` bump `seq`
+/// to the gateway's current unix-second ONLY when the payload CHANGES, so an unchanged periodic
+/// re-broadcast keeps the same `seq` (relays don't re-flood it) while a genuine new value floods
+/// once. Fixed `.bss`, no heap. Only a gateway writes it (a leaf never originates downlink).
+struct DlOrigin {
+    seq: u32,
+    last: [u8; BATT_PAYLOAD_MAX], // BATT_PAYLOAD_MAX == GRID_PAYLOAD_MAX (96); reused for both
+    len: usize,
+}
+
+impl DlOrigin {
+    const fn new() -> Self {
+        Self { seq: 0, last: [0; BATT_PAYLOAD_MAX], len: 0 }
+    }
+
+    /// The freshness `seq` to stamp on `payload`. On a CHANGE, bump to `now_unix` but never below
+    /// `seq+1` — so the seq is strictly monotonic across changes even if the clock is unsynced
+    /// (small `now_unix`) or two changes land in the same second, yet tracks wall-time so it
+    /// survives a gateway reboot (a post-reboot `now_unix` outranks any pre-reboot seq a leaf holds).
+    fn seq_for(&mut self, payload: &[u8], now_unix: u32) -> u32 {
+        let n = payload.len().min(BATT_PAYLOAD_MAX);
+        let changed = n != self.len || self.last[..n] != payload[..n];
+        if changed {
+            self.seq = now_unix.max(self.seq.saturating_add(1));
+            self.last[..n].copy_from_slice(&payload[..n]);
+            self.len = n;
+        }
+        self.seq
+    }
 }
 
 /// #21/#56 leaf-relay: buffers the most-recent inbound `SMOLv1 CFG` value that targeted
@@ -1630,6 +1712,11 @@ pub struct RadioManager {
     /// Twin of `batt` (issue #16): most-recent inbound SMOLv1 GRID payload, buffered
     /// for `main` to store into its `GridCache`.
     grid: GridTracker,
+    /// #13 Stage B: GATEWAY-origin freshness state for the BATT2/GRID2 downlink — assigns the
+    /// monotonic `dl_seq` (bumped only on a value change) so relays re-flood strictly-newer data.
+    /// Inert on a leaf (a leaf never originates downlink; it adopts via the trackers above).
+    dl_batt: DlOrigin,
+    dl_grid: DlOrigin,
     /// #21/#56 leaf-relay (LEAF side): most-recent inbound `SMOLv1 CFG` value PER config
     /// key that targeted THIS leaf, buffered for `main` to apply via `take_cfg_offer(key)`.
     cfg: CfgTracker,
@@ -1842,6 +1929,8 @@ impl RadioManager {
             roster: Roster::new(),
             batt: BattTracker::new(),
             grid: GridTracker::new(),
+            dl_batt: DlOrigin::new(),
+            dl_grid: DlOrigin::new(),
             cfg: CfgTracker::new(),
             cfg_cache: crate::net::wifi::CfgCache::new(),
             stat_cache: crate::net::wifi::CfgCache::new(),
@@ -2279,18 +2368,18 @@ impl RadioManager {
 
     // --- Battery downlink relay (see the BATT_PREFIX + BattTracker sections) ---
 
-    /// Broadcast one SMOLv1 BATT frame: the 12-B tag + the verbatim `BATT|…`
-    /// `payload` (byte-for-byte the gateway's `BattCache`). GATEWAY-ONLY by
-    /// convention — `main` calls this on a slow cadence while `is_gateway` and the
-    /// cache is non-empty, so neighbour leaves fill their own cache. No length byte
-    /// (payload is the rest of the frame); safe in either radio mode.
-    pub fn broadcast_batt(&mut self, payload: &[u8]) {
-        // 12-B tag + ≤ 96-B payload = ≤ 108 B, well under the 250-B ESP-NOW limit.
-        let mut msg = [0u8; BATT_PREFIX.len() + BATT_PAYLOAD_MAX];
-        msg[..BATT_PREFIX.len()].copy_from_slice(BATT_PREFIX);
-        let n = payload.len().min(BATT_PAYLOAD_MAX);
-        msg[BATT_PREFIX.len()..BATT_PREFIX.len() + n].copy_from_slice(&payload[..n]);
-        self.send_to(&BROADCAST_ADDRESS, &msg[..BATT_PREFIX.len() + n]);
+    /// #13 Stage B: broadcast the battery downlink as a `SMOLv1 BATT2` frame — the tag + a
+    /// 10-digit freshness `dl_seq` + the verbatim `BATT|…` `payload` (byte-for-byte the gateway's
+    /// `BattCache`). GATEWAY-ONLY — `main` calls this on a slow cadence while `is_gateway` + the
+    /// cache is non-empty, passing the gateway's current `now_unix`. The `dl_seq` is bumped only
+    /// when the payload CHANGES (see [`DlOrigin::seq_for`]), so an unchanged periodic re-broadcast
+    /// isn't re-flooded by relays while a genuine new value floods to stranded leaves once.
+    /// (Supersedes the v1 single-hop `BATT` send; leaves still PARSE v1 `BATT` from an old gateway.)
+    pub fn broadcast_batt(&mut self, payload: &[u8], now_unix: u32) {
+        let seq = self.dl_batt.seq_for(payload, now_unix);
+        let mut msg = [0u8; DL_FRAME_MAX];
+        let len = encode_dl(BATT2_PREFIX, seq, payload, &mut msg);
+        self.send_to(&BROADCAST_ADDRESS, &msg[..len]);
     }
 
     /// Take the buffered inbound BATT payload (if any), clearing it. `main` stores
@@ -2306,17 +2395,16 @@ impl RadioManager {
         }
     }
 
-    /// Broadcast one SMOLv1 GRID frame — the exact TWIN of [`broadcast_batt`]
-    /// (issue #16). GATEWAY-ONLY by convention (`main` gates on `is_gateway` + a
-    /// non-empty cache); 12-B tag + verbatim `GRID|…` payload, no length byte.
+    /// #13 Stage B: broadcast the grid downlink as a `SMOLv1 GRID2` frame — the exact TWIN of
+    /// [`broadcast_batt`] (issue #16): tag + 10-digit `dl_seq` + verbatim `GRID|…` payload, seq
+    /// bumped only on a value change. GATEWAY-ONLY.
     ///
     /// [`broadcast_batt`]: RadioManager::broadcast_batt
-    pub fn broadcast_grid(&mut self, payload: &[u8]) {
-        let mut msg = [0u8; GRID_PREFIX.len() + GRID_PAYLOAD_MAX];
-        msg[..GRID_PREFIX.len()].copy_from_slice(GRID_PREFIX);
-        let n = payload.len().min(GRID_PAYLOAD_MAX);
-        msg[GRID_PREFIX.len()..GRID_PREFIX.len() + n].copy_from_slice(&payload[..n]);
-        self.send_to(&BROADCAST_ADDRESS, &msg[..GRID_PREFIX.len() + n]);
+    pub fn broadcast_grid(&mut self, payload: &[u8], now_unix: u32) {
+        let seq = self.dl_grid.seq_for(payload, now_unix);
+        let mut msg = [0u8; DL_FRAME_MAX];
+        let len = encode_dl(GRID2_PREFIX, seq, payload, &mut msg);
+        self.send_to(&BROADCAST_ADDRESS, &msg[..len]);
     }
 
     /// Take the buffered inbound GRID payload (if any), clearing it. Twin of
@@ -2576,7 +2664,7 @@ impl RadioManager {
         // score P2/P3; `fwd == 0` fleet-wide is the C0 all-hear byte-identical canary).
         let mesh_hop = if self.relay.latch.latched() { crate::net::flood::MAX_HOP } else { 1 };
         let mut rec = alloc::format!(
-            "DIAG|slot={}|rst={}|boot={}|ota={}|up={}|heap={}|hmin={}|btn={}|btnl={}|fok={}|ffl={}|vok={}|vfl={}|loss={}|rtt={}|rx={}|tx={}|led={}:{}|tage={}|tsrc={}|net={}:{}|brk={}|otah={}|fwd={}|dedup={}|ttl={}|hop={}",
+            "DIAG|slot={}|rst={}|boot={}|ota={}|up={}|heap={}|hmin={}|btn={}|btnl={}|fok={}|ffl={}|vok={}|vfl={}|loss={}|rtt={}|rx={}|tx={}|led={}:{}|tage={}|tsrc={}|net={}:{}|brk={}|otah={}|fwd={}|dedup={}|ttl={}|hop={}|dlseq={}",
             d.boot_slot,
             d.reset_reason,
             d.boot_count,
@@ -2606,6 +2694,10 @@ impl RadioManager {
             self.diag.dedup,
             self.diag.ttl,
             mesh_hop,
+            // #13 Stage B: the leaf's last-adopted BATT2 downlink freshness (rig P4 watches this
+            // stay unchanged when an older/replayed dl_seq is dropped). 0 on a gateway (source) or
+            // a v1-only leaf. Representative of the downlink channel; GRID2 uses the same mechanism.
+            self.batt.dl_seq,
         );
         // #74 item 3 (stage-2): fold in the APPLIED-config string for HA config-drift, ONLY when
         // `main` populated it (espnow build). ASCII by construction (as_wire/to_wire/hex/F24). HA
@@ -4297,6 +4389,45 @@ impl RadioManager {
                     self.roster.heard(src, None, rssi, now);
                     label = Some(alloc::string::String::from("grid"));
                 }
+                Some(Frame::Batt2 { seq, payload }) => {
+                    // #13 Stage B: a freshness-stamped battery downlink. A LEAF adopts + RE-FLOODS
+                    // it ONLY when strictly newer than what it holds (the TIME strict-newer template)
+                    // — that both bounds the flood (a replay/echo is dropped, no loop) and carries a
+                    // genuinely-new value one hop further toward a stranded leaf. A GATEWAY ignores
+                    // inbound downlink entirely: it IS the source (its `BattCache` comes from HA), so
+                    // it must never adopt a mesh value back into its own cache. Only a well-formed
+                    // `BATT|` is kept (a stray frame can't wipe a good reading).
+                    self.peers.last_hello_ms = now;
+                    self.roster.heard(src, None, rssi, now);
+                    if !self.relay.is_gateway
+                        && payload.starts_with(b"BATT|")
+                        && self.batt.set_fresh(payload, seq)
+                    {
+                        // Re-broadcast the SAME frame verbatim (payload + seq). `payload` borrows the
+                        // RX buffer; it's copied into the local frame buffer before the &mut-self send.
+                        let mut fb = [0u8; DL_FRAME_MAX];
+                        let len = encode_dl(BATT2_PREFIX, seq, payload, &mut fb);
+                        self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
+                        log::info!("smol: BATT2 seq {} adopted + reflooded", seq);
+                    }
+                    label = Some(alloc::format!("batt2 {}", seq));
+                }
+                Some(Frame::Grid2 { seq, payload }) => {
+                    // #13 Stage B: the grid twin of the Batt2 arm — leaf adopts + re-floods strictly
+                    // newer; gateway ignores (it's the source).
+                    self.peers.last_hello_ms = now;
+                    self.roster.heard(src, None, rssi, now);
+                    if !self.relay.is_gateway
+                        && payload.starts_with(b"GRID|")
+                        && self.grid.set_fresh(payload, seq)
+                    {
+                        let mut fb = [0u8; DL_FRAME_MAX];
+                        let len = encode_dl(GRID2_PREFIX, seq, payload, &mut fb);
+                        self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
+                        log::info!("smol: GRID2 seq {} adopted + reflooded", seq);
+                    }
+                    label = Some(alloc::format!("grid2 {}", seq));
+                }
                 Some(Frame::Cfg { target, key, value }) => {
                     // #21/#56 leaf-relay: a gateway's keyed CONFIG downlink. Target-filter
                     // FIRST — buffer if addressed to US (`self.id`) OR to the #43 broadcast
@@ -4730,6 +4861,14 @@ fn parse_frame(data: &[u8]) -> Option<Frame<'_>> {
         // Twin of BATT (issue #16): the rest is the verbatim `GRID|…` payload.
         return Some(Frame::Grid(rest));
     }
+    // #13 Stage B freshness variants. Exclusive from BATT/GRID (the `2` at byte 11 vs the
+    // trailing space), so order is moot; kept adjacent to their base tag.
+    if let Some((seq, payload)) = parse_dl(BATT2_PREFIX, data) {
+        return Some(Frame::Batt2 { seq, payload });
+    }
+    if let Some((seq, payload)) = parse_dl(GRID2_PREFIX, data) {
+        return Some(Frame::Grid2 { seq, payload });
+    }
     if let Some(rest) = data.strip_prefix(CFG_PREFIX) {
         // #21/#56 leaf-relay: "NNN<KEY><value>" — 3-ASCII target id, a 1-byte config KEY,
         // then the verbatim value (to end-of-frame; empty = clear that key). `parse_id`
@@ -5011,6 +5150,38 @@ fn parse_relayack2(data: &[u8]) -> Option<(u8, u16, u8, u8)> {
 /// all-zero, so this synthetic key can never alias a single-hop leaf's real MAC.
 fn synth_origin_mac(origin: u8) -> [u8; 6] {
     [0, 0, 0, 0, 0, origin]
+}
+
+// --- #13 Stage B downlink freshness codec (BATT2 / GRID2) ------------------
+
+/// Encode a downlink freshness frame `<prefix> + "SSSSSSSSSS " + <payload>` into `out`; returns
+/// length. `prefix` is `BATT2_PREFIX`/`GRID2_PREFIX`; `seq` is the 10-digit freshness (full u32,
+/// like TIME's `synced_at` — see [`write_u10`]); `payload` is the verbatim `BATT|…`/`GRID|…` bytes
+/// (truncated to `BATT_PAYLOAD_MAX`). Mirrors [`encode_time`]'s fixed-width discipline.
+fn encode_dl(prefix: &[u8], seq: u32, payload: &[u8], out: &mut [u8]) -> usize {
+    let mut n = 0;
+    out[..prefix.len()].copy_from_slice(prefix);
+    n += prefix.len();
+    write_u10(seq, &mut out[n..]);
+    n += 10;
+    out[n] = b' ';
+    n += 1;
+    let len = payload.len().min(BATT_PAYLOAD_MAX);
+    out[n..n + len].copy_from_slice(&payload[..len]);
+    n + len
+}
+
+/// Parse a downlink freshness frame with `prefix` into `(seq, payload)`, or `None`. `payload`
+/// borrows `data` (the verbatim `BATT|…`/`GRID|…` bytes after the 10-digit seq + its space). The
+/// caller validates the `BATT|`/`GRID|` marker (a stray frame can't wipe a good reading).
+fn parse_dl<'a>(prefix: &[u8], data: &'a [u8]) -> Option<(u32, &'a [u8])> {
+    let rest = data.strip_prefix(prefix)?;
+    // "SSSSSSSSSS " = 10 seq digits + a space, then the payload.
+    if rest.len() < 11 {
+        return None;
+    }
+    let seq = parse_u10(&rest[0..10])?;
+    Some((seq, &rest[11..]))
 }
 
 // -------------------------------------------------------------------------

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -131,6 +131,27 @@ const TIME_PREFIX: &[u8] = b"SMOLv1 TIME "; // + "NNN UUUUUUUUUU SSSSSSSSSS"
 /// (`"SMOLv1 RELAY "[12]` is ' ' where RELAYACK has 'A'), so match order is moot.
 const RELAY_PREFIX: &[u8] = b"SMOLv1 RELAY "; // + "NNN MMMMM F C " + chunk
 const RELAYACK_PREFIX: &[u8] = b"SMOLv1 RELAYACK "; // + "MMMMM BBB"
+/// #13 multi-hop uplink tags (see the "#13 routed multi-hop mesh" section below +
+/// `net/flood.rs`). A frame is byte-identical to today UNLESS a leaf is genuinely
+/// stranded (can't reach the gateway directly), so these tags appear ONLY when a hop
+/// count ≥ 2 is actually needed. Both are NEW tags (not an append to RELAY/RELAYACK,
+/// whose headers are fixed-offset): a stranded leaf emits `RELAY2` (hop-limited,
+/// origin-stamped) and a relay re-broadcasts it; the gateway floods `RELAYACK2` back
+/// (R1 table-free ACK). An OLD firmware `classify()`s both to `None` (harmless text) —
+/// it can't relay anyway — so no flag-day flash and no rolling-upgrade regression:
+/// a leaf that needs hop ≥ 2 was, by definition, out of direct gateway range, i.e.
+/// already stranded pre-#13. `RELAY2` diverges from `RELAY` at byte 12 (`'2'` vs `' '`)
+/// and `RELAYACK2` from `RELAYACK` at byte 15 (`'2'` vs `' '`), so `strip_prefix` never
+/// confuses the base tag with its multi-hop variant regardless of match order.
+const RELAY2_PREFIX: &[u8] = b"SMOLv1 RELAY2 "; // + "OOO MMMMM H F C " + chunk
+const RELAYACK2_PREFIX: &[u8] = b"SMOLv1 RELAYACK2 "; // + "TTT MMMMM BBB H"
+/// Max RELAY2 frame length on the wire (30-byte header + full chunk); sizes stack buffers.
+/// Header = 14-byte prefix + "OOO MMMMM H F C " (16) = 30, vs RELAY's 27 (the extra 3 =
+/// the origin↔src split's `H ` hop field; `OOO` is the ORIGIN id, distinct from the
+/// re-broadcasting relay's own src MAC).
+const RELAY2_FRAME_MAX: usize = 30 + RELAY_CHUNK;
+/// Max RELAYACK2 frame length ("SMOLv1 RELAYACK2 " + "TTT MMMMM BBB H" = 32); rounded up.
+const RELAYACK2_FRAME_MAX: usize = 40;
 /// Battery-downlink tag: the 12-B `"SMOLv1 BATT "` (trailing space, mirroring TIME)
 /// then the VERBATIM `smol/display/batt` payload INCLUDING its `BATT|` marker
 /// (e.g. `SMOLv1 BATT BATT|48V 52.8V|HV 391.9V|d 43mV`). NO length byte — the
@@ -417,6 +438,24 @@ enum Frame<'a> {
     /// A gateway's acknowledgement of a relay message: the `msgid` and the u8
     /// bitmap of fragments received so far, so the leaf resends only the gaps.
     RelayAck { msgid: u16, bitmap: u8 },
+    /// #13 multi-hop: one fragment of a STRANDED leaf's telemetry uplink, carrying the
+    /// true `origin` id (stamped by the source, survives forwarding — unlike `src_mac`,
+    /// which is the last relay) and a hop-limit `hop` (decremented at each forward,
+    /// dropped at ≤ 1 by a non-gateway). Otherwise identical to `Relay`. `chunk` borrows
+    /// the RX buffer. Emitted only by an escalated leaf + re-broadcast by relays.
+    Relay2 {
+        origin: u8,
+        msgid: u16,
+        hop: u8,
+        frag: u8,
+        count: u8,
+        chunk: &'a [u8],
+    },
+    /// #13 multi-hop: the gateway's flooded-back ACK for a `Relay2` message (R1,
+    /// table-free) — `target` = the origin leaf to ACK, `msgid` + `bitmap` as `RelayAck`,
+    /// plus a `hop` limit so relays flood it back the same 2-hop distance. Loop-safety
+    /// rides the hop decrement (MAX_HOP=2), not a seen-set.
+    RelayAck2 { target: u8, msgid: u16, bitmap: u8, hop: u8 },
     /// A battery-downlink payload from a gateway: the verbatim `BATT|…` bytes
     /// (`payload` borrows the RX buffer; copied into `BattTracker` in `service`).
     Batt(&'a [u8]),
@@ -462,6 +501,14 @@ struct DiagCounters {
     /// (OTA verify ok/fail is read live from `OtaLeafSession`, not mirrored here.)
     flush_ok: u32,
     flush_fail: u32,
+    /// #13 multi-hop mesh counters (surfaced as `fwd=`/`dedup=`/`ttl=` in the DIAG record; the
+    /// rig scores P2/P3 off them, and the C0 byte-identical canary is exactly `fwd == 0` on every
+    /// node across a normal all-hear window). `fwd` = inbound `RELAY2` frames this node re-broadcast;
+    /// `dedup` = `RELAY2` frames dropped as already-seen `(origin,msgid,frag)`; `ttl` = `RELAY2`
+    /// frames dropped for an exhausted hop budget. All stay 0 in the single-hop / all-hear case.
+    fwd: u32,
+    dedup: u32,
+    ttl: u32,
 }
 
 impl DiagCounters {
@@ -472,6 +519,9 @@ impl DiagCounters {
             btnl: 0,
             flush_ok: 0,
             flush_fail: 0,
+            fwd: 0,
+            dedup: 0,
+            ttl: 0,
         }
     }
 }
@@ -1158,8 +1208,6 @@ const RELAY_MAX_FRAGS: usize = 4;
 /// Max reassembled message length (bytes) = 256. A leaf truncates telemetry to
 /// this (documented) — this is SHORT-telemetry relay, not bulk transfer.
 const RELAY_MAX_MSG: usize = RELAY_CHUNK * RELAY_MAX_FRAGS;
-/// Max RELAY frame length on the wire (header + full chunk); sizes stack buffers.
-const RELAY_FRAME_MAX: usize = 27 + RELAY_CHUNK;
 /// Max RELAYACK frame length ("SMOLv1 RELAYACK " + "MMMMM BBB" = 25); rounded up.
 const RELAYACK_FRAME_MAX: usize = 32;
 /// Concurrent (src_mac, msgid) reassemblies a gateway tracks. Bounded table.
@@ -1174,6 +1222,11 @@ const RELAY_STALE_MS: u64 = 10_000;
 const RELAY_EMIT_INTERVAL_MS: u64 = 15_000;
 /// Leaf waits this long for a fuller RELAYACK before retransmitting the gaps.
 const RELAY_RETX_MS: u64 = 2_000;
+/// #13 un-latch Gate A: a latched (stranded) leaf only fires an `H=1` direct probe while
+/// the elected owner's HELLO is being heard THIS recently — proof the downlink is back.
+/// ~3× the ~2 s HELLO cadence, so one dropped HELLO doesn't falsely read as "still
+/// stranded", but a genuinely deaf leaf never wastes probe airtime.
+const RELAY_DOWNLINK_FRESH_MS: u64 = 6_000;
 /// Gateway flushes its queue this often (if non-empty), or at once when full.
 const RELAY_FLUSH_INTERVAL_MS: u64 = 30_000;
 /// After this many CONSECUTIVE failed flushes, shed the OLDEST queued message on
@@ -1273,10 +1326,15 @@ struct RelayTx {
     active: bool,
     msgid: u16,
     count: u8,
-    acked: u8, // fragments the gateway has confirmed (from RELAYACK)
+    acked: u8, // fragments the gateway has confirmed (from RELAYACK / RELAYACK2)
     tries: u8,
     total_len: usize,
     last_ms: u64,
+    /// #13: the hop-limit this message was ORIGINATED at (chosen once per emit from the
+    /// `HopLatch`): `1` ⇒ plain `RELAY` (the byte-identical single-hop / probe case),
+    /// `MAX_HOP` ⇒ `RELAY2`. Retransmits re-encode with the SAME framing so a message's
+    /// gaps stay on the wire form it started on.
+    hop: u8,
     buf: [u8; RELAY_MAX_MSG],
 }
 
@@ -1290,6 +1348,7 @@ impl RelayTx {
             tries: 0,
             total_len: 0,
             last_ms: 0,
+            hop: 1,
             buf: [0; RELAY_MAX_MSG],
         }
     }
@@ -1315,6 +1374,16 @@ struct Relay {
     /// retransmits so a message is never enqueued (UDP-delivered) twice (finding 3).
     done: [Option<([u8; 6], u16)>; DONE_RING],
     done_cursor: usize,
+    /// #13 relay-role: the `(origin, msgid, frag)` loop/dup guard for FORWARDING inbound
+    /// `RELAY2` frames. Only a NON-gateway consults it (the gateway reassembles + dedups
+    /// via its own `reasm`/`done`, so it never marks a frame "seen" — else a lost-ACK
+    /// retransmit would be dropped before it could be re-ACKed). See `net/flood.rs`.
+    seen: crate::net::flood::SeenSet,
+    /// #13 leaf-role: the single-hop⇄multi-hop escalation state machine. Stays inert
+    /// (single-hop, byte-identical) until this leaf's telemetry goes fully un-ACKed
+    /// (`relay_retransmit` exhaust) — then it latches `RELAY2` at `MAX_HOP` and probes
+    /// its way back down. See `net/flood.rs`.
+    latch: crate::net::flood::HopLatch,
 }
 
 impl Relay {
@@ -1330,6 +1399,8 @@ impl Relay {
             flush_fails: 0,
             done: [None; DONE_RING],
             done_cursor: 0,
+            seen: crate::net::flood::SeenSet::new(),
+            latch: crate::net::flood::HopLatch::new(),
         }
     }
 
@@ -2484,8 +2555,13 @@ impl RadioManager {
             _ => "baked",
         };
         let otah = if net.ota_host.is_some() { "ovr" } else { "slot" };
+        // #13: this leaf's CURRENT origin hop — 1 = single-hop (normal / byte-identical),
+        // MAX_HOP = escalated (stranded, emitting RELAY2). A gateway never originates, so it
+        // reads 1. Surfaced so the rig sees a leaf latch/un-latch (and `fwd`/`dedup`/`ttl`
+        // score P2/P3; `fwd == 0` fleet-wide is the C0 all-hear byte-identical canary).
+        let mesh_hop = if self.relay.latch.latched() { crate::net::flood::MAX_HOP } else { 1 };
         let mut rec = alloc::format!(
-            "DIAG|slot={}|rst={}|boot={}|ota={}|up={}|heap={}|hmin={}|btn={}|btnl={}|fok={}|ffl={}|vok={}|vfl={}|loss={}|rtt={}|rx={}|tx={}|led={}:{}|tage={}|tsrc={}|net={}:{}|brk={}|otah={}",
+            "DIAG|slot={}|rst={}|boot={}|ota={}|up={}|heap={}|hmin={}|btn={}|btnl={}|fok={}|ffl={}|vok={}|vfl={}|loss={}|rtt={}|rx={}|tx={}|led={}:{}|tage={}|tsrc={}|net={}:{}|brk={}|otah={}|fwd={}|dedup={}|ttl={}|hop={}",
             d.boot_slot,
             d.reset_reason,
             d.boot_count,
@@ -2511,6 +2587,10 @@ impl RadioManager {
             net_fb,
             brk,
             otah,
+            self.diag.fwd,
+            self.diag.dedup,
+            self.diag.ttl,
+            mesh_hop,
         );
         // #74 item 3 (stage-2): fold in the APPLIED-config string for HA config-drift, ONLY when
         // `main` populated it (espnow build). ASCII by construction (as_wire/to_wire/hex/F24). HA
@@ -2770,6 +2850,30 @@ impl RadioManager {
                 || now.saturating_sub(self.relay.last_emit_ms) >= RELAY_EMIT_INTERVAL_MS)
     }
 
+    /// #13: emit ONE fragment of OUR OWN uplink at the message's chosen framing.
+    /// `hop <= 1` → plain `RELAY` (the byte-identical single-hop case AND the `H=1`
+    /// un-latch probe); `hop > 1` → `RELAY2` (origin-stamped, hop-limited, forwarded by
+    /// relays). The chunk is copied into a LOCAL frame buffer BEFORE `send_to`, so no
+    /// borrow of `self.relay` is held across the `&mut self` send.
+    fn relay_send_frag(&mut self, msgid: u16, hop: u8, frag: u8, count: u8, off: usize, end: usize) {
+        let mut fb = [0u8; RELAY2_FRAME_MAX];
+        let len = if hop <= 1 {
+            encode_relay(self.id, msgid, frag, count, &self.relay.tx.buf[off..end], &mut fb)
+        } else {
+            encode_relay2(self.id, msgid, hop, frag, count, &self.relay.tx.buf[off..end], &mut fb)
+        };
+        self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
+    }
+
+    /// #13 gateway: flood a RELAYACK2 back toward the stranded `target` origin (R1,
+    /// table-free) at `MAX_HOP`, so a relay carries it the same distance the RELAY2 came.
+    /// Broadcast (the origin isn't directly reachable — that's why it's stranded).
+    fn flood_relayack2(&mut self, target: u8, msgid: u16, bitmap: u8) {
+        let mut fb = [0u8; RELAYACK2_FRAME_MAX];
+        let len = encode_relayack2(target, msgid, bitmap, crate::net::flood::MAX_HOP, &mut fb);
+        self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
+    }
+
     /// Leaf only: fragment `telemetry` into RELAY frames and BROADCAST them all,
     /// staging the message for bounded retransmit. No-op on a gateway.
     pub fn relay_emit(&mut self, telemetry: &[u8], now: u64) {
@@ -2781,18 +2885,29 @@ impl RadioManager {
             return;
         }
         self.relay.last_emit_ms = now;
+        // #13: pick this message's framing from the escalation latch. `downlink_up` = the
+        // elected owner's HELLO is being heard DIRECTLY + fresh (Gate A: only probe back
+        // toward single-hop when the downlink is demonstrably alive — else we KNOW we're
+        // still stranded, so don't waste probe airtime). `should_probe` is a no-op unless
+        // latched, so the non-escalated path emits plain `RELAY` (hop 1) = byte-identical.
+        let downlink_up = self.owner_hello_seen
+            && now.saturating_sub(self.last_owner_heard_ms) < RELAY_DOWNLINK_FRESH_MS;
+        let is_probe = self.relay.latch.should_probe(downlink_up);
+        let hop = self.relay.latch.origin_hop(is_probe);
+        self.relay.tx.hop = hop;
         let (msgid, total_len) = (self.relay.tx.msgid, self.relay.tx.total_len);
         for frag in 0..count {
             let off = frag as usize * RELAY_CHUNK;
             let end = (off + RELAY_CHUNK).min(total_len);
-            // Encode into a LOCAL frame buffer (copying the chunk out of tx.buf)
-            // BEFORE send_to, so no borrow of self.relay is held across the
-            // &mut-self send call.
-            let mut fb = [0u8; RELAY_FRAME_MAX];
-            let len = encode_relay(self.id, msgid, frag, count, &self.relay.tx.buf[off..end], &mut fb);
-            self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
+            self.relay_send_frag(msgid, hop, frag, count, off, end);
         }
-        log::info!("smol: relay emit msgid {} ({} frag)", msgid, count);
+        log::info!(
+            "smol: relay emit msgid {} ({} frag) hop {}{}",
+            msgid,
+            count,
+            hop,
+            if is_probe { " probe" } else { "" }
+        );
     }
 
     /// Leaf only: retransmit the fragments still unacked, bounded to
@@ -2807,17 +2922,31 @@ impl RadioManager {
             return;
         }
         if self.relay.tx.tries >= RELAY_MAX_TRIES {
+            // #13 escalation / un-latch hook: this message is out of tries.
+            if self.relay.latch.latched() && self.relay.tx.hop <= 1 {
+                // A latched leaf emitting at hop 1 was firing an un-latch PROBE — its failure
+                // means the direct uplink is still down, so RESET the un-latch streak but stay
+                // latched (multi-hop keeps carrying telemetry). Distinct from escalation.
+                self.relay.latch.on_probe_miss();
+            } else {
+                // A normal emit out of tries: if the gateway ACKed NOTHING (acked == 0) it heard
+                // nothing from us directly → latch multi-hop (`RELAY2` next emit). If it ACKed ≥ 1
+                // frag (direct, or via the flooded RELAYACK2 once already multi-hop) we're heard,
+                // just lossy → no escalation.
+                self.relay.latch.on_relay_exhausted(self.relay.tx.acked != 0);
+            }
             self.relay.tx.active = false; // give up — telemetry is loss-tolerant
             return;
         }
         if now.saturating_sub(self.relay.tx.last_ms) < RELAY_RETX_MS {
             return; // give the gateway time to ACK before resending
         }
-        let (msgid, count, acked, total_len) = (
+        let (msgid, count, acked, total_len, hop) = (
             self.relay.tx.msgid,
             self.relay.tx.count,
             self.relay.tx.acked,
             self.relay.tx.total_len,
+            self.relay.tx.hop,
         );
         for frag in 0..count {
             if acked & (1u8 << frag) != 0 {
@@ -2825,9 +2954,8 @@ impl RadioManager {
             }
             let off = frag as usize * RELAY_CHUNK;
             let end = (off + RELAY_CHUNK).min(total_len);
-            let mut fb = [0u8; RELAY_FRAME_MAX];
-            let len = encode_relay(self.id, msgid, frag, count, &self.relay.tx.buf[off..end], &mut fb);
-            self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
+            // Retransmit on the SAME framing the message was originated with (`tx.hop`).
+            self.relay_send_frag(msgid, hop, frag, count, off, end);
         }
         self.relay.tx.tries += 1;
         self.relay.tx.last_ms = now;
@@ -4023,7 +4151,90 @@ impl RadioManager {
                     // Leaf: the gateway confirmed these fragments — stop resending
                     // them. On a gateway (no outstanding tx) this is a no-op.
                     self.relay.apply_ack(msgid, bitmap);
+                    // #13: a DIRECT (unicast) RELAYACK proves the gateway heard an H=1 frame
+                    // from us directly → the uplink is back. While latched, count it toward
+                    // un-latching (UNLATCH_STREAK consecutive drops the latch back to
+                    // single-hop). A no-op when not latched. NOTE: the flooded RELAYACK2 does
+                    // NOT call this — it proves only the multi-hop path, not direct reach.
+                    self.relay.latch.on_direct_ack();
                     label = Some(alloc::format!("ack {:05}", msgid));
+                }
+                Some(Frame::Relay2 { origin, msgid, hop, frag, count, chunk }) => {
+                    // #13 multi-hop uplink fragment. Proves the SENDER (the last relay, or the
+                    // origin itself) is audible (LED detected + roster, attributed to `origin`).
+                    self.peers.last_hello_ms = now;
+                    self.roster.heard(src, Some(origin), rssi, now);
+                    if origin == self.id {
+                        // Our OWN frame echoed back by a relay — never re-forward or reassemble it
+                        // (that would count as a bogus fwd + could loop). Just drop it.
+                        label = Some(alloc::format!("relay2 self {:03}", origin));
+                    } else if self.relay.is_gateway {
+                        // GATEWAY = the flood's sink. Reassemble keyed by ORIGIN (a synthetic MAC
+                        // `00:00:00:00:00:<origin>`), NOT `src` — `src` is the last relay's MAC, but
+                        // reassembly + late-retransmit dedup must key on the true source. We do NOT
+                        // consult the seen-set here: `accept()` + `DONE_RING` already dedup
+                        // fragments/retransmits, and a seen-set drop would kill a lost-RELAYACK2
+                        // retransmit's re-ACK (the single-hop path's finding 3, one hop out). On each
+                        // accepted fragment, FLOOD a RELAYACK2 back toward the origin (R1, table-free)
+                        // carrying the cumulative bitmap so the stranded leaf learns completion.
+                        let synth = synth_origin_mac(origin);
+                        let (bitmap, complete) =
+                            self.relay.accept(synth, (origin, msgid, frag, count), chunk, now);
+                        self.flood_relayack2(origin, msgid, bitmap);
+                        label = Some(if complete {
+                            alloc::format!("relay2 {:03} ok", origin)
+                        } else {
+                            alloc::format!("relay2 {:03} {}/{}", origin, bitmap.count_ones(), count)
+                        });
+                    } else {
+                        // RELAY role: the seen-set-gated forward. `forward_decision` (pure) picks
+                        // the fate from (is_gateway=false, hop, already-seen `(origin,msgid,frag)`).
+                        let seen = self.relay.seen.seen_or_insert(origin, msgid, frag);
+                        match crate::net::flood::forward_decision(false, hop, seen) {
+                            crate::net::flood::ForwardAction::Forward { hop: next_hop } => {
+                                self.diag.fwd = self.diag.fwd.saturating_add(1);
+                                // Re-broadcast at the decremented hop. `chunk` borrows the RX buffer;
+                                // it's copied into the local frame buffer before the `&mut self` send.
+                                let mut fb = [0u8; RELAY2_FRAME_MAX];
+                                let len =
+                                    encode_relay2(origin, msgid, next_hop, frag, count, chunk, &mut fb);
+                                self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
+                                label = Some(alloc::format!("fwd {:03} h{} f{}", origin, next_hop, frag));
+                            }
+                            crate::net::flood::ForwardAction::DedupDrop => {
+                                self.diag.dedup = self.diag.dedup.saturating_add(1);
+                                label = Some(alloc::format!("dedup {:03}", origin));
+                            }
+                            crate::net::flood::ForwardAction::TtlDrop => {
+                                self.diag.ttl = self.diag.ttl.saturating_add(1);
+                                label = Some(alloc::format!("ttl {:03}", origin));
+                            }
+                            // Reassemble is only returned for is_gateway=true (handled above).
+                            crate::net::flood::ForwardAction::Reassemble => {}
+                        }
+                    }
+                }
+                Some(Frame::RelayAck2 { target, msgid, bitmap, hop }) => {
+                    // #13 multi-hop ACK. Proves the SENDER is audible.
+                    self.peers.last_hello_ms = now;
+                    self.roster.heard(src, None, rssi, now);
+                    if target == self.id {
+                        // We're the stranded origin being ACKed — fold in the bitmap (stop resending
+                        // the confirmed frags), exactly like a direct RELAYACK. We do NOT call
+                        // `on_direct_ack`: this arrived via the flood, so it proves the multi-hop path
+                        // works, NOT that the gateway can hear us DIRECTLY (only an H=1 probe drawing a
+                        // direct RELAYACK un-latches us). Never re-forward an ACK addressed to us.
+                        self.relay.apply_ack(msgid, bitmap);
+                        label = Some(alloc::format!("ack2 {:05}", msgid));
+                    } else if hop > 1 {
+                        // Not for us + hops left: flood it one hop further toward the target. Loop
+                        // safety rides the hop decrement (MAX_HOP=2 ⇒ at most one forward), so this
+                        // needs no seen-set. A 3-hop future would add a RELAYACK2 seen-set.
+                        let mut fb = [0u8; RELAYACK2_FRAME_MAX];
+                        let len = encode_relayack2(target, msgid, bitmap, hop - 1, &mut fb);
+                        self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
+                        label = Some(alloc::format!("fwdack {:03} h{}", target, hop - 1));
+                    }
                 }
                 Some(Frame::Batt(payload)) => {
                     // A gateway's battery downlink. Buffer the verbatim payload for
@@ -4469,6 +4680,16 @@ fn parse_frame(data: &[u8]) -> Option<Frame<'_>> {
     if let Some((msgid, bitmap)) = parse_relayack(data) {
         return Some(Frame::RelayAck { msgid, bitmap });
     }
+    // #13 multi-hop variants. Order vs RELAY/RELAYACK is moot — `strip_prefix` is exact and
+    // the `2` at the disambiguating byte makes base + variant mutually exclusive — but keep
+    // them adjacent to their base tag. A plain-RELAY frame never matches RELAY2 (byte 12 is
+    // ' ' not '2') and vice-versa, so a non-escalated leaf's frames stay byte-identical.
+    if let Some((origin, msgid, hop, frag, count, chunk)) = parse_relay2(data) {
+        return Some(Frame::Relay2 { origin, msgid, hop, frag, count, chunk });
+    }
+    if let Some((target, msgid, bitmap, hop)) = parse_relayack2(data) {
+        return Some(Frame::RelayAck2 { target, msgid, bitmap, hop });
+    }
     if let Some(rest) = data.strip_prefix(BATT_PREFIX) {
         // The rest is the verbatim `BATT|…` payload (no length byte).
         return Some(Frame::Batt(rest));
@@ -4641,6 +4862,123 @@ fn parse_relayack(data: &[u8]) -> Option<(u16, u8)> {
     let msgid = u16::try_from(parse_u5(&rest[0..5])?).ok()?;
     let bitmap = parse_id(&rest[6..9])?;
     Some((msgid, bitmap))
+}
+
+// --- #13 multi-hop wire codec (RELAY2 / RELAYACK2) --------------------------
+
+/// Encode a RELAY2 fragment `"SMOLv1 RELAY2 " + "OOO MMMMM H F C " + <chunk>` into
+/// `out`; returns total length (30-byte header + chunk). `OOO` = ORIGIN id (the true
+/// source, distinct from the re-broadcasting relay's MAC), `MMMMM` = msgid, `H` = 1-digit
+/// hop-limit (1..=`MAX_HOP`), `F`/`C` = frag index / count. Twin of [`encode_relay`] with
+/// the origin + hop fields; `chunk` truncated to `RELAY_CHUNK`.
+fn encode_relay2(origin: u8, msgid: u16, hop: u8, frag: u8, count: u8, chunk: &[u8], out: &mut [u8]) -> usize {
+    let mut n = 0;
+    out[..RELAY2_PREFIX.len()].copy_from_slice(RELAY2_PREFIX);
+    n += RELAY2_PREFIX.len();
+    out[n] = b'0' + (origin / 100) % 10;
+    out[n + 1] = b'0' + (origin / 10) % 10;
+    out[n + 2] = b'0' + origin % 10;
+    n += 3;
+    out[n] = b' ';
+    n += 1;
+    write_u5(msgid as u32, &mut out[n..]);
+    n += 5;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + hop; // hop is 1..=MAX_HOP (single digit)
+    n += 1;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + frag;
+    n += 1;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + count;
+    n += 1;
+    out[n] = b' ';
+    n += 1;
+    let len = chunk.len().min(RELAY_CHUNK);
+    out[n..n + len].copy_from_slice(&chunk[..len]);
+    n + len
+}
+
+/// Parse a RELAY2 frame into `(origin, msgid, hop, frag, count, chunk)`, or `None`.
+/// `chunk` borrows `data`. The caller re-validates `count`/`frag`/`chunk.len()`.
+// The return mirrors `parse_relay`'s tuple shape + the one `hop` field (6 = just over the
+// complexity heuristic); `parse_frame` immediately destructures it into `Frame::Relay2`, so
+// a named struct would add a type for no call-site clarity. (Codebase precedent: the
+// `#[allow(clippy::too_many_arguments)]` on the relay-offer service fn.)
+#[allow(clippy::type_complexity)]
+fn parse_relay2(data: &[u8]) -> Option<(u8, u16, u8, u8, u8, &[u8])> {
+    let rest = data.strip_prefix(RELAY2_PREFIX)?;
+    // "OOO MMMMM H F C " = 16 header bytes (origin 3, sp, msgid 5, sp, hop 1, sp, frag 1,
+    // sp, count 1, sp), then the chunk.
+    if rest.len() < 16 {
+        return None;
+    }
+    let origin = parse_id(&rest[0..3])?;
+    let msgid = u16::try_from(parse_u5(&rest[4..9])?).ok()?;
+    if !rest[10].is_ascii_digit() || !rest[12].is_ascii_digit() || !rest[14].is_ascii_digit() {
+        return None;
+    }
+    let hop = rest[10] - b'0';
+    let frag = rest[12] - b'0';
+    let count = rest[14] - b'0';
+    Some((origin, msgid, hop, frag, count, &rest[16..]))
+}
+
+/// Encode a `"SMOLv1 RELAYACK2 " + "TTT MMMMM BBB H"` frame into `out`; returns length (32).
+/// `TTT` = TARGET origin id being ACKed, `MMMMM` = msgid, `BBB` = 3-digit bitmap, `H` = hop.
+fn encode_relayack2(target: u8, msgid: u16, bitmap: u8, hop: u8, out: &mut [u8]) -> usize {
+    let mut n = 0;
+    out[..RELAYACK2_PREFIX.len()].copy_from_slice(RELAYACK2_PREFIX);
+    n += RELAYACK2_PREFIX.len();
+    out[n] = b'0' + (target / 100) % 10;
+    out[n + 1] = b'0' + (target / 10) % 10;
+    out[n + 2] = b'0' + target % 10;
+    n += 3;
+    out[n] = b' ';
+    n += 1;
+    write_u5(msgid as u32, &mut out[n..]);
+    n += 5;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + (bitmap / 100) % 10;
+    out[n + 1] = b'0' + (bitmap / 10) % 10;
+    out[n + 2] = b'0' + bitmap % 10;
+    n += 3;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + hop;
+    n += 1;
+    n
+}
+
+/// Parse a RELAYACK2 frame into `(target, msgid, bitmap, hop)`, or `None`.
+fn parse_relayack2(data: &[u8]) -> Option<(u8, u16, u8, u8)> {
+    let rest = data.strip_prefix(RELAYACK2_PREFIX)?;
+    // "TTT MMMMM BBB H" = 15 bytes (target 3, sp, msgid 5, sp, bitmap 3, sp, hop 1).
+    if rest.len() < 15 {
+        return None;
+    }
+    let target = parse_id(&rest[0..3])?;
+    let msgid = u16::try_from(parse_u5(&rest[4..9])?).ok()?;
+    let bitmap = parse_id(&rest[10..13])?;
+    if !rest[14].is_ascii_digit() {
+        return None;
+    }
+    let hop = rest[14] - b'0';
+    Some((target, msgid, bitmap, hop))
+}
+
+/// #13: the synthetic MAC a gateway keys a RELAY2 reassembly by — `00:00:00:00:00:<origin>`.
+/// Reassembly + late-retransmit dedup must key on the true SOURCE, but a RELAY2's `src_mac` is
+/// the LAST RELAY's MAC (changes per hop). The `origin` id (u8, stamped by the source, survives
+/// forwarding) maps into the existing `(src_mac, msgid)`-keyed `ReasmSlot`/`DONE_RING` tables
+/// WITHOUT collision: a real ESP32 STA MAC carries an Espressif OUI in its top bytes, never
+/// all-zero, so this synthetic key can never alias a single-hop leaf's real MAC.
+fn synth_origin_mac(origin: u8) -> [u8; 6] {
+    [0, 0, 0, 0, 0, origin]
 }
 
 // -------------------------------------------------------------------------

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2983,6 +2983,25 @@ impl RadioManager {
         if self.relay.is_gateway {
             return;
         }
+        // #13 P1 fix (deaf-list rig): the escalation streak must NOT depend solely on the
+        // retry-exhaustion path. A totally-deaf gateway yields ZERO ACKs, and the retransmit loop
+        // that feeds `on_relay_exhausted` can be starved — a stranded leaf is pinned in blocking
+        // WiFi recovery bursts, and the 15 s emit re-stages `tries=1` before `relay_retransmit`
+        // accumulates to `RELAY_MAX_TRIES` — so a fully-out-of-earshot leaf (the flagship case!)
+        // never latched. Feed the streak at SUPERSESSION too: the message we're about to replace,
+        // if still active with ZERO acks, went fully un-ACKed. Mutually exclusive with the
+        // retry-exhaustion feed (which clears `active`), so no double-count; a totally-silent
+        // gateway now latches in ESCALATE_STREAK emit cycles (~45 s) regardless of retransmit timing.
+        let was_latched = self.relay.latch.latched();
+        if self.relay.tx.active && self.relay.tx.acked == 0 {
+            self.relay.latch.on_relay_exhausted(false);
+        }
+        if !was_latched && self.relay.latch.latched() {
+            log::info!(
+                "smol #13: leaf escalated to multi-hop (RELAY2) — gateway unreachable, {} un-ACKed msgs",
+                crate::net::flood::ESCALATE_STREAK
+            );
+        }
         let count = self.relay.stage_tx(telemetry, now);
         if count == 0 {
             return;

--- a/rust/clock/src/net/wire.rs
+++ b/rust/clock/src/net/wire.rs
@@ -1,0 +1,303 @@
+//! #13 — the PURE SMOLv1 relay-family wire codec + its ASCII field helpers.
+//!
+//! Extracted verbatim from `net/mode.rs` (byte-identical — a pure move, no logic change) so the
+//! frame formats are HOST-unit-testable off-target, mirroring the `net/flood.rs` pure split. The
+//! bidirectional byte-compat guard in `experiments/relay_compat` `#[path]`-includes this module and
+//! asserts (a) a NEW-code frame parses under a vendored pre-#13 parser and (b) an old-format
+//! RELAYACK parses under this matcher — the permanent mixed-fleet / #124-migration insurance.
+//!
+//! `mode.rs` re-exports everything here via `use crate::net::wire::*;`, so its call sites are
+//! unchanged. No `esp-hal`/`esp-wifi` deps — everything is `&[u8]` in / out.
+
+// ---- codec-shared consts ---------------------------------------------------
+
+/// Relay-bridge tags. RELAY carries a fragment of a leaf's telemetry uplink; RELAYACK is the
+/// gateway's per-message received-fragment bitmap. The trailing space on RELAY disambiguates it
+/// from RELAYACK at byte 12 (`' '` vs `'A'`), so match order is moot.
+pub const RELAY_PREFIX: &[u8] = b"SMOLv1 RELAY "; // + "NNN MMMMM F C " + chunk
+pub const RELAYACK_PREFIX: &[u8] = b"SMOLv1 RELAYACK "; // + "MMMMM BBB"
+/// #13 multi-hop uplink tags (see the `#13` section in `mode.rs` + `net/flood.rs`). NEW tags — an
+/// old firmware `classify()`s them to `None` (harmless). `RELAY2` diverges from `RELAY` at byte 12
+/// (`'2'` vs `' '`) and `RELAYACK2` from `RELAYACK` at byte 15, so `strip_prefix` never confuses a
+/// base tag with its variant regardless of order.
+pub const RELAY2_PREFIX: &[u8] = b"SMOLv1 RELAY2 "; // + "OOO MMMMM H F C " + chunk
+pub const RELAYACK2_PREFIX: &[u8] = b"SMOLv1 RELAYACK2 "; // + "TTT MMMMM BBB H"
+/// #13 Stage B downlink freshness tags (10-digit `dl_seq` + verbatim `BATT|`/`GRID|` payload).
+pub const BATT2_PREFIX: &[u8] = b"SMOLv1 BATT2 ";
+pub const GRID2_PREFIX: &[u8] = b"SMOLv1 GRID2 ";
+
+/// Max telemetry payload per RELAY fragment (bytes) — encoders truncate the chunk to this.
+pub const RELAY_CHUNK: usize = 64;
+/// Max BATT/GRID downlink payload (bytes) — `encode_dl` truncates to this (matches the caches).
+pub const BATT_PAYLOAD_MAX: usize = 96;
+
+// ---- fixed-width ASCII field helpers --------------------------------------
+
+/// Write a 5-digit zero-padded decimal (value mod 100000) into `out[..5]`.
+pub fn write_u5(v: u32, out: &mut [u8]) {
+    let v = v % 100_000;
+    out[0] = b'0' + ((v / 10_000) % 10) as u8;
+    out[1] = b'0' + ((v / 1_000) % 10) as u8;
+    out[2] = b'0' + ((v / 100) % 10) as u8;
+    out[3] = b'0' + ((v / 10) % 10) as u8;
+    out[4] = b'0' + (v % 10) as u8;
+}
+
+/// Write a 10-digit zero-padded decimal into `out[..10]`. 10 digits holds every u32, so no clamp
+/// is needed — the full value round-trips through [`parse_u10`]. Filled least-significant-digit first.
+pub fn write_u10(mut v: u32, out: &mut [u8]) {
+    for i in (0..10).rev() {
+        out[i] = b'0' + (v % 10) as u8;
+        v /= 10;
+    }
+}
+
+/// Parse a 3-digit ASCII id (`b"007"` -> 7). Rejects non-digits / short input.
+pub fn parse_id(rest: &[u8]) -> Option<u8> {
+    if rest.len() < 3 {
+        return None;
+    }
+    let mut val: u16 = 0;
+    for &b in &rest[..3] {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        val = val * 10 + (b - b'0') as u16;
+    }
+    (val <= 255).then_some(val as u8)
+}
+
+/// Parse exactly 5 ASCII digits into a u32. Rejects short/non-digit input.
+pub fn parse_u5(rest: &[u8]) -> Option<u32> {
+    if rest.len() < 5 {
+        return None;
+    }
+    let mut val: u32 = 0;
+    for &b in &rest[..5] {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        val = val * 10 + (b - b'0') as u32;
+    }
+    Some(val)
+}
+
+/// Parse exactly 10 ASCII digits into a u32. Accumulates in u64 + range-checks on the way out, so a
+/// garbled 10-digit field that exceeds `u32::MAX` is rejected rather than silently wrapping.
+pub fn parse_u10(rest: &[u8]) -> Option<u32> {
+    if rest.len() < 10 {
+        return None;
+    }
+    let mut val: u64 = 0;
+    for &b in &rest[..10] {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        val = val * 10 + (b - b'0') as u64;
+    }
+    u32::try_from(val).ok()
+}
+
+// ---- RELAY / RELAYACK (single-hop) ----------------------------------------
+
+/// Encode a RELAY fragment `"SMOLv1 RELAY NNN MMMMM F C " + <chunk>` into `out`; returns total
+/// length (27-byte header + chunk). `chunk` is truncated to [`RELAY_CHUNK`].
+pub fn encode_relay(src_id: u8, msgid: u16, frag: u8, count: u8, chunk: &[u8], out: &mut [u8]) -> usize {
+    let mut n = 0;
+    out[..RELAY_PREFIX.len()].copy_from_slice(RELAY_PREFIX);
+    n += RELAY_PREFIX.len();
+    out[n] = b'0' + (src_id / 100) % 10;
+    out[n + 1] = b'0' + (src_id / 10) % 10;
+    out[n + 2] = b'0' + src_id % 10;
+    n += 3;
+    out[n] = b' ';
+    n += 1;
+    write_u5(msgid as u32, &mut out[n..]);
+    n += 5;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + frag;
+    n += 1;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + count;
+    n += 1;
+    out[n] = b' ';
+    n += 1;
+    let len = chunk.len().min(RELAY_CHUNK);
+    out[n..n + len].copy_from_slice(&chunk[..len]);
+    n + len
+}
+
+/// Parse a RELAY frame into `(src_id, msgid, frag, count, chunk)`, or `None`. `chunk` borrows `data`.
+pub fn parse_relay(data: &[u8]) -> Option<(u8, u16, u8, u8, &[u8])> {
+    let rest = data.strip_prefix(RELAY_PREFIX)?;
+    if rest.len() < 14 {
+        return None;
+    }
+    let src_id = parse_id(&rest[0..3])?;
+    let msgid = u16::try_from(parse_u5(&rest[4..9])?).ok()?;
+    if !rest[10].is_ascii_digit() || !rest[12].is_ascii_digit() {
+        return None;
+    }
+    let frag = rest[10] - b'0';
+    let count = rest[12] - b'0';
+    Some((src_id, msgid, frag, count, &rest[14..]))
+}
+
+/// Encode a `"SMOLv1 RELAYACK MMMMM BBB"` frame into `out`; returns length (25). `BBB` = the
+/// 3-digit received-fragment bitmap (0..255).
+pub fn encode_relayack(msgid: u16, bitmap: u8, out: &mut [u8]) -> usize {
+    let mut n = 0;
+    out[..RELAYACK_PREFIX.len()].copy_from_slice(RELAYACK_PREFIX);
+    n += RELAYACK_PREFIX.len();
+    write_u5(msgid as u32, &mut out[n..]);
+    n += 5;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + (bitmap / 100) % 10;
+    out[n + 1] = b'0' + (bitmap / 10) % 10;
+    out[n + 2] = b'0' + bitmap % 10;
+    n += 3;
+    n
+}
+
+/// Parse a RELAYACK frame into `(msgid, bitmap)`, or `None`.
+pub fn parse_relayack(data: &[u8]) -> Option<(u16, u8)> {
+    let rest = data.strip_prefix(RELAYACK_PREFIX)?;
+    if rest.len() < 9 {
+        return None;
+    }
+    let msgid = u16::try_from(parse_u5(&rest[0..5])?).ok()?;
+    let bitmap = parse_id(&rest[6..9])?;
+    Some((msgid, bitmap))
+}
+
+// ---- RELAY2 / RELAYACK2 (#13 multi-hop) -----------------------------------
+
+/// Encode a RELAY2 fragment `"SMOLv1 RELAY2 OOO MMMMM H F C " + <chunk>` into `out`; returns total
+/// length (30-byte header + chunk). `OOO` = ORIGIN id, `H` = 1-digit hop-limit.
+pub fn encode_relay2(origin: u8, msgid: u16, hop: u8, frag: u8, count: u8, chunk: &[u8], out: &mut [u8]) -> usize {
+    let mut n = 0;
+    out[..RELAY2_PREFIX.len()].copy_from_slice(RELAY2_PREFIX);
+    n += RELAY2_PREFIX.len();
+    out[n] = b'0' + (origin / 100) % 10;
+    out[n + 1] = b'0' + (origin / 10) % 10;
+    out[n + 2] = b'0' + origin % 10;
+    n += 3;
+    out[n] = b' ';
+    n += 1;
+    write_u5(msgid as u32, &mut out[n..]);
+    n += 5;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + hop;
+    n += 1;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + frag;
+    n += 1;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + count;
+    n += 1;
+    out[n] = b' ';
+    n += 1;
+    let len = chunk.len().min(RELAY_CHUNK);
+    out[n..n + len].copy_from_slice(&chunk[..len]);
+    n + len
+}
+
+/// Parse a RELAY2 frame into `(origin, msgid, hop, frag, count, chunk)`, or `None`.
+// Mirrors `parse_relay`'s tuple shape + the one `hop` field; the caller destructures immediately.
+#[allow(clippy::type_complexity)]
+pub fn parse_relay2(data: &[u8]) -> Option<(u8, u16, u8, u8, u8, &[u8])> {
+    let rest = data.strip_prefix(RELAY2_PREFIX)?;
+    if rest.len() < 16 {
+        return None;
+    }
+    let origin = parse_id(&rest[0..3])?;
+    let msgid = u16::try_from(parse_u5(&rest[4..9])?).ok()?;
+    if !rest[10].is_ascii_digit() || !rest[12].is_ascii_digit() || !rest[14].is_ascii_digit() {
+        return None;
+    }
+    let hop = rest[10] - b'0';
+    let frag = rest[12] - b'0';
+    let count = rest[14] - b'0';
+    Some((origin, msgid, hop, frag, count, &rest[16..]))
+}
+
+/// Encode a `"SMOLv1 RELAYACK2 TTT MMMMM BBB H"` frame into `out`; returns length (32).
+pub fn encode_relayack2(target: u8, msgid: u16, bitmap: u8, hop: u8, out: &mut [u8]) -> usize {
+    let mut n = 0;
+    out[..RELAYACK2_PREFIX.len()].copy_from_slice(RELAYACK2_PREFIX);
+    n += RELAYACK2_PREFIX.len();
+    out[n] = b'0' + (target / 100) % 10;
+    out[n + 1] = b'0' + (target / 10) % 10;
+    out[n + 2] = b'0' + target % 10;
+    n += 3;
+    out[n] = b' ';
+    n += 1;
+    write_u5(msgid as u32, &mut out[n..]);
+    n += 5;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + (bitmap / 100) % 10;
+    out[n + 1] = b'0' + (bitmap / 10) % 10;
+    out[n + 2] = b'0' + bitmap % 10;
+    n += 3;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + hop;
+    n += 1;
+    n
+}
+
+/// Parse a RELAYACK2 frame into `(target, msgid, bitmap, hop)`, or `None`.
+pub fn parse_relayack2(data: &[u8]) -> Option<(u8, u16, u8, u8)> {
+    let rest = data.strip_prefix(RELAYACK2_PREFIX)?;
+    if rest.len() < 15 {
+        return None;
+    }
+    let target = parse_id(&rest[0..3])?;
+    let msgid = u16::try_from(parse_u5(&rest[4..9])?).ok()?;
+    let bitmap = parse_id(&rest[10..13])?;
+    if !rest[14].is_ascii_digit() {
+        return None;
+    }
+    let hop = rest[14] - b'0';
+    Some((target, msgid, bitmap, hop))
+}
+
+/// The synthetic MAC a gateway keys a RELAY2 reassembly by — `00:00:00:00:00:<origin>`. A real
+/// Espressif STA MAC is never all-zero, so this can't alias a single-hop leaf's real MAC.
+pub fn synth_origin_mac(origin: u8) -> [u8; 6] {
+    [0, 0, 0, 0, 0, origin]
+}
+
+// ---- BATT2 / GRID2 (#13 Stage B downlink freshness) -----------------------
+
+/// Encode a downlink freshness frame `<prefix> + "SSSSSSSSSS " + <payload>` into `out`; returns
+/// length. `prefix` is [`BATT2_PREFIX`]/[`GRID2_PREFIX`]; `seq` is the 10-digit freshness.
+pub fn encode_dl(prefix: &[u8], seq: u32, payload: &[u8], out: &mut [u8]) -> usize {
+    let mut n = 0;
+    out[..prefix.len()].copy_from_slice(prefix);
+    n += prefix.len();
+    write_u10(seq, &mut out[n..]);
+    n += 10;
+    out[n] = b' ';
+    n += 1;
+    let len = payload.len().min(BATT_PAYLOAD_MAX);
+    out[n..n + len].copy_from_slice(&payload[..len]);
+    n + len
+}
+
+/// Parse a downlink freshness frame with `prefix` into `(seq, payload)`, or `None`. `payload` borrows `data`.
+pub fn parse_dl<'a>(prefix: &[u8], data: &'a [u8]) -> Option<(u32, &'a [u8])> {
+    let rest = data.strip_prefix(prefix)?;
+    if rest.len() < 11 {
+        return None;
+    }
+    let seq = parse_u10(&rest[0..10])?;
+    Some((seq, &rest[11..]))
+}


### PR DESCRIPTION
Closes the single-hop limitation on smol's mesh: a leaf out of direct ESP-NOW range of the elected gateway is stranded today. This adds Meshtastic-lineage **managed flood** (hop-limit + `(origin,msgid,frag)` seen-set + forward path) on the uplink, freshness-gated flood on the downlink, and a test rig to validate it — rooted at the #76-elected owner, table-free.

Design + sign-off: `scratch/13-multihop/scope-proposal.md` (+ ADDENDUM). Rig: `scratch/smol-dreamteam/13-rig-design.md`. Pure decision core: `net/flood.rs` (host-tested in `experiments/flood_verify`).

## What's in this PR

**Stage A — routed multi-hop uplink** (`8044cd4`)
- New tags `SMOLv1 RELAY2` (hop-limited, origin-stamped fragment) + `SMOLv1 RELAYACK2` (R1 flooded ACK). A stranded leaf (telemetry fully un-ACKed after `RELAY_MAX_TRIES`) escalates from plain `RELAY` to `RELAY2` at `MAX_HOP=2`.
- Relays re-broadcast via `flood::forward_decision` gated by the `(origin,msgid,frag)` seen-set; the gateway reassembles **re-keyed by origin** (a synthetic `00:00:00:00:00:<id>` MAC — a real Espressif MAC is never all-zero, so it can't alias) and floods `RELAYACK2` back.
- Un-latch hysteresis: back to single-hop after `UNLATCH_STREAK=2` **direct**-ACK probes, and only probes (1-in-8 `H=1` emit) while the owner's HELLO is heard **directly + fresh** (Gate A). DIAG += `fwd`/`dedup`/`ttl`/`hop`.

**Stage B — downlink freshness** (`5b0a4ed`)
- New tags `SMOLv1 BATT2`/`GRID2` = tag + 10-digit `dl_seq` + verbatim `BATT|`/`GRID|` payload. `dl_seq` = the gateway's unix-second of the last **value change** (survives a gateway reboot + never wraps — the TIME `synced_at` template), bumped only on a change so an unchanged re-broadcast isn't re-flooded.
- A leaf adopts + **re-floods** a frame only when its `dl_seq` is **strictly newer** than what it holds — reaching a stranded leaf via a relay and dropping replays (no loop). A gateway ignores inbound downlink (it IS the source). Leaves still parse v1 `BATT`/`GRID` from an old gateway. DIAG += `dlseq`. Closes the #10 HA-staleness gap + rig P4.
- Deferred (small follow-up, Luna's screen domain): the leaf **data-age render**. This stage delivers reach + freshness; the existing render shows the value.

**Stage C — mesh-test deaf-list rig hook** (`847bf52`)
- Default-OFF `mesh-test` cargo feature + a per-board `board::DEAF_MACS` list; `service()` drops inbound frames from listed sources before any handler — a deterministic stand-in for RF attenuation that forces a 2-hop topology (G→R→F) on today's 3 boards. DIAG += `deaf`/`ddrops`.

## Byte-identical invariant (the uplink safety gate)

A **non-escalated** leaf emits ONLY plain `RELAY` (hop 1), so in the all-hear case **no `RELAY2`/`RELAYACK2` frame ever exists and nobody forwards**. Canary gate **C0 = `fwd=0` on every node** = the measurement of this claim (run it before any deaf-list test). Proven byte-free by cfg-gating, not ELF equality. (Downlink, like TIME, does re-flood on strictly-newer `dl_seq` — bounded, and only on an actual value change.)

## Mixed-fleet / rolling-upgrade compat

All new tags are ADDITIONS (not appends to the fixed-offset `RELAY`/`RELAYACK`/`BATT`/`GRID` headers): old firmware `classify()`s them to `None` (harmless) and cannot relay anyway — no flag-day flash. **A leaf that needs H≥2 was, by definition, out of direct gateway range — i.e. already stranded pre-#13** — so no rolling-upgrade window can strand a leaf that worked before. #13 only ever ADDS reach.

## Design note — the gap I found, and why RELAY2 (not UP2) for v1

While wiring Stage A I found the signed RELAY2-only scope can't carry a **stranded** leaf's `STAT`/`DIAG` (those are separate single-hop frames), so rig **P1's `/stat`+`/diag`-via-R only partially passes** and the `deaf=` visibility on a stranded board can't reach HA. I flagged it and recommended generalizing to a single **UP2 envelope** (wrap any inner frame). Team-lead's call, and I agree: **RELAY2 stands for v1** — it's only ever on-air for a genuinely-stranded leaf, so the tag-migration cost is near-theoretical, and reworking a proven, green stage buys less than it costs. The envelope lands as a **post-v1 migration** (#124) that *replaces* RELAY2→UP2 and brings the observability reach. P1's telemetry reach passes in v1.

## Correctness fix to the inherited core (approved)

The host-tested `SeenSet` was keyed `(origin,msgid)`. RELAY messages **fragment**, so a per-message key marks the whole message "seen" on fragment 0 and a relay would drop fragments 1..N — a multi-fragment message could never reassemble. Widened to `(origin,msgid,frag)`; the `SeenSet`/`HopLatch`/`forward_decision` logic is otherwise unchanged, and `flood_verify` gained a multi-fragment regression assert.

## Known v1 limitation (documented)

Multi-hop uplink is **best-effort**. In a single-relay topology a lost `RELAYACK2` isn't recovered within the message (the relay's seen-set suppresses the retransmit forward) — telemetry is loss-tolerant, next `msgid` is a fresh flood. Two closure options for a follow-up: a **2+-relay** topology, or a **RELAYACK2 seen-set**. `RELAYACK2` loop-safety rides the `MAX_HOP=2` hop decrement (a 3-hop follow-up would add the seen-set).

## Canary checklist (team-lead)

1. **C0** (precondition): `fwd=0` on every node across a normal all-hear window = byte-identical proof.
2. Flash 3 boards `--features espnow,mesh-test`; set `board.rs` `DEAF_MACS` so **F** is deaf to gateway **G** and **G** deaf to **F** (see `board.rs.example`).
3. **P1** F's `/telemetry` reaches HA via R (note: `/stat`+`/diag`-via-R is the #124 follow-up). **P2** `fwd≈1`/msg at R, `dedup>0`, airtime steady. **P3** TTL honored (`ttl` increments, no forward past hop 1). **P4** change a BATT/GRID value → F renders it via R + `dlseq` advances; replay an older seq → dropped (`dlseq` unchanged).
4. Restore: re-flash with empty `DEAF_MACS`; confirm every DIAG `deaf=0`.

## Follow-ups

- **#124 — A.5 RELAY2→UP2 migration** (post-v1): one uplink envelope, brings `/stat`+`/diag`+`deaf=`-via-R. Constraints captured in the issue (reduced-MTU const + clamp; envelope-own msgid).
- Leaf data-age **render** for BATT2/GRID2 (Luna's screen domain).

## Verification

- `cargo clippy -- -D warnings` clean: default / espnow / espnow,cast,io (#119 canonical) / espnow,wled / espnow,mesh-test / espnow,cast,io,mesh-test.
- `cargo build --release` **links clean** (valid RISC-V ELF): default / espnow / espnow,cast,io / espnow,wled / espnow,mesh-test.
- Host `experiments/flood_verify`: ALL PASS (SeenSet incl. multi-frag regression + forward_decision + HopLatch hysteresis).
- Rebased onto current `main`; re-verified clippy + release link post-rebase.

Refs #13. Follow-up: #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update — C0 canary + hardening (post first-canary)

The first canary flagged `fwd≠0` on the fleet. Joint root cause (both team-lead and I were half-right, on the record): a fair-weather counter read taken during a 1 MB **OTA-convergence window** (crown legitimately mesh-deaf for long stretches) → the leaves' telemetry genuinely went un-ACKed → the escalation machinery responded per spec — but the latch **threshold treated one bad message as strandedness**. Not a wire bug, not an ACK-recognition bug (the whole H=1 RELAY/RELAYACK path is byte-identical to base; the executable guard below proves it).

Two hardening commits landed on top:

**C0 fix — escalation hysteresis** (`1de3184`)
- `HopLatch` now latches multi-hop only after `ESCALATE_STREAK=3` **consecutive** fully-un-ACKed messages (~45 s of genuine strandedness at the 15 s cadence); **any** ACK resets the streak. A single transient full-loss — normal over a 15-min window, and guaranteed during an OTA feed — no longer latches a leaf into RELAY2, so the `fwd=0` byte-identical invariant holds under ordinary packet loss. `flood_verify` gains the regression asserts.
- Plus a rate-limited serial log in the RELAY2 forward arm (was OLED-only).

**Codec extraction + byte-compat guard** (`1fbd367`)
- The relay-family wire codec moved to a pure, host-testable `net/wire.rs` (byte-identical move; the `espnow,cast,io` release ELF is unchanged in size). New `experiments/relay_compat` `#[path]`-includes the REAL codec and asserts the mixed-fleet contract **both directions** (new-frame→pre-#13-parser with golden bytes; old-RELAYACK→new-matcher) + RELAY2/RELAYACK2/BATT2 round-trips + tag disambiguation. The permanent guard the bench asked for, and the #124 UP2-migration checkpoint.

**Re-canary:** on an all-#13 fleet (DUT wears the crown), C0 on a quiet fleet with the 15-min counter watch, then the deaf-list rig P1–P4.

Full green: clippy `-D warnings` on default / espnow / espnow,cast,io / espnow,wled / espnow,mesh-test; release links clean; `flood_verify` + `relay_compat` ALL PASS.


### C0 verdict + DIAG counter semantics (`c382d76`)

C0 **PASSED** the uplink invariant on a quiet all-#13 fleet (15-min window): crown `fwd=0`/`dedup=0`, `hop=1` at rest, telemetry flowing, zero RELAY2/forward logs — the hysteresis held through normal loss.

`fwd` is the uplink invariant and increments at exactly one site (the RELAY2 forward arm) — it counts inbound uplink RELAY2 re-broadcasts only, and must be 0 fleet-wide in all-hear. Stage B's **downlink** BATT2/GRID2 re-flood is nonzero *by design* (strictly-newer flood, like TIME) and now has its own `dfwd=` counter — kept separate so the uplink invariant stays machine-checkable. Any nonzero `fwd` in all-hear is therefore always a real uplink signal (e.g. storm-tail residue from a pre-quiet convergence window), never a downlink artifact.

Note: the `DiagCounters` reset on boot (plain struct, not `noinit`); absolute counter values are same-boot accumulation, so score C0 off the **delta** in the observation window (which was 0).


### Hardware canary: C0 + deaf-list rig — BOTH PASS

The deaf-list rig caught (and this PR fixes) two escalation-trigger bugs the green build + the host HopLatch math could not — exactly the rig's purpose:
- **C0 over-eager latch** → fixed by the consecutive-unACK hysteresis (`1de3184`).
- **P1 under-eager latch** (a totally-deaf leaf never escalated — the retry-exhaustion path is starved for a leaf pinned in blocking recovery bursts) → fixed by feeding the streak at message **supersession** (`e0554a7`).

**P1 PASS — first routed frame in smol's history.** Latch fired at ~3 emit cycles as designed (`escalated to multi-hop (RELAY2) — gateway unreachable, 3 un-ACKed msgs`), steady RELAY2 at hop 2, R forwarded, and `smol/9/telemetry` arrived at the broker **from a leaf that provably cannot hear its crown**.

**Documented v1 limitation — multi-hop throughput (follow-up #126):** a stranded leaf never locks a channel (it never hears its owner's HELLO), so it keeps hopping ch 1/6/11 while scanning; its RELAY2 lands on the relay's channel only ~1/3 of the time (rig: R forwarded ~1 of ~30). The RELAYACK2 flood-back hits the same ~1/3 in reverse — the rig's F received zero ACKs and stayed latched on the escalation streak alone (correct for a genuinely-stranded leaf). **Pre-#13 the delivered count was ZERO, so v1's bar — a stranded leaf CAN reach home — is met.** #126 (latched-leaf channel parking) raises the rate.

### DIAG counter / uptime semantics (authoritative)

- `fwd` = **uplink** RELAY2 forwards only (the C0 invariant; must be 0 fleet-wide in all-hear). `dfwd` = **downlink** BATT2/GRID2 re-floods (nonzero by design). Split so the invariant stays machine-checkable.
- `DiagCounters` (incl. `fwd`/`dfwd`/`dedup`/`ttl`) are plain RAM — **reset to 0 on every boot** (not `noinit`). Score invariants off the **delta** in the observation window, not absolutes (which can hold same-boot storm residue).
- `boot` (`boot_count`) is NVS-persisted, +1 per boot — the **only** authoritative reboot marker. `up` is systimer-based and **survives `software_reset`** (continues across an OTA/soft reboot) — it is NOT a reboot indicator. A genuine reboot shows `boot`+1 AND `fwd`→0 together.
