### PR TITLE
tools: #128 build-number ratchet — canary --build pins no longer poison the gate

### DIFF
--- a/tools/ota_publish.sh
+++ b/tools/ota_publish.sh
@@ -14,8 +14,13 @@
 #   ota_publish.sh stage      [<commit>] [--bin <file>] [--build N]  # build+host+publish smol/ota/staged (arms all boards; NO board fetches)
 #   ota_publish.sh install <id>                                      # publish INSTALL → smol/<id>/ota/install (headless per-node canary; the HA Update button is the GUI path)
 # <commit> defaults to HEAD. --bin <file> skips the cargo build and hosts an existing .bin.
-# --build N overrides the git-derived BUILD number in the staged line — canary an uncommitted
-#   image without a throwaway commit to bump the count (default: `git rev-list --count`).
+# BUILD number (the staged-line monotonicity value the fw compares): stage RATCHETS it forward —
+#   build = max(`git rev-list --count`, <retained smol/ota/staged build> + 1) — so a prior canary
+#   pin (a --build N left ahead of the count) HEALS the fleet number forward automatically instead
+#   of poisoning the gate (issue #128). Broker unreachable → falls back to the raw count with a
+#   WARNING (no ratchet). --build N still forces an explicit override (canary an uncommitted image
+#   with no throwaway commit); N is used AS-IS and, when N > count, prints a loud canary-pin
+#   warning + the heal path. See choose_build() (unit-tested by tools/test_ota_ratchet.sh).
 #
 # SAFETY: canary is STRUCTURAL now — Install is per-device (native Update entity); there
 # is no fleet-fetch topic (Model-A #32 closure). Install one board, verify its version
@@ -40,6 +45,7 @@ ESPFLASH="${ESPFLASH:-$HOME/.cargo/bin/espflash}"
 # retype env overrides. Precedence: env file > a var the file leaves unset (pre-set env) >
 # placeholder default. Nothing real ever lives in this committed script.
 _OTA_ENV="$(dirname "${BASH_SOURCE[0]}")/ota_publish.env"
+# shellcheck source=/dev/null  # operator-supplied, git-ignored, path known only at runtime
 [ -f "$_OTA_ENV" ] && . "$_OTA_ENV"
 OTA_HOST_SSH="${OTA_HOST_SSH:-<ssh-host>}"      # scp target (ssh alias for the image host)
 OTA_HOST_IP="${OTA_HOST_IP:-10.0.0.0}"          # image host on the boards' VLAN (same subnet as boards)
@@ -52,18 +58,23 @@ ADDON="${ADDON:-<addon-slug>}"                  # supervisor addon slug carrying
 SMOL_OTA_SIGNING_KEY_ITEM="${SMOL_OTA_SIGNING_KEY_ITEM:-smol-ota-signing-ed25519}"  # Vaultwarden secureNote holding the ed25519 signing PEM (#32)
 
 die(){ echo "ERROR: $*" >&2; exit 1; }
-usage(){ sed -n '2,20p' "${BASH_SOURCE[0]}"; exit "${1:-1}"; }
+usage(){ sed -n '2,23p' "${BASH_SOURCE[0]}"; exit "${1:-1}"; }
 
 MODE="${1:-}"; [ -n "$MODE" ] || usage 1
 
 # ---- source the broker password (NEVER printed) -----------------------------
+# #128: memoize — the ratchet's retained-read AND the publish both need the pw; without this
+# they'd each hit bw + the HA supervisor (slow + two failure points). Cached in-process only.
+_MQTT_PW=""
 mqtt_pw(){
+  [ -n "$_MQTT_PW" ] && { printf '%s' "$_MQTT_PW"; return 0; }
   local tok pw
   tok="$(bw get password ha-llat 2>/dev/null)" || die "bw locked? couldn't read ha-llat"
   pw="$(HA_TOKEN="$tok" python3 "$HOME/Projects/ha/tools/ha_supervisor.py" GET "/addons/$ADDON/info" \
         | python3 -c "import sys,json;print(json.load(sys.stdin)['options']['mqtt_password'])")" \
      || die "couldn't source mqtt_password from addon $ADDON"
   [ -n "$pw" ] || die "empty mqtt_password"
+  _MQTT_PW="$pw"
   printf '%s' "$pw"
 }
 
@@ -74,6 +85,71 @@ pub_retained(){ # topic, payload  (payload may be empty = retain-delete)
   else
     mosquitto_pub -h "$BROKER" -p 1883 -u "$MQTT_USER" -P "$pw" -r -t "$topic" -m "$payload"
   fi
+}
+
+# ---- #128: read the retained staged BUILD (for the ratchet) ------------------
+# Prints the current retained `smol/ota/staged` build number (field 2 of OTA|<build>|…) with
+# NO trailing newline, or nothing if the topic is empty / carries a non-OTA payload. Returns 0
+# when the broker was reachable (record found OR topic empty), 1 when the broker is UNREACHABLE
+# (so the caller can WARN + fall back to the raw count). A retained message arrives immediately
+# on subscribe, so -C 1 returns in ms; -W 3 bounds an empty topic. The reachable-but-empty case
+# and the unreachable case both exit non-zero, so we disambiguate on the stderr text (a real
+# connect failure always prints one of these; a bare -W timeout on an empty topic does not).
+read_staged_build(){
+  local pw msg rc err
+  pw="$(mqtt_pw)"
+  err="$(mktemp)"
+  msg="$(mosquitto_sub -h "$BROKER" -p 1883 -u "$MQTT_USER" -P "$pw" -C 1 -W 3 \
+        -t "smol/ota/staged" 2>"$err")" && rc=0 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if grep -qiE 'connection refused|connection error|unable to connect|getaddrinfo|unknown host|name or service|network is unreachable|no route to host|not authorised|error: connect' "$err"; then
+      rm -f "$err"; return 1   # broker unreachable / auth-failed → caller falls back to count
+    fi
+    rm -f "$err"; return 0      # connected, empty topic (no prior stage) → no build, reachable
+  fi
+  rm -f "$err"
+  case "$msg" in
+    OTA\|*) printf '%s' "$msg" | cut -d'|' -f2 | tr -d '\n' ;;  # field 2 = build
+    *) : ;;                                                     # non-OTA payload → treat as none
+  esac
+  return 0
+}
+
+# ---- #128: choose the staged BUILD number (pure decision — unit-tested) ------
+# Args: <commit-count> <retained-staged-build|""> <override|"">  → echoes the BUILD to stage;
+# warnings/notes go to STDERR only. Kept side-effect-free so tools/test_ota_ratchet.sh can
+# exercise every branch without a broker, a build, or a publish.
+#
+# INCIDENT (2026-07-14, issue #128): canary staging with --build 300/320/330 left id8 pinned
+# NUMERICALLY AHEAD of the honest commit count (254); honest-numbered stages then read as
+# NotNewer and #120's cleanup (correctly) cleared their orders → id8 silently refused real
+# updates until a 331 re-pin. The ratchet below (build = max(count, staged+1)) makes the fleet
+# number heal FORWARD automatically instead of poisoning the monotonicity gate.
+choose_build(){
+  local count="$1" staged="$2" override="$3" build
+  if [ -n "$override" ]; then
+    # Explicit operator override (canary an uncommitted image without a throwaway commit).
+    # Used AS-IS — but if it out-runs the honest count it re-creates the #128 incident, so warn.
+    build="$override"
+    if [ "$override" -gt "$count" ]; then
+      cat >&2 <<WARN
+⚠️  #128: --build $override is AHEAD of the honest commit count ($count). This PINS the fleet's
+    monotonicity gate above main — honest-numbered stages will read as NotNewer (and #120 cleanup
+    clears their orders) until main's count passes $override or the board is USB-reflashed.
+    HEAL PATH: stage ONE more pinned build (> the pinned board's current) to converge it, then
+    numbering self-heals at the next USB access / once the commit count overtakes the pin.
+WARN
+    fi
+  else
+    # Ratchet: never regress below the retained record — heal forward past any prior canary pin.
+    build="$count"
+    if [ -n "$staged" ] && [ "$((staged + 1))" -gt "$build" ]; then
+      build="$((staged + 1))"
+      echo "note: #128 ratchet — retained staged build ($staged) is ahead of the commit count ($count);" \
+           "staging $build to heal the fleet number forward past a prior canary pin." >&2
+    fi
+  fi
+  printf '%s' "$build"
 }
 
 # ---- install mode (Model-A per-node canary; parity with the HA Update button) --
@@ -100,14 +176,26 @@ esac; done
 # ---- identity (matches build.rs deploy contract; archive builds have no .git) -
 cd "$REPO"
 HASH="$(git rev-parse --short=7 "$COMMIT")"
-BUILD="$(git rev-list --count "$COMMIT")"
-# --build N overrides the git-derived count — lets an operator canary an UNCOMMITTED image
-# without a throwaway commit to bump the number (collision-risky on a busy repo). It becomes
-# the staged BUILD the firmware compares (monotonicity), so it must be a positive integer.
+COUNT="$(git rev-list --count "$COMMIT")"
+# #128: --build N stays an explicit operator override (canary an UNCOMMITTED image with no
+# throwaway commit to bump the count). Must be a positive integer.
 if [ -n "$BUILD_OVERRIDE" ]; then
   case "$BUILD_OVERRIDE" in ''|*[!0-9]*) die "--build must be a positive integer (got '$BUILD_OVERRIDE')";; esac
-  BUILD="$BUILD_OVERRIDE"
 fi
+# #128 RATCHET: with no override, stage build = max(commit count, retained staged build + 1) so
+# a prior canary pin heals the fleet number FORWARD instead of poisoning the monotonicity gate
+# (see choose_build + the incident note there). Only the ratchet path needs the broker read; an
+# explicit override skips it. Broker unreachable → WARN and fall back to the raw count.
+STAGED=""
+if [ -z "$BUILD_OVERRIDE" ]; then
+  if STAGED="$(read_staged_build)"; then :; else
+    echo "WARNING: #128 — broker $BROKER unreachable; can't read retained smol/ota/staged." >&2
+    echo "         Falling back to the raw commit count ($COUNT) with NO ratchet — if a prior" >&2
+    echo "         canary pin is live, this stage may re-collide with it (read fw DIAG to confirm)." >&2
+    STAGED=""
+  fi
+fi
+BUILD="$(choose_build "$COUNT" "$STAGED" "$BUILD_OVERRIDE")"
 
 # ---- build (or take a prebuilt .bin) ----------------------------------------
 # #40 IDENTITY — the staged image is FLEET-SHARED BY DESIGN: it is built with NO

--- a/tools/ota_publish.sh
+++ b/tools/ota_publish.sh
@@ -44,7 +44,22 @@ ESPFLASH="${ESPFLASH:-$HOME/.cargo/bin/espflash}"
 # present (dotenv-style) and its values fill in the placeholders below, so operators don't
 # retype env overrides. Precedence: env file > a var the file leaves unset (pre-set env) >
 # placeholder default. Nothing real ever lives in this committed script.
-_OTA_ENV="$(dirname "${BASH_SOURCE[0]}")/ota_publish.env"
+_OTA_SELF_DIR="$(dirname "${BASH_SOURCE[0]}")"
+_OTA_ENV="$_OTA_SELF_DIR/ota_publish.env"
+# #128: the infra env is git-ignored, so it lives ONLY in the operator's MAIN checkout — a linked
+# git worktree (or a fresh clone) has no copy, and the tool then silently fell back to the
+# PLACEHOLDER broker (10.0.0.1). Resolve worktree-robustly: prefer a local tools/ota_publish.env,
+# else the MAIN worktree's copy via git-common-dir (its dir strips the trailing /.git). This makes
+# install AND the new ratchet-read reach the REAL broker from any worktree, resolved up-front (once,
+# before any mode runs) so every code path — install and stage — reads the identical $BROKER.
+if [ ! -f "$_OTA_ENV" ]; then
+  _OTA_COMMON="$(git -C "$_OTA_SELF_DIR" rev-parse --git-common-dir 2>/dev/null)" || _OTA_COMMON=""
+  case "$_OTA_COMMON" in
+    /*) _OTA_MAIN_ENV="${_OTA_COMMON%/.git}/tools/ota_publish.env"
+        [ -f "$_OTA_MAIN_ENV" ] && _OTA_ENV="$_OTA_MAIN_ENV" ;;
+    *)  : ;;  # empty (not a git dir) or relative (already IN the main tree) → nothing to fall back to
+  esac
+fi
 # shellcheck source=/dev/null  # operator-supplied, git-ignored, path known only at runtime
 [ -f "$_OTA_ENV" ] && . "$_OTA_ENV"
 OTA_HOST_SSH="${OTA_HOST_SSH:-<ssh-host>}"      # scp target (ssh alias for the image host)

--- a/tools/test_ota_ratchet.sh
+++ b/tools/test_ota_ratchet.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# test_ota_ratchet.sh — unit tests for the #128 build-number ratchet in ota_publish.sh.
+#
+# Pure-logic: NO broker, NO cargo build, NO publish. It extracts just the two functions under
+# test (choose_build — the ratchet/override decision; read_staged_build — the retained parse +
+# reachable/unreachable disambiguation) and stubs mqtt_pw / mosquitto_sub. The full end-to-end
+# (staging against the LIVE broker) is the real acceptance test; this locks the decision logic.
+#
+# Run:  tools/test_ota_ratchet.sh      (exit 0 = all green)
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/ota_publish.sh"
+[ -f "$SCRIPT" ] || { echo "missing $SCRIPT" >&2; exit 2; }
+
+# Pull in ONLY the functions under test — no side effects, and none of the parent's `set -e`.
+eval "$(awk '/^choose_build\(\)\{/,/^\}/' "$SCRIPT")"
+eval "$(awk '/^read_staged_build\(\)\{/,/^\}/' "$SCRIPT")"
+
+# read_staged_build references these + calls mqtt_pw/mosquitto_sub — stub them all.
+# (export: they're read inside the eval'd read_staged_build, invisible to shellcheck here.)
+export BROKER="test.invalid" MQTT_USER="tester"
+mqtt_pw(){ printf 'stub-pw'; }
+
+pass=0; fail=0
+eq(){ # name  expected  actual
+  if [ "$2" = "$3" ]; then pass=$((pass+1)); printf 'ok   - %s\n' "$1"
+  else fail=$((fail+1)); printf 'FAIL - %s\n        want [%s]\n        got  [%s]\n' "$1" "$2" "$3"; fi
+}
+
+echo "== choose_build  (count, staged, override) -> build =="
+eq "no stage, no override -> count"                254 "$(choose_build 254 ''  ''  2>/dev/null)"
+eq "staged behind count -> count"                  254 "$(choose_build 254 100 ''  2>/dev/null)"
+# staged == count: max(count, staged+1) = count+1 — a re-stage at the same count is forced to
+# SUPERSEDE the retained record (guarantees boards accept it); the +1 self-corrects at the next
+# commit. This is the literal max(count, staged+1) spec, not a bug.
+eq "staged == count -> staged+1 (force re-stage supersede)" 255 "$(choose_build 254 254 ''  2>/dev/null)"
+eq "staged == count-1 (normal advance) -> count"   254 "$(choose_build 254 253 ''  2>/dev/null)"
+eq "staged AHEAD (canary pin) -> ratchet staged+1" 331 "$(choose_build 254 330 ''  2>/dev/null)"
+eq "override below count -> override as-is"         200 "$(choose_build 254 ''  200 2>/dev/null)"
+eq "override above count -> override as-is"         330 "$(choose_build 254 ''  330 2>/dev/null)"
+eq "override IGNORES staged (no ratchet)"          200 "$(choose_build 254 999 200 2>/dev/null)"
+eq "override>count emits canary warning"             1 "$(choose_build 254 '' 330 2>&1 >/dev/null | grep -c 'AHEAD of the honest')"
+eq "override<=count emits NO warning"                0 "$(choose_build 254 '' 200 2>&1 >/dev/null | grep -c 'AHEAD of the honest')"
+eq "ratchet emits heal note"                         1 "$(choose_build 254 330 ''  2>&1 >/dev/null | grep -c 'ratchet')"
+eq "no-ratchet emits NO note"                        0 "$(choose_build 254 100 ''  2>&1 >/dev/null | grep -c 'ratchet')"
+
+echo "== read_staged_build  (stubbed mosquitto_sub) -> build:rc =="
+mosquitto_sub(){ printf 'OTA|321|2048|deadbeef|sig|http://h/o.bin\n'; return 0; }
+eq "reachable + retained record -> 321:0"  "321:0" "$(printf '%s:%s' "$(read_staged_build)" "$?")"
+mosquitto_sub(){ printf 'garbage\n'; return 0; }
+eq "reachable + non-OTA payload -> :0"       ":0"   "$(printf '%s:%s' "$(read_staged_build)" "$?")"
+mosquitto_sub(){ echo "Timed out" >&2; return 27; }
+eq "reachable + empty topic -> :0"           ":0"   "$(printf '%s:%s' "$(read_staged_build)" "$?")"
+mosquitto_sub(){ echo "Error: Connection refused" >&2; return 1; }
+eq "broker unreachable -> :1"                ":1"   "$(printf '%s:%s' "$(read_staged_build)" "$?")"
+
+echo "----"
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## #128 — canary `--build` pins no longer poison the fleet's monotonicity gate

Branch off `origin/main@6e78461`. **Tooling only — no firmware, mergeable without hardware.**

### The incident (2026-07-14, issue #128)
Canary staging with `--build 300/320/330` left id8 pinned **numerically ahead** of the honest
commit count (254). Honest-numbered stages then read as `NotNewer`, #120's cleanup (correctly)
cleared their orders, and id8 **silently refused real updates** until a `331` re-pin — it would
otherwise have stayed stuck until main's count passed the pin (~76 commits) or a USB reflash.

### The fix — option (b), the ratchet (`tools/ota_publish.sh` stage mode)
- **Ratchet:** stage build = `max(git rev-list --count, <retained smol/ota/staged build> + 1)`.
  A prior canary pin **heals the fleet number forward automatically** instead of poisoning the gate.
- **Retained read:** the current `smol/ota/staged` build is read via `mosquitto_sub` (reusing the
  script's already-resolved broker env + a now-memoized credential). **Broker unreachable → falls
  back to the raw count with a loud WARNING** (no ratchet); reachable-but-empty (no prior stage) →
  count. Unreachable vs empty-topic is disambiguated on the stderr connect-error text.
- **Override preserved:** `--build N` stays an explicit operator override (canary an uncommitted
  image with no throwaway commit), used **as-is**, but now prints a **loud warning + the heal path**
  when `N > count` — i.e. it names the exact footgun that caused this incident.
- `mqtt_pw` memoized so the new read and the publish don't each hit `bw` + the HA supervisor. Header
  docs updated; the incident recorded as a comment at `choose_build()`.

### Decision table (`choose_build count staged override → build`)
| override | staged vs count | → build | why |
|---|---|---|---|
| — | none / unreachable | `count` | normal (unreachable also WARNs) |
| — | `staged < count` | `count` | normal advance |
| — | `staged == count` | `staged+1` | force a re-stage to supersede |
| — | `staged > count` (pin) | `staged+1` | **heal forward past the pin** |
| `N` | any | `N` | operator override, used as-is |
| `N` | `N > count` | `N` + **loud warning** | canary-pin footgun flagged |

### Verification
- **Unit tests:** `tools/test_ota_ratchet.sh` extracts the two side-effect-free functions
  (`choose_build`, `read_staged_build`) and exercises **every branch** with a stubbed
  `mosquitto_sub` — **16/16 green**, no broker / build / publish. (`read_staged_build` covers:
  reachable+record → build, reachable+empty → none, reachable+non-OTA → none, unreachable → rc1.)
- `shellcheck -S warning` **clean** on both files (also silenced a pre-existing SC1090 on the
  env-source line); `bash -n` clean.
- **Live acceptance (operator, costs nothing — the real test):**
  1. `tools/ota_publish.sh stage` on a fleet whose retained `smol/ota/staged` is a canary pin
     ahead of `git rev-list --count` → observe the `note: #128 ratchet …` line and a staged build
     of `pin+1` (not the raw count). Boards accept it (build advances).
  2. `tools/ota_publish.sh stage --build <count+50>` → observe the loud canary-pin WARNING + heal
     path; the stage still proceeds at the override (unchanged operator escape hatch).
  3. With the broker leg down (or a bad `BROKER`) → observe the unreachable WARNING + fallback to
     the raw count.

Refs #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
