### PR TITLE
feat(fw): #124 UP2 envelope + #126 channel parking — multi-hop uplink & observability (HW-gate held)

### DIFF
--- a/experiments/flood_verify/src/main.rs
+++ b/experiments/flood_verify/src/main.rs
@@ -6,8 +6,8 @@
 mod flood;
 
 use flood::{
-    forward_decision, ForwardAction, HopLatch, SeenSet, ESCALATE_STREAK, MAX_HOP, PROBE_EVERY,
-    SEEN_RING, UNLATCH_STREAK,
+    forward_decision, ChannelPark, ForwardAction, HopLatch, SeenSet, ESCALATE_STREAK, MAX_HOP,
+    PARK_DWELL_MS, PARK_STALE_MS, PROBE_EVERY, SEEN_RING, UNLATCH_STREAK,
 };
 
 /// Drive a fresh latch into multi-hop the way a genuinely-stranded leaf does: ESCALATE_STREAK
@@ -120,5 +120,57 @@ fn main() {
     l3.on_direct_ack();
     assert!(!l3.latched());
 
-    println!("flood_verify: ALL CHECKS PASSED (SeenSet + forward_decision + HopLatch)");
+    // --- #126 ChannelPark: latched-leaf channel parking ------------------
+    // The #123 LESSON: last campaign only the HopLatch MATH was host-tested, not the trigger WIRING,
+    // so an on-air bug slipped past green builds. ChannelPark owns the ENTIRE latched-leaf channel
+    // decision (poll = the channel to be on; on_signal = a relay-echo/RELAYACK2 arrived; reset =
+    // un-latched), so exercising these here IS the wiring coverage — mode.rs only applies + feeds.
+    const C: [u8; 3] = [1, 6, 11]; // must match mode.rs's CANDIDATES
+
+    // (a) BOOTSTRAP HUNT: with no signal yet, round-robin the candidates every PARK_DWELL_MS. poll
+    //     returns Some only on an actual change (so the radio re-tunes exactly as sparsely as the
+    //     round-robin), None mid-dwell.
+    let mut p = ChannelPark::new();
+    assert_eq!(p.poll(0, &C), Some(1), "first selection tunes to candidate 0");
+    assert_eq!(p.poll(500, &C), None, "mid-dwell: no re-tune");
+    assert_eq!(p.poll(PARK_DWELL_MS, &C), Some(6), "dwell elapsed ⇒ hop to candidate 1");
+    assert_eq!(p.poll(2 * PARK_DWELL_MS, &C), Some(11), "hop to candidate 2");
+    assert_eq!(p.poll(3 * PARK_DWELL_MS, &C), Some(1), "round-robin wraps to candidate 0");
+    assert_eq!(p.parked(), None, "no signal yet ⇒ not parked (still hunting)");
+
+    // (b) PARK ON SIGNAL: a relay echoed our UP2 (or a RELAYACK2 for us arrived) while on candidate 0
+    //     ⇒ park there. Subsequent polls DWELL on it (no hop) for the whole freshness window.
+    p.on_signal(3 * PARK_DWELL_MS); // signalled while current == candidate 0 (from the poll above)
+    assert_eq!(p.parked(), Some(1), "signal ⇒ parked on the channel we're physically on");
+    assert_eq!(p.poll(4 * PARK_DWELL_MS, &C), None, "parked+fresh ⇒ dwell, do NOT hop");
+    assert_eq!(p.poll(3 * PARK_DWELL_MS + PARK_STALE_MS - 1, &C), None, "still parked just under stale");
+    assert_eq!(p.parked(), Some(1), "park held across the fresh window");
+
+    // (c) FRESHNESS REFRESH: another signal while parked extends the window (a leaf that keeps
+    //     drawing ACKs stays parked indefinitely).
+    let t_refresh = 4 * PARK_DWELL_MS;
+    p.on_signal(t_refresh);
+    assert_eq!(p.poll(t_refresh + PARK_STALE_MS - 1, &C), None, "refreshed park still fresh");
+    assert_eq!(p.parked(), Some(1), "refresh held the park");
+
+    // (d) STALENESS RECOVERY: no signal for PARK_STALE_MS ⇒ forget the park and resume the hunt
+    //     (self-healing when the relay roams / dies).
+    let after_stale = t_refresh + PARK_STALE_MS;
+    let ch = p.poll(after_stale, &C).expect("stale park ⇒ re-tune (resume hunt)");
+    assert_ne!(ch, 1, "resumed hunt moves off the stale parked channel");
+    assert_eq!(p.parked(), None, "stale park cleared");
+
+    // (e) RESET (un-latch): forget the park immediately; the next poll re-bootstraps from ch 0.
+    p.on_signal(after_stale); // re-park first
+    assert!(p.parked().is_some(), "re-parked");
+    p.reset();
+    assert_eq!(p.parked(), None, "reset (un-latch) clears the park");
+    assert!(p.poll(after_stale + 10 * PARK_DWELL_MS, &C).is_some(), "post-reset re-tune (re-bootstrap)");
+
+    // (f) DEFENSIVE: a signal before any poll (current == unset sentinel) must NOT park on 0.
+    let mut q = ChannelPark::new();
+    q.on_signal(100);
+    assert_eq!(q.parked(), None, "no park on the unset-channel sentinel");
+
+    println!("flood_verify: ALL CHECKS PASSED (SeenSet + forward_decision + HopLatch + ChannelPark)");
 }

--- a/experiments/relay_compat/src/main.rs
+++ b/experiments/relay_compat/src/main.rs
@@ -135,5 +135,34 @@ fn main() {
     let (_, _, _, clamped) = wire::parse_up2(&up[..cn]).unwrap();
     assert_eq!(clamped.len(), wire::UP2_INNER_MAX, "inner clamped to UP2_INNER_MAX");
 
-    println!("relay_compat: ALL CHECKS PASSED (bidirectional byte-compat + golden bytes + #13/#124 tag round-trips + disambiguation + UP2 clamp)");
+    // #124 Stage 2 — field-boundary clamp (a wrapped DIAG/SCAN never truncates mid `key=val`).
+    // Fits: returns the full length, no clamp.
+    assert_eq!(wire::clamp_inner_field_boundary(b"aa|bb|cc", 100), 8, "clamp: fits => full len");
+    // Over budget: truncate at the LAST `|` at or before max, dropping the straddling tail field.
+    assert_eq!(wire::clamp_inner_field_boundary(b"aa|bb|cc", 5), 5, "clamp: cut at `|` index 5 => aa|bb");
+    assert_eq!(wire::clamp_inner_field_boundary(b"aa|bb|cc", 4), 2, "clamp: cut at `|` index 2 => aa");
+    // No `|` inside max (a single oversized field): raw fallback to max.
+    assert_eq!(wire::clamp_inner_field_boundary(b"aaaaaa", 3), 3, "clamp: no separator => raw max");
+
+    // A realistic over-budget DIAG frame: "SMOLv1 DIAG 007" + a long `|`-joined record (> MTU). The
+    // wrapped envelope must (a) fit ESP_NOW_MTU, (b) cut at a field boundary (the cut index is a `|`,
+    // and the surviving slice does NOT end mid-field), (c) keep the SMOLv1 DIAG prefix intact so the
+    // gateway still classifies + caches it.
+    let mut diag = b"SMOLv1 DIAG 007".to_vec();
+    for i in 0..40u32 {
+        diag.push(b'|');
+        diag.extend_from_slice(format!("k{i:02}=vvvvv").as_bytes());
+    }
+    assert!(diag.len() > wire::ESP_NOW_MTU, "test DIAG must exceed the MTU to exercise the clamp");
+    let cut = wire::clamp_inner_field_boundary(&diag, wire::UP2_INNER_MAX);
+    assert!(cut <= wire::UP2_INNER_MAX, "clamp <= UP2_INNER_MAX");
+    assert_eq!(diag[cut], b'|', "clamp lands ON a `|` separator (dropped tail field starts here)");
+    assert_ne!(diag[cut - 1], b'|', "surviving slice ends on a complete field, not a bare `|`");
+    let dn = wire::encode_up2(7, 3, 2, &diag[..cut], &mut up);
+    assert!(dn <= wire::ESP_NOW_MTU, "wrapped over-budget DIAG still fits the MTU");
+    let (_, _, _, dinner) = wire::parse_up2(&up[..dn]).expect("parse wrapped DIAG");
+    assert_eq!(dinner, &diag[..cut], "unwrapped inner == the field-boundary-clamped DIAG verbatim");
+    assert!(dinner.starts_with(b"SMOLv1 DIAG 007"), "clamped DIAG keeps its classify-able prefix");
+
+    println!("relay_compat: ALL CHECKS PASSED (bidirectional byte-compat + golden bytes + #13/#124 tag round-trips + disambiguation + UP2 clamp + field-boundary DIAG clamp)");
 }

--- a/experiments/relay_compat/src/main.rs
+++ b/experiments/relay_compat/src/main.rs
@@ -114,5 +114,37 @@ fn main() {
     // a BATT2 frame must not parse under the GRID2 prefix (tag isolation).
     assert!(wire::parse_dl(wire::GRID2_PREFIX, &dl[..dln]).is_none(), "BATT2 is not a GRID2");
 
-    println!("relay_compat: ALL CHECKS PASSED (bidirectional byte-compat + golden bytes + #13 tag round-trips + disambiguation)");
+    // #124 UP2 envelope — golden bytes + wrap→unwrap→re-parse-inner both directions + disambiguation.
+    // Wrap a plain RELAY (the RELAY2-subsuming case): the gateway unwraps → the inner is a verbatim
+    // RELAY that re-parses under the SAME parse_relay used for a single-hop leaf.
+    let inner_relay = {
+        let mut ib = [0u8; 128];
+        let iln = wire::encode_relay(7, 100, 0, 1, b"cpu=42", &mut ib);
+        ib[..iln].to_vec()
+    };
+    let mut up = [0u8; 256];
+    let upn = wire::encode_up2(7, 5, 2, &inner_relay, &mut up);
+    // GOLDEN: "SMOLv1 UP2 007 00005 2 " + <the verbatim RELAY frame>.
+    let mut golden_up = b"SMOLv1 UP2 007 00005 2 ".to_vec();
+    golden_up.extend_from_slice(&inner_relay);
+    assert_eq!(&up[..upn], &golden_up[..], "encode_up2 golden wire bytes");
+    let (o, em, h, inner) = wire::parse_up2(&up[..upn]).expect("parse_up2");
+    assert_eq!((o, em, h), (7, 5, 2), "UP2 header: origin / envelope-msgid / hop");
+    // the unwrapped inner is a verbatim RELAY → re-parses under the ordinary parser (gateway dispatch).
+    let (rid, rmid, rfrag, rcnt, rchunk) = wire::parse_relay(inner).expect("inner is a verbatim RELAY");
+    assert_eq!((rid, rmid, rfrag, rcnt, rchunk), (7, 100, 0, 1, &b"cpu=42"[..]), "inner RELAY round-trip");
+    // envelope msgid (5) is DISTINCT from the inner RELAY msgid (100) — the two-layer contract.
+    assert_ne!(em, rmid, "envelope msgid != inner RELAY msgid (flood-dedup vs reassembly layers)");
+    // disambiguation: UP2 must NOT classify as RELAY/RELAY2, and vice-versa.
+    assert!(wire::parse_relay(&up[..upn]).is_none(), "UP2 must NOT parse as plain RELAY");
+    assert!(wire::parse_relay2(&up[..upn]).is_none(), "UP2 must NOT parse as RELAY2");
+    assert!(wire::parse_up2(&fb[..n]).is_none(), "a plain RELAY must NOT parse as UP2");
+    // CONSTRAINT 1: a max inner is clamped so the envelope never exceeds ESP_NOW_MTU.
+    let big_inner = [b'z'; 240];
+    let cn = wire::encode_up2(9, 1, 2, &big_inner, &mut up);
+    assert!(cn <= wire::ESP_NOW_MTU, "UP2 clamps inner → frame never exceeds ESP_NOW_MTU");
+    let (_, _, _, clamped) = wire::parse_up2(&up[..cn]).unwrap();
+    assert_eq!(clamped.len(), wire::UP2_INNER_MAX, "inner clamped to UP2_INNER_MAX");
+
+    println!("relay_compat: ALL CHECKS PASSED (bidirectional byte-compat + golden bytes + #13/#124 tag round-trips + disambiguation + UP2 clamp)");
 }

--- a/experiments/relay_compat/src/main.rs
+++ b/experiments/relay_compat/src/main.rs
@@ -84,18 +84,8 @@ fn main() {
     let an = wire::encode_relayack(12345, 3, &mut ab);
     assert_eq!(&ab[..an], old_ack, "encode_relayack golden wire bytes");
 
-    // #13 tag round-trips + DISAMBIGUATION (the no-flag-day guarantee) ------------------------
-    // A RELAY2 frame must NEVER classify as a plain RELAY (old fw would mis-read it), and a plain
-    // RELAY must never classify as RELAY2. Same for RELAYACK/RELAYACK2.
-    let mut r2 = [0u8; 128];
-    let r2n = wire::encode_relay2(9, 42, 2, 1, 2, b"hi", &mut r2);
-    assert!(wire::parse_relay(&r2[..r2n]).is_none(), "RELAY2 must NOT parse as plain RELAY");
-    assert_eq!(
-        wire::parse_relay2(&r2[..r2n]).unwrap(),
-        (9, 42, 2, 1, 2, &b"hi"[..]),
-        "RELAY2 round-trip"
-    );
-    assert!(wire::parse_relay2(&fb[..n2]).is_none(), "plain RELAY must NOT parse as RELAY2");
+    // #13/#124 RELAYACK2 round-trip + DISAMBIGUATION (the no-flag-day guarantee) --------------
+    // (RELAY2 is retired — replaced by UP2 below; RELAYACK2 stays as the flooded ACK.)
     // the gateway's origin-keyed reassembly MAC (never aliases a real Espressif MAC).
     assert_eq!(wire::synth_origin_mac(9), [0, 0, 0, 0, 0, 9], "synth_origin_mac layout");
 
@@ -135,9 +125,8 @@ fn main() {
     assert_eq!((rid, rmid, rfrag, rcnt, rchunk), (7, 100, 0, 1, &b"cpu=42"[..]), "inner RELAY round-trip");
     // envelope msgid (5) is DISTINCT from the inner RELAY msgid (100) — the two-layer contract.
     assert_ne!(em, rmid, "envelope msgid != inner RELAY msgid (flood-dedup vs reassembly layers)");
-    // disambiguation: UP2 must NOT classify as RELAY/RELAY2, and vice-versa.
+    // disambiguation: UP2 must NOT classify as a plain RELAY, and vice-versa.
     assert!(wire::parse_relay(&up[..upn]).is_none(), "UP2 must NOT parse as plain RELAY");
-    assert!(wire::parse_relay2(&up[..upn]).is_none(), "UP2 must NOT parse as RELAY2");
     assert!(wire::parse_up2(&fb[..n]).is_none(), "a plain RELAY must NOT parse as UP2");
     // CONSTRAINT 1: a max inner is clamped so the envelope never exceeds ESP_NOW_MTU.
     let big_inner = [b'z'; 240];

--- a/rust/clock/src/net/flood.rs
+++ b/rust/clock/src/net/flood.rs
@@ -251,3 +251,115 @@ impl Default for HopLatch {
         Self::new()
     }
 }
+
+// ---- #126 latched-leaf channel parking (multi-hop throughput) ---------------
+
+/// Bootstrap dwell per candidate while HUNTING for the relay's channel (matches `mode.rs`'s scan
+/// dwell). A leaf that can't hear its owner blind-hops the candidate channels, so an uplink lands
+/// on the relay's channel only ~1/N of the time (#123's ~1/3 finding).
+pub const PARK_DWELL_MS: u64 = 1500;
+
+/// No park signal (a relay echoing our UP2, or a RELAYACK2 for us) on the parked channel for this
+/// long ⇒ the relay moved or died; forget the park and resume the hunt. A few dwell cycles — long
+/// enough to ride a lossy gap, short enough to re-discover promptly. Self-healing.
+pub const PARK_STALE_MS: u64 = 12_000;
+
+/// #126: a LATCHED leaf's channel-selection state machine (pure). A stranded leaf never locks a
+/// channel (it can't hear its owner's HELLO), so #13 v1 left it blind-hopping the candidates — its
+/// uplink coincides with the relay's channel only ~1/N of the time, and the `RELAYACK2` flood-back
+/// hits the same ~1/N in reverse. This PARKS the leaf on the channel that last drew a park signal
+/// (a relay re-broadcasting our own UP2 — the early "forwarded" proof — or a `RELAYACK2` addressed
+/// to us — the end-to-end proof), so subsequent emits AND ACKs ride the channel that demonstrably
+/// works. Self-healing: a park that stops drawing signals ([`PARK_STALE_MS`]) is dropped and the
+/// round-robin hunt resumes (rides relay roam / re-election for free).
+///
+/// It owns the ENTIRE latched-leaf channel decision so the firmware wiring is trivial: apply
+/// [`ChannelPark::poll`]'s result via `set_channel`, feed [`ChannelPark::on_signal`] when a relay
+/// echoes our UP2 or a `RELAYACK2` for us arrives, and [`ChannelPark::reset`] when the leaf
+/// un-latches. Host tests over these methods therefore ARE the trigger-wiring coverage — the #123
+/// lesson: last campaign only the [`HopLatch`] MATH was host-tested, NOT the wiring that drives it,
+/// so an on-air trigger bug slipped past green builds. Here the wiring is reduced to "apply + feed".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChannelPark {
+    /// The channel that last drew a park signal while latched — the park target. `None` ⇒ hunting.
+    parked: Option<u8>,
+    /// When `parked` last drew a signal (freshness anchor for [`PARK_STALE_MS`]).
+    last_signal_ms: u64,
+    /// Round-robin cursor into the candidate list during the bootstrap / re-hunt.
+    scan_idx: usize,
+    /// When the bootstrap cursor last advanced (the dwell gate).
+    last_hop_ms: u64,
+    /// The channel [`poll`] last selected — what the leaf is physically tuned to; a signal parks here.
+    ///
+    /// [`poll`]: ChannelPark::poll
+    current: u8,
+}
+
+impl ChannelPark {
+    pub const fn new() -> Self {
+        Self { parked: None, last_signal_ms: 0, scan_idx: 0, last_hop_ms: 0, current: 0 }
+    }
+
+    /// Decide the channel to be on NOW; return `Some(ch)` IFF it changed since the last selection
+    /// (so the caller re-tunes only on a real hop or park-switch, never mid-dwell). Parks on the
+    /// signalling channel while fresh; else round-robins `candidates` every [`PARK_DWELL_MS`] (the
+    /// #126 "dwell-per-channel" hunt). Lazily forgets a stale park. `candidates` must be non-empty
+    /// (empty ⇒ keep the current channel, defensively).
+    pub fn poll(&mut self, now: u64, candidates: &[u8]) -> Option<u8> {
+        let next = self.decide(now, candidates);
+        if next != self.current {
+            self.current = next;
+            Some(next)
+        } else {
+            None
+        }
+    }
+
+    fn decide(&mut self, now: u64, candidates: &[u8]) -> u8 {
+        if let Some(ch) = self.parked {
+            if now.saturating_sub(self.last_signal_ms) < PARK_STALE_MS {
+                return ch; // fresh park — dwell here, do not hop
+            }
+            self.parked = None; // stale → resume the hunt
+        }
+        if candidates.is_empty() {
+            return self.current; // defensive: never index an empty candidate list
+        }
+        if now.saturating_sub(self.last_hop_ms) >= PARK_DWELL_MS {
+            self.scan_idx = (self.scan_idx + 1) % candidates.len();
+            self.last_hop_ms = now;
+        }
+        candidates[self.scan_idx % candidates.len()]
+    }
+
+    /// A park signal arrived on the channel we're physically on (a relay echoed our UP2, or a
+    /// `RELAYACK2` addressed to us) — proof the relay path works HERE. Park on it. Called only while
+    /// latched, after [`poll`] has selected a real candidate, so `current` is non-zero by then; the
+    /// zero-guard is belt-and-suspenders (never park on the sentinel "unset" channel).
+    ///
+    /// [`poll`]: ChannelPark::poll
+    pub fn on_signal(&mut self, now: u64) {
+        if self.current != 0 {
+            self.parked = Some(self.current);
+            self.last_signal_ms = now;
+        }
+    }
+
+    /// The leaf un-latched (re-acquired its owner / re-elected) — forget the park so a future latch
+    /// re-bootstraps from a clean hunt. Leaves the round-robin cursor (start index is immaterial).
+    pub fn reset(&mut self) {
+        self.parked = None;
+        self.current = 0;
+    }
+
+    /// The channel the leaf is currently parked on, or `None` while hunting. Observability / tests.
+    pub fn parked(&self) -> Option<u8> {
+        self.parked
+    }
+}
+
+impl Default for ChannelPark {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1459,6 +1459,10 @@ struct Relay {
     /// (each inner frame / RELAY fragment gets a unique one), the FLOOD-DEDUP key. DISTINCT from the
     /// inner RELAY `msgid` (`tx.msgid`), which stays the reassembly/RELAYACK2 key. Wraps like `next_msgid`.
     up_env_msgid: u16,
+    /// #126 leaf-role: the latched-leaf channel-parking state machine. Inert until the leaf latches
+    /// multi-hop; then it parks on the channel that drew a relay-echo/`RELAYACK2` instead of blind-
+    /// hopping (raising the ~1/3 channel-coincidence throughput). See `net/flood.rs`.
+    park: crate::net::flood::ChannelPark,
 }
 
 impl Relay {
@@ -1477,6 +1481,7 @@ impl Relay {
             seen: crate::net::flood::SeenSet::new(),
             latch: crate::net::flood::HopLatch::new(),
             up_env_msgid: 0,
+            park: crate::net::flood::ChannelPark::new(),
         }
     }
 
@@ -2002,6 +2007,26 @@ impl RadioManager {
         if self.scan_locked {
             return;
         }
+        // #126 channel parking: a LATCHED leaf (stranded — never locked an owner) delegates its
+        // channel choice to ChannelPark, which parks on the channel that drew a relay-echo/RELAYACK2
+        // instead of blind-hopping (raising the ~1/3 channel-coincidence throughput). It hunts the
+        // SAME candidates when bootstrapping / after a park goes stale, so a not-yet-signalled latched
+        // leaf behaves like today's blind scan. `poll` returns Some only on an actual change, so we
+        // re-tune the radio exactly as sparsely as the round-robin did (never mid-dwell).
+        if self.relay.latch.latched() {
+            if let Some(ch) = self.relay.park.poll(now, &CANDIDATES) {
+                let _ = self.esp_now.set_channel(ch);
+                log::info!(
+                    "smol #126: latched-leaf channel {} ({})",
+                    ch,
+                    if self.relay.park.parked() == Some(ch) { "parked" } else { "hunting" }
+                );
+            }
+            return;
+        }
+        // NOT latched → the ordinary blind scan for our owner. Forget any stale park so a future
+        // latch re-bootstraps from a clean hunt.
+        self.relay.park.reset();
         if now.saturating_sub(self.last_scan_hop_ms) >= DWELL_MS {
             self.scan_idx = (self.scan_idx + 1) % CANDIDATES.len();
             let ch = CANDIDATES[self.scan_idx];
@@ -4339,7 +4364,12 @@ impl RadioManager {
                     self.roster.heard(src, Some(origin), rssi, now);
                     if origin == self.id {
                         // Our OWN envelope echoed back by a relay — never re-forward/reassemble it
-                        // (bogus fwd + could loop). Just drop it.
+                        // (bogus fwd + could loop). But the echo PROVES a relay heard + forwarded us
+                        // on the channel we're physically on → the #126 early park signal (arrives a
+                        // hop sooner than the gateway's RELAYACK2). Feed it while latched.
+                        if self.relay.latch.latched() {
+                            self.relay.park.on_signal(now);
+                        }
                         label = Some(alloc::format!("up2 self {:03}", origin));
                     } else if self.relay.is_gateway {
                         // GATEWAY SINK: dispatch by the INNER frame type (#124 Stage 2). Everything is
@@ -4433,6 +4463,11 @@ impl RadioManager {
                         // the escalation streak (does NOT un-latch — that still needs a direct probe).
                         if bitmap != 0 {
                             self.relay.latch.on_uplink_progress();
+                        }
+                        // #126: the ACK reached us on the channel we're physically on → the round-trip
+                        // works HERE. Park on it (confirming signal; complements the earlier UP2-echo).
+                        if self.relay.latch.latched() {
+                            self.relay.park.on_signal(now);
                         }
                         label = Some(alloc::format!("ack2 {:05}", msgid));
                     } else if hop > 1 {

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2449,6 +2449,7 @@ impl RadioManager {
         let n = value.len().min(crate::net::wifi::CFG_VALUE_MAX);
         msg[base + 3..base + 3 + n].copy_from_slice(&value[..n]);
         self.send_to(&BROADCAST_ADDRESS, &msg[..base + 3 + n]);
+        self.relay_wrap_observability(&msg[..base + 3 + n]);
     }
 
     /// #70/#49: broadcast this node's compact key=val DIAG record as a `SMOLv1 DIAG` frame —
@@ -2468,6 +2469,7 @@ impl RadioManager {
         let n = value.len().min(crate::net::wifi::RELAY_VALUE_MAX);
         msg[base + 3..base + 3 + n].copy_from_slice(&value[..n]);
         self.send_to(&BROADCAST_ADDRESS, &msg[..base + 3 + n]);
+        self.relay_wrap_observability(&msg[..base + 3 + n]);
     }
 
     /// #71: broadcast this node's one-shot WiFi-scan record as a `SMOLv1 SCAN` frame — twin of
@@ -2486,6 +2488,29 @@ impl RadioManager {
         let n = value.len().min(crate::net::wifi::RELAY_VALUE_MAX);
         msg[base + 3..base + 3 + n].copy_from_slice(&value[..n]);
         self.send_to(&BROADCAST_ADDRESS, &msg[..base + 3 + n]);
+        self.relay_wrap_observability(&msg[..base + 3 + n]);
+    }
+
+    /// #124 Stage 2 (observability closure) — when this leaf is LATCHED (multi-hop, gateway out of
+    /// direct earshot), ALSO emit `frame` (a fully-built plain STAT/DIAG/SCAN) wrapped in a UP2
+    /// envelope so a relay floods our /stat /diag /scan to the gateway. Closes the P1 gap: a
+    /// stranded leaf that can't RELAY-uplink was previously observability-DARK (STAT/DIAG/SCAN are
+    /// plain broadcasts, never forwarded). No-op on a gateway or when NOT latched — so a healthy
+    /// leaf's on-air behaviour is BYTE-IDENTICAL (only the plain broadcast, no UP2). The inner is
+    /// clamped at a FIELD BOUNDARY (last `|` ≤ [`UP2_INNER_MAX`]) so an over-budget DIAG/SCAN record
+    /// truncates its tail cleanly (never mid `key=val`); STAT (≤ 79 B) never clamps. Each wrap gets a
+    /// fresh envelope msgid (the flood-dedup key; fire-and-forget — no inner ACK). `frame` is a local
+    /// buffer in the caller, so no borrow of `self` is held across the `&mut self` send.
+    fn relay_wrap_observability(&mut self, frame: &[u8]) {
+        if self.relay.is_gateway || !self.relay.latch.latched() {
+            return;
+        }
+        let env_msgid = self.relay.up_env_msgid;
+        self.relay.up_env_msgid = self.relay.up_env_msgid.wrapping_add(1);
+        let ilen = clamp_inner_field_boundary(frame, UP2_INNER_MAX);
+        let mut fb = [0u8; ESP_NOW_MTU];
+        let len = encode_up2(self.id, env_msgid, crate::net::flood::MAX_HOP, &frame[..ilen], &mut fb);
+        self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
     }
 
     /// #71: run ONE on-demand WiFi AP scan (triggered by applying the `W` command) → publish the
@@ -4316,61 +4341,81 @@ impl RadioManager {
                         // Our OWN envelope echoed back by a relay — never re-forward/reassemble it
                         // (bogus fwd + could loop). Just drop it.
                         label = Some(alloc::format!("up2 self {:03}", origin));
-                    } else if let Some((_sid, imsgid, frag, count, chunk)) = parse_relay(inner) {
-                        // 1b: the inner is a plain RELAY (the RELAY2-subsuming case). `imsgid` is the
-                        // INNER RELAY msgid — the reassembly/ACK key, distinct from the envelope msgid.
-                        if self.relay.is_gateway {
-                            // GATEWAY sink: reassemble keyed by ORIGIN (synthetic MAC), NOT `src` (the
-                            // last relay). accept()+DONE_RING dedup fragments/retransmits, so we do NOT
-                            // consult the seen-set here (a seen-set drop would kill a lost-ACK
-                            // retransmit's re-ACK). On each accepted fragment flood a RELAYACK2 back
-                            // toward the origin (R1) carrying the cumulative bitmap, keyed on `imsgid`.
-                            let synth = synth_origin_mac(origin);
-                            let (bitmap, complete) =
-                                self.relay.accept(synth, (origin, imsgid, frag, count), chunk, now);
-                            self.flood_relayack2(origin, imsgid, bitmap);
-                            label = Some(if complete {
-                                alloc::format!("up2 {:03} ok", origin)
-                            } else {
-                                alloc::format!("up2 {:03} {}/{}", origin, bitmap.count_ones(), count)
-                            });
-                        } else {
-                            // RELAY role: seen-set-gated forward, keyed on the ENVELOPE msgid
-                            // `(origin, env_msgid, 0)` — each UP2 is one atomic frame (frag dimension
-                            // is absorbed into env_msgid, which is unique per emitted/retransmitted UP2).
-                            let seen = self.relay.seen.seen_or_insert(origin, env_msgid, 0);
-                            match crate::net::flood::forward_decision(false, hop, seen) {
-                                crate::net::flood::ForwardAction::Forward { hop: next_hop } => {
-                                    self.diag.fwd = self.diag.fwd.saturating_add(1);
-                                    // Re-wrap the SAME inner verbatim at hop-1 (env_msgid preserved).
-                                    // `inner` borrows the RX buffer; copied into `fb` before the send.
-                                    let mut fb = [0u8; ESP_NOW_MTU];
-                                    let len = encode_up2(origin, env_msgid, next_hop, inner, &mut fb);
-                                    self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
-                                    if self.diag.fwd.is_multiple_of(8) {
-                                        log::info!(
-                                            "smol #124: fwd {} (origin {:03} env_msgid {} -> h{})",
-                                            self.diag.fwd, origin, env_msgid, next_hop
-                                        );
-                                    }
-                                    label = Some(alloc::format!("fwd {:03} h{}", origin, next_hop));
-                                }
-                                crate::net::flood::ForwardAction::DedupDrop => {
-                                    self.diag.dedup = self.diag.dedup.saturating_add(1);
-                                    label = Some(alloc::format!("dedup {:03}", origin));
-                                }
-                                crate::net::flood::ForwardAction::TtlDrop => {
-                                    self.diag.ttl = self.diag.ttl.saturating_add(1);
-                                    label = Some(alloc::format!("ttl {:03}", origin));
-                                }
-                                // Reassemble is only returned for is_gateway=true (handled above).
-                                crate::net::flood::ForwardAction::Reassemble => {}
+                    } else if self.relay.is_gateway {
+                        // GATEWAY SINK: dispatch by the INNER frame type (#124 Stage 2). Everything is
+                        // keyed by the envelope `origin` (the stranded leaf), NOT `src` (the last relay):
+                        //   • RELAY → reassemble (synthetic origin MAC) + flood a RELAYACK2 back toward
+                        //     the origin. `imsgid` is the INNER RELAY msgid = reassembly/ACK key (distinct
+                        //     from env_msgid). accept()+DONE_RING dedup fragments/retransmits, so we do
+                        //     NOT consult the seen-set here (a seen-set drop would kill a lost-ACK
+                        //     retransmit's re-ACK).
+                        //   • STAT/DIAG/SCAN → the same gateway caches the DIRECT arms feed (the P1
+                        //     observability closure): a stranded leaf's /stat /diag /scan now reach HA.
+                        //     STAT stamps the synthetic origin MAC so the leaf stays mac-resolvable
+                        //     (mirror of the direct STAT arm, which stamps the real `src`).
+                        let synth = synth_origin_mac(origin);
+                        match parse_frame(inner) {
+                            Some(Frame::Relay { msgid: imsgid, frag, count, chunk, .. }) => {
+                                let (bitmap, complete) =
+                                    self.relay.accept(synth, (origin, imsgid, frag, count), chunk, now);
+                                self.flood_relayack2(origin, imsgid, bitmap);
+                                label = Some(if complete {
+                                    alloc::format!("up2 {:03} ok", origin)
+                                } else {
+                                    alloc::format!("up2 {:03} {}/{}", origin, bitmap.count_ones(), count)
+                                });
                             }
+                            Some(Frame::Stat { value, .. }) => {
+                                self.stat_cache.set(
+                                    origin, crate::net::wifi::CFG_KEY_SCREEN, value, synth, now,
+                                );
+                                label = Some(alloc::format!("up2 {:03} stat", origin));
+                            }
+                            Some(Frame::Diag { value, .. }) => {
+                                self.diag_cache.set(origin, value, now);
+                                label = Some(alloc::format!("up2 {:03} diag", origin));
+                            }
+                            Some(Frame::Scan { value, .. }) => {
+                                self.scan_cache.set(origin, value, now);
+                                label = Some(alloc::format!("up2 {:03} scan", origin));
+                            }
+                            // An inner we don't sink (nested/unknown) — drop, never re-wrap.
+                            _ => label = Some(alloc::format!("up2 {:03} ?inner", origin)),
                         }
                     } else {
-                        // Stage 2: a non-RELAY inner (STAT/DIAG/SCAN) — full parse_frame + dispatch to
-                        // the caches lands next stage; for 1b it's dropped (only RELAY is wrapped yet).
-                        label = Some(alloc::format!("up2 {:03} non-relay", origin));
+                        // RELAY role: envelope-only, inner-AGNOSTIC flood — forwards RELAY and
+                        // STAT/DIAG/SCAN alike (the relay never parses the inner). Seen-set-gated on
+                        // the ENVELOPE msgid `(origin, env_msgid, 0)` — each UP2 is one atomic frame
+                        // (the frag dimension is absorbed into env_msgid, unique per emitted/
+                        // retransmitted UP2).
+                        let seen = self.relay.seen.seen_or_insert(origin, env_msgid, 0);
+                        match crate::net::flood::forward_decision(false, hop, seen) {
+                            crate::net::flood::ForwardAction::Forward { hop: next_hop } => {
+                                self.diag.fwd = self.diag.fwd.saturating_add(1);
+                                // Re-wrap the SAME inner verbatim at hop-1 (env_msgid preserved).
+                                // `inner` borrows the RX buffer; copied into `fb` before the send.
+                                let mut fb = [0u8; ESP_NOW_MTU];
+                                let len = encode_up2(origin, env_msgid, next_hop, inner, &mut fb);
+                                self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
+                                if self.diag.fwd.is_multiple_of(8) {
+                                    log::info!(
+                                        "smol #124: fwd {} (origin {:03} env_msgid {} -> h{})",
+                                        self.diag.fwd, origin, env_msgid, next_hop
+                                    );
+                                }
+                                label = Some(alloc::format!("fwd {:03} h{}", origin, next_hop));
+                            }
+                            crate::net::flood::ForwardAction::DedupDrop => {
+                                self.diag.dedup = self.diag.dedup.saturating_add(1);
+                                label = Some(alloc::format!("dedup {:03}", origin));
+                            }
+                            crate::net::flood::ForwardAction::TtlDrop => {
+                                self.diag.ttl = self.diag.ttl.saturating_add(1);
+                                label = Some(alloc::format!("ttl {:03}", origin));
+                            }
+                            // Reassemble is only returned for is_gateway=true (handled above).
+                            crate::net::flood::ForwardAction::Reassemble => {}
+                        }
                     }
                 }
                 Some(Frame::RelayAck2 { target, msgid, bitmap, hop }) => {

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -128,16 +128,12 @@ const BEACON_PREFIX: &[u8] = b"SMOLv1 BEACON "; // + "NNN SSSSS EEEEE"
 /// on a private fixed channel; harden with a signed payload or an ESP-NOW LMK
 /// if it ever matters. Documented, not defended.
 const TIME_PREFIX: &[u8] = b"SMOLv1 TIME "; // + "NNN UUUUUUUUUU SSSSSSSSSS"
-// #13: the RELAY / RELAYACK / RELAY2 / RELAYACK2 wire TAGS + their whole codec live in the
+// #13/#124: the RELAY / RELAYACK / UP2 / RELAYACK2 wire TAGS + their whole codec live in the
 // pure, host-testable `net::wire` module (glob-imported above — RELAY carries a leaf-telemetry
-// fragment; RELAYACK the gateway's fragment-bitmap; RELAY2/RELAYACK2 the #13 multi-hop variants,
-// NEW tags an old firmware classifies to None → no flag-day). The `*_FRAME_MAX` buffer-size
-// consts stay here — they size call-site stack buffers in this module, not the codec.
-/// Max RELAY2 frame length on the wire (30-byte header + full chunk); sizes stack buffers.
-/// Header = 14-byte prefix + "OOO MMMMM H F C " (16) = 30, vs RELAY's 27 (the extra 3 =
-/// the origin↔src split's `H ` hop field; `OOO` is the ORIGIN id, distinct from the
-/// re-broadcasting relay's own src MAC).
-const RELAY2_FRAME_MAX: usize = 30 + RELAY_CHUNK;
+// fragment; RELAYACK the gateway's fragment-bitmap; UP2 the #124 generic uplink ENVELOPE that
+// wraps ANY inner frame from a stranded leaf (subsumes the retired RELAY2), RELAYACK2 the
+// flooded-back ACK — NEW tags an old firmware classifies to None → no flag-day). The
+// `*_FRAME_MAX`/`ESP_NOW_MTU` buffer-size consts size call-site stack buffers in this module.
 /// Max RELAYACK2 frame length ("SMOLv1 RELAYACK2 " + "TTT MMMMM BBB H" = 32); rounded up.
 const RELAYACK2_FRAME_MAX: usize = 40;
 /// Battery-downlink tag: the 12-B `"SMOLv1 BATT "` (trailing space, mirroring TIME)
@@ -435,18 +431,17 @@ enum Frame<'a> {
     /// A gateway's acknowledgement of a relay message: the `msgid` and the u8
     /// bitmap of fragments received so far, so the leaf resends only the gaps.
     RelayAck { msgid: u16, bitmap: u8 },
-    /// #13 multi-hop: one fragment of a STRANDED leaf's telemetry uplink, carrying the
-    /// true `origin` id (stamped by the source, survives forwarding — unlike `src_mac`,
-    /// which is the last relay) and a hop-limit `hop` (decremented at each forward,
-    /// dropped at ≤ 1 by a non-gateway). Otherwise identical to `Relay`. `chunk` borrows
-    /// the RX buffer. Emitted only by an escalated leaf + re-broadcast by relays.
-    Relay2 {
+    /// #124 UP2 generic uplink envelope from a STRANDED leaf: the true `origin` id (stamped by the
+    /// source, survives forwarding — unlike `src_mac`, the last relay), the envelope's own
+    /// `env_msgid` (per-origin rolling — the FLOOD-DEDUP key, distinct from any inner RELAY msgid),
+    /// a hop-limit `hop` (decremented per forward, dropped at ≤ 1 by a non-gateway), and the verbatim
+    /// `inner` SMOLv1 frame (RELAY/STAT/DIAG/SCAN — `inner` borrows the RX buffer). The gateway
+    /// unwraps + re-dispatches `inner`. Emitted only by an escalated leaf + re-broadcast by relays.
+    Up2 {
         origin: u8,
-        msgid: u16,
+        env_msgid: u16,
         hop: u8,
-        frag: u8,
-        count: u8,
-        chunk: &'a [u8],
+        inner: &'a [u8],
     },
     /// #13 multi-hop: the gateway's flooded-back ACK for a `Relay2` message (R1,
     /// table-free) — `target` = the origin leaf to ACK, `msgid` + `bitmap` as `RelayAck`,
@@ -1449,16 +1444,21 @@ struct Relay {
     /// retransmits so a message is never enqueued (UDP-delivered) twice (finding 3).
     done: [Option<([u8; 6], u16)>; DONE_RING],
     done_cursor: usize,
-    /// #13 relay-role: the `(origin, msgid, frag)` loop/dup guard for FORWARDING inbound
-    /// `RELAY2` frames. Only a NON-gateway consults it (the gateway reassembles + dedups
-    /// via its own `reasm`/`done`, so it never marks a frame "seen" — else a lost-ACK
-    /// retransmit would be dropped before it could be re-ACKed). See `net/flood.rs`.
+    /// #13 relay-role: the `(origin, env_msgid, 0)` loop/dup guard for FORWARDING inbound `UP2`
+    /// envelopes (#124: keyed on the envelope msgid; each UP2 is one atomic frame so `frag`=0). Only
+    /// a NON-gateway consults it (the gateway reassembles + dedups via its own `reasm`/`done`, so it
+    /// never marks a frame "seen" — else a lost-ACK retransmit would be dropped before it could be
+    /// re-ACKed). See `net/flood.rs`.
     seen: crate::net::flood::SeenSet,
     /// #13 leaf-role: the single-hop⇄multi-hop escalation state machine. Stays inert
     /// (single-hop, byte-identical) until this leaf's telemetry goes fully un-ACKed
-    /// (`relay_retransmit` exhaust) — then it latches `RELAY2` at `MAX_HOP` and probes
+    /// (`relay_retransmit` exhaust / supersession) — then it latches `UP2` at `MAX_HOP` and probes
     /// its way back down. See `net/flood.rs`.
     latch: crate::net::flood::HopLatch,
+    /// #124 leaf-role: the envelope's own per-origin rolling msgid — bumped once per `UP2` emitted
+    /// (each inner frame / RELAY fragment gets a unique one), the FLOOD-DEDUP key. DISTINCT from the
+    /// inner RELAY `msgid` (`tx.msgid`), which stays the reassembly/RELAYACK2 key. Wraps like `next_msgid`.
+    up_env_msgid: u16,
 }
 
 impl Relay {
@@ -1476,6 +1476,7 @@ impl Relay {
             done_cursor: 0,
             seen: crate::net::flood::SeenSet::new(),
             latch: crate::net::flood::HopLatch::new(),
+            up_env_msgid: 0,
         }
     }
 
@@ -2953,17 +2954,27 @@ impl RadioManager {
                 || now.saturating_sub(self.relay.last_emit_ms) >= RELAY_EMIT_INTERVAL_MS)
     }
 
-    /// #13: emit ONE fragment of OUR OWN uplink at the message's chosen framing.
-    /// `hop <= 1` → plain `RELAY` (the byte-identical single-hop case AND the `H=1`
-    /// un-latch probe); `hop > 1` → `RELAY2` (origin-stamped, hop-limited, forwarded by
-    /// relays). The chunk is copied into a LOCAL frame buffer BEFORE `send_to`, so no
-    /// borrow of `self.relay` is held across the `&mut self` send.
+    /// #124: emit ONE fragment of OUR OWN uplink at the message's chosen framing.
+    /// `hop <= 1` → plain `RELAY` (the byte-identical single-hop case AND the `H=1` un-latch probe);
+    /// `hop > 1` → the fragment's plain `RELAY` frame WRAPPED in a `UP2` envelope (origin-stamped,
+    /// hop-limited, forwarded by relays). Each wrapped fragment gets a FRESH per-origin envelope
+    /// msgid (the flood-dedup key — distinct from the inner RELAY `msgid`, which stays the gateway's
+    /// reassembly/RELAYACK2 key); a fresh env_msgid per (re)send means a retransmit is re-forwarded
+    /// (the relay's seen-set doesn't suppress it — closing #13's single-relay retransmit gap). The
+    /// inner + frame are built into LOCAL buffers before `send_to`, so no borrow of `self.relay` is
+    /// held across the `&mut self` send.
     fn relay_send_frag(&mut self, msgid: u16, hop: u8, frag: u8, count: u8, off: usize, end: usize) {
-        let mut fb = [0u8; RELAY2_FRAME_MAX];
+        let mut fb = [0u8; ESP_NOW_MTU];
         let len = if hop <= 1 {
             encode_relay(self.id, msgid, frag, count, &self.relay.tx.buf[off..end], &mut fb)
         } else {
-            encode_relay2(self.id, msgid, hop, frag, count, &self.relay.tx.buf[off..end], &mut fb)
+            // Build the inner plain RELAY, then wrap it in UP2 with a fresh envelope msgid.
+            let mut inner = [0u8; 96]; // RELAY frame ≤ 27-byte header + RELAY_CHUNK(64) = 91
+            let ilen =
+                encode_relay(self.id, msgid, frag, count, &self.relay.tx.buf[off..end], &mut inner);
+            let env_msgid = self.relay.up_env_msgid;
+            self.relay.up_env_msgid = self.relay.up_env_msgid.wrapping_add(1);
+            encode_up2(self.id, env_msgid, hop, &inner[..ilen], &mut fb)
         };
         self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
     }
@@ -4296,67 +4307,70 @@ impl RadioManager {
                     self.relay.latch.on_direct_ack();
                     label = Some(alloc::format!("ack {:05}", msgid));
                 }
-                Some(Frame::Relay2 { origin, msgid, hop, frag, count, chunk }) => {
-                    // #13 multi-hop uplink fragment. Proves the SENDER (the last relay, or the
-                    // origin itself) is audible (LED detected + roster, attributed to `origin`).
+                Some(Frame::Up2 { origin, env_msgid, hop, inner }) => {
+                    // #124 multi-hop uplink ENVELOPE. Proves the SENDER (last relay, or the origin)
+                    // is audible (LED detected + roster, attributed to `origin`).
                     self.peers.last_hello_ms = now;
                     self.roster.heard(src, Some(origin), rssi, now);
                     if origin == self.id {
-                        // Our OWN frame echoed back by a relay — never re-forward or reassemble it
-                        // (that would count as a bogus fwd + could loop). Just drop it.
-                        label = Some(alloc::format!("relay2 self {:03}", origin));
-                    } else if self.relay.is_gateway {
-                        // GATEWAY = the flood's sink. Reassemble keyed by ORIGIN (a synthetic MAC
-                        // `00:00:00:00:00:<origin>`), NOT `src` — `src` is the last relay's MAC, but
-                        // reassembly + late-retransmit dedup must key on the true source. We do NOT
-                        // consult the seen-set here: `accept()` + `DONE_RING` already dedup
-                        // fragments/retransmits, and a seen-set drop would kill a lost-RELAYACK2
-                        // retransmit's re-ACK (the single-hop path's finding 3, one hop out). On each
-                        // accepted fragment, FLOOD a RELAYACK2 back toward the origin (R1, table-free)
-                        // carrying the cumulative bitmap so the stranded leaf learns completion.
-                        let synth = synth_origin_mac(origin);
-                        let (bitmap, complete) =
-                            self.relay.accept(synth, (origin, msgid, frag, count), chunk, now);
-                        self.flood_relayack2(origin, msgid, bitmap);
-                        label = Some(if complete {
-                            alloc::format!("relay2 {:03} ok", origin)
+                        // Our OWN envelope echoed back by a relay — never re-forward/reassemble it
+                        // (bogus fwd + could loop). Just drop it.
+                        label = Some(alloc::format!("up2 self {:03}", origin));
+                    } else if let Some((_sid, imsgid, frag, count, chunk)) = parse_relay(inner) {
+                        // 1b: the inner is a plain RELAY (the RELAY2-subsuming case). `imsgid` is the
+                        // INNER RELAY msgid — the reassembly/ACK key, distinct from the envelope msgid.
+                        if self.relay.is_gateway {
+                            // GATEWAY sink: reassemble keyed by ORIGIN (synthetic MAC), NOT `src` (the
+                            // last relay). accept()+DONE_RING dedup fragments/retransmits, so we do NOT
+                            // consult the seen-set here (a seen-set drop would kill a lost-ACK
+                            // retransmit's re-ACK). On each accepted fragment flood a RELAYACK2 back
+                            // toward the origin (R1) carrying the cumulative bitmap, keyed on `imsgid`.
+                            let synth = synth_origin_mac(origin);
+                            let (bitmap, complete) =
+                                self.relay.accept(synth, (origin, imsgid, frag, count), chunk, now);
+                            self.flood_relayack2(origin, imsgid, bitmap);
+                            label = Some(if complete {
+                                alloc::format!("up2 {:03} ok", origin)
+                            } else {
+                                alloc::format!("up2 {:03} {}/{}", origin, bitmap.count_ones(), count)
+                            });
                         } else {
-                            alloc::format!("relay2 {:03} {}/{}", origin, bitmap.count_ones(), count)
-                        });
-                    } else {
-                        // RELAY role: the seen-set-gated forward. `forward_decision` (pure) picks
-                        // the fate from (is_gateway=false, hop, already-seen `(origin,msgid,frag)`).
-                        let seen = self.relay.seen.seen_or_insert(origin, msgid, frag);
-                        match crate::net::flood::forward_decision(false, hop, seen) {
-                            crate::net::flood::ForwardAction::Forward { hop: next_hop } => {
-                                self.diag.fwd = self.diag.fwd.saturating_add(1);
-                                // Re-broadcast at the decremented hop. `chunk` borrows the RX buffer;
-                                // it's copied into the local frame buffer before the `&mut self` send.
-                                let mut fb = [0u8; RELAY2_FRAME_MAX];
-                                let len =
-                                    encode_relay2(origin, msgid, next_hop, frag, count, chunk, &mut fb);
-                                self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
-                                // Rate-limited serial trace (the forward path was previously OLED-only —
-                                // a rig watching serial saw the fwd counter climb with no log). Every 8th.
-                                if self.diag.fwd.is_multiple_of(8) {
-                                    log::info!(
-                                        "smol #13: fwd {} (origin {:03} msgid {} frag {} -> h{})",
-                                        self.diag.fwd, origin, msgid, frag, next_hop
-                                    );
+                            // RELAY role: seen-set-gated forward, keyed on the ENVELOPE msgid
+                            // `(origin, env_msgid, 0)` — each UP2 is one atomic frame (frag dimension
+                            // is absorbed into env_msgid, which is unique per emitted/retransmitted UP2).
+                            let seen = self.relay.seen.seen_or_insert(origin, env_msgid, 0);
+                            match crate::net::flood::forward_decision(false, hop, seen) {
+                                crate::net::flood::ForwardAction::Forward { hop: next_hop } => {
+                                    self.diag.fwd = self.diag.fwd.saturating_add(1);
+                                    // Re-wrap the SAME inner verbatim at hop-1 (env_msgid preserved).
+                                    // `inner` borrows the RX buffer; copied into `fb` before the send.
+                                    let mut fb = [0u8; ESP_NOW_MTU];
+                                    let len = encode_up2(origin, env_msgid, next_hop, inner, &mut fb);
+                                    self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
+                                    if self.diag.fwd.is_multiple_of(8) {
+                                        log::info!(
+                                            "smol #124: fwd {} (origin {:03} env_msgid {} -> h{})",
+                                            self.diag.fwd, origin, env_msgid, next_hop
+                                        );
+                                    }
+                                    label = Some(alloc::format!("fwd {:03} h{}", origin, next_hop));
                                 }
-                                label = Some(alloc::format!("fwd {:03} h{} f{}", origin, next_hop, frag));
+                                crate::net::flood::ForwardAction::DedupDrop => {
+                                    self.diag.dedup = self.diag.dedup.saturating_add(1);
+                                    label = Some(alloc::format!("dedup {:03}", origin));
+                                }
+                                crate::net::flood::ForwardAction::TtlDrop => {
+                                    self.diag.ttl = self.diag.ttl.saturating_add(1);
+                                    label = Some(alloc::format!("ttl {:03}", origin));
+                                }
+                                // Reassemble is only returned for is_gateway=true (handled above).
+                                crate::net::flood::ForwardAction::Reassemble => {}
                             }
-                            crate::net::flood::ForwardAction::DedupDrop => {
-                                self.diag.dedup = self.diag.dedup.saturating_add(1);
-                                label = Some(alloc::format!("dedup {:03}", origin));
-                            }
-                            crate::net::flood::ForwardAction::TtlDrop => {
-                                self.diag.ttl = self.diag.ttl.saturating_add(1);
-                                label = Some(alloc::format!("ttl {:03}", origin));
-                            }
-                            // Reassemble is only returned for is_gateway=true (handled above).
-                            crate::net::flood::ForwardAction::Reassemble => {}
                         }
+                    } else {
+                        // Stage 2: a non-RELAY inner (STAT/DIAG/SCAN) — full parse_frame + dispatch to
+                        // the caches lands next stage; for 1b it's dropped (only RELAY is wrapped yet).
+                        label = Some(alloc::format!("up2 {:03} non-relay", origin));
                     }
                 }
                 Some(Frame::RelayAck2 { target, msgid, bitmap, hop }) => {
@@ -4855,12 +4869,11 @@ fn parse_frame(data: &[u8]) -> Option<Frame<'_>> {
     if let Some((msgid, bitmap)) = parse_relayack(data) {
         return Some(Frame::RelayAck { msgid, bitmap });
     }
-    // #13 multi-hop variants. Order vs RELAY/RELAYACK is moot — `strip_prefix` is exact and
-    // the `2` at the disambiguating byte makes base + variant mutually exclusive — but keep
-    // them adjacent to their base tag. A plain-RELAY frame never matches RELAY2 (byte 12 is
-    // ' ' not '2') and vice-versa, so a non-escalated leaf's frames stay byte-identical.
-    if let Some((origin, msgid, hop, frag, count, chunk)) = parse_relay2(data) {
-        return Some(Frame::Relay2 { origin, msgid, hop, frag, count, chunk });
+    // #124 multi-hop variants. Order vs RELAY/RELAYACK is moot — `strip_prefix` is exact and UP2
+    // diverges from RELAY at byte 7 (`'U'` vs `'R'`), RELAYACK2 from RELAYACK at byte 15 — so a
+    // non-escalated leaf's plain frames never mis-classify (byte-identical) and vice-versa.
+    if let Some((origin, env_msgid, hop, inner)) = parse_up2(data) {
+        return Some(Frame::Up2 { origin, env_msgid, hop, inner });
     }
     if let Some((target, msgid, bitmap, hop)) = parse_relayack2(data) {
         return Some(Frame::RelayAck2 { target, msgid, bitmap, hop });

--- a/rust/clock/src/net/wire.rs
+++ b/rust/clock/src/net/wire.rs
@@ -16,18 +16,15 @@
 /// from RELAYACK at byte 12 (`' '` vs `'A'`), so match order is moot.
 pub const RELAY_PREFIX: &[u8] = b"SMOLv1 RELAY "; // + "NNN MMMMM F C " + chunk
 pub const RELAYACK_PREFIX: &[u8] = b"SMOLv1 RELAYACK "; // + "MMMMM BBB"
-/// #13 multi-hop uplink tags (see the `#13` section in `mode.rs` + `net/flood.rs`). NEW tags — an
-/// old firmware `classify()`s them to `None` (harmless). `RELAY2` diverges from `RELAY` at byte 12
-/// (`'2'` vs `' '`) and `RELAYACK2` from `RELAYACK` at byte 15, so `strip_prefix` never confuses a
-/// base tag with its variant regardless of order.
-pub const RELAY2_PREFIX: &[u8] = b"SMOLv1 RELAY2 "; // + "OOO MMMMM H F C " + chunk
+/// #13 multi-hop ACK tag (the R1 flooded RELAYACK2 — kept; the RELAY2 uplink tag was replaced by
+/// UP2 in #124). NEW tag — an old firmware `classify()`s it to `None` (harmless). Diverges from
+/// `RELAYACK` at byte 15, so `strip_prefix` never confuses them.
 pub const RELAYACK2_PREFIX: &[u8] = b"SMOLv1 RELAYACK2 "; // + "TTT MMMMM BBB H"
 /// #13 Stage B downlink freshness tags (10-digit `dl_seq` + verbatim `BATT|`/`GRID|` payload).
 pub const BATT2_PREFIX: &[u8] = b"SMOLv1 BATT2 ";
 pub const GRID2_PREFIX: &[u8] = b"SMOLv1 GRID2 ";
-/// #124 generic uplink envelope tag (see the UP2 section below). Diverges from `RELAY`/`RELAY2` at
-/// byte 7 (`'U'` vs `'R'`), so `strip_prefix` never confuses it. wip-unwired until Stage 1b.
-#[allow(dead_code)]
+/// #124 generic uplink envelope tag (see the UP2 section below). Diverges from `RELAY` at byte 7
+/// (`'U'` vs `'R'`), so `strip_prefix` never confuses it.
 pub const UP2_PREFIX: &[u8] = b"SMOLv1 UP2 "; // + "OOO MMMMM H " + <inner frame>
 
 /// Max telemetry payload per RELAY fragment (bytes) — encoders truncate the chunk to this.
@@ -177,59 +174,7 @@ pub fn parse_relayack(data: &[u8]) -> Option<(u16, u8)> {
     Some((msgid, bitmap))
 }
 
-// ---- RELAY2 / RELAYACK2 (#13 multi-hop) -----------------------------------
-
-/// Encode a RELAY2 fragment `"SMOLv1 RELAY2 OOO MMMMM H F C " + <chunk>` into `out`; returns total
-/// length (30-byte header + chunk). `OOO` = ORIGIN id, `H` = 1-digit hop-limit.
-pub fn encode_relay2(origin: u8, msgid: u16, hop: u8, frag: u8, count: u8, chunk: &[u8], out: &mut [u8]) -> usize {
-    let mut n = 0;
-    out[..RELAY2_PREFIX.len()].copy_from_slice(RELAY2_PREFIX);
-    n += RELAY2_PREFIX.len();
-    out[n] = b'0' + (origin / 100) % 10;
-    out[n + 1] = b'0' + (origin / 10) % 10;
-    out[n + 2] = b'0' + origin % 10;
-    n += 3;
-    out[n] = b' ';
-    n += 1;
-    write_u5(msgid as u32, &mut out[n..]);
-    n += 5;
-    out[n] = b' ';
-    n += 1;
-    out[n] = b'0' + hop;
-    n += 1;
-    out[n] = b' ';
-    n += 1;
-    out[n] = b'0' + frag;
-    n += 1;
-    out[n] = b' ';
-    n += 1;
-    out[n] = b'0' + count;
-    n += 1;
-    out[n] = b' ';
-    n += 1;
-    let len = chunk.len().min(RELAY_CHUNK);
-    out[n..n + len].copy_from_slice(&chunk[..len]);
-    n + len
-}
-
-/// Parse a RELAY2 frame into `(origin, msgid, hop, frag, count, chunk)`, or `None`.
-// Mirrors `parse_relay`'s tuple shape + the one `hop` field; the caller destructures immediately.
-#[allow(clippy::type_complexity)]
-pub fn parse_relay2(data: &[u8]) -> Option<(u8, u16, u8, u8, u8, &[u8])> {
-    let rest = data.strip_prefix(RELAY2_PREFIX)?;
-    if rest.len() < 16 {
-        return None;
-    }
-    let origin = parse_id(&rest[0..3])?;
-    let msgid = u16::try_from(parse_u5(&rest[4..9])?).ok()?;
-    if !rest[10].is_ascii_digit() || !rest[12].is_ascii_digit() || !rest[14].is_ascii_digit() {
-        return None;
-    }
-    let hop = rest[10] - b'0';
-    let frag = rest[12] - b'0';
-    let count = rest[14] - b'0';
-    Some((origin, msgid, hop, frag, count, &rest[16..]))
-}
+// ---- RELAYACK2 (#124/#13 flooded ACK — kept; RELAY2 removed, UP2 replaces it) ----------------
 
 /// Encode a `"SMOLv1 RELAYACK2 TTT MMMMM BBB H"` frame into `out`; returns length (32).
 pub fn encode_relayack2(target: u8, msgid: u16, bitmap: u8, hop: u8, out: &mut [u8]) -> usize {
@@ -280,36 +225,28 @@ pub fn synth_origin_mac(origin: u8) -> [u8; 6] {
     [0, 0, 0, 0, 0, origin]
 }
 
-// ---- UP2 generic uplink envelope (#124 — REPLACES RELAY2) ------------------
-// wip (Stage 1a): the codec + host tests land here host-verified but UNWIRED in the clock crate
-// (mode.rs still emits RELAY2). The allow(dead_code)s below DROP in Stage 1b when mode.rs migrates
-// RELAY2→UP2 + removes the RELAY2 codec — then the -D warnings gate applies. relay_compat (a
-// separate crate) exercises these NOW via #[path], so byte-format regressions are caught immediately.
-//
+// ---- UP2 generic uplink envelope (#124 — REPLACED RELAY2) -----------------
 // `SMOLv1 UP2 ` + `"OOO MMMMM H "` + <verbatim inner SMOLv1 frame (RELAY/STAT/DIAG/SCAN)>. A latched
 // leaf wraps ANY uplink frame so a stranded leaf's observability (/stat /diag /scan) reaches the
 // gateway via the relay — RELAY2 could only carry telemetry. `OOO` = origin id; `MMMMM` = the
 // ENVELOPE msgid (per-origin rolling, the FLOOD-DEDUP key — DISTINCT from any inner RELAY msgid,
 // which stays the reassembly/ACK key); `H` = hop-limit. Old firmware classify()s UP2 → None
 // (harmless) + can't relay anyway → no flag-day (a leaf needing H≥2 was already stranded pre-#13).
+// Host-tested in experiments/relay_compat (golden bytes + wrap→unwrap→re-parse-inner + clamp).
 
 /// Max ESP-NOW payload (bytes) — a frame MUST NOT exceed this on the wire.
-#[allow(dead_code)]
 pub const ESP_NOW_MTU: usize = 250;
 /// UP2 envelope overhead: prefix `"SMOLv1 UP2 "` (11) + header `"OOO MMMMM H "` (12) = 23 B.
-#[allow(dead_code)]
 pub const UP2_OVERHEAD: usize = UP2_PREFIX.len() + 12;
 /// Max inner frame a latched leaf may wrap so UP2 fits [`ESP_NOW_MTU`]: 250 − 23 = 227.
 /// `encode_up2` CLAMPS the inner to this + never emits > MTU. For a prefix-tolerant inner
 /// (DIAG/SCAN are `key=val`), clamping truncates the TAIL fields — the record still parses; the
 /// tail that falls off (cfg=/io=/dlseq=/dfwd=, appended last) matters less than the record arriving.
-#[allow(dead_code)]
 pub const UP2_INNER_MAX: usize = ESP_NOW_MTU - UP2_OVERHEAD;
 
 /// Encode a UP2 envelope: `"SMOLv1 UP2 " + "OOO MMMMM H " + <inner>`; returns total length (≤ MTU).
 /// `env_msgid` is the envelope's own per-origin rolling counter (flood dedup). The inner is CLAMPED
 /// to [`UP2_INNER_MAX`] so the frame never exceeds [`ESP_NOW_MTU`] (constraint: never emit > MTU).
-#[allow(dead_code)]
 pub fn encode_up2(origin: u8, env_msgid: u16, hop: u8, inner: &[u8], out: &mut [u8]) -> usize {
     let mut n = 0;
     out[..UP2_PREFIX.len()].copy_from_slice(UP2_PREFIX);
@@ -335,7 +272,6 @@ pub fn encode_up2(origin: u8, env_msgid: u16, hop: u8, inner: &[u8], out: &mut [
 
 /// Parse a UP2 envelope into `(origin, env_msgid, hop, inner)`, or `None`. `inner` borrows `data` —
 /// the verbatim inner SMOLv1 frame, which the caller re-runs through `parse_frame` + dispatches.
-#[allow(dead_code)]
 pub fn parse_up2(data: &[u8]) -> Option<(u8, u16, u8, &[u8])> {
     let rest = data.strip_prefix(UP2_PREFIX)?;
     // "OOO MMMMM H " = 12 header bytes (origin 3, sp, env_msgid 5, sp, hop 1, sp), then the inner frame.

--- a/rust/clock/src/net/wire.rs
+++ b/rust/clock/src/net/wire.rs
@@ -287,6 +287,33 @@ pub fn parse_up2(data: &[u8]) -> Option<(u8, u16, u8, &[u8])> {
     Some((origin, env_msgid, hop, &rest[12..]))
 }
 
+/// #124 Stage 2 — return a truncation length for `inner` that fits within `max` bytes AND ends on a
+/// FIELD BOUNDARY (the last `|` separator at or before `max`), so a wrapped DIAG/SCAN record that
+/// overflows [`UP2_INNER_MAX`] never truncates mid `key=val`. The dropped tail (the straddling field
+/// plus any fields past it) is what prefix-tolerant parsers would ignore anyway.
+///
+/// When `inner.len() <= max` it returns `inner.len()` (fits, no clamp). Otherwise it returns the
+/// index of the last `|` at position `<= max`, so bytes `[0..i)` are all whole fields (that `|` and
+/// the partial field after it are excluded). With no `|` inside `max` (a single oversized field —
+/// pathological; real DIAG/SCAN records are `|`-joined) it falls back to `max` (a raw cut). The frame
+/// prefix ("SMOLv1 DIAG " + "OOO") holds no `|`, so scanning the whole buffer is safe.
+///
+/// The result is always `<= max` and `<= inner.len()`; pass `&inner[..clamp_inner_field_boundary(..)]`
+/// to `encode_up2` (whose own raw clamp then never fires). Pure + deterministic — host-tested.
+pub fn clamp_inner_field_boundary(inner: &[u8], max: usize) -> usize {
+    if inner.len() <= max {
+        return inner.len();
+    }
+    // Largest `|` index at or before `max` (max < len here, so `max` indexes a real byte).
+    let mut cut = None;
+    for (i, &b) in inner.iter().enumerate().take(max + 1) {
+        if b == b'|' {
+            cut = Some(i);
+        }
+    }
+    cut.unwrap_or(max)
+}
+
 // ---- BATT2 / GRID2 (#13 Stage B downlink freshness) -----------------------
 
 /// Encode a downlink freshness frame `<prefix> + "SSSSSSSSSS " + <payload>` into `out`; returns

--- a/rust/clock/src/net/wire.rs
+++ b/rust/clock/src/net/wire.rs
@@ -25,6 +25,10 @@ pub const RELAYACK2_PREFIX: &[u8] = b"SMOLv1 RELAYACK2 "; // + "TTT MMMMM BBB H"
 /// #13 Stage B downlink freshness tags (10-digit `dl_seq` + verbatim `BATT|`/`GRID|` payload).
 pub const BATT2_PREFIX: &[u8] = b"SMOLv1 BATT2 ";
 pub const GRID2_PREFIX: &[u8] = b"SMOLv1 GRID2 ";
+/// #124 generic uplink envelope tag (see the UP2 section below). Diverges from `RELAY`/`RELAY2` at
+/// byte 7 (`'U'` vs `'R'`), so `strip_prefix` never confuses it. wip-unwired until Stage 1b.
+#[allow(dead_code)]
+pub const UP2_PREFIX: &[u8] = b"SMOLv1 UP2 "; // + "OOO MMMMM H " + <inner frame>
 
 /// Max telemetry payload per RELAY fragment (bytes) — encoders truncate the chunk to this.
 pub const RELAY_CHUNK: usize = 64;
@@ -271,8 +275,80 @@ pub fn parse_relayack2(data: &[u8]) -> Option<(u8, u16, u8, u8)> {
 
 /// The synthetic MAC a gateway keys a RELAY2 reassembly by — `00:00:00:00:00:<origin>`. A real
 /// Espressif STA MAC is never all-zero, so this can't alias a single-hop leaf's real MAC.
+/// (#124: reused verbatim for the UP2 gateway-reassembly of an inner RELAY, keyed by origin.)
 pub fn synth_origin_mac(origin: u8) -> [u8; 6] {
     [0, 0, 0, 0, 0, origin]
+}
+
+// ---- UP2 generic uplink envelope (#124 — REPLACES RELAY2) ------------------
+// wip (Stage 1a): the codec + host tests land here host-verified but UNWIRED in the clock crate
+// (mode.rs still emits RELAY2). The allow(dead_code)s below DROP in Stage 1b when mode.rs migrates
+// RELAY2→UP2 + removes the RELAY2 codec — then the -D warnings gate applies. relay_compat (a
+// separate crate) exercises these NOW via #[path], so byte-format regressions are caught immediately.
+//
+// `SMOLv1 UP2 ` + `"OOO MMMMM H "` + <verbatim inner SMOLv1 frame (RELAY/STAT/DIAG/SCAN)>. A latched
+// leaf wraps ANY uplink frame so a stranded leaf's observability (/stat /diag /scan) reaches the
+// gateway via the relay — RELAY2 could only carry telemetry. `OOO` = origin id; `MMMMM` = the
+// ENVELOPE msgid (per-origin rolling, the FLOOD-DEDUP key — DISTINCT from any inner RELAY msgid,
+// which stays the reassembly/ACK key); `H` = hop-limit. Old firmware classify()s UP2 → None
+// (harmless) + can't relay anyway → no flag-day (a leaf needing H≥2 was already stranded pre-#13).
+
+/// Max ESP-NOW payload (bytes) — a frame MUST NOT exceed this on the wire.
+#[allow(dead_code)]
+pub const ESP_NOW_MTU: usize = 250;
+/// UP2 envelope overhead: prefix `"SMOLv1 UP2 "` (11) + header `"OOO MMMMM H "` (12) = 23 B.
+#[allow(dead_code)]
+pub const UP2_OVERHEAD: usize = UP2_PREFIX.len() + 12;
+/// Max inner frame a latched leaf may wrap so UP2 fits [`ESP_NOW_MTU`]: 250 − 23 = 227.
+/// `encode_up2` CLAMPS the inner to this + never emits > MTU. For a prefix-tolerant inner
+/// (DIAG/SCAN are `key=val`), clamping truncates the TAIL fields — the record still parses; the
+/// tail that falls off (cfg=/io=/dlseq=/dfwd=, appended last) matters less than the record arriving.
+#[allow(dead_code)]
+pub const UP2_INNER_MAX: usize = ESP_NOW_MTU - UP2_OVERHEAD;
+
+/// Encode a UP2 envelope: `"SMOLv1 UP2 " + "OOO MMMMM H " + <inner>`; returns total length (≤ MTU).
+/// `env_msgid` is the envelope's own per-origin rolling counter (flood dedup). The inner is CLAMPED
+/// to [`UP2_INNER_MAX`] so the frame never exceeds [`ESP_NOW_MTU`] (constraint: never emit > MTU).
+#[allow(dead_code)]
+pub fn encode_up2(origin: u8, env_msgid: u16, hop: u8, inner: &[u8], out: &mut [u8]) -> usize {
+    let mut n = 0;
+    out[..UP2_PREFIX.len()].copy_from_slice(UP2_PREFIX);
+    n += UP2_PREFIX.len();
+    out[n] = b'0' + (origin / 100) % 10;
+    out[n + 1] = b'0' + (origin / 10) % 10;
+    out[n + 2] = b'0' + origin % 10;
+    n += 3;
+    out[n] = b' ';
+    n += 1;
+    write_u5(env_msgid as u32, &mut out[n..]);
+    n += 5;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + hop;
+    n += 1;
+    out[n] = b' ';
+    n += 1;
+    let len = inner.len().min(UP2_INNER_MAX);
+    out[n..n + len].copy_from_slice(&inner[..len]);
+    n + len
+}
+
+/// Parse a UP2 envelope into `(origin, env_msgid, hop, inner)`, or `None`. `inner` borrows `data` —
+/// the verbatim inner SMOLv1 frame, which the caller re-runs through `parse_frame` + dispatches.
+#[allow(dead_code)]
+pub fn parse_up2(data: &[u8]) -> Option<(u8, u16, u8, &[u8])> {
+    let rest = data.strip_prefix(UP2_PREFIX)?;
+    // "OOO MMMMM H " = 12 header bytes (origin 3, sp, env_msgid 5, sp, hop 1, sp), then the inner frame.
+    if rest.len() < 12 {
+        return None;
+    }
+    let origin = parse_id(&rest[0..3])?;
+    let env_msgid = u16::try_from(parse_u5(&rest[4..9])?).ok()?;
+    if !rest[10].is_ascii_digit() {
+        return None;
+    }
+    let hop = rest[10] - b'0';
+    Some((origin, env_msgid, hop, &rest[12..]))
 }
 
 // ---- BATT2 / GRID2 (#13 Stage B downlink freshness) -----------------------


### PR DESCRIPTION
## #124 — UP2 uplink envelope (replaces RELAY2; closes the P1 observability gap)

Replaces the `RELAY2` multi-hop frame with a single generic **UP2 envelope** that wraps *any* inner
`SMOLv1` frame. `RELAY2` was just "UP2 wrapping a RELAY", so this subsumes it — and because the
envelope is inner-agnostic, a stranded leaf's **STAT / DIAG / SCAN** now reach the gateway too.
That's the closure of the `#13` P1 finding: a leaf too far to RELAY-uplink was previously
*observability-dark* (STAT/DIAG/SCAN are plain broadcasts that relays never forward).

### Wire format
```
SMOLv1 UP2 <OOO> <MMMMM> <H> <verbatim inner SMOLv1 frame>
           origin env_msgid hop
```
- `UP2_OVERHEAD = 23` (`"SMOLv1 UP2 "` 11 + `"OOO MMMMM H "` 12), `ESP_NOW_MTU = 250`,
  `UP2_INNER_MAX = 250 − 23 = 227`.

### The two binding constraints
1. **MTU budget (reduced-MTU const + field-boundary clamp).** A latched leaf encodes its inner
   frame against the named `UP2_INNER_MAX = 227` const (arithmetic documented in a comment) and the
   encoder clamps so a frame **never exceeds 250 B**. A DIAG/SCAN record can be up to 247 B, so the
   tail may truncate — `wire::clamp_inner_field_boundary` cuts at the **last `|` ≤ 227**, i.e. always
   on a field boundary, **never mid `key=val`**. Prefix-tolerant parsers keep every surviving field;
   the dropped tail (the appended `cfg=/io=/dlseq=/dfwd=`) is exactly what a truncation-tolerant
   reader ignores. STAT (≤ 79 B) never clamps.
2. **Two-layer msgid.** The **envelope** carries its own per-origin rolling `env_msgid` = the
   flood-dedup key (relay seen-set `(origin, env_msgid, 0)`). The **inner RELAY** keeps its own
   `msgid` = reassembly + RELAYACK2 key. They are distinct by construction — a fresh `env_msgid` per
   (re)transmit means a relay no longer suppresses a retransmit as a duplicate, closing `#13`'s
   single-relay retransmit gap.

### Stages (one branch, staged commits)
- **1a** `ae72caf` — UP2 codec in `net/wire.rs` (host-tested, unwired).
- **1b** `9ba99cb` — wire UP2 into the relay path; **retire RELAY2 entirely**
  (`encode_relay2`/`parse_relay2`/`RELAY2_PREFIX`/`RELAY2_FRAME_MAX`/`Frame::Relay2` removed; the UP2
  `allow(dead_code)`s dropped so clippy *proves* it's wired). `hop<=1` still emits a plain RELAY →
  **byte-identical** for a healthy leaf.
- **2** `3df3da5` — observability closure. Latched leaves also wrap STAT/DIAG/SCAN; the gateway
  `Frame::Up2` arm is restructured to split **transport** (relay forwards envelope-only,
  inner-agnostic) from **sink** (gateway `parse_frame`s the inner and routes RELAY→reassemble+ACK,
  STAT/DIAG/SCAN→the same caches the direct arms feed, all keyed by origin via `synth_origin_mac`).

### Invariants preserved
- **C0 byte-identical** — a non-escalated leaf emits plain RELAY/STAT/DIAG/SCAN; UP2 appears *only*
  once latched (`hop>1`). No flag-day.
- **Mixed-fleet safe** — UP2 is a new tag; `0b83714`-era firmware classifies it as `None` (harmless)
  and can't relay it anyway. Only already-stranded-leaf traffic is affected during a rolling upgrade.
- `seen-set` / `HopLatch` / `forward_decision` and the `#13` escalation/hysteresis/supersession
  logic are reused **untouched** (envelope-agnostic).

---

## #126 — latched-leaf channel parking (`a698a9a`, stacked on this branch)

`#13` v1 proved a stranded leaf *can* reach home, but throughput is low **by physics**: a latched
leaf never locks a channel (it can't hear its owner's HELLO), so it blind-hops 1/6/11 and its UP2
lands on the relay's channel only **~1/3** of the time — and the `RELAYACK2` flood-back hits the same
~1/3 in reverse (rig P1: F received *zero* ACKs). #126 parks the leaf on the channel that
demonstrably works, in **both** directions.

- **`net/flood.rs` — new `ChannelPark` (pure, beside `HopLatch`).** `poll(now, candidates)` is the
  *entire* latched-leaf channel decision: park on the signalling channel while fresh, else
  round-robin the candidates every `PARK_DWELL_MS` (the "dwell-per-channel" hunt). Returns `Some`
  only on an actual change (re-tunes as sparsely as the old scan). `on_signal(now)` parks on the
  current channel; `reset()` forgets the park on un-latch. Self-healing: no signal for
  `PARK_STALE_MS` (12 s) → drop the park, resume the hunt (rides relay roam / re-election for free).
- **Two park signals** (both fed only while latched): (1) hearing our **own UP2 echoed by a relay**
  — the *early* "forwarded" proof, a hop sooner than the round-trip; (2) a **`RELAYACK2` addressed
  to us** — the end-to-end confirming proof. Once any signal lands (even at 1/3 during bootstrap)
  the leaf parks and subsequent emits + ACKs ride the winning channel.
- **Coexist/priority preserved** — the OTA ch6 hold and the owner scan-lock both `return` *before*
  parking, so parking acts only for a genuinely stranded (latched, unlocked, no-OTA) leaf.
  Re-election (`maybe_leaf_reelect`) is unaffected (it re-associates regardless of ESP-NOW channel).

**The `#123` lesson applied.** `ChannelPark` owns the whole *decision*, so `mode.rs` only *applies*
`poll()` and *feeds* `on_signal` — and `flood_verify` drives the full lifecycle (bootstrap hunt →
park on signal → freshness refresh → staleness recovery → reset → defensive unset-guard). That host
coverage **is** the trigger-wiring coverage the `#123` gap asked for (last campaign only the pure
`HopLatch` math was tested, so an on-air trigger bug slipped past green builds).

### Verification (host + build only — see merge gate)
- `clippy -D warnings` clean on **all 5 profiles** (`default` / `espnow` / `espnow,cast,io` /
  `espnow,wled` / `espnow,mesh-test`).
- Release links clean on `espnow` and `espnow,cast,io` (the `#119` canonical fleet image), valid
  RISC-V ELF.
- `experiments/flood_verify` (SeenSet + forward_decision + HopLatch + **`ChannelPark` full
  lifecycle**) and `experiments/relay_compat` (bidirectional byte-compat + golden bytes + UP2
  round-trips + disambiguation + UP2 clamp + **field-boundary DIAG clamp**) — **ALL PASS**.

---

## ⛔ MERGE GATE: HW rig canary pending hardware

**Do not merge on green builds alone.** The `#13`/`#123` lesson is that the on-air *trigger wiring*
(escalation → wrap → forward → gateway dispatch) can fail in ways green builds and host HopLatch math
cannot see — the hardware deaf-list rig caught two such bugs (C0 over-eager latch, P1 under-eager
latch) that no host test surfaced. This PR is **host-proven only**; the fleet is currently **1 board**
(no multi-node rig available). Hold until a ≥3-node deaf-list canary confirms, end-to-end:

1. A latched leaf's RELAY uplink reassembles at the gateway via UP2 + gets a flooded RELAYACK2.
2. A latched leaf's DIAG/SCAN reaches `smol/<id>/diag` + `smol/<id>/scan` through a relay.
3. The field-boundary DIAG clamp lands on-air (no mid-field truncation in a real oversized record).
4. C0 all-hear stays byte-identical (`fwd=0`, no spurious UP2 from healthy leaves).

Canary ONE node first (OTA rollback discipline), same as every prior smol on-air change.

**#126 parking adds two more rig checks** (P2 — measure before/after on the deaf-list rig):
5. A latched leaf **parks** on the relay's channel after the first echo/ACK (watch the `#126`
   "parked" log) and delivery-rate rises materially above the ~1/3 baseline.
6. When the relay roams/dies, the parked leaf **re-hunts** within `PARK_STALE_MS` (12 s) and
   re-parks on the new channel — no permanent wedge on a dead channel.

Refs #124, #126, #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
