### PR TITLE
feat(fw): #126 latched-leaf channel parking — bias a stranded leaf to the channel that delivers

### DIFF
--- a/experiments/flood_verify/src/main.rs
+++ b/experiments/flood_verify/src/main.rs
@@ -6,9 +6,9 @@
 mod flood;
 
 use flood::{
-    forward_decision, ChannelPark, ForwardAction, HopLatch, SeenSet, ESCALATE_STREAK, MAX_HOP,
-    PARK_BURSTS_PER_DWELL, PARK_BURST_EVERY_MS, PARK_CHANNELS, PARK_DWELL_MS, PARK_SILENCE_MS,
-    PROBE_EVERY, SEEN_RING, UNLATCH_STREAK,
+    forward_decision, park_scan_action, ChannelPark, ForwardAction, HopLatch, ParkAction, SeenSet,
+    ESCALATE_STREAK, MAX_HOP, PARK_BURSTS_PER_DWELL, PARK_BURST_EVERY_MS, PARK_CHANNELS,
+    PARK_DWELL_MS, PARK_SILENCE_MS, PROBE_EVERY, SEEN_RING, UNLATCH_STREAK,
 };
 
 /// Drive a fresh latch into multi-hop the way a genuinely-stranded leaf does: ESCALATE_STREAK
@@ -228,5 +228,51 @@ fn main() {
         assert!(!inert.engaged(), "inert leaf never engages parking");
     }
 
-    println!("flood_verify: ALL CHECKS PASSED (SeenSet + forward_decision + HopLatch + #126 ChannelPark)");
+    // --- #126 park_scan_action: the extracted TRIGGER decision (#123 lesson) -----
+    // The trigger wiring (which channel / when to burst / the latched+locked gating) is what hid
+    // the last two on-air bugs. It's now a pure fn covered here, not buried in the no_std tick.
+    let mut ps = ChannelPark::new();
+    // healthy leaf (not latched) ⇒ no channel override, no burst, park stays inert.
+    assert_eq!(
+        park_scan_action(&mut ps, false, false, 0),
+        ParkAction { channel: None, burst: false },
+        "not latched ⇒ blind scan governs (byte-identical)"
+    );
+    assert!(!ps.engaged(), "not latched ⇒ park inert");
+    // latched but LOCKED onto an owner ⇒ never override the locked channel (stay on the owner's).
+    let a = park_scan_action(&mut ps, true, true, 10);
+    assert_eq!(a.channel, None, "latched+locked ⇒ stay on the owner's channel");
+    assert!(!a.burst, "no burst while locked onto an owner");
+    assert!(ps.engaged(), "latched ⇒ park engaged (ready) even while locked");
+    // latched + UNLOCKED (stranded) ⇒ drive the sweep: candidate 0 + the first burst.
+    let a = park_scan_action(&mut ps, true, false, 20);
+    assert_eq!(a.channel, Some(PARK_CHANNELS[0]), "stranded+unlocked ⇒ sweep candidate 0");
+    assert!(a.burst, "first burst of the dwell fires");
+    // un-latch (uplink recovered) ⇒ disengage, channel None again.
+    assert_eq!(
+        park_scan_action(&mut ps, false, false, 30),
+        ParkAction { channel: None, burst: false },
+        "un-latch ⇒ disengage back to the blind scan"
+    );
+    assert!(!ps.engaged());
+    // through park_scan_action the sweep advances 1→6→11→1 across dwell-boundary calls (the hop is
+    // applied AFTER the channel is read, so a fresh candidate surfaces on the FOLLOWING boundary).
+    let mut sw2 = ChannelPark::new();
+    let a0 = park_scan_action(&mut sw2, true, false, 0);
+    assert_eq!(a0.channel, Some(PARK_CHANNELS[0]), "sweep starts on candidate 0");
+    let _ = park_scan_action(&mut sw2, true, false, PARK_DWELL_MS); // hops internally
+    assert_eq!(
+        park_scan_action(&mut sw2, true, false, PARK_DWELL_MS * 2).channel,
+        Some(PARK_CHANNELS[1]), "advanced to candidate 1"
+    );
+    assert_eq!(
+        park_scan_action(&mut sw2, true, false, PARK_DWELL_MS * 3).channel,
+        Some(PARK_CHANNELS[2]), "advanced to candidate 2"
+    );
+    assert_eq!(
+        park_scan_action(&mut sw2, true, false, PARK_DWELL_MS * 4).channel,
+        Some(PARK_CHANNELS[0]), "wrapped back to candidate 0"
+    );
+
+    println!("flood_verify: ALL CHECKS PASSED (SeenSet + forward_decision + HopLatch + #126 ChannelPark + park_scan_action trigger)");
 }

--- a/experiments/flood_verify/src/main.rs
+++ b/experiments/flood_verify/src/main.rs
@@ -6,8 +6,9 @@
 mod flood;
 
 use flood::{
-    forward_decision, ForwardAction, HopLatch, SeenSet, ESCALATE_STREAK, MAX_HOP, PROBE_EVERY,
-    SEEN_RING, UNLATCH_STREAK,
+    forward_decision, ChannelPark, ForwardAction, HopLatch, SeenSet, ESCALATE_STREAK, MAX_HOP,
+    PARK_BURSTS_PER_DWELL, PARK_BURST_EVERY_MS, PARK_CHANNELS, PARK_DWELL_MS, PARK_SILENCE_MS,
+    PROBE_EVERY, SEEN_RING, UNLATCH_STREAK,
 };
 
 /// Drive a fresh latch into multi-hop the way a genuinely-stranded leaf does: ESCALATE_STREAK
@@ -120,5 +121,112 @@ fn main() {
     l3.on_direct_ack();
     assert!(!l3.latched());
 
-    println!("flood_verify: ALL CHECKS PASSED (SeenSet + forward_decision + HopLatch)");
+    // --- #126 ChannelPark: engage / disengage from the latch -------------
+    let mut p = ChannelPark::new();
+    assert!(!p.engaged(), "fresh park is inert");
+    assert_eq!(p.channel(), None, "idle ⇒ None ⇒ blind scan governs");
+    assert!(!p.should_burst(0), "idle never bursts");
+    p.on_feedback(0);
+    assert!(!p.engaged(), "feedback while idle is ignored (single-hop ACKs aren't park signals)");
+    // latched ⇒ engage, sweeping from candidate 0.
+    p.sync(true, 0);
+    assert!(p.engaged() && !p.parked(), "latched ⇒ sweeping");
+    assert_eq!(p.channel(), Some(PARK_CHANNELS[0]), "sweep starts on candidate 0");
+    // un-latched (uplink recovered) ⇒ disengage back to the blind scan.
+    p.sync(false, 10);
+    assert!(!p.engaged(), "un-latch disengages parking");
+    assert_eq!(p.channel(), None, "disengaged ⇒ blind scan governs again");
+
+    // --- ChannelPark: burst bootstrap (spacing + per-dwell cap) -----------
+    let mut sp = ChannelPark::new();
+    sp.sync(true, 0);
+    assert!(sp.should_burst(0), "first burst of a dwell fires immediately");
+    assert!(!sp.should_burst(PARK_BURST_EVERY_MS - 1), "next burst gated until PARK_BURST_EVERY_MS");
+    assert!(sp.should_burst(PARK_BURST_EVERY_MS), "next burst fires after the spacing gap");
+    // exactly PARK_BURSTS_PER_DWELL bursts fire per dwell, the rest are capped.
+    let mut cap = ChannelPark::new();
+    cap.sync(true, 0);
+    let mut fired = 0u8;
+    let mut t = 0u64;
+    for _ in 0..(PARK_BURSTS_PER_DWELL + 3) {
+        if cap.should_burst(t) {
+            fired += 1;
+        }
+        t += PARK_BURST_EVERY_MS;
+    }
+    assert_eq!(fired, PARK_BURSTS_PER_DWELL, "exactly PARK_BURSTS_PER_DWELL bursts per dwell");
+
+    // --- ChannelPark: TRIGGER CONTRACT (the #123 lesson) ------------------
+    // The emit-trigger wiring is where on-air bugs lived. Contract: the sweep must NOT hop off a
+    // candidate until ≥1 burst has actually probed it (no channel skipped), and it must visit
+    // 1→6→11→1 in order. This exercises the exact should_burst()-then-tick() call sequence the
+    // live `leaf_scan_tick` uses.
+    let mut noburst = ChannelPark::new();
+    noburst.sync(true, 0);
+    noburst.tick(PARK_DWELL_MS * 4); // dwell long past, but ZERO bursts fired
+    assert_eq!(noburst.channel(), Some(PARK_CHANNELS[0]), "no hop until ≥1 burst probes the candidate");
+    assert!(noburst.should_burst(PARK_DWELL_MS * 4), "now probe it");
+    noburst.tick(PARK_DWELL_MS * 4 + PARK_DWELL_MS); // dwell elapsed AND probed ⇒ hop
+    assert_eq!(noburst.channel(), Some(PARK_CHANNELS[1]), "hops once the candidate has been probed");
+    // full rotation 1→6→11→1, one burst + one full dwell per candidate.
+    let mut sw = ChannelPark::new();
+    sw.sync(true, 0);
+    let mut clk = 0u64;
+    for expect in [PARK_CHANNELS[0], PARK_CHANNELS[1], PARK_CHANNELS[2], PARK_CHANNELS[0]] {
+        assert_eq!(sw.channel(), Some(expect), "sweep visits each candidate in [1,6,11] order");
+        assert!(sw.should_burst(clk), "≥1 burst per candidate before hopping");
+        clk += PARK_DWELL_MS;
+        sw.tick(clk);
+    }
+
+    // --- ChannelPark: park on feedback, hold, un-park on silence ----------
+    let mut pk = ChannelPark::new();
+    pk.sync(true, 0);
+    assert!(pk.should_burst(0));
+    pk.tick(PARK_DWELL_MS); // hop to candidate 1 (ch6)
+    assert_eq!(pk.channel(), Some(PARK_CHANNELS[1]));
+    pk.on_feedback(PARK_DWELL_MS); // a RELAYACK2 came back on ch6 ⇒ PARK
+    assert!(pk.parked(), "feedback while sweeping parks on the current channel");
+    assert_eq!(pk.channel(), Some(PARK_CHANNELS[1]), "parked on the channel that drew the ACK");
+    assert!(!pk.should_burst(PARK_DWELL_MS + 100), "parked ⇒ no bursts (telemetry carries the held channel)");
+    // holds well within the silence window; a refresh resets the silence clock.
+    pk.tick(PARK_DWELL_MS + PARK_SILENCE_MS - 1);
+    assert!(pk.parked(), "still parked within PARK_SILENCE_MS");
+    pk.on_feedback(PARK_DWELL_MS + PARK_SILENCE_MS - 1); // refresh
+    pk.tick(PARK_DWELL_MS + PARK_SILENCE_MS - 1 + PARK_SILENCE_MS - 1);
+    assert!(pk.parked(), "a refresh keeps it parked past the original window");
+    // sustained silence past PARK_SILENCE_MS ⇒ channel went cold ⇒ resume sweeping from it.
+    let last_fb = PARK_DWELL_MS + PARK_SILENCE_MS - 1;
+    pk.tick(last_fb + PARK_SILENCE_MS + 1);
+    assert!(pk.engaged() && !pk.parked(), "cold parked channel ⇒ resume sweeping");
+    assert_eq!(pk.channel(), Some(PARK_CHANNELS[1]), "re-sweep starts from the last good channel");
+
+    // --- ChannelPark: #76 re-election restarts the sweep ------------------
+    let mut rc = ChannelPark::new();
+    rc.sync(true, 0);
+    rc.should_burst(0);
+    rc.tick(PARK_DWELL_MS); // → candidate 1
+    rc.should_burst(PARK_DWELL_MS);
+    rc.tick(PARK_DWELL_MS * 2); // → candidate 2
+    assert_eq!(rc.channel(), Some(PARK_CHANNELS[2]));
+    rc.on_rechannel(PARK_DWELL_MS * 2 + 50); // owner/channel changed under us
+    assert!(rc.engaged() && !rc.parked(), "re-election ⇒ back to sweeping");
+    assert_eq!(rc.channel(), Some(PARK_CHANNELS[0]), "#76 re-election restarts the sweep at candidate 0");
+    let mut rc2 = ChannelPark::new();
+    rc2.on_rechannel(0);
+    assert!(!rc2.engaged(), "on_rechannel while idle stays idle (not stranded)");
+
+    // --- ChannelPark: INVARIANT — a never-latched leaf is fully inert ------
+    // (mirrors HopLatch's fwd=0 gate: no parking, no bursts, feedback ignored, channel None).
+    let mut inert = ChannelPark::new();
+    for t in [0u64, 500, PARK_DWELL_MS, PARK_DWELL_MS * 2, PARK_SILENCE_MS] {
+        inert.sync(false, t); // healthy leaf: never latched
+        assert!(!inert.should_burst(t), "inert leaf never bursts");
+        inert.tick(t);
+        inert.on_feedback(t);
+        assert_eq!(inert.channel(), None, "inert leaf never overrides the blind scan");
+        assert!(!inert.engaged(), "inert leaf never engages parking");
+    }
+
+    println!("flood_verify: ALL CHECKS PASSED (SeenSet + forward_decision + HopLatch + #126 ChannelPark)");
 }

--- a/experiments/relay_compat/src/main.rs
+++ b/experiments/relay_compat/src/main.rs
@@ -135,5 +135,34 @@ fn main() {
     let (_, _, _, clamped) = wire::parse_up2(&up[..cn]).unwrap();
     assert_eq!(clamped.len(), wire::UP2_INNER_MAX, "inner clamped to UP2_INNER_MAX");
 
-    println!("relay_compat: ALL CHECKS PASSED (bidirectional byte-compat + golden bytes + #13/#124 tag round-trips + disambiguation + UP2 clamp)");
+    // #124 Stage 2 — field-boundary clamp (a wrapped DIAG/SCAN never truncates mid `key=val`).
+    // Fits: returns the full length, no clamp.
+    assert_eq!(wire::clamp_inner_field_boundary(b"aa|bb|cc", 100), 8, "clamp: fits => full len");
+    // Over budget: truncate at the LAST `|` at or before max, dropping the straddling tail field.
+    assert_eq!(wire::clamp_inner_field_boundary(b"aa|bb|cc", 5), 5, "clamp: cut at `|` index 5 => aa|bb");
+    assert_eq!(wire::clamp_inner_field_boundary(b"aa|bb|cc", 4), 2, "clamp: cut at `|` index 2 => aa");
+    // No `|` inside max (a single oversized field): raw fallback to max.
+    assert_eq!(wire::clamp_inner_field_boundary(b"aaaaaa", 3), 3, "clamp: no separator => raw max");
+
+    // A realistic over-budget DIAG frame: "SMOLv1 DIAG 007" + a long `|`-joined record (> MTU). The
+    // wrapped envelope must (a) fit ESP_NOW_MTU, (b) cut at a field boundary (the cut index is a `|`,
+    // and the surviving slice does NOT end mid-field), (c) keep the SMOLv1 DIAG prefix intact so the
+    // gateway still classifies + caches it.
+    let mut diag = b"SMOLv1 DIAG 007".to_vec();
+    for i in 0..40u32 {
+        diag.push(b'|');
+        diag.extend_from_slice(format!("k{i:02}=vvvvv").as_bytes());
+    }
+    assert!(diag.len() > wire::ESP_NOW_MTU, "test DIAG must exceed the MTU to exercise the clamp");
+    let cut = wire::clamp_inner_field_boundary(&diag, wire::UP2_INNER_MAX);
+    assert!(cut <= wire::UP2_INNER_MAX, "clamp <= UP2_INNER_MAX");
+    assert_eq!(diag[cut], b'|', "clamp lands ON a `|` separator (dropped tail field starts here)");
+    assert_ne!(diag[cut - 1], b'|', "surviving slice ends on a complete field, not a bare `|`");
+    let dn = wire::encode_up2(7, 3, 2, &diag[..cut], &mut up);
+    assert!(dn <= wire::ESP_NOW_MTU, "wrapped over-budget DIAG still fits the MTU");
+    let (_, _, _, dinner) = wire::parse_up2(&up[..dn]).expect("parse wrapped DIAG");
+    assert_eq!(dinner, &diag[..cut], "unwrapped inner == the field-boundary-clamped DIAG verbatim");
+    assert!(dinner.starts_with(b"SMOLv1 DIAG 007"), "clamped DIAG keeps its classify-able prefix");
+
+    println!("relay_compat: ALL CHECKS PASSED (bidirectional byte-compat + golden bytes + #13/#124 tag round-trips + disambiguation + UP2 clamp + field-boundary DIAG clamp)");
 }

--- a/experiments/relay_compat/src/main.rs
+++ b/experiments/relay_compat/src/main.rs
@@ -114,5 +114,37 @@ fn main() {
     // a BATT2 frame must not parse under the GRID2 prefix (tag isolation).
     assert!(wire::parse_dl(wire::GRID2_PREFIX, &dl[..dln]).is_none(), "BATT2 is not a GRID2");
 
-    println!("relay_compat: ALL CHECKS PASSED (bidirectional byte-compat + golden bytes + #13 tag round-trips + disambiguation)");
+    // #124 UP2 envelope — golden bytes + wrap→unwrap→re-parse-inner both directions + disambiguation.
+    // Wrap a plain RELAY (the RELAY2-subsuming case): the gateway unwraps → the inner is a verbatim
+    // RELAY that re-parses under the SAME parse_relay used for a single-hop leaf.
+    let inner_relay = {
+        let mut ib = [0u8; 128];
+        let iln = wire::encode_relay(7, 100, 0, 1, b"cpu=42", &mut ib);
+        ib[..iln].to_vec()
+    };
+    let mut up = [0u8; 256];
+    let upn = wire::encode_up2(7, 5, 2, &inner_relay, &mut up);
+    // GOLDEN: "SMOLv1 UP2 007 00005 2 " + <the verbatim RELAY frame>.
+    let mut golden_up = b"SMOLv1 UP2 007 00005 2 ".to_vec();
+    golden_up.extend_from_slice(&inner_relay);
+    assert_eq!(&up[..upn], &golden_up[..], "encode_up2 golden wire bytes");
+    let (o, em, h, inner) = wire::parse_up2(&up[..upn]).expect("parse_up2");
+    assert_eq!((o, em, h), (7, 5, 2), "UP2 header: origin / envelope-msgid / hop");
+    // the unwrapped inner is a verbatim RELAY → re-parses under the ordinary parser (gateway dispatch).
+    let (rid, rmid, rfrag, rcnt, rchunk) = wire::parse_relay(inner).expect("inner is a verbatim RELAY");
+    assert_eq!((rid, rmid, rfrag, rcnt, rchunk), (7, 100, 0, 1, &b"cpu=42"[..]), "inner RELAY round-trip");
+    // envelope msgid (5) is DISTINCT from the inner RELAY msgid (100) — the two-layer contract.
+    assert_ne!(em, rmid, "envelope msgid != inner RELAY msgid (flood-dedup vs reassembly layers)");
+    // disambiguation: UP2 must NOT classify as RELAY/RELAY2, and vice-versa.
+    assert!(wire::parse_relay(&up[..upn]).is_none(), "UP2 must NOT parse as plain RELAY");
+    assert!(wire::parse_relay2(&up[..upn]).is_none(), "UP2 must NOT parse as RELAY2");
+    assert!(wire::parse_up2(&fb[..n]).is_none(), "a plain RELAY must NOT parse as UP2");
+    // CONSTRAINT 1: a max inner is clamped so the envelope never exceeds ESP_NOW_MTU.
+    let big_inner = [b'z'; 240];
+    let cn = wire::encode_up2(9, 1, 2, &big_inner, &mut up);
+    assert!(cn <= wire::ESP_NOW_MTU, "UP2 clamps inner → frame never exceeds ESP_NOW_MTU");
+    let (_, _, _, clamped) = wire::parse_up2(&up[..cn]).unwrap();
+    assert_eq!(clamped.len(), wire::UP2_INNER_MAX, "inner clamped to UP2_INNER_MAX");
+
+    println!("relay_compat: ALL CHECKS PASSED (bidirectional byte-compat + golden bytes + #13/#124 tag round-trips + disambiguation + UP2 clamp)");
 }

--- a/experiments/relay_compat/src/main.rs
+++ b/experiments/relay_compat/src/main.rs
@@ -84,18 +84,8 @@ fn main() {
     let an = wire::encode_relayack(12345, 3, &mut ab);
     assert_eq!(&ab[..an], old_ack, "encode_relayack golden wire bytes");
 
-    // #13 tag round-trips + DISAMBIGUATION (the no-flag-day guarantee) ------------------------
-    // A RELAY2 frame must NEVER classify as a plain RELAY (old fw would mis-read it), and a plain
-    // RELAY must never classify as RELAY2. Same for RELAYACK/RELAYACK2.
-    let mut r2 = [0u8; 128];
-    let r2n = wire::encode_relay2(9, 42, 2, 1, 2, b"hi", &mut r2);
-    assert!(wire::parse_relay(&r2[..r2n]).is_none(), "RELAY2 must NOT parse as plain RELAY");
-    assert_eq!(
-        wire::parse_relay2(&r2[..r2n]).unwrap(),
-        (9, 42, 2, 1, 2, &b"hi"[..]),
-        "RELAY2 round-trip"
-    );
-    assert!(wire::parse_relay2(&fb[..n2]).is_none(), "plain RELAY must NOT parse as RELAY2");
+    // #13/#124 RELAYACK2 round-trip + DISAMBIGUATION (the no-flag-day guarantee) --------------
+    // (RELAY2 is retired — replaced by UP2 below; RELAYACK2 stays as the flooded ACK.)
     // the gateway's origin-keyed reassembly MAC (never aliases a real Espressif MAC).
     assert_eq!(wire::synth_origin_mac(9), [0, 0, 0, 0, 0, 9], "synth_origin_mac layout");
 
@@ -135,9 +125,8 @@ fn main() {
     assert_eq!((rid, rmid, rfrag, rcnt, rchunk), (7, 100, 0, 1, &b"cpu=42"[..]), "inner RELAY round-trip");
     // envelope msgid (5) is DISTINCT from the inner RELAY msgid (100) — the two-layer contract.
     assert_ne!(em, rmid, "envelope msgid != inner RELAY msgid (flood-dedup vs reassembly layers)");
-    // disambiguation: UP2 must NOT classify as RELAY/RELAY2, and vice-versa.
+    // disambiguation: UP2 must NOT classify as a plain RELAY, and vice-versa.
     assert!(wire::parse_relay(&up[..upn]).is_none(), "UP2 must NOT parse as plain RELAY");
-    assert!(wire::parse_relay2(&up[..upn]).is_none(), "UP2 must NOT parse as RELAY2");
     assert!(wire::parse_up2(&fb[..n]).is_none(), "a plain RELAY must NOT parse as UP2");
     // CONSTRAINT 1: a max inner is clamped so the envelope never exceeds ESP_NOW_MTU.
     let big_inner = [b'z'; 240];

--- a/rust/clock/src/net/flood.rs
+++ b/rust/clock/src/net/flood.rs
@@ -13,6 +13,8 @@
 //!   2. [`forward_decision`] — what a node does with an inbound multi-hop RELAY2 frame.
 //!   3. [`HopLatch`] — the leaf's single-hop⇄multi-hop escalation state machine with
 //!      un-latch hysteresis (so a leaf that moves back into range stops flooding).
+//!   4. [`ChannelPark`] (#126) — a stranded leaf's channel-bias state machine: sweep +
+//!      burst to find the channel that draws a forward/ACK, then park on it (throughput).
 //!
 //! ## The byte-identical invariant (team-lead's gate)
 //! A non-escalated leaf sends plain `SMOLv1 RELAY` with an implicit `H=1`; nodes
@@ -247,6 +249,212 @@ impl HopLatch {
 }
 
 impl Default for HopLatch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---- #126 channel parking (latched-leaf multi-hop throughput) --------------
+//
+// A stranded (latched) leaf never hears its elected owner's HELLO, so it never LOCKS a
+// channel — `leaf_scan_tick` keeps it blind-hopping 1/6/11. Its uplink therefore lands on
+// the relay's channel only ~1/3 of the time (channel coincidence), and the flooded-back
+// RELAYACK2 hits the same ~1/3 in reverse. `ChannelPark` biases a LATCHED leaf toward the
+// channel that actually drew a forward/ACK, raising delivery toward ~1/1 (issue #126).
+//
+// The ACK-feedback bootstrap (chicken-and-egg: parking wants to key on "which channel drew a
+// forward/ACK", but that signal can't exist until we've emitted there): a `Sweeping` phase
+// dwells per candidate and fires short EMISSION BURSTS (K frames/channel, ≥1 guaranteed before
+// hopping) so a returning RELAYACK2 — or a relay re-broadcasting OUR origin — can be attributed
+// to the channel that worked. `on_feedback` then PARKS there; parked, the leaf simply HOLDS the
+// channel and lets the normal telemetry cadence flow (no extra airtime) — the bias IS the win.
+//
+// INVARIANT: parking engages ONLY while latched (`sync`), so a healthy (never-latched) leaf's
+// blind scan + byte-identical `fwd=0` behaviour is completely untouched. Un-latch (uplink
+// recovered) or a #76 re-election (`on_rechannel`) disengages/restarts the sweep.
+
+/// Candidate ESP-NOW channels a leaf sweeps while unlocked (JP's roam plan). SINGLE SOURCE OF
+/// TRUTH — `mode.rs::leaf_scan_tick`'s blind scan, `current_channel`, and #126 parking all index
+/// this, so the scan plan and the park plan can never silently drift apart.
+// #126 wip (Stage A): the whole ChannelPark block is host-tested in flood_verify but UNWIRED in the
+// clock crate — the allow(dead_code)s DROP in Stage B when leaf_scan_tick/emit start driving it.
+#[allow(dead_code)]
+pub const PARK_CHANNELS: [u8; 3] = [1, 6, 11];
+
+/// Per-candidate dwell while SWEEPING (ms). Matches `leaf_scan_tick`'s blind-scan dwell, so
+/// parking only re-orders WHICH channel a stranded leaf favours, not the dwell shape.
+#[allow(dead_code)]
+pub const PARK_DWELL_MS: u64 = 1500;
+
+/// Min gap between emission bursts within one dwell (ms). A "burst" re-broadcasts the leaf's
+/// staged uplink so a relay on THIS channel forwards it + the gateway floods a RELAYACK2 back —
+/// the ACK-feedback bootstrap. Only fires while LATCHED + sweeping (stranded); never on a healthy leaf.
+#[allow(dead_code)]
+pub const PARK_BURST_EVERY_MS: u64 = 400;
+
+/// Emission bursts per candidate before the sweep may hop off it — the "emit K frames per channel
+/// before hopping" bootstrap. Guarantees every candidate is actually probed, never skipped.
+#[allow(dead_code)]
+pub const PARK_BURSTS_PER_DWELL: u8 = 3;
+
+/// A PARKED channel that draws no forward/ACK for this long (ms) is assumed cold (relay roamed /
+/// re-elected) ⇒ resume sweeping. > 1 telemetry cycle (~15 s) so a single lost ACK on a live-but-
+/// lossy channel doesn't abandon a good park.
+#[allow(dead_code)]
+pub const PARK_SILENCE_MS: u64 = 30_000;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ParkPhase {
+    /// Not stranded (or uplink recovered) — blind scan governs; parking is inert.
+    Idle,
+    /// Cycling candidates + bursting, waiting for the first forward/ACK to attribute.
+    Sweeping,
+    /// A candidate drew feedback — HOLD it (both uplink + RELAYACK2 land on the relay's channel).
+    Parked,
+}
+
+/// The leaf's #126 channel-parking state machine (pure). Companion to [`HopLatch`]: `HopLatch`
+/// answers *single- or multi-hop?*, `ChannelPark` answers *which channel should a stranded leaf
+/// be on?*. Driven by the live `leaf_scan_tick`/emit path (which supplies `now` + acts on the
+/// outputs); host-unit-tested in `flood_verify` (state machine AND the emit-trigger contract).
+#[allow(dead_code)] // #126 wip: unwired in the clock crate until Stage B (see the block note above).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChannelPark {
+    phase: ParkPhase,
+    /// Current candidate index into [`PARK_CHANNELS`].
+    idx: u8,
+    /// When we arrived on the current candidate (sweeping dwell clock).
+    dwell_started_ms: u64,
+    /// Emission bursts already fired on the current candidate this dwell.
+    bursts_this_dwell: u8,
+    /// Last burst emit time (spacing clock).
+    last_burst_ms: u64,
+    /// Last forward/ACK attributed to the parked channel (silence clock).
+    last_feedback_ms: u64,
+}
+
+#[allow(dead_code)] // #126 wip: the whole API is exercised by flood_verify; wired in Stage B.
+impl ChannelPark {
+    pub const fn new() -> Self {
+        Self {
+            phase: ParkPhase::Idle,
+            idx: 0,
+            dwell_started_ms: 0,
+            bursts_this_dwell: 0,
+            last_burst_ms: 0,
+            last_feedback_ms: 0,
+        }
+    }
+
+    /// Is parking active (leaf is stranded)? `false` ⇒ the blind scan governs the channel.
+    pub fn engaged(&self) -> bool {
+        !matches!(self.phase, ParkPhase::Idle)
+    }
+
+    /// Have we locked onto a working channel (as opposed to still sweeping)?
+    pub fn parked(&self) -> bool {
+        matches!(self.phase, ParkPhase::Parked)
+    }
+
+    /// The channel the leaf should be on right now, or `None` while [`ParkPhase::Idle`] (the
+    /// caller falls back to the normal blind scan). Indexes [`PARK_CHANNELS`].
+    pub fn channel(&self) -> Option<u8> {
+        match self.phase {
+            ParkPhase::Idle => None,
+            _ => Some(PARK_CHANNELS[(self.idx as usize) % PARK_CHANNELS.len()]),
+        }
+    }
+
+    fn start_sweep(&mut self, idx: u8, now: u64) {
+        self.phase = ParkPhase::Sweeping;
+        self.idx = idx % PARK_CHANNELS.len() as u8;
+        self.dwell_started_ms = now;
+        self.bursts_this_dwell = 0;
+        self.last_burst_ms = 0;
+    }
+
+    /// Drive from the escalation latch each tick (edge-safe / idempotent). Latched + inert ⇒
+    /// engage, sweeping from candidate 0. Un-latched (uplink recovered) + engaged ⇒ disengage to
+    /// [`ParkPhase::Idle`] so the blind scan resumes. Otherwise a no-op.
+    pub fn sync(&mut self, latched: bool, now: u64) {
+        if latched && !self.engaged() {
+            self.start_sweep(0, now);
+        } else if !latched && self.engaged() {
+            self.phase = ParkPhase::Idle;
+        }
+    }
+
+    /// #76: the elected owner / its channel changed under us, so the swept/parked channel is
+    /// stale — restart the sweep from candidate 0. No-op while [`ParkPhase::Idle`] (not stranded).
+    pub fn on_rechannel(&mut self, now: u64) {
+        if self.engaged() {
+            self.start_sweep(0, now);
+        }
+    }
+
+    /// Advance dwell/park timing. SWEEPING: hop to the next candidate once the dwell elapsed AND
+    /// ≥1 burst went out on this one (so no candidate is skipped un-probed — the caller MUST call
+    /// [`should_burst`] each tick BEFORE `tick`, see `flood_verify`'s trigger-contract test).
+    /// PARKED: if the channel has been silent past [`PARK_SILENCE_MS`] it went cold ⇒ resume
+    /// sweeping from it. IDLE: nothing.
+    pub fn tick(&mut self, now: u64) {
+        match self.phase {
+            ParkPhase::Sweeping => {
+                let dwell_done = now.saturating_sub(self.dwell_started_ms) >= PARK_DWELL_MS;
+                if dwell_done && self.bursts_this_dwell >= 1 {
+                    let next = (self.idx + 1) % PARK_CHANNELS.len() as u8;
+                    self.start_sweep(next, now);
+                }
+            }
+            ParkPhase::Parked => {
+                if now.saturating_sub(self.last_feedback_ms) >= PARK_SILENCE_MS {
+                    self.start_sweep(self.idx, now); // re-sweep from the last good channel
+                }
+            }
+            ParkPhase::Idle => {}
+        }
+    }
+
+    /// Should the leaf fire an emission BURST this tick? Only while SWEEPING (the ACK-feedback
+    /// bootstrap): up to [`PARK_BURSTS_PER_DWELL`] per candidate, spaced ≥ [`PARK_BURST_EVERY_MS`]
+    /// (the first of each dwell fires immediately). PARKED/IDLE ⇒ `false` (normal telemetry cadence
+    /// carries the held channel). MUTATES the burst counters — call at most once per tick.
+    pub fn should_burst(&mut self, now: u64) -> bool {
+        if self.phase != ParkPhase::Sweeping {
+            return false;
+        }
+        if self.bursts_this_dwell >= PARK_BURSTS_PER_DWELL {
+            return false;
+        }
+        if self.bursts_this_dwell > 0
+            && now.saturating_sub(self.last_burst_ms) < PARK_BURST_EVERY_MS
+        {
+            return false; // not yet time for the next burst of this dwell
+        }
+        self.bursts_this_dwell = self.bursts_this_dwell.saturating_add(1);
+        self.last_burst_ms = now;
+        true
+    }
+
+    /// A forward/ACK signal — a RELAYACK2 addressed to us, or a relay re-broadcasting OUR origin —
+    /// arrived while on the current channel ⇒ that channel WORKS. SWEEPING ⇒ PARK here. PARKED ⇒
+    /// refresh freshness so the silence timer doesn't abandon a live channel. IDLE ⇒ ignore
+    /// (a non-stranded leaf's ACKs are normal single-hop traffic, not park feedback).
+    pub fn on_feedback(&mut self, now: u64) {
+        match self.phase {
+            ParkPhase::Sweeping => {
+                self.phase = ParkPhase::Parked;
+                self.last_feedback_ms = now;
+            }
+            ParkPhase::Parked => {
+                self.last_feedback_ms = now;
+            }
+            ParkPhase::Idle => {}
+        }
+    }
+}
+
+impl Default for ChannelPark {
     fn default() -> Self {
         Self::new()
     }

--- a/rust/clock/src/net/flood.rs
+++ b/rust/clock/src/net/flood.rs
@@ -276,31 +276,24 @@ impl Default for HopLatch {
 /// Candidate ESP-NOW channels a leaf sweeps while unlocked (JP's roam plan). SINGLE SOURCE OF
 /// TRUTH — `mode.rs::leaf_scan_tick`'s blind scan, `current_channel`, and #126 parking all index
 /// this, so the scan plan and the park plan can never silently drift apart.
-// #126 wip (Stage A): the whole ChannelPark block is host-tested in flood_verify but UNWIRED in the
-// clock crate — the allow(dead_code)s DROP in Stage B when leaf_scan_tick/emit start driving it.
-#[allow(dead_code)]
 pub const PARK_CHANNELS: [u8; 3] = [1, 6, 11];
 
 /// Per-candidate dwell while SWEEPING (ms). Matches `leaf_scan_tick`'s blind-scan dwell, so
 /// parking only re-orders WHICH channel a stranded leaf favours, not the dwell shape.
-#[allow(dead_code)]
 pub const PARK_DWELL_MS: u64 = 1500;
 
 /// Min gap between emission bursts within one dwell (ms). A "burst" re-broadcasts the leaf's
 /// staged uplink so a relay on THIS channel forwards it + the gateway floods a RELAYACK2 back —
 /// the ACK-feedback bootstrap. Only fires while LATCHED + sweeping (stranded); never on a healthy leaf.
-#[allow(dead_code)]
 pub const PARK_BURST_EVERY_MS: u64 = 400;
 
 /// Emission bursts per candidate before the sweep may hop off it — the "emit K frames per channel
 /// before hopping" bootstrap. Guarantees every candidate is actually probed, never skipped.
-#[allow(dead_code)]
 pub const PARK_BURSTS_PER_DWELL: u8 = 3;
 
 /// A PARKED channel that draws no forward/ACK for this long (ms) is assumed cold (relay roamed /
 /// re-elected) ⇒ resume sweeping. > 1 telemetry cycle (~15 s) so a single lost ACK on a live-but-
 /// lossy channel doesn't abandon a good park.
-#[allow(dead_code)]
 pub const PARK_SILENCE_MS: u64 = 30_000;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -317,7 +310,6 @@ enum ParkPhase {
 /// answers *single- or multi-hop?*, `ChannelPark` answers *which channel should a stranded leaf
 /// be on?*. Driven by the live `leaf_scan_tick`/emit path (which supplies `now` + acts on the
 /// outputs); host-unit-tested in `flood_verify` (state machine AND the emit-trigger contract).
-#[allow(dead_code)] // #126 wip: unwired in the clock crate until Stage B (see the block note above).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ChannelPark {
     phase: ParkPhase,
@@ -333,7 +325,6 @@ pub struct ChannelPark {
     last_feedback_ms: u64,
 }
 
-#[allow(dead_code)] // #126 wip: the whole API is exercised by flood_verify; wired in Stage B.
 impl ChannelPark {
     pub const fn new() -> Self {
         Self {
@@ -458,4 +449,45 @@ impl Default for ChannelPark {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// What a scan tick should DO this iteration for the channel-park path — the output of
+/// [`park_scan_action`], applied by the live `leaf_scan_tick` (set the channel, maybe burst).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ParkAction {
+    /// Channel to switch to before (maybe) bursting. `None` ⇒ leave the channel alone (the caller's
+    /// blind scan governs, or we're locked onto an owner).
+    pub channel: Option<u8>,
+    /// Fire ONE dwell-per-channel emission burst (re-broadcast the staged uplink) on `channel` this
+    /// tick — the ACK-feedback bootstrap. Always `false` unless sweeping.
+    pub burst: bool,
+}
+
+/// The PURE per-tick channel-park decision, extracted from `leaf_scan_tick` so the emit-TRIGGER
+/// wiring — not just the state-machine math — is host-testable. This is the standing #123 lesson:
+/// the on-air bugs lived in the trigger wiring (which channel / when to emit / the gating), invisible
+/// to a green build, TWICE. Everything bug-prone now lives here and is covered by `flood_verify`.
+///
+/// Owns the whole decision + its ORDER: latch-sync, then (only when stranded AND not locked onto an
+/// owner) pick the swept/parked channel, decide the burst, and advance the sweep — the exact
+/// should_burst()→tick() sequence the SM contract requires. The caller supplies the CURRENT
+/// (`latched`, `scan_locked`) and mechanically APPLIES the returned [`ParkAction`] (no logic).
+///
+/// * not stranded (`!latched`) ⇒ park disengaged, `channel: None` (blind scan governs, byte-identical).
+/// * stranded but `scan_locked` (hears an owner directly) ⇒ `channel: None` (stay on the owner's channel).
+/// * stranded + unlocked ⇒ `channel: Some(swept/parked)`, `burst` per the bootstrap cadence.
+pub fn park_scan_action(
+    park: &mut ChannelPark,
+    latched: bool,
+    scan_locked: bool,
+    now: u64,
+) -> ParkAction {
+    park.sync(latched, now);
+    if scan_locked || !latched {
+        return ParkAction { channel: None, burst: false };
+    }
+    let channel = park.channel();
+    let burst = park.should_burst(now);
+    park.tick(now);
+    ParkAction { channel, burst }
 }

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2449,6 +2449,7 @@ impl RadioManager {
         let n = value.len().min(crate::net::wifi::CFG_VALUE_MAX);
         msg[base + 3..base + 3 + n].copy_from_slice(&value[..n]);
         self.send_to(&BROADCAST_ADDRESS, &msg[..base + 3 + n]);
+        self.relay_wrap_observability(&msg[..base + 3 + n]);
     }
 
     /// #70/#49: broadcast this node's compact key=val DIAG record as a `SMOLv1 DIAG` frame —
@@ -2468,6 +2469,7 @@ impl RadioManager {
         let n = value.len().min(crate::net::wifi::RELAY_VALUE_MAX);
         msg[base + 3..base + 3 + n].copy_from_slice(&value[..n]);
         self.send_to(&BROADCAST_ADDRESS, &msg[..base + 3 + n]);
+        self.relay_wrap_observability(&msg[..base + 3 + n]);
     }
 
     /// #71: broadcast this node's one-shot WiFi-scan record as a `SMOLv1 SCAN` frame — twin of
@@ -2486,6 +2488,29 @@ impl RadioManager {
         let n = value.len().min(crate::net::wifi::RELAY_VALUE_MAX);
         msg[base + 3..base + 3 + n].copy_from_slice(&value[..n]);
         self.send_to(&BROADCAST_ADDRESS, &msg[..base + 3 + n]);
+        self.relay_wrap_observability(&msg[..base + 3 + n]);
+    }
+
+    /// #124 Stage 2 (observability closure) — when this leaf is LATCHED (multi-hop, gateway out of
+    /// direct earshot), ALSO emit `frame` (a fully-built plain STAT/DIAG/SCAN) wrapped in a UP2
+    /// envelope so a relay floods our /stat /diag /scan to the gateway. Closes the P1 gap: a
+    /// stranded leaf that can't RELAY-uplink was previously observability-DARK (STAT/DIAG/SCAN are
+    /// plain broadcasts, never forwarded). No-op on a gateway or when NOT latched — so a healthy
+    /// leaf's on-air behaviour is BYTE-IDENTICAL (only the plain broadcast, no UP2). The inner is
+    /// clamped at a FIELD BOUNDARY (last `|` ≤ [`UP2_INNER_MAX`]) so an over-budget DIAG/SCAN record
+    /// truncates its tail cleanly (never mid `key=val`); STAT (≤ 79 B) never clamps. Each wrap gets a
+    /// fresh envelope msgid (the flood-dedup key; fire-and-forget — no inner ACK). `frame` is a local
+    /// buffer in the caller, so no borrow of `self` is held across the `&mut self` send.
+    fn relay_wrap_observability(&mut self, frame: &[u8]) {
+        if self.relay.is_gateway || !self.relay.latch.latched() {
+            return;
+        }
+        let env_msgid = self.relay.up_env_msgid;
+        self.relay.up_env_msgid = self.relay.up_env_msgid.wrapping_add(1);
+        let ilen = clamp_inner_field_boundary(frame, UP2_INNER_MAX);
+        let mut fb = [0u8; ESP_NOW_MTU];
+        let len = encode_up2(self.id, env_msgid, crate::net::flood::MAX_HOP, &frame[..ilen], &mut fb);
+        self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
     }
 
     /// #71: run ONE on-demand WiFi AP scan (triggered by applying the `W` command) → publish the
@@ -4316,61 +4341,81 @@ impl RadioManager {
                         // Our OWN envelope echoed back by a relay — never re-forward/reassemble it
                         // (bogus fwd + could loop). Just drop it.
                         label = Some(alloc::format!("up2 self {:03}", origin));
-                    } else if let Some((_sid, imsgid, frag, count, chunk)) = parse_relay(inner) {
-                        // 1b: the inner is a plain RELAY (the RELAY2-subsuming case). `imsgid` is the
-                        // INNER RELAY msgid — the reassembly/ACK key, distinct from the envelope msgid.
-                        if self.relay.is_gateway {
-                            // GATEWAY sink: reassemble keyed by ORIGIN (synthetic MAC), NOT `src` (the
-                            // last relay). accept()+DONE_RING dedup fragments/retransmits, so we do NOT
-                            // consult the seen-set here (a seen-set drop would kill a lost-ACK
-                            // retransmit's re-ACK). On each accepted fragment flood a RELAYACK2 back
-                            // toward the origin (R1) carrying the cumulative bitmap, keyed on `imsgid`.
-                            let synth = synth_origin_mac(origin);
-                            let (bitmap, complete) =
-                                self.relay.accept(synth, (origin, imsgid, frag, count), chunk, now);
-                            self.flood_relayack2(origin, imsgid, bitmap);
-                            label = Some(if complete {
-                                alloc::format!("up2 {:03} ok", origin)
-                            } else {
-                                alloc::format!("up2 {:03} {}/{}", origin, bitmap.count_ones(), count)
-                            });
-                        } else {
-                            // RELAY role: seen-set-gated forward, keyed on the ENVELOPE msgid
-                            // `(origin, env_msgid, 0)` — each UP2 is one atomic frame (frag dimension
-                            // is absorbed into env_msgid, which is unique per emitted/retransmitted UP2).
-                            let seen = self.relay.seen.seen_or_insert(origin, env_msgid, 0);
-                            match crate::net::flood::forward_decision(false, hop, seen) {
-                                crate::net::flood::ForwardAction::Forward { hop: next_hop } => {
-                                    self.diag.fwd = self.diag.fwd.saturating_add(1);
-                                    // Re-wrap the SAME inner verbatim at hop-1 (env_msgid preserved).
-                                    // `inner` borrows the RX buffer; copied into `fb` before the send.
-                                    let mut fb = [0u8; ESP_NOW_MTU];
-                                    let len = encode_up2(origin, env_msgid, next_hop, inner, &mut fb);
-                                    self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
-                                    if self.diag.fwd.is_multiple_of(8) {
-                                        log::info!(
-                                            "smol #124: fwd {} (origin {:03} env_msgid {} -> h{})",
-                                            self.diag.fwd, origin, env_msgid, next_hop
-                                        );
-                                    }
-                                    label = Some(alloc::format!("fwd {:03} h{}", origin, next_hop));
-                                }
-                                crate::net::flood::ForwardAction::DedupDrop => {
-                                    self.diag.dedup = self.diag.dedup.saturating_add(1);
-                                    label = Some(alloc::format!("dedup {:03}", origin));
-                                }
-                                crate::net::flood::ForwardAction::TtlDrop => {
-                                    self.diag.ttl = self.diag.ttl.saturating_add(1);
-                                    label = Some(alloc::format!("ttl {:03}", origin));
-                                }
-                                // Reassemble is only returned for is_gateway=true (handled above).
-                                crate::net::flood::ForwardAction::Reassemble => {}
+                    } else if self.relay.is_gateway {
+                        // GATEWAY SINK: dispatch by the INNER frame type (#124 Stage 2). Everything is
+                        // keyed by the envelope `origin` (the stranded leaf), NOT `src` (the last relay):
+                        //   • RELAY → reassemble (synthetic origin MAC) + flood a RELAYACK2 back toward
+                        //     the origin. `imsgid` is the INNER RELAY msgid = reassembly/ACK key (distinct
+                        //     from env_msgid). accept()+DONE_RING dedup fragments/retransmits, so we do
+                        //     NOT consult the seen-set here (a seen-set drop would kill a lost-ACK
+                        //     retransmit's re-ACK).
+                        //   • STAT/DIAG/SCAN → the same gateway caches the DIRECT arms feed (the P1
+                        //     observability closure): a stranded leaf's /stat /diag /scan now reach HA.
+                        //     STAT stamps the synthetic origin MAC so the leaf stays mac-resolvable
+                        //     (mirror of the direct STAT arm, which stamps the real `src`).
+                        let synth = synth_origin_mac(origin);
+                        match parse_frame(inner) {
+                            Some(Frame::Relay { msgid: imsgid, frag, count, chunk, .. }) => {
+                                let (bitmap, complete) =
+                                    self.relay.accept(synth, (origin, imsgid, frag, count), chunk, now);
+                                self.flood_relayack2(origin, imsgid, bitmap);
+                                label = Some(if complete {
+                                    alloc::format!("up2 {:03} ok", origin)
+                                } else {
+                                    alloc::format!("up2 {:03} {}/{}", origin, bitmap.count_ones(), count)
+                                });
                             }
+                            Some(Frame::Stat { value, .. }) => {
+                                self.stat_cache.set(
+                                    origin, crate::net::wifi::CFG_KEY_SCREEN, value, synth, now,
+                                );
+                                label = Some(alloc::format!("up2 {:03} stat", origin));
+                            }
+                            Some(Frame::Diag { value, .. }) => {
+                                self.diag_cache.set(origin, value, now);
+                                label = Some(alloc::format!("up2 {:03} diag", origin));
+                            }
+                            Some(Frame::Scan { value, .. }) => {
+                                self.scan_cache.set(origin, value, now);
+                                label = Some(alloc::format!("up2 {:03} scan", origin));
+                            }
+                            // An inner we don't sink (nested/unknown) — drop, never re-wrap.
+                            _ => label = Some(alloc::format!("up2 {:03} ?inner", origin)),
                         }
                     } else {
-                        // Stage 2: a non-RELAY inner (STAT/DIAG/SCAN) — full parse_frame + dispatch to
-                        // the caches lands next stage; for 1b it's dropped (only RELAY is wrapped yet).
-                        label = Some(alloc::format!("up2 {:03} non-relay", origin));
+                        // RELAY role: envelope-only, inner-AGNOSTIC flood — forwards RELAY and
+                        // STAT/DIAG/SCAN alike (the relay never parses the inner). Seen-set-gated on
+                        // the ENVELOPE msgid `(origin, env_msgid, 0)` — each UP2 is one atomic frame
+                        // (the frag dimension is absorbed into env_msgid, unique per emitted/
+                        // retransmitted UP2).
+                        let seen = self.relay.seen.seen_or_insert(origin, env_msgid, 0);
+                        match crate::net::flood::forward_decision(false, hop, seen) {
+                            crate::net::flood::ForwardAction::Forward { hop: next_hop } => {
+                                self.diag.fwd = self.diag.fwd.saturating_add(1);
+                                // Re-wrap the SAME inner verbatim at hop-1 (env_msgid preserved).
+                                // `inner` borrows the RX buffer; copied into `fb` before the send.
+                                let mut fb = [0u8; ESP_NOW_MTU];
+                                let len = encode_up2(origin, env_msgid, next_hop, inner, &mut fb);
+                                self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
+                                if self.diag.fwd.is_multiple_of(8) {
+                                    log::info!(
+                                        "smol #124: fwd {} (origin {:03} env_msgid {} -> h{})",
+                                        self.diag.fwd, origin, env_msgid, next_hop
+                                    );
+                                }
+                                label = Some(alloc::format!("fwd {:03} h{}", origin, next_hop));
+                            }
+                            crate::net::flood::ForwardAction::DedupDrop => {
+                                self.diag.dedup = self.diag.dedup.saturating_add(1);
+                                label = Some(alloc::format!("dedup {:03}", origin));
+                            }
+                            crate::net::flood::ForwardAction::TtlDrop => {
+                                self.diag.ttl = self.diag.ttl.saturating_add(1);
+                                label = Some(alloc::format!("ttl {:03}", origin));
+                            }
+                            // Reassemble is only returned for is_gateway=true (handled above).
+                            crate::net::flood::ForwardAction::Reassemble => {}
+                        }
                     }
                 }
                 Some(Frame::RelayAck2 { target, msgid, bitmap, hop }) => {

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -128,16 +128,12 @@ const BEACON_PREFIX: &[u8] = b"SMOLv1 BEACON "; // + "NNN SSSSS EEEEE"
 /// on a private fixed channel; harden with a signed payload or an ESP-NOW LMK
 /// if it ever matters. Documented, not defended.
 const TIME_PREFIX: &[u8] = b"SMOLv1 TIME "; // + "NNN UUUUUUUUUU SSSSSSSSSS"
-// #13: the RELAY / RELAYACK / RELAY2 / RELAYACK2 wire TAGS + their whole codec live in the
+// #13/#124: the RELAY / RELAYACK / UP2 / RELAYACK2 wire TAGS + their whole codec live in the
 // pure, host-testable `net::wire` module (glob-imported above — RELAY carries a leaf-telemetry
-// fragment; RELAYACK the gateway's fragment-bitmap; RELAY2/RELAYACK2 the #13 multi-hop variants,
-// NEW tags an old firmware classifies to None → no flag-day). The `*_FRAME_MAX` buffer-size
-// consts stay here — they size call-site stack buffers in this module, not the codec.
-/// Max RELAY2 frame length on the wire (30-byte header + full chunk); sizes stack buffers.
-/// Header = 14-byte prefix + "OOO MMMMM H F C " (16) = 30, vs RELAY's 27 (the extra 3 =
-/// the origin↔src split's `H ` hop field; `OOO` is the ORIGIN id, distinct from the
-/// re-broadcasting relay's own src MAC).
-const RELAY2_FRAME_MAX: usize = 30 + RELAY_CHUNK;
+// fragment; RELAYACK the gateway's fragment-bitmap; UP2 the #124 generic uplink ENVELOPE that
+// wraps ANY inner frame from a stranded leaf (subsumes the retired RELAY2), RELAYACK2 the
+// flooded-back ACK — NEW tags an old firmware classifies to None → no flag-day). The
+// `*_FRAME_MAX`/`ESP_NOW_MTU` buffer-size consts size call-site stack buffers in this module.
 /// Max RELAYACK2 frame length ("SMOLv1 RELAYACK2 " + "TTT MMMMM BBB H" = 32); rounded up.
 const RELAYACK2_FRAME_MAX: usize = 40;
 /// Battery-downlink tag: the 12-B `"SMOLv1 BATT "` (trailing space, mirroring TIME)
@@ -435,18 +431,17 @@ enum Frame<'a> {
     /// A gateway's acknowledgement of a relay message: the `msgid` and the u8
     /// bitmap of fragments received so far, so the leaf resends only the gaps.
     RelayAck { msgid: u16, bitmap: u8 },
-    /// #13 multi-hop: one fragment of a STRANDED leaf's telemetry uplink, carrying the
-    /// true `origin` id (stamped by the source, survives forwarding — unlike `src_mac`,
-    /// which is the last relay) and a hop-limit `hop` (decremented at each forward,
-    /// dropped at ≤ 1 by a non-gateway). Otherwise identical to `Relay`. `chunk` borrows
-    /// the RX buffer. Emitted only by an escalated leaf + re-broadcast by relays.
-    Relay2 {
+    /// #124 UP2 generic uplink envelope from a STRANDED leaf: the true `origin` id (stamped by the
+    /// source, survives forwarding — unlike `src_mac`, the last relay), the envelope's own
+    /// `env_msgid` (per-origin rolling — the FLOOD-DEDUP key, distinct from any inner RELAY msgid),
+    /// a hop-limit `hop` (decremented per forward, dropped at ≤ 1 by a non-gateway), and the verbatim
+    /// `inner` SMOLv1 frame (RELAY/STAT/DIAG/SCAN — `inner` borrows the RX buffer). The gateway
+    /// unwraps + re-dispatches `inner`. Emitted only by an escalated leaf + re-broadcast by relays.
+    Up2 {
         origin: u8,
-        msgid: u16,
+        env_msgid: u16,
         hop: u8,
-        frag: u8,
-        count: u8,
-        chunk: &'a [u8],
+        inner: &'a [u8],
     },
     /// #13 multi-hop: the gateway's flooded-back ACK for a `Relay2` message (R1,
     /// table-free) — `target` = the origin leaf to ACK, `msgid` + `bitmap` as `RelayAck`,
@@ -1449,16 +1444,21 @@ struct Relay {
     /// retransmits so a message is never enqueued (UDP-delivered) twice (finding 3).
     done: [Option<([u8; 6], u16)>; DONE_RING],
     done_cursor: usize,
-    /// #13 relay-role: the `(origin, msgid, frag)` loop/dup guard for FORWARDING inbound
-    /// `RELAY2` frames. Only a NON-gateway consults it (the gateway reassembles + dedups
-    /// via its own `reasm`/`done`, so it never marks a frame "seen" — else a lost-ACK
-    /// retransmit would be dropped before it could be re-ACKed). See `net/flood.rs`.
+    /// #13 relay-role: the `(origin, env_msgid, 0)` loop/dup guard for FORWARDING inbound `UP2`
+    /// envelopes (#124: keyed on the envelope msgid; each UP2 is one atomic frame so `frag`=0). Only
+    /// a NON-gateway consults it (the gateway reassembles + dedups via its own `reasm`/`done`, so it
+    /// never marks a frame "seen" — else a lost-ACK retransmit would be dropped before it could be
+    /// re-ACKed). See `net/flood.rs`.
     seen: crate::net::flood::SeenSet,
     /// #13 leaf-role: the single-hop⇄multi-hop escalation state machine. Stays inert
     /// (single-hop, byte-identical) until this leaf's telemetry goes fully un-ACKed
-    /// (`relay_retransmit` exhaust) — then it latches `RELAY2` at `MAX_HOP` and probes
+    /// (`relay_retransmit` exhaust / supersession) — then it latches `UP2` at `MAX_HOP` and probes
     /// its way back down. See `net/flood.rs`.
     latch: crate::net::flood::HopLatch,
+    /// #124 leaf-role: the envelope's own per-origin rolling msgid — bumped once per `UP2` emitted
+    /// (each inner frame / RELAY fragment gets a unique one), the FLOOD-DEDUP key. DISTINCT from the
+    /// inner RELAY `msgid` (`tx.msgid`), which stays the reassembly/RELAYACK2 key. Wraps like `next_msgid`.
+    up_env_msgid: u16,
 }
 
 impl Relay {
@@ -1476,6 +1476,7 @@ impl Relay {
             done_cursor: 0,
             seen: crate::net::flood::SeenSet::new(),
             latch: crate::net::flood::HopLatch::new(),
+            up_env_msgid: 0,
         }
     }
 
@@ -2953,17 +2954,27 @@ impl RadioManager {
                 || now.saturating_sub(self.relay.last_emit_ms) >= RELAY_EMIT_INTERVAL_MS)
     }
 
-    /// #13: emit ONE fragment of OUR OWN uplink at the message's chosen framing.
-    /// `hop <= 1` → plain `RELAY` (the byte-identical single-hop case AND the `H=1`
-    /// un-latch probe); `hop > 1` → `RELAY2` (origin-stamped, hop-limited, forwarded by
-    /// relays). The chunk is copied into a LOCAL frame buffer BEFORE `send_to`, so no
-    /// borrow of `self.relay` is held across the `&mut self` send.
+    /// #124: emit ONE fragment of OUR OWN uplink at the message's chosen framing.
+    /// `hop <= 1` → plain `RELAY` (the byte-identical single-hop case AND the `H=1` un-latch probe);
+    /// `hop > 1` → the fragment's plain `RELAY` frame WRAPPED in a `UP2` envelope (origin-stamped,
+    /// hop-limited, forwarded by relays). Each wrapped fragment gets a FRESH per-origin envelope
+    /// msgid (the flood-dedup key — distinct from the inner RELAY `msgid`, which stays the gateway's
+    /// reassembly/RELAYACK2 key); a fresh env_msgid per (re)send means a retransmit is re-forwarded
+    /// (the relay's seen-set doesn't suppress it — closing #13's single-relay retransmit gap). The
+    /// inner + frame are built into LOCAL buffers before `send_to`, so no borrow of `self.relay` is
+    /// held across the `&mut self` send.
     fn relay_send_frag(&mut self, msgid: u16, hop: u8, frag: u8, count: u8, off: usize, end: usize) {
-        let mut fb = [0u8; RELAY2_FRAME_MAX];
+        let mut fb = [0u8; ESP_NOW_MTU];
         let len = if hop <= 1 {
             encode_relay(self.id, msgid, frag, count, &self.relay.tx.buf[off..end], &mut fb)
         } else {
-            encode_relay2(self.id, msgid, hop, frag, count, &self.relay.tx.buf[off..end], &mut fb)
+            // Build the inner plain RELAY, then wrap it in UP2 with a fresh envelope msgid.
+            let mut inner = [0u8; 96]; // RELAY frame ≤ 27-byte header + RELAY_CHUNK(64) = 91
+            let ilen =
+                encode_relay(self.id, msgid, frag, count, &self.relay.tx.buf[off..end], &mut inner);
+            let env_msgid = self.relay.up_env_msgid;
+            self.relay.up_env_msgid = self.relay.up_env_msgid.wrapping_add(1);
+            encode_up2(self.id, env_msgid, hop, &inner[..ilen], &mut fb)
         };
         self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
     }
@@ -4296,67 +4307,70 @@ impl RadioManager {
                     self.relay.latch.on_direct_ack();
                     label = Some(alloc::format!("ack {:05}", msgid));
                 }
-                Some(Frame::Relay2 { origin, msgid, hop, frag, count, chunk }) => {
-                    // #13 multi-hop uplink fragment. Proves the SENDER (the last relay, or the
-                    // origin itself) is audible (LED detected + roster, attributed to `origin`).
+                Some(Frame::Up2 { origin, env_msgid, hop, inner }) => {
+                    // #124 multi-hop uplink ENVELOPE. Proves the SENDER (last relay, or the origin)
+                    // is audible (LED detected + roster, attributed to `origin`).
                     self.peers.last_hello_ms = now;
                     self.roster.heard(src, Some(origin), rssi, now);
                     if origin == self.id {
-                        // Our OWN frame echoed back by a relay — never re-forward or reassemble it
-                        // (that would count as a bogus fwd + could loop). Just drop it.
-                        label = Some(alloc::format!("relay2 self {:03}", origin));
-                    } else if self.relay.is_gateway {
-                        // GATEWAY = the flood's sink. Reassemble keyed by ORIGIN (a synthetic MAC
-                        // `00:00:00:00:00:<origin>`), NOT `src` — `src` is the last relay's MAC, but
-                        // reassembly + late-retransmit dedup must key on the true source. We do NOT
-                        // consult the seen-set here: `accept()` + `DONE_RING` already dedup
-                        // fragments/retransmits, and a seen-set drop would kill a lost-RELAYACK2
-                        // retransmit's re-ACK (the single-hop path's finding 3, one hop out). On each
-                        // accepted fragment, FLOOD a RELAYACK2 back toward the origin (R1, table-free)
-                        // carrying the cumulative bitmap so the stranded leaf learns completion.
-                        let synth = synth_origin_mac(origin);
-                        let (bitmap, complete) =
-                            self.relay.accept(synth, (origin, msgid, frag, count), chunk, now);
-                        self.flood_relayack2(origin, msgid, bitmap);
-                        label = Some(if complete {
-                            alloc::format!("relay2 {:03} ok", origin)
+                        // Our OWN envelope echoed back by a relay — never re-forward/reassemble it
+                        // (bogus fwd + could loop). Just drop it.
+                        label = Some(alloc::format!("up2 self {:03}", origin));
+                    } else if let Some((_sid, imsgid, frag, count, chunk)) = parse_relay(inner) {
+                        // 1b: the inner is a plain RELAY (the RELAY2-subsuming case). `imsgid` is the
+                        // INNER RELAY msgid — the reassembly/ACK key, distinct from the envelope msgid.
+                        if self.relay.is_gateway {
+                            // GATEWAY sink: reassemble keyed by ORIGIN (synthetic MAC), NOT `src` (the
+                            // last relay). accept()+DONE_RING dedup fragments/retransmits, so we do NOT
+                            // consult the seen-set here (a seen-set drop would kill a lost-ACK
+                            // retransmit's re-ACK). On each accepted fragment flood a RELAYACK2 back
+                            // toward the origin (R1) carrying the cumulative bitmap, keyed on `imsgid`.
+                            let synth = synth_origin_mac(origin);
+                            let (bitmap, complete) =
+                                self.relay.accept(synth, (origin, imsgid, frag, count), chunk, now);
+                            self.flood_relayack2(origin, imsgid, bitmap);
+                            label = Some(if complete {
+                                alloc::format!("up2 {:03} ok", origin)
+                            } else {
+                                alloc::format!("up2 {:03} {}/{}", origin, bitmap.count_ones(), count)
+                            });
                         } else {
-                            alloc::format!("relay2 {:03} {}/{}", origin, bitmap.count_ones(), count)
-                        });
-                    } else {
-                        // RELAY role: the seen-set-gated forward. `forward_decision` (pure) picks
-                        // the fate from (is_gateway=false, hop, already-seen `(origin,msgid,frag)`).
-                        let seen = self.relay.seen.seen_or_insert(origin, msgid, frag);
-                        match crate::net::flood::forward_decision(false, hop, seen) {
-                            crate::net::flood::ForwardAction::Forward { hop: next_hop } => {
-                                self.diag.fwd = self.diag.fwd.saturating_add(1);
-                                // Re-broadcast at the decremented hop. `chunk` borrows the RX buffer;
-                                // it's copied into the local frame buffer before the `&mut self` send.
-                                let mut fb = [0u8; RELAY2_FRAME_MAX];
-                                let len =
-                                    encode_relay2(origin, msgid, next_hop, frag, count, chunk, &mut fb);
-                                self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
-                                // Rate-limited serial trace (the forward path was previously OLED-only —
-                                // a rig watching serial saw the fwd counter climb with no log). Every 8th.
-                                if self.diag.fwd.is_multiple_of(8) {
-                                    log::info!(
-                                        "smol #13: fwd {} (origin {:03} msgid {} frag {} -> h{})",
-                                        self.diag.fwd, origin, msgid, frag, next_hop
-                                    );
+                            // RELAY role: seen-set-gated forward, keyed on the ENVELOPE msgid
+                            // `(origin, env_msgid, 0)` — each UP2 is one atomic frame (frag dimension
+                            // is absorbed into env_msgid, which is unique per emitted/retransmitted UP2).
+                            let seen = self.relay.seen.seen_or_insert(origin, env_msgid, 0);
+                            match crate::net::flood::forward_decision(false, hop, seen) {
+                                crate::net::flood::ForwardAction::Forward { hop: next_hop } => {
+                                    self.diag.fwd = self.diag.fwd.saturating_add(1);
+                                    // Re-wrap the SAME inner verbatim at hop-1 (env_msgid preserved).
+                                    // `inner` borrows the RX buffer; copied into `fb` before the send.
+                                    let mut fb = [0u8; ESP_NOW_MTU];
+                                    let len = encode_up2(origin, env_msgid, next_hop, inner, &mut fb);
+                                    self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
+                                    if self.diag.fwd.is_multiple_of(8) {
+                                        log::info!(
+                                            "smol #124: fwd {} (origin {:03} env_msgid {} -> h{})",
+                                            self.diag.fwd, origin, env_msgid, next_hop
+                                        );
+                                    }
+                                    label = Some(alloc::format!("fwd {:03} h{}", origin, next_hop));
                                 }
-                                label = Some(alloc::format!("fwd {:03} h{} f{}", origin, next_hop, frag));
+                                crate::net::flood::ForwardAction::DedupDrop => {
+                                    self.diag.dedup = self.diag.dedup.saturating_add(1);
+                                    label = Some(alloc::format!("dedup {:03}", origin));
+                                }
+                                crate::net::flood::ForwardAction::TtlDrop => {
+                                    self.diag.ttl = self.diag.ttl.saturating_add(1);
+                                    label = Some(alloc::format!("ttl {:03}", origin));
+                                }
+                                // Reassemble is only returned for is_gateway=true (handled above).
+                                crate::net::flood::ForwardAction::Reassemble => {}
                             }
-                            crate::net::flood::ForwardAction::DedupDrop => {
-                                self.diag.dedup = self.diag.dedup.saturating_add(1);
-                                label = Some(alloc::format!("dedup {:03}", origin));
-                            }
-                            crate::net::flood::ForwardAction::TtlDrop => {
-                                self.diag.ttl = self.diag.ttl.saturating_add(1);
-                                label = Some(alloc::format!("ttl {:03}", origin));
-                            }
-                            // Reassemble is only returned for is_gateway=true (handled above).
-                            crate::net::flood::ForwardAction::Reassemble => {}
                         }
+                    } else {
+                        // Stage 2: a non-RELAY inner (STAT/DIAG/SCAN) — full parse_frame + dispatch to
+                        // the caches lands next stage; for 1b it's dropped (only RELAY is wrapped yet).
+                        label = Some(alloc::format!("up2 {:03} non-relay", origin));
                     }
                 }
                 Some(Frame::RelayAck2 { target, msgid, bitmap, hop }) => {
@@ -4855,12 +4869,11 @@ fn parse_frame(data: &[u8]) -> Option<Frame<'_>> {
     if let Some((msgid, bitmap)) = parse_relayack(data) {
         return Some(Frame::RelayAck { msgid, bitmap });
     }
-    // #13 multi-hop variants. Order vs RELAY/RELAYACK is moot — `strip_prefix` is exact and
-    // the `2` at the disambiguating byte makes base + variant mutually exclusive — but keep
-    // them adjacent to their base tag. A plain-RELAY frame never matches RELAY2 (byte 12 is
-    // ' ' not '2') and vice-versa, so a non-escalated leaf's frames stay byte-identical.
-    if let Some((origin, msgid, hop, frag, count, chunk)) = parse_relay2(data) {
-        return Some(Frame::Relay2 { origin, msgid, hop, frag, count, chunk });
+    // #124 multi-hop variants. Order vs RELAY/RELAYACK is moot — `strip_prefix` is exact and UP2
+    // diverges from RELAY at byte 7 (`'U'` vs `'R'`), RELAYACK2 from RELAYACK at byte 15 — so a
+    // non-escalated leaf's plain frames never mis-classify (byte-identical) and vice-versa.
+    if let Some((origin, env_msgid, hop, inner)) = parse_up2(data) {
+        return Some(Frame::Up2 { origin, env_msgid, hop, inner });
     }
     if let Some((target, msgid, bitmap, hop)) = parse_relayack2(data) {
         return Some(Frame::RelayAck2 { target, msgid, bitmap, hop });

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1459,6 +1459,10 @@ struct Relay {
     /// (each inner frame / RELAY fragment gets a unique one), the FLOOD-DEDUP key. DISTINCT from the
     /// inner RELAY `msgid` (`tx.msgid`), which stays the reassembly/RELAYACK2 key. Wraps like `next_msgid`.
     up_env_msgid: u16,
+    /// #126 leaf-role: the channel-parking state machine. Inert until `latch` engages; then it biases
+    /// a stranded leaf toward the channel that drew a forward/ACK (sweep+burst → park), instead of the
+    /// blind 1/6/11 hop. Un-latch / #76 re-election disengage it. See `net/flood.rs::ChannelPark`.
+    park: crate::net::flood::ChannelPark,
 }
 
 impl Relay {
@@ -1477,6 +1481,7 @@ impl Relay {
             seen: crate::net::flood::SeenSet::new(),
             latch: crate::net::flood::HopLatch::new(),
             up_env_msgid: 0,
+            park: crate::net::flood::ChannelPark::new(),
         }
     }
 
@@ -1974,7 +1979,9 @@ impl RadioManager {
     /// roam), it unlocks + resumes scanning. Gateways never scan (they ride their AP
     /// channel via the live association).
     pub fn leaf_scan_tick(&mut self, now: u64) {
-        const CANDIDATES: [u8; 3] = [1, 6, 11]; // JP's roam plan
+        // #126: the blind-scan plan is now `net::flood::PARK_CHANNELS` (single source of truth,
+        // shared with channel parking so the two can never drift). Aliased to keep the blind path below.
+        use crate::net::flood::PARK_CHANNELS as CANDIDATES;
         const DWELL_MS: u64 = 1500; // listen this long per candidate before hopping
         const SCAN_SILENCE_MS: u64 = 6000; // owner silence → assume roam → re-scan
         if self.relay.is_gateway {
@@ -1994,14 +2001,33 @@ impl RadioManager {
         // RESTORED old behavior: unlock + re-scan on owner-silence. A leaf MUST re-acquire the
         // gateway after routine beacon loss to keep mesh membership. The fetch-drift is handled
         // narrowly instead: (i) receiving an OTA frame locks the leaf to ch6 (`handle_ota_frame`),
-        // (ii) the gateway's OTAM wake-burst lets a hopping leaf catch the first announce.
+        // (ii) the gateway's OTAM wake-burst lets a hopping leaf catch the first announce. This runs
+        // BEFORE the park decision so `scan_locked` is current when `park_scan_action` gates on it.
         if self.scan_locked && now.saturating_sub(self.last_owner_heard_ms) > SCAN_SILENCE_MS {
             self.scan_locked = false;
             log::info!("smol: leaf lost gateway id{} — re-scanning", self.elected_owner);
         }
-        if self.scan_locked {
-            return;
+        // #126 channel parking: the PURE per-tick decision (latch-sync + swept/parked channel +
+        // dwell-burst + advance, plus the latched/locked gating) lives in `net::flood::park_scan_action`
+        // so the emit TRIGGER is host-tested (the #123 lesson). Here we only APPLY it. A stranded leaf
+        // is LATCHED + never locks → parking drives its channel; a healthy leaf leaves it inert
+        // (`channel: None` ⇒ the blind scan below runs byte-identically).
+        let latched = self.relay.latch.latched();
+        let act =
+            crate::net::flood::park_scan_action(&mut self.relay.park, latched, self.scan_locked, now);
+        if let Some(ch) = act.channel {
+            let _ = self.esp_now.set_channel(ch);
         }
+        if act.burst {
+            self.relay_park_burst();
+        }
+        if self.scan_locked {
+            return; // we hear the owner directly → stay on its channel (park returned None).
+        }
+        if latched {
+            return; // parking governed the channel above → skip the blind hop.
+        }
+        // Healthy leaf: the original blind round-robin over PARK_CHANNELS (byte-identical behaviour).
         if now.saturating_sub(self.last_scan_hop_ms) >= DWELL_MS {
             self.scan_idx = (self.scan_idx + 1) % CANDIDATES.len();
             let ch = CANDIDATES[self.scan_idx];
@@ -2150,6 +2176,10 @@ impl RadioManager {
         // #114 H1: a CHANGED owner must re-prove itself by HELLO before we trust it as heard.
         if elect.owner_id != self.elected_owner {
             self.owner_hello_seen = false;
+            // #126: the elected owner (hence its mesh channel) changed under us — any parked/swept
+            // channel bias is now stale, so restart the sweep from candidate 0. No-op unless parking
+            // is engaged (a healthy re-election just re-scans normally).
+            self.relay.park.on_rechannel(now);
         }
         self.elected_owner = elect.owner_id;
         self.scan_locked = false;
@@ -2910,18 +2940,20 @@ impl RadioManager {
     }
 
     /// #27/#29: this node's current ESP-NOW channel for the peers + MC publish. Leaf = its
-    /// locked scan channel (`CANDIDATES[scan_idx]` while `scan_locked`), else 0 (scanning);
-    /// gateway = its `learned_channel` (#29 — the channel `rx_control` last saw a frame on;
-    /// 0 until the first frame). `0` ⇒ advisory-only: HA/leaves treat the `<ch>` field as absent
-    /// and fall back (no roam-flag / HELLO-scan), so this never ships a false positive.
+    /// swept/parked channel (#126) while stranded, its locked scan channel while `scan_locked`,
+    /// else 0 (scanning); gateway = its `learned_channel` (#29 — the channel `rx_control` last saw a
+    /// frame on; 0 until the first frame). `0` ⇒ advisory-only: HA/leaves treat the `<ch>` field as
+    /// absent and fall back (no roam-flag / HELLO-scan), so this never ships a false positive.
     fn current_channel(&self) -> u8 {
-        const CANDIDATES: [u8; 3] = [1, 6, 11]; // must match the scan plan above
+        use crate::net::flood::PARK_CHANNELS;
         if self.relay.is_gateway {
             self.learned_channel // #29: real gateway channel from rx_control (0 until learned)
+        } else if let Some(ch) = self.relay.park.channel() {
+            ch // #126: a stranded (latched) leaf reports its swept/parked channel (advisory)
         } else if !self.scan_locked {
             0
         } else {
-            CANDIDATES[self.scan_idx % CANDIDATES.len()]
+            PARK_CHANNELS[self.scan_idx % PARK_CHANNELS.len()]
         }
     }
 
@@ -3004,6 +3036,30 @@ impl RadioManager {
         self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
     }
 
+    /// #126: fire ONE dwell-per-channel emission burst — re-broadcast the currently-staged uplink on
+    /// the channel the park SM just selected, so a relay on THIS channel forwards it and the gateway
+    /// floods a RELAYACK2 back (attributed to this channel → the leaf parks). No-op if nothing is
+    /// staged. Re-sends every fragment at the staged hop (`tx.hop` = MAX_HOP while latched →
+    /// UP2-wrapped); each frag draws a FRESH env_msgid in `relay_send_frag`, so a relay's seen-set
+    /// never dedup-drops the re-broadcast. Only ever called for a LATCHED leaf (see `leaf_scan_tick`),
+    /// so a healthy leaf's airtime/behaviour is completely unchanged.
+    fn relay_park_burst(&mut self) {
+        if !self.relay.tx.active {
+            return; // nothing staged → nothing to probe the channel with
+        }
+        let (msgid, count, total_len, hop) = (
+            self.relay.tx.msgid,
+            self.relay.tx.count,
+            self.relay.tx.total_len,
+            self.relay.tx.hop,
+        );
+        for frag in 0..count {
+            let off = frag as usize * RELAY_CHUNK;
+            let end = (off + RELAY_CHUNK).min(total_len);
+            self.relay_send_frag(msgid, hop, frag, count, off, end);
+        }
+    }
+
     /// #13 gateway: flood a RELAYACK2 back toward the stranded `target` origin (R1,
     /// table-free) at `MAX_HOP`, so a relay carries it the same distance the RELAY2 came.
     /// Broadcast (the origin isn't directly reachable — that's why it's stranded).
@@ -3059,12 +3115,26 @@ impl RadioManager {
             let end = (off + RELAY_CHUNK).min(total_len);
             self.relay_send_frag(msgid, hop, frag, count, off, end);
         }
+        // #126: surface the stranded-leaf channel-park state in the emit log — the #123 lesson that
+        // on-air trigger state MUST be visible to the rig (a green build hid the last two on-air bugs).
+        // Blank on a healthy leaf (park inert), so a normal node's serial is unchanged.
+        let park = if self.relay.park.engaged() {
+            let ch = self.relay.park.channel().unwrap_or(0);
+            if self.relay.park.parked() {
+                alloc::format!(" [parked ch{}]", ch)
+            } else {
+                alloc::format!(" [sweep ch{}]", ch)
+            }
+        } else {
+            alloc::string::String::new()
+        };
         log::info!(
-            "smol: relay emit msgid {} ({} frag) hop {}{}",
+            "smol: relay emit msgid {} ({} frag) hop {}{}{}",
             msgid,
             count,
             hop,
-            if is_probe { " probe" } else { "" }
+            if is_probe { " probe" } else { "" },
+            park
         );
     }
 
@@ -4339,7 +4409,10 @@ impl RadioManager {
                     self.roster.heard(src, Some(origin), rssi, now);
                     if origin == self.id {
                         // Our OWN envelope echoed back by a relay — never re-forward/reassemble it
-                        // (bogus fwd + could loop). Just drop it.
+                        // (bogus fwd + could loop). Just drop it. #126: BUT hearing our own UP2
+                        // re-broadcast proves a relay on our CURRENT channel heard + forwarded us — an
+                        // (early) park-feedback signal, so bias/park toward this channel.
+                        self.relay.park.on_feedback(now);
                         label = Some(alloc::format!("up2 self {:03}", origin));
                     } else if self.relay.is_gateway {
                         // GATEWAY SINK: dispatch by the INNER frame type (#124 Stage 2). Everything is
@@ -4433,6 +4506,9 @@ impl RadioManager {
                         // the escalation streak (does NOT un-latch — that still needs a direct probe).
                         if bitmap != 0 {
                             self.relay.latch.on_uplink_progress();
+                            // #126: the flood-back reached us on our CURRENT channel → the full
+                            // uplink+return path works here → PARK on it (the strongest park signal).
+                            self.relay.park.on_feedback(now);
                         }
                         label = Some(alloc::format!("ack2 {:05}", msgid));
                     } else if hop > 1 {

--- a/rust/clock/src/net/wire.rs
+++ b/rust/clock/src/net/wire.rs
@@ -16,18 +16,15 @@
 /// from RELAYACK at byte 12 (`' '` vs `'A'`), so match order is moot.
 pub const RELAY_PREFIX: &[u8] = b"SMOLv1 RELAY "; // + "NNN MMMMM F C " + chunk
 pub const RELAYACK_PREFIX: &[u8] = b"SMOLv1 RELAYACK "; // + "MMMMM BBB"
-/// #13 multi-hop uplink tags (see the `#13` section in `mode.rs` + `net/flood.rs`). NEW tags — an
-/// old firmware `classify()`s them to `None` (harmless). `RELAY2` diverges from `RELAY` at byte 12
-/// (`'2'` vs `' '`) and `RELAYACK2` from `RELAYACK` at byte 15, so `strip_prefix` never confuses a
-/// base tag with its variant regardless of order.
-pub const RELAY2_PREFIX: &[u8] = b"SMOLv1 RELAY2 "; // + "OOO MMMMM H F C " + chunk
+/// #13 multi-hop ACK tag (the R1 flooded RELAYACK2 — kept; the RELAY2 uplink tag was replaced by
+/// UP2 in #124). NEW tag — an old firmware `classify()`s it to `None` (harmless). Diverges from
+/// `RELAYACK` at byte 15, so `strip_prefix` never confuses them.
 pub const RELAYACK2_PREFIX: &[u8] = b"SMOLv1 RELAYACK2 "; // + "TTT MMMMM BBB H"
 /// #13 Stage B downlink freshness tags (10-digit `dl_seq` + verbatim `BATT|`/`GRID|` payload).
 pub const BATT2_PREFIX: &[u8] = b"SMOLv1 BATT2 ";
 pub const GRID2_PREFIX: &[u8] = b"SMOLv1 GRID2 ";
-/// #124 generic uplink envelope tag (see the UP2 section below). Diverges from `RELAY`/`RELAY2` at
-/// byte 7 (`'U'` vs `'R'`), so `strip_prefix` never confuses it. wip-unwired until Stage 1b.
-#[allow(dead_code)]
+/// #124 generic uplink envelope tag (see the UP2 section below). Diverges from `RELAY` at byte 7
+/// (`'U'` vs `'R'`), so `strip_prefix` never confuses it.
 pub const UP2_PREFIX: &[u8] = b"SMOLv1 UP2 "; // + "OOO MMMMM H " + <inner frame>
 
 /// Max telemetry payload per RELAY fragment (bytes) — encoders truncate the chunk to this.
@@ -177,59 +174,7 @@ pub fn parse_relayack(data: &[u8]) -> Option<(u16, u8)> {
     Some((msgid, bitmap))
 }
 
-// ---- RELAY2 / RELAYACK2 (#13 multi-hop) -----------------------------------
-
-/// Encode a RELAY2 fragment `"SMOLv1 RELAY2 OOO MMMMM H F C " + <chunk>` into `out`; returns total
-/// length (30-byte header + chunk). `OOO` = ORIGIN id, `H` = 1-digit hop-limit.
-pub fn encode_relay2(origin: u8, msgid: u16, hop: u8, frag: u8, count: u8, chunk: &[u8], out: &mut [u8]) -> usize {
-    let mut n = 0;
-    out[..RELAY2_PREFIX.len()].copy_from_slice(RELAY2_PREFIX);
-    n += RELAY2_PREFIX.len();
-    out[n] = b'0' + (origin / 100) % 10;
-    out[n + 1] = b'0' + (origin / 10) % 10;
-    out[n + 2] = b'0' + origin % 10;
-    n += 3;
-    out[n] = b' ';
-    n += 1;
-    write_u5(msgid as u32, &mut out[n..]);
-    n += 5;
-    out[n] = b' ';
-    n += 1;
-    out[n] = b'0' + hop;
-    n += 1;
-    out[n] = b' ';
-    n += 1;
-    out[n] = b'0' + frag;
-    n += 1;
-    out[n] = b' ';
-    n += 1;
-    out[n] = b'0' + count;
-    n += 1;
-    out[n] = b' ';
-    n += 1;
-    let len = chunk.len().min(RELAY_CHUNK);
-    out[n..n + len].copy_from_slice(&chunk[..len]);
-    n + len
-}
-
-/// Parse a RELAY2 frame into `(origin, msgid, hop, frag, count, chunk)`, or `None`.
-// Mirrors `parse_relay`'s tuple shape + the one `hop` field; the caller destructures immediately.
-#[allow(clippy::type_complexity)]
-pub fn parse_relay2(data: &[u8]) -> Option<(u8, u16, u8, u8, u8, &[u8])> {
-    let rest = data.strip_prefix(RELAY2_PREFIX)?;
-    if rest.len() < 16 {
-        return None;
-    }
-    let origin = parse_id(&rest[0..3])?;
-    let msgid = u16::try_from(parse_u5(&rest[4..9])?).ok()?;
-    if !rest[10].is_ascii_digit() || !rest[12].is_ascii_digit() || !rest[14].is_ascii_digit() {
-        return None;
-    }
-    let hop = rest[10] - b'0';
-    let frag = rest[12] - b'0';
-    let count = rest[14] - b'0';
-    Some((origin, msgid, hop, frag, count, &rest[16..]))
-}
+// ---- RELAYACK2 (#124/#13 flooded ACK — kept; RELAY2 removed, UP2 replaces it) ----------------
 
 /// Encode a `"SMOLv1 RELAYACK2 TTT MMMMM BBB H"` frame into `out`; returns length (32).
 pub fn encode_relayack2(target: u8, msgid: u16, bitmap: u8, hop: u8, out: &mut [u8]) -> usize {
@@ -280,36 +225,28 @@ pub fn synth_origin_mac(origin: u8) -> [u8; 6] {
     [0, 0, 0, 0, 0, origin]
 }
 
-// ---- UP2 generic uplink envelope (#124 — REPLACES RELAY2) ------------------
-// wip (Stage 1a): the codec + host tests land here host-verified but UNWIRED in the clock crate
-// (mode.rs still emits RELAY2). The allow(dead_code)s below DROP in Stage 1b when mode.rs migrates
-// RELAY2→UP2 + removes the RELAY2 codec — then the -D warnings gate applies. relay_compat (a
-// separate crate) exercises these NOW via #[path], so byte-format regressions are caught immediately.
-//
+// ---- UP2 generic uplink envelope (#124 — REPLACED RELAY2) -----------------
 // `SMOLv1 UP2 ` + `"OOO MMMMM H "` + <verbatim inner SMOLv1 frame (RELAY/STAT/DIAG/SCAN)>. A latched
 // leaf wraps ANY uplink frame so a stranded leaf's observability (/stat /diag /scan) reaches the
 // gateway via the relay — RELAY2 could only carry telemetry. `OOO` = origin id; `MMMMM` = the
 // ENVELOPE msgid (per-origin rolling, the FLOOD-DEDUP key — DISTINCT from any inner RELAY msgid,
 // which stays the reassembly/ACK key); `H` = hop-limit. Old firmware classify()s UP2 → None
 // (harmless) + can't relay anyway → no flag-day (a leaf needing H≥2 was already stranded pre-#13).
+// Host-tested in experiments/relay_compat (golden bytes + wrap→unwrap→re-parse-inner + clamp).
 
 /// Max ESP-NOW payload (bytes) — a frame MUST NOT exceed this on the wire.
-#[allow(dead_code)]
 pub const ESP_NOW_MTU: usize = 250;
 /// UP2 envelope overhead: prefix `"SMOLv1 UP2 "` (11) + header `"OOO MMMMM H "` (12) = 23 B.
-#[allow(dead_code)]
 pub const UP2_OVERHEAD: usize = UP2_PREFIX.len() + 12;
 /// Max inner frame a latched leaf may wrap so UP2 fits [`ESP_NOW_MTU`]: 250 − 23 = 227.
 /// `encode_up2` CLAMPS the inner to this + never emits > MTU. For a prefix-tolerant inner
 /// (DIAG/SCAN are `key=val`), clamping truncates the TAIL fields — the record still parses; the
 /// tail that falls off (cfg=/io=/dlseq=/dfwd=, appended last) matters less than the record arriving.
-#[allow(dead_code)]
 pub const UP2_INNER_MAX: usize = ESP_NOW_MTU - UP2_OVERHEAD;
 
 /// Encode a UP2 envelope: `"SMOLv1 UP2 " + "OOO MMMMM H " + <inner>`; returns total length (≤ MTU).
 /// `env_msgid` is the envelope's own per-origin rolling counter (flood dedup). The inner is CLAMPED
 /// to [`UP2_INNER_MAX`] so the frame never exceeds [`ESP_NOW_MTU`] (constraint: never emit > MTU).
-#[allow(dead_code)]
 pub fn encode_up2(origin: u8, env_msgid: u16, hop: u8, inner: &[u8], out: &mut [u8]) -> usize {
     let mut n = 0;
     out[..UP2_PREFIX.len()].copy_from_slice(UP2_PREFIX);
@@ -335,7 +272,6 @@ pub fn encode_up2(origin: u8, env_msgid: u16, hop: u8, inner: &[u8], out: &mut [
 
 /// Parse a UP2 envelope into `(origin, env_msgid, hop, inner)`, or `None`. `inner` borrows `data` —
 /// the verbatim inner SMOLv1 frame, which the caller re-runs through `parse_frame` + dispatches.
-#[allow(dead_code)]
 pub fn parse_up2(data: &[u8]) -> Option<(u8, u16, u8, &[u8])> {
     let rest = data.strip_prefix(UP2_PREFIX)?;
     // "OOO MMMMM H " = 12 header bytes (origin 3, sp, env_msgid 5, sp, hop 1, sp), then the inner frame.

--- a/rust/clock/src/net/wire.rs
+++ b/rust/clock/src/net/wire.rs
@@ -287,6 +287,33 @@ pub fn parse_up2(data: &[u8]) -> Option<(u8, u16, u8, &[u8])> {
     Some((origin, env_msgid, hop, &rest[12..]))
 }
 
+/// #124 Stage 2 — return a truncation length for `inner` that fits within `max` bytes AND ends on a
+/// FIELD BOUNDARY (the last `|` separator at or before `max`), so a wrapped DIAG/SCAN record that
+/// overflows [`UP2_INNER_MAX`] never truncates mid `key=val`. The dropped tail (the straddling field
+/// plus any fields past it) is what prefix-tolerant parsers would ignore anyway.
+///
+/// When `inner.len() <= max` it returns `inner.len()` (fits, no clamp). Otherwise it returns the
+/// index of the last `|` at position `<= max`, so bytes `[0..i)` are all whole fields (that `|` and
+/// the partial field after it are excluded). With no `|` inside `max` (a single oversized field —
+/// pathological; real DIAG/SCAN records are `|`-joined) it falls back to `max` (a raw cut). The frame
+/// prefix ("SMOLv1 DIAG " + "OOO") holds no `|`, so scanning the whole buffer is safe.
+///
+/// The result is always `<= max` and `<= inner.len()`; pass `&inner[..clamp_inner_field_boundary(..)]`
+/// to `encode_up2` (whose own raw clamp then never fires). Pure + deterministic — host-tested.
+pub fn clamp_inner_field_boundary(inner: &[u8], max: usize) -> usize {
+    if inner.len() <= max {
+        return inner.len();
+    }
+    // Largest `|` index at or before `max` (max < len here, so `max` indexes a real byte).
+    let mut cut = None;
+    for (i, &b) in inner.iter().enumerate().take(max + 1) {
+        if b == b'|' {
+            cut = Some(i);
+        }
+    }
+    cut.unwrap_or(max)
+}
+
 // ---- BATT2 / GRID2 (#13 Stage B downlink freshness) -----------------------
 
 /// Encode a downlink freshness frame `<prefix> + "SSSSSSSSSS " + <payload>` into `out`; returns

--- a/rust/clock/src/net/wire.rs
+++ b/rust/clock/src/net/wire.rs
@@ -25,6 +25,10 @@ pub const RELAYACK2_PREFIX: &[u8] = b"SMOLv1 RELAYACK2 "; // + "TTT MMMMM BBB H"
 /// #13 Stage B downlink freshness tags (10-digit `dl_seq` + verbatim `BATT|`/`GRID|` payload).
 pub const BATT2_PREFIX: &[u8] = b"SMOLv1 BATT2 ";
 pub const GRID2_PREFIX: &[u8] = b"SMOLv1 GRID2 ";
+/// #124 generic uplink envelope tag (see the UP2 section below). Diverges from `RELAY`/`RELAY2` at
+/// byte 7 (`'U'` vs `'R'`), so `strip_prefix` never confuses it. wip-unwired until Stage 1b.
+#[allow(dead_code)]
+pub const UP2_PREFIX: &[u8] = b"SMOLv1 UP2 "; // + "OOO MMMMM H " + <inner frame>
 
 /// Max telemetry payload per RELAY fragment (bytes) — encoders truncate the chunk to this.
 pub const RELAY_CHUNK: usize = 64;
@@ -271,8 +275,80 @@ pub fn parse_relayack2(data: &[u8]) -> Option<(u8, u16, u8, u8)> {
 
 /// The synthetic MAC a gateway keys a RELAY2 reassembly by — `00:00:00:00:00:<origin>`. A real
 /// Espressif STA MAC is never all-zero, so this can't alias a single-hop leaf's real MAC.
+/// (#124: reused verbatim for the UP2 gateway-reassembly of an inner RELAY, keyed by origin.)
 pub fn synth_origin_mac(origin: u8) -> [u8; 6] {
     [0, 0, 0, 0, 0, origin]
+}
+
+// ---- UP2 generic uplink envelope (#124 — REPLACES RELAY2) ------------------
+// wip (Stage 1a): the codec + host tests land here host-verified but UNWIRED in the clock crate
+// (mode.rs still emits RELAY2). The allow(dead_code)s below DROP in Stage 1b when mode.rs migrates
+// RELAY2→UP2 + removes the RELAY2 codec — then the -D warnings gate applies. relay_compat (a
+// separate crate) exercises these NOW via #[path], so byte-format regressions are caught immediately.
+//
+// `SMOLv1 UP2 ` + `"OOO MMMMM H "` + <verbatim inner SMOLv1 frame (RELAY/STAT/DIAG/SCAN)>. A latched
+// leaf wraps ANY uplink frame so a stranded leaf's observability (/stat /diag /scan) reaches the
+// gateway via the relay — RELAY2 could only carry telemetry. `OOO` = origin id; `MMMMM` = the
+// ENVELOPE msgid (per-origin rolling, the FLOOD-DEDUP key — DISTINCT from any inner RELAY msgid,
+// which stays the reassembly/ACK key); `H` = hop-limit. Old firmware classify()s UP2 → None
+// (harmless) + can't relay anyway → no flag-day (a leaf needing H≥2 was already stranded pre-#13).
+
+/// Max ESP-NOW payload (bytes) — a frame MUST NOT exceed this on the wire.
+#[allow(dead_code)]
+pub const ESP_NOW_MTU: usize = 250;
+/// UP2 envelope overhead: prefix `"SMOLv1 UP2 "` (11) + header `"OOO MMMMM H "` (12) = 23 B.
+#[allow(dead_code)]
+pub const UP2_OVERHEAD: usize = UP2_PREFIX.len() + 12;
+/// Max inner frame a latched leaf may wrap so UP2 fits [`ESP_NOW_MTU`]: 250 − 23 = 227.
+/// `encode_up2` CLAMPS the inner to this + never emits > MTU. For a prefix-tolerant inner
+/// (DIAG/SCAN are `key=val`), clamping truncates the TAIL fields — the record still parses; the
+/// tail that falls off (cfg=/io=/dlseq=/dfwd=, appended last) matters less than the record arriving.
+#[allow(dead_code)]
+pub const UP2_INNER_MAX: usize = ESP_NOW_MTU - UP2_OVERHEAD;
+
+/// Encode a UP2 envelope: `"SMOLv1 UP2 " + "OOO MMMMM H " + <inner>`; returns total length (≤ MTU).
+/// `env_msgid` is the envelope's own per-origin rolling counter (flood dedup). The inner is CLAMPED
+/// to [`UP2_INNER_MAX`] so the frame never exceeds [`ESP_NOW_MTU`] (constraint: never emit > MTU).
+#[allow(dead_code)]
+pub fn encode_up2(origin: u8, env_msgid: u16, hop: u8, inner: &[u8], out: &mut [u8]) -> usize {
+    let mut n = 0;
+    out[..UP2_PREFIX.len()].copy_from_slice(UP2_PREFIX);
+    n += UP2_PREFIX.len();
+    out[n] = b'0' + (origin / 100) % 10;
+    out[n + 1] = b'0' + (origin / 10) % 10;
+    out[n + 2] = b'0' + origin % 10;
+    n += 3;
+    out[n] = b' ';
+    n += 1;
+    write_u5(env_msgid as u32, &mut out[n..]);
+    n += 5;
+    out[n] = b' ';
+    n += 1;
+    out[n] = b'0' + hop;
+    n += 1;
+    out[n] = b' ';
+    n += 1;
+    let len = inner.len().min(UP2_INNER_MAX);
+    out[n..n + len].copy_from_slice(&inner[..len]);
+    n + len
+}
+
+/// Parse a UP2 envelope into `(origin, env_msgid, hop, inner)`, or `None`. `inner` borrows `data` —
+/// the verbatim inner SMOLv1 frame, which the caller re-runs through `parse_frame` + dispatches.
+#[allow(dead_code)]
+pub fn parse_up2(data: &[u8]) -> Option<(u8, u16, u8, &[u8])> {
+    let rest = data.strip_prefix(UP2_PREFIX)?;
+    // "OOO MMMMM H " = 12 header bytes (origin 3, sp, env_msgid 5, sp, hop 1, sp), then the inner frame.
+    if rest.len() < 12 {
+        return None;
+    }
+    let origin = parse_id(&rest[0..3])?;
+    let env_msgid = u16::try_from(parse_u5(&rest[4..9])?).ok()?;
+    if !rest[10].is_ascii_digit() {
+        return None;
+    }
+    let hop = rest[10] - b'0';
+    Some((origin, env_msgid, hop, &rest[12..]))
 }
 
 // ---- BATT2 / GRID2 (#13 Stage B downlink freshness) -----------------------


### PR DESCRIPTION
⛔ **MERGE GATE: HW-rig canary pending hardware.** The parking state machine + trigger wiring are fully host-tested, but the ON-AIR behaviour (dwell-burst timing, RELAYACK2 return under the same channel physics, park/un-park on a live 2-hop rig) is UNVALIDATED — the fleet is one powered board. Do not merge until the deaf-list rig confirms #126 P2 (airtime + before/after delivery rate). Standing #123 lesson: green builds hid the last two on-air bugs.

📚 **Stacked on #130 (#124 UP2) — merge AFTER it.** Parking builds directly on the UP2 uplink envelope + HopLatch structure from #124 (`dream/124-up2` @3df3da5). This branch is based on that tip; rebase onto `main` once #130 lands.

## What & why (#126)
A stranded (latched) leaf never hears its owner's HELLO, so it never locks a channel — it blind-hops 1/6/11 and its uplink lands on the relay's channel only ~1/3 of the time (the RELAYACK2 flood-back the same ~1/3 in reverse). This biases a latched leaf toward the channel that actually drew a forward/ACK, targeting ~1/1 delivery.

## Design — `net::flood::ChannelPark` (pure, companion to `HopLatch`)
- **Sweeping**: dwell per candidate + fire dwell-per-channel emission bursts (K/channel, ≥1 guaranteed before hopping) — the ACK-feedback bootstrap.
- **Parked**: hold the channel that drew feedback; normal telemetry then flows reliably (no extra airtime — the bias *is* the win).
- Un-park on un-latch (uplink recovered) / park-silence (30 s cold) / #76 re-election.
- Feedback: a RELAYACK2 addressed to us (full-path ACK) **or** a relay re-broadcasting our own origin (early "a relay heard us" signal).

## The #123 lesson, honoured
The whole per-tick trigger decision — which channel, whether to burst, sweep-advance, and the latched/locked gating — is extracted into a pure `park_scan_action()` and host-tested. The on-air bugs lived in the trigger WIRING, not the state-machine math; it's no longer buried in the `no_std` tick.

## Invariant
Parking engages ONLY while latched → a healthy leaf is byte-identical (`fwd=0`, blind scan unchanged). `default`/non-espnow builds don't compile `flood` at all.

## Verification (host — the HW rig is the remaining gate)
- **flood_verify**: SeenSet + forward_decision + HopLatch + **ChannelPark** + **park_scan_action** trigger contract — ALL PASS.
- **relay_compat**: #124 UP2 byte-compat + field-boundary DIAG clamp — ALL PASS.
- **Full profile bar**: `clippy -D warnings` on default / espnow / espnow,cast,io / espnow,wled / espnow,mesh-test + release link — all green.

## Provenance
Built on the #124 UP2 foundation (Stages 1a/1b/2, PR #130). #126 channel parking (this PR) is Stage 3, done solo in an isolated worktree. A spawn-race early in the session (two engineers briefly pointed at #124) was caught and cleanly resolved by the orchestrator before any divergence — #124 landed single-history in #130.

Stages: A `88c8110` (pure SM + tests, unwired) → B `13f4f75` (wired + trigger extraction).

Refs #126. Builds on #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)