### PR TITLE
feat(fw): headless boot — screenless C3 superminis run without an OLED

### DIFF
--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -396,7 +396,16 @@ fn main() -> ! {
     let mut display = raw_display;
     #[cfg(feature = "cast")]
     let mut display = crate::net::cast_oled::CastOled::new(raw_display);
-    display.init().expect("display init");
+    // Headless boards (screenless C3 superminis — the fleet's 2026-07-14 growth): a
+    // missing OLED NACKs this init. TOLERATE it and run headless: draws land in the
+    // in-RAM buffer (buffered-graphics mode) and every flush in the codebase is already
+    // `.ok()`-tolerated, so the whole render path degrades to a silent no-op while the
+    // radio/mesh/MQTT stack runs unaffected. The only per-cycle cost is one fast I2C
+    // NACK per flush attempt. (Cast still works headless — the tee mirrors the RAM
+    // buffer, which draws fill regardless of the panel.)
+    if display.init().is_err() {
+        log::warn!("smol: no OLED responded on I2C — running HEADLESS (renders buffered, flushes no-op)");
+    }
 
     // (Text styles now live inside each plugin's render — CLOCK's big-digit
     // FONT_10X20 moved to clock.rs; Snake/Menu/Bench/About build their own.)


### PR DESCRIPTION
## What
A missing OLED previously panicked at boot (`display.init().expect(...)`). Screenless ESP32-C3 superminis now tolerate the NACK, log one warning, and run headless — draws fill the buffered-graphics RAM buffer, flushes no-op (already `.ok()`-tolerated everywhere), radio/mesh/MQTT/IO unaffected.

## Why it can't regress the screened fleet
Strictly additive: a board WITH an OLED has `init()` succeed → `is_err()` false → byte-identical to the prior code path. id7/8/9 boot the same image with no behavior change.

## Hardware-proven
Two new screenless boards factory-flashed (erase → `SMOL_NODE_ID` pinned):
- **id6** (3C:0F:02:29:6D:68): booted headless (`no OLED responded — running HEADLESS`), joined the mesh, reports STAT via the crown. ✅
- **id5** (E8:F6:0A:1C:27:BC): booted headless cleanly (same warning, sensors + IO selftest + ESP-NOW up) but is NOT completing its mesh join — absent from the crown's peer list while id6 sits in it. **Firmware-clean; an RF/placement/unit issue for JP's eyes** (identical board+image joined on id6).

## Verification
clippy -D warnings clean on default + espnow,cast,io; id6 live on the mesh. No merge gate — this is desk-proven and can't regress screened boards.

Closes nothing (no issue filed; opportunistic hardware-support change). Filing an id5-join tracking issue separately.