### PR TITLE
fix(ota): #134 don't burn a leaf install order on a pre-relay fetch failure (HW-gate held)

### DIFF
--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1804,12 +1804,14 @@ pub struct RadioManager {
     /// independent drain timing). Persists the current staged image for every leaf relay.
     staged_raw: Option<crate::ota::Announce>,
     /// #40 headless observability + clear/retry: the LAST leaf-OTA attempt's `(leaf_id,
-    /// phase, clear_install)`, set by `main` after `run_leaf_ota_relay`, PUBLISHED to
+    /// phase, clear_install, retry_n)`, set by `main` after `run_leaf_ota_relay`, PUBLISHED to
     /// `smol/<leaf>/ota/diag` on the gateway's next burst and used to drive the install
     /// clear (terminal/exhausted) vs retry (transient). `None` when nothing is pending.
     /// The phase is stored as the rendered `&'static str` (not the espnow-only enum) so the
-    /// shared `wifi::mqtt_session` signature stays buildable in the wifi-only profile.
-    leaf_ota_diag: Option<(u8, &'static str, bool)>,
+    /// shared `wifi::mqtt_session` signature stays buildable in the wifi-only profile. `retry_n`
+    /// (#134) is the current consecutive-failure count for this outcome class — surfaced in the
+    /// retained payload (`fetch-failed retry=3`) so a stuck fetch is visible headlessly.
+    leaf_ota_diag: Option<(u8, &'static str, bool, u8)>,
     /// #40 #1 DECOUPLE: true while a leaf-OTA relay is pending/in-flight (armed until its
     /// outcome is terminal or the retry cap is hit). While set, the gateway SUPPRESSES its own
     /// self-OTA (`do_install`) so a relay is never interrupted by the gateway rebooting into a
@@ -1837,9 +1839,15 @@ pub struct RadioManager {
     /// chunk-loss stall. `last_wb` is in chunk units (matches `total = om::total_chunks`).
     /// Carries the leaf's `LDBG` self-report too (captured during the relay) — see `RelayDiag`.
     leaf_relay_rx: Option<crate::net::wifi::RelayDiag>,
-    /// #40: consecutive non-terminal (transient) relay attempts for the current install —
-    /// caps the auto-retry so a persistently-failing leaf can't loop the mesh-deaf relay.
+    /// #40: consecutive POST-HANDOFF transient relay attempts (`RelayFailed`/`Timeout`/`Aborted`)
+    /// for the current install — caps the auto-retry so a persistently-failing (doomed) IMAGE can't
+    /// loop the mesh-deaf relay. Does NOT count pre-relay failures (see `leaf_ota_fetch_retries`).
     leaf_ota_retries: u8,
+    /// #134: consecutive PRE-RELAY failures (`FetchFailed`/`MacUnknown` — the feed never handed off
+    /// to the leaf) for the current install. Counted for the retained `ota/diag` retry number ONLY —
+    /// it NEVER burns the order (a gateway-local fetch failure says nothing about the leaf/image, so
+    /// the install survives for the next attempt / the next crown). Reset on a terminal outcome.
+    leaf_ota_fetch_retries: u8,
     /// #21 node-manager: the parsed default-screen command surfaced by a burst,
     /// pending `main`'s `take_config_offer` → apply. `None` when nothing is pending.
     config_offer: Option<crate::app::DefaultScreen>,
@@ -1951,6 +1959,7 @@ impl RadioManager {
             staged_raw: None,
             leaf_ota_diag: None,
             leaf_ota_retries: 0,
+            leaf_ota_fetch_retries: 0,
             leaf_ota_pending: false,
             leaf_installs_outstanding: false,
             leaf_ota_mac: None,
@@ -3179,22 +3188,39 @@ impl RadioManager {
     /// cap is hit) vs LEAVE it retained to retry (mac-unknown / fetch / relay / timeout). The
     /// phase is published to `smol/<leaf>/ota/diag` on the next burst (headless observability).
     pub fn record_leaf_ota(&mut self, leaf_id: u8, outcome: crate::ota_mesh::LeafOtaOutcome) {
-        let clear = if outcome.is_terminal() {
+        // #134 clear/retry policy — THREE cases, not two:
+        //  1. terminal (leaf DEFINITIVELY acted: installed / rolled-back / id-mismatch) → CLEAR,
+        //     reset both counters.
+        //  2. PRE-RELAY transient (`FetchFailed`/`MacUnknown` — `!reached_leaf()`): the feed NEVER
+        //     handed off to the leaf, so this is GATEWAY-LOCAL and says nothing about the leaf/image.
+        //     NEVER clear — the retained install must survive for the next attempt or the NEXT CROWN
+        //     (crown-portable per #111). Only count it, for the ota/diag retry number. THIS is the
+        //     #134 fix: previously a fetch-broken crown (e.g. unicast-deaf) burned the order after
+        //     LEAF_OTA_MAX_RETRIES fetch-fails, destroying an install a healthy successor would finish.
+        //  3. POST-HANDOFF transient (`RelayFailed`/`Timeout`/`Aborted` — the image DID reach the
+        //     leaf): the DOOMED-image backstop → bounded retries, then CLEAR so a bad image can't
+        //     re-arm forever.
+        let (clear, retry_n) = if outcome.is_terminal() {
             self.leaf_ota_retries = 0;
-            true
+            self.leaf_ota_fetch_retries = 0;
+            (true, 0)
+        } else if !outcome.reached_leaf() {
+            self.leaf_ota_fetch_retries = self.leaf_ota_fetch_retries.saturating_add(1);
+            (false, self.leaf_ota_fetch_retries)
         } else {
             self.leaf_ota_retries = self.leaf_ota_retries.saturating_add(1);
+            let n = self.leaf_ota_retries;
             let exhausted = self.leaf_ota_retries >= LEAF_OTA_MAX_RETRIES;
             if exhausted {
                 self.leaf_ota_retries = 0;
             }
-            exhausted
+            (exhausted, n)
         };
         log::info!(
-            "smol #40: leaf id{} OTA phase={} (clear_install={}, retries={})",
-            leaf_id, outcome.as_str(), clear, self.leaf_ota_retries
+            "smol #40/#134: leaf id{} OTA phase={} (clear_install={}, reached_leaf={}, retry={})",
+            leaf_id, outcome.as_str(), clear, outcome.reached_leaf(), retry_n
         );
-        self.leaf_ota_diag = Some((leaf_id, outcome.as_str(), clear));
+        self.leaf_ota_diag = Some((leaf_id, outcome.as_str(), clear, retry_n));
         // #1 DECOUPLE: the relay session is done for this install iff we're clearing it
         // (terminal outcome or retry cap). While NOT cleared (transient retry) it stays
         // pending so the gateway keeps suppressing its own self-OTA until the leaf resolves.

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1640,7 +1640,7 @@ fn mqtt_session(
     // PUBLISHED to `smol/<leaf>/ota/diag` here, and drives the retained-install clear (on a
     // terminal/exhausted phase) vs retry (transient). Consumed (set None) after publish.
     // `&mut None` off-gateway.
-    leaf_diag: &mut Option<(u8, &'static str, bool)>,
+    leaf_diag: &mut Option<(u8, &'static str, bool, u8)>,
     // #3 RELAY RX-DIAG: the last relay's `(leaf_id, rx_any, otan_valid, last_wb, total)`.
     // PUBLISHED to retained `smol/<leaf>/ota/relaydiag` here, consumed after. `&mut None` off-gw.
     leaf_relay_rx: &mut Option<RelayDiag>,
@@ -2612,15 +2612,24 @@ fn mqtt_session(
     // = the leaf installed/rolled-back, or the transient-retry cap was hit) or LEAVE it
     // retained to retry. On a clear, also null `pending_leaf` for THIS flush so we don't
     // re-arm a just-finished leaf. Runs BEFORE the arm below. Consumed after publish.
-    if let Some((lid, phase, clear)) = *leaf_diag {
+    if let Some((lid, phase, clear, retry)) = *leaf_diag {
         let mut dtopic = MqttScratch::new();
         let _ = write!(dtopic, "smol/{}/ota/diag", lid);
+        // #134: surface the consecutive-failure count in the retained payload ("fetch-failed
+        // retry=3") so a stuck fetch is VISIBLE headlessly instead of silently burning the order.
+        // retry == 0 (a terminal / first attempt) → just the bare phase, unchanged from before.
+        let mut dpayload = MqttScratch::new();
+        if retry > 0 {
+            let _ = write!(dpayload, "{} retry={}", phase, retry);
+        } else {
+            let _ = write!(dpayload, "{}", phase);
+        }
         if let Some(n) =
-            crate::net::mqtt::encode_publish(&mut pkt, dtopic.as_bytes(), phase.as_bytes(), true)
+            crate::net::mqtt::encode_publish(&mut pkt, dtopic.as_bytes(), dpayload.as_bytes(), true)
         {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
-        log::info!("smol #40: published smol/{}/ota/diag = {} (clear={})", lid, phase, clear);
+        log::info!("smol #40: published smol/{}/ota/diag = {} retry={} (clear={})", lid, phase, retry, clear);
         if clear {
             let mut itopic = MqttScratch::new();
             let _ = write!(itopic, "smol/{}/ota/install", lid);
@@ -3229,7 +3238,7 @@ pub fn run_mqtt_burst(
     staged_raw: &mut Option<crate::ota::Announce>,
     // #40: last relay attempt's `(leaf_id, phase, clear)` → published to `smol/<leaf>/ota/diag`
     // (see `mqtt_session`). `&mut None` on boot/leaf bursts.
-    leaf_diag: &mut Option<(u8, &'static str, bool)>,
+    leaf_diag: &mut Option<(u8, &'static str, bool, u8)>,
     // #3: last relay attempt's RX evidence → published to `smol/<leaf>/ota/relaydiag` (see
     // `mqtt_session`). `&mut None` on boot/leaf bursts.
     leaf_relay_rx: &mut Option<RelayDiag>,

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -396,6 +396,18 @@ impl LeafOtaOutcome {
             LeafOtaOutcome::Confirmed | LeafOtaOutcome::RolledBack | LeafOtaOutcome::IdMismatch
         )
     }
+
+    /// #134: did the image feed actually HAND OFF to the leaf (relay bytes started flowing)?
+    /// `false` for the GATEWAY-LOCAL pre-relay failures — `FetchFailed` (couldn't stage the image
+    /// from the OTA host) and `MacUnknown` (never learned the target MAC) — where the feed never
+    /// reached the leaf. Such a failure says nothing about the leaf or the image, so the retained
+    /// `smol/<leaf>/ota/install` must SURVIVE it (for the next attempt / the next crown — orders are
+    /// crown-portable per #111) instead of counting toward the doomed-image retry cap. `true` for the
+    /// terminals and the post-handoff transients (`RelayFailed`/`Timeout` — bytes were flowing — and
+    /// `Aborted`), which keep the bounded-retry-then-clear backstop.
+    pub fn reached_leaf(&self) -> bool {
+        !matches!(self, LeafOtaOutcome::FetchFailed | LeafOtaOutcome::MacUnknown)
+    }
 }
 
 /// What `service()` must do after handing a frame / a tick to the leaf session.


### PR DESCRIPTION
Closes #134.

## Problem

A gateway (crown) that fails to **fetch** the staged image still **burns** the retained
`smol/<leaf>/ota/install` order. Fetching happens *before* any bytes are relayed to the leaf, so a
fetch failure is **gateway-local and transient** — it says nothing about the leaf or the image — yet
it was counted against the same 3-strike `LEAF_OTA_MAX_RETRIES` cap meant to retire a genuinely
*doomed image*.

**Live incident:** a unicast-deaf crown (AP-side FDB pathology — TX worked, all inbound unicast incl.
ARP replies blackholed, so its TCP fetch from the OTA host never completed) fetch-failed 3× and
burned the order — three separately re-armed orders this way — before the mesh dethroned it. The
healthy successor crown then had nothing to relay, and the leaf silently never updated.

## Fix

`record_leaf_ota` (`net/mode.rs`) now applies a **three-way** clear/retry policy instead of two:

| Outcome class | Examples | Policy |
|---|---|---|
| terminal (leaf acted) | `Confirmed` / `RolledBack` / `IdMismatch` | **CLEAR**, reset counters |
| pre-relay transient (feed never handed off) | `FetchFailed` / `MacUnknown` | **NEVER clear** — order survives for the next attempt / the next crown (crown-portable per #111); counted only |
| post-handoff transient (image reached the leaf) | `RelayFailed` / `Timeout` / `Aborted` | bounded retry (`LEAF_OTA_MAX_RETRIES`) then CLEAR — the doomed-image backstop, unchanged |

- `ota_mesh.rs` — new `LeafOtaOutcome::reached_leaf()` = the never-relayed set `{FetchFailed,
  MacUnknown}`. This is the semantic boundary: "did the image feed actually hand off to the leaf?"
- `net/mode.rs` — the split above + a new `leaf_ota_fetch_retries` counter (observability only —
  it never burns the order).
- `net/wifi.rs` — the retained `smol/<leaf>/ota/diag` payload now carries the retry count
  (`fetch-failed retry=3`) so a stuck fetch is visible headlessly instead of a silent order-burn;
  `retry=0` keeps the bare phase (unchanged). The `leaf_ota_diag` tuple widened to
  `(id, phase, clear, retry_n)`.

## Verification (host + build only)

- `cargo build --release --features espnow,cast,io` — passes (valid RISC-V ELF).
- `clippy --features espnow,cast,io -- -D warnings` — clean.
- No flash, no MQTT publish, no mesh interaction (a live fleet cascade was in progress).

## ⛔ MERGE GATE: HW rig canary pending hardware

Do **not** merge on green builds alone (the #123/#130 lesson — on-air behaviour can diverge from what
green builds show). One canary board must prove, on air:

1. Force a crown fetch failure (block its route to the OTA host) → the retained
   `smol/<leaf>/ota/install` **survives**, and a healthy crown completes it on its next flush.
2. A genuinely doomed image still retires via the bounded relay-retry cap (unchanged path).
3. `smol/<leaf>/ota/diag` shows `fetch-failed retry=N` climbing (the headless-visibility win).

Canary ONE node first (OTA rollback discipline).

## Review question — per-tenure fetch throttle (trade-off)

With this fix a genuinely deaf crown re-fetches **every flush** (a blocking fetch each time) until it
recovers or is dethroned. The order is preserved (the point), but the crown keeps spending fetch
attempts. A refinement would be a per-tenure fetch throttle that stops *this crown* re-arming a leaf
after N fetch-fails **without clearing the order** (a RAM "abandoned-this-tenure" set, not a retained
clear) — leaving the order for the next crown. Not required for correctness (the mesh dethroning the
deaf crown is the real recovery), so left out of this PR. Want it in, or as a follow-up?

Refs #40, #111, #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
