### PR TITLE
fix(fw): #136 — don't take over a live owner during a re-assoc flush [HW-GATE-HELD]

### DIFF
--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2077,6 +2077,15 @@ impl RadioManager {
         // never heard (a forged/phantom retained MC — the standoff) is taken over promptly instead
         // of waiting the RSSI backoff (which exists to stagger takeover of a possibly-live owner).
         elect.owner_never_heard = !self.owner_hello_seen;
+        // #136: seed the heard-path takeover floor = the worst-case gap between a LIVE owner's
+        // OBSERVED MC seq advances (one flush interval + a slow/failed flush bounded by the flush
+        // budget). Computed here (espnow tier, where both constants live) so the wifi-tier resolver
+        // honors it without a cross-cfg dependency. Keeps a budget-edge re-assoc flush from being
+        // mistaken for a dead owner (issue #136); tracks #122 B1's flush interval automatically.
+        // `as_secs()*1000` (not `as_millis() as u64`): as_secs() is u64-native (no cast) and the
+        // budget is defined in whole seconds, so it's exact — and clippy-clean under -D warnings.
+        elect.recovery_stale_floor_ms =
+            RELAY_FLUSH_INTERVAL_MS + crate::net::wifi::RELAY_FLUSH_BUDGET.as_secs() * 1000;
         // #6 OTA / #21 config / #33 install: a leaf's recovery burst can also surface these.
         let mut ota_offer: Option<crate::ota::Announce> = None;
         let mut config_offer: Option<crate::app::DefaultScreen> = None;

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -121,6 +121,16 @@ pub struct MeshElect {
     /// overrides the FROZEN-seq safety gate: an owner whose seq still advances is alive and is never
     /// taken over regardless of this flag (RF-dead-zone protection intact).
     pub owner_never_heard: bool,
+    /// #136: (recovery only) a floor for the HEARD-path takeover window = the worst-case gap
+    /// between a LIVE owner's *observed* MC seq advances (`RELAY_FLUSH_INTERVAL_MS` + a slow/failed
+    /// flush bounded by `RELAY_FLUSH_BUDGET`). The caller (espnow tier) computes it from those two
+    /// constants and seeds it here so the wifi-tier resolver can honor it without a cross-cfg
+    /// dependency. The resolver takes over a heard-then-lost owner only past
+    /// `max(RECOVERY_STALE_MS, recovery_stale_floor_ms)`, so a gateway that republishes within a
+    /// flush-interval-plus-budget always advances its seq before the window completes → adopted,
+    /// never taken over (even at a budget-edge re-assoc flush). 0 on boot/gateway-flush/wifi-only
+    /// (those use the single-signal `MC_STALE_MS` path anyway) → `max(35s, 0)` = unchanged.
+    pub recovery_stale_floor_ms: u64,
     /// #51 return-flap fix: true ONLY on the one-shot BOOT election. A freshly-booted board
     /// must NEVER claim over a DIFFERENT owner already present in the retained MC — it comes
     /// up as a leaf and lets leaf-scan (fast HELLO lock) + the recovery election decide (live
@@ -152,6 +162,7 @@ impl MeshElect {
             my_channel: 0, // #29: advisory 0 until a frame's rx_control is learned
             recovery: false,
             owner_never_heard: false,
+            recovery_stale_floor_ms: 0, // #136: seeded by the caller on a recovery election
             boot: false,
             i_am_owner: false,
             owner_id: my_id,
@@ -320,7 +331,7 @@ const SYNC_BUDGET: Duration = Duration::from_secs(30);
 /// below the old 30 s spin. Tradeoff unchanged: longer budget = longer worst-case
 /// display/input freeze per attempt during an outage.
 #[cfg(feature = "espnow")]
-const RELAY_FLUSH_BUDGET: Duration = Duration::from_secs(15);
+pub(crate) const RELAY_FLUSH_BUDGET: Duration = Duration::from_secs(15); // #136: read by the leaf-reelect floor
 
 // -------------------------------------------------------------------------
 // Peripheral bundle handed over from `main` (single esp_hal::init()).
@@ -2807,8 +2818,20 @@ fn mqtt_session(
             // just at 90s instead of 35s — election stability > speed). A HEARD-then-lost owner keeps
             // the fast RECOVERY_STALE_MS (35s): the owner-HELLO silence that opened this recovery is
             // independent corroboration of death, so no live board can be misjudged there.
+            // #136: the HEARD-then-lost window is floored at the worst-case gap between a LIVE
+            // owner's OBSERVED seq advances (`recovery_stale_floor_ms` = flush interval + a slow
+            // flush bounded by RELAY_FLUSH_BUDGET, seeded by the caller). At today's 30 s flush that
+            // lifts the effective window 35→45 s so a budget-edge re-assoc flush (seq merely delayed,
+            // not frozen) can't cross it — the owner advances its seq and is adopted, never taken
+            // over (#136 canary 1). A genuinely-dead owner's seq is frozen forever, so it is still
+            // taken over at the window (#136 canary 2). Tracks #122 B1 automatically (at F=20 the
+            // floor is 20+15=35, already covered). NEVER-heard keeps MC_STALE_MS (3×F, ≥ the floor).
             let stale_limit = if elect.recovery {
-                if elect.owner_never_heard { MC_STALE_MS } else { RECOVERY_STALE_MS }
+                if elect.owner_never_heard {
+                    MC_STALE_MS
+                } else {
+                    RECOVERY_STALE_MS.max(elect.recovery_stale_floor_ms)
+                }
             } else {
                 MC_STALE_MS
             };


### PR DESCRIPTION
> **⚠️ HW-GATE-HELD** — do not merge until the canary checks below pass on the rig. Closes #136 (option-(c) from #122's derivation; separate from B1). Branch off main `0a94b1c`.

## The bug
The recovery **re-election trigger** keys on owner-**HELLO** silence (`last_owner_heard_ms`); the **takeover** keys on a *separate* broker anchor (`mc_seen_ms`, refreshed only during recovery bursts). A live gateway's worst-case gap between *observed* MC seq advances is `RELAY_FLUSH_INTERVAL_MS + RELAY_FLUSH_BUDGET` (an interval + a slow/failed re-associating flush) = up to **45 s** at the 30 s flush, which **exceeds** the heard-path window `RECOVERY_STALE_MS` = **35 s**. So a leaf can take over a live-but-slowly-flushing owner during a budget-edge re-assoc flush — *silence accrual counts a live owner as absent while its seq is still advancing*. (#121/#125 closed the never-heard mis-takeover and the perpetual churn, but not this heard-path window.)

## The fix (code, not a constant bump)
Floor the heard-path takeover window at the worst-case live republish gap:

```
effective_recovery_stale = max(RECOVERY_STALE_MS, RELAY_FLUSH_INTERVAL_MS + RELAY_FLUSH_BUDGET)
```

A gateway that republishes within a flush-interval-plus-budget always advances its seq **before** the window completes → it is **adopted, never taken over**, even at a budget-edge re-assoc flush. The floor is computed caller-side (espnow tier, where both constants live) and threaded through `MeshElect` so the wifi-tier resolver honors it with **no cross-cfg dependency**. It **auto-tracks #122 B1**: at F=20 the floor is 20+15 = 35 (already covered); at today's F=30 it lifts the effective window to 45, closing the hole now.

**Unchanged:** the never-heard path (`MC_STALE_MS` = 3×F, already ≥ the floor); boot / gateway-flush single-signal paths (floor = 0 → `max(35, 0)` = 35). Blast radius: the recovery heard-path takeover window only.

## Decision (heard-path recovery takeover)
| owner seq vs leaf's last observation | → |
|---|---|
| advanced this burst (`reset`) | ADOPT (alive) — never taken over |
| frozen < `max(RECOVERY_STALE, F+BUDGET)` | ADOPT (deferred) |
| frozen ≥ `max(RECOVERY_STALE, F+BUDGET)` | take over (dead) |

## Canary checks (must pass before un-gating)
1. **No false takeover:** a re-assoc flush that runs HELLO-silent to the budget edge, **while the owner's MC seq keeps advancing**, must NOT trigger a takeover — the leaf adopts. (Repro: force a gateway re-assoc/roam so it's HELLO-silent ~15 s while its flush still republishes MC; a following leaf must stay a leaf.)
2. **Dead owner still healed:** a genuinely-dead owner (MC seq frozen) must still be taken over within the H1 window — `max(RECOVERY_STALE, F+BUDGET)` ≈ 35 s at F=20, ≈ 45 s at F=30.

## Verification (static)
- Full profile bar `clippy -D warnings` clean: default / wifi / espnow / cast / io / wled / espnow,cast,io.
- `cargo build --release --features espnow,cast,io` green — valid RISC-V ELF.
- No flush/MQTT/mesh behavior changed beyond the takeover-window floor; no constant values changed (that's #122).

Refs #136 #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
