### PR TITLE
feat(fw): #138 chunked HTTP Range OTA fetch + #139 early PowerSaveMode::None

### DIFF
--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1892,6 +1892,14 @@ impl RadioManager {
         let (mut controller, interfaces) = esp_wifi::wifi::new(ctrl, p.wifi).ok()?;
         controller.set_mode(WifiMode::Sta).ok()?;
         controller.start().ok()?;
+        // #139: assert PowerSaveMode::None at RADIO INIT — the esp-wifi/IDF default is
+        // WIFI_PS_MIN_MODEM (the STA sleeps between DTIMs; the AP then buffers UNICAST at DTIM and
+        // drops it on marginal links → the re-ARP-after-reply / forwarded-NTP-never-arrives /
+        // TX-fine-RX-deaf class). This is the baseline; `switch()` re-asserts after each connect()
+        // (which resets ps to the default), and the post-is_connected() sites stay belt-and-
+        // suspenders. Shared by every espnow association (NTP/MQTT/OTA/re-election). See nebula
+        // finding 2 (scratch/smol-ha-batt/nebula-c3-wifi-research.md).
+        let _ = controller.set_power_saving(esp_wifi::config::PowerSaveMode::None);
 
         // #68/#76 SELF-MAC: capture our STA MAC (ESP-NOW rides the STA interface) so service()
         // can DROP frames from our own address. The esp-wifi RX queue can deliver our own
@@ -2268,6 +2276,13 @@ impl RadioManager {
                 // to the AP's channel automatically; ESP-NOW then coexists on
                 // that channel. (Caller must have valid credentials set.)
                 let _ = self.controller.connect();
+                // #139: connect() resets power-save to the WIFI_PS_MIN_MODEM default, so the
+                // association/auth handshake that follows would otherwise run under modem-sleep
+                // (unicast-deaf window). Re-assert None NOW — before the handshake completes — not
+                // only after the downstream is_connected() gates (MQTT flush / OTA fetch).
+                let _ = self
+                    .controller
+                    .set_power_saving(esp_wifi::config::PowerSaveMode::None);
                 log::info!("smol: radio -> WiFi STA (coexist)");
             }
         }

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1810,6 +1810,11 @@ pub struct RadioManager {
     /// The phase is stored as the rendered `&'static str` (not the espnow-only enum) so the
     /// shared `wifi::mqtt_session` signature stays buildable in the wifi-only profile.
     leaf_ota_diag: Option<(u8, &'static str, bool)>,
+    /// #139-followup: on a failed SELF-fetch, `(chunk_k, chunk_n, retries, stalls)` buffered by
+    /// `run_ota_update` → formatted + published retained to `smol/<id>/ota/diag` on the next gateway
+    /// flush (fleet-visible failure diag; release images are serial-silent). Consumed once (set to
+    /// `None` after publish), mirroring `leaf_ota_diag`.
+    ota_self_fail: Option<(u32, u32, u32, u32)>,
     /// #40 #1 DECOUPLE: true while a leaf-OTA relay is pending/in-flight (armed until its
     /// outcome is terminal or the retry cap is hit). While set, the gateway SUPPRESSES its own
     /// self-OTA (`do_install`) so a relay is never interrupted by the gateway rebooting into a
@@ -1958,6 +1963,7 @@ impl RadioManager {
             ota_offer: None,
             staged_raw: None,
             leaf_ota_diag: None,
+            ota_self_fail: None,
             leaf_ota_retries: 0,
             leaf_ota_pending: false,
             leaf_installs_outstanding: false,
@@ -2125,6 +2131,7 @@ impl RadioManager {
                     &mut None, // #40: recovery burst carries no persistent staged
                     &mut None, // #40: recovery burst publishes no relay diag
                     &mut None, // #3: recovery burst publishes no relay RX-diag
+                    &mut None, // #139-followup: a leaf recovery burst is never a self-OTA fetch
                     tick,
                 )
             }
@@ -3176,16 +3183,29 @@ impl RadioManager {
         log::info!("smol OTA: opening update burst (mesh deaf for the whole download)");
         let _ = self.switch(Mode::WifiSta);
         let rng = self.rng;
-        match self.sta.as_mut() {
+        let mut fail: Option<(u32, u32, u32, u32)> = None;
+        let ok = match self.sta.as_mut() {
             None => false,
             Some(sta) => {
                 // Self-OTA: activate-on-success (relay_mode = false; the slot out-param is
                 // unused since a successful self-fetch reboots inside `activate`).
                 crate::net::wifi::run_ota_fetch(
-                    &mut self.controller, sta, rng, announce, tick, false, &mut None,
+                    &mut self.controller, sta, rng, announce, tick, false, &mut None, &mut fail,
                 )
             }
+        };
+        // #139-followup: a SUCCESS reboots INSIDE the fetch (never returns here), so reaching this
+        // with ok==false is a genuine self-fetch failure — buffer the (chunk_k, chunk_n, retries,
+        // stalls) snapshot so the next gateway flush publishes it retained to smol/<id>/ota/diag.
+        // Release images are serial-silent, so this retained record is the ONLY fleet-visible signal
+        // of WHY a self-fetch died (the blindness that turned tonight's mid-body deaths into a
+        // three-hour diagnosis). `id` avoids borrowing self across the field set.
+        if !ok {
+            if let Some(rec) = fail {
+                self.ota_self_fail = Some(rec);
+            }
         }
+        ok
     }
 
     /// #40: record a leaf-OTA attempt's outcome (called by `main` after `run_leaf_ota_relay`,
@@ -3359,7 +3379,7 @@ impl RadioManager {
         let mut staged: Option<Slot> = None;
         let fetched = match self.sta.as_mut() {
             Some(sta) => crate::net::wifi::run_ota_fetch(
-                &mut self.controller, sta, rng, announce, tick, true, &mut staged,
+                &mut self.controller, sta, rng, announce, tick, true, &mut staged, &mut None,
             ),
             None => false,
         };
@@ -3853,6 +3873,7 @@ impl RadioManager {
                     &mut self.staged_raw, // #40: persist the staged across flushes (pair-safe)
                     &mut self.leaf_ota_diag, // #40: publish smol/<leaf>/ota/diag + clear/retry
                     &mut self.leaf_relay_rx, // #3: publish smol/<leaf>/ota/relaydiag (RX evidence)
+                    &mut self.ota_self_fail, // #139-followup: publish own smol/<id>/ota/diag on self-fetch fail
                     tick,
                 )
             }

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -3685,125 +3685,255 @@ pub fn run_ota_fetch(
         }
     }
 
-    // TCP connect to the (allowlisted) image host.
-    let src_port = 49152 + (rng.random() % 16384) as u16;
-    {
-        let s = sockets.get_mut::<tcp::Socket>(tcp_handle);
-        if s.connect(iface.context(), (IpAddress::Ipv4(ip), port), src_port)
-            .is_err()
-        {
-            log::error!("smol OTA: TCP connect failed");
-            return false;
-        }
-    }
-    loop {
-        iface.poll(smoltcp_now(), device, &mut sockets);
-        if sockets.get_mut::<tcp::Socket>(tcp_handle).may_send() {
-            break;
-        }
-        if tick() {
-            return false;
-        }
-        if Instant::now() > deadline {
-            log::warn!("smol OTA: TCP connect timed out");
-            return false;
-        }
-    }
-
-    // Send the request in pieces (no format buffer; total « the 512 B tx ring).
-    {
-        let s = sockets.get_mut::<tcp::Socket>(tcp_handle);
-        let ok = s.send_slice(b"GET ").is_ok()
-            && s.send_slice(path.as_bytes()).is_ok()
-            && s.send_slice(b" HTTP/1.0\r\nHost: ").is_ok()
-            && s.send_slice(host.as_bytes()).is_ok()
-            && s.send_slice(b"\r\nConnection: close\r\n\r\n").is_ok();
-        if !ok {
-            log::error!("smol OTA: failed to send HTTP request");
-            return false;
-        }
-    }
-
-    // Open the inactive-slot writer (image is streamed here, never buffered whole).
+    // Open the inactive-slot writer ONCE (image is streamed here across chunks, never buffered
+    // whole). `writer.written()` doubles as the RESUME cursor and the running-SHA position.
     let Some(mut writer) = crate::ota::ImageWriter::begin() else {
         log::error!("smol OTA: cannot open inactive slot (no OTA partition table?)");
         return false;
     };
     let target = writer.target();
 
-    // Receive: accumulate the HTTP headers (validate 200 + Content-Length == size),
-    // then STREAM every body byte straight into the flash writer.
-    let mut header_buf = [0u8; 512];
-    let mut header_len = 0usize;
-    let mut headers_done = false;
-    loop {
+    // #138: fetch the image as sequential HTTP Range chunks instead of one fragile minutes-long
+    // GET. Each chunk is its own short HTTP/1.0 GET+`Range` on a FRESH connection (Connection:
+    // close) — many reliable short transfers inside the socket window that demonstrably works
+    // (seconds-long MQTT/DHCP on the same association are rock-solid; only the single long GET
+    // died mid-body — nebula finding 1b / IDF esp_https_ota partial_http_download). The running
+    // SHA-256 composes across chunks (the writer accumulates), so the verify gate below is
+    // UNCHANGED. A broken chunk resumes from `writer.written()` rather than restarting the whole
+    // image; `OTA_FETCH_BUDGET` stays the overall cap. `chunk_retries` is surfaced to serial
+    // (the fetch reboots on success, so an in-RAM diag counter wouldn't survive — serial is the
+    // rig's forensic sink).
+    const OTA_CHUNK: u32 = 48 * 1024;
+    /// Consecutive zero-progress attempts before giving up (livelock guard inside the budget).
+    const OTA_MAX_STALL: u32 = 6;
+
+    // Variable-width decimal into `out` (Range byte-positions must NOT be zero-padded for all
+    // servers); returns the digit count. `v` is a u32 → at most 10 digits.
+    fn write_dec(mut v: u32, out: &mut [u8]) -> usize {
+        if v == 0 {
+            out[0] = b'0';
+            return 1;
+        }
+        let mut tmp = [0u8; 10];
+        let mut i = 0;
+        while v > 0 {
+            tmp[i] = b'0' + (v % 10) as u8;
+            v /= 10;
+            i += 1;
+        }
+        for j in 0..i {
+            out[j] = tmp[i - 1 - j];
+        }
+        i
+    }
+
+    let mut range_ok = true; // flips false if chunk 0 returns 200 (server ignored Range)
+    let mut chunk_retries: u32 = 0; // re-requests forced by a short/failed chunk
+    let mut stall: u32 = 0; // consecutive zero-progress attempts
+
+    while writer.written() < announce.size {
         if tick() {
             log::warn!("smol OTA: aborted by long-press (slot untouched)");
             return false;
-        }
-        iface.poll(smoltcp_now(), device, &mut sockets);
-        let mut closed = false;
-        {
-            let s = sockets.get_mut::<tcp::Socket>(tcp_handle);
-            if s.can_recv() {
-                let outcome = s.recv(|data| {
-                    if !headers_done {
-                        let take = core::cmp::min(header_buf.len() - header_len, data.len());
-                        if take == 0 {
-                            return (0, false); // headers exceed the buffer → give up
-                        }
-                        header_buf[header_len..header_len + take]
-                            .copy_from_slice(&data[..take]);
-                        header_len += take;
-                        if let Some(bstart) = crate::ota::header_end(&header_buf[..header_len]) {
-                            if crate::ota::status_code(&header_buf[..header_len]) != Some(200) {
-                                return (take, false); // non-200 → abort
-                            }
-                            if let Some(cl) = crate::ota::content_length(&header_buf[..header_len])
-                            {
-                                if cl != announce.size {
-                                    return (take, false); // length mismatch → abort
-                                }
-                            }
-                            headers_done = true;
-                            // feed body bytes already captured past the header terminator
-                            let fed = writer.feed(&header_buf[bstart..header_len]);
-                            return (take, fed);
-                        }
-                        (take, true) // headers still arriving
-                    } else {
-                        let fed = writer.feed(data);
-                        (data.len(), fed)
-                    }
-                });
-                match outcome {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        log::error!("smol OTA: bad HTTP response or flash write error");
-                        return false;
-                    }
-                    Err(_) => closed = true,
-                }
-            } else if !s.may_recv() {
-                closed = true; // peer closed (Connection: close) + rx drained
-            }
-        }
-        // OTA throughput fix: poll AGAIN right after draining the rx ring so the
-        // reopened window (and its ACK) hits the wire this iteration instead of
-        // waiting for the next loop's top-of-loop poll — halves the window-closed gap
-        // that made the transfer round-trip-bound.
-        iface.poll(smoltcp_now(), device, &mut sockets);
-        if headers_done && writer.written() >= announce.size {
-            break;
-        }
-        if closed {
-            break;
         }
         if Instant::now() > deadline {
             log::warn!("smol OTA: download timed out (slot untouched)");
             return false;
         }
+        let off = writer.written();
+        let end = core::cmp::min(off + OTA_CHUNK, announce.size) - 1; // inclusive last byte
+
+        // Fresh connection for this chunk: abort any prior (closed) socket, then reconnect on a
+        // new ephemeral port (avoids TIME_WAIT collisions).
+        {
+            let s = sockets.get_mut::<tcp::Socket>(tcp_handle);
+            s.abort();
+        }
+        iface.poll(smoltcp_now(), device, &mut sockets);
+        let src_port = 49152 + (rng.random() % 16384) as u16;
+        {
+            let s = sockets.get_mut::<tcp::Socket>(tcp_handle);
+            if s.connect(iface.context(), (IpAddress::Ipv4(ip), port), src_port)
+                .is_err()
+            {
+                chunk_retries += 1;
+                stall += 1;
+                if stall >= OTA_MAX_STALL {
+                    log::error!("smol OTA: repeated TCP connect failures — aborting (slot untouched)");
+                    return false;
+                }
+                continue;
+            }
+        }
+        {
+            let mut connected = false;
+            while !connected {
+                iface.poll(smoltcp_now(), device, &mut sockets);
+                if sockets.get_mut::<tcp::Socket>(tcp_handle).may_send() {
+                    connected = true;
+                } else if tick() {
+                    return false;
+                } else if Instant::now() > deadline {
+                    log::warn!("smol OTA: TCP connect timed out (slot untouched)");
+                    return false;
+                }
+            }
+        }
+
+        // Request the byte range [off, end]. Sent in pieces (no format buffer; « the 512 B tx ring).
+        // `Range: bytes=<off>-<end>` — a 206-capable server returns exactly that slice; a server
+        // that ignores Range answers 200 with the whole body (handled as a fallback on chunk 0).
+        let mut rbuf = [0u8; 32];
+        let mut rl = 6;
+        rbuf[..6].copy_from_slice(b"bytes=");
+        rl += write_dec(off, &mut rbuf[rl..]);
+        rbuf[rl] = b'-';
+        rl += 1;
+        rl += write_dec(end, &mut rbuf[rl..]);
+        {
+            let s = sockets.get_mut::<tcp::Socket>(tcp_handle);
+            let ok = s.send_slice(b"GET ").is_ok()
+                && s.send_slice(path.as_bytes()).is_ok()
+                && s.send_slice(b" HTTP/1.0\r\nHost: ").is_ok()
+                && s.send_slice(host.as_bytes()).is_ok()
+                && s.send_slice(b"\r\nRange: ").is_ok()
+                && s.send_slice(&rbuf[..rl]).is_ok()
+                && s.send_slice(b"\r\nConnection: close\r\n\r\n").is_ok();
+            if !ok {
+                chunk_retries += 1;
+                stall += 1;
+                if stall >= OTA_MAX_STALL {
+                    log::error!("smol OTA: repeated request-send failures — aborting (slot untouched)");
+                    return false;
+                }
+                continue;
+            }
+        }
+
+        // Drain this chunk's response into the writer (streaming; headers validated once/chunk).
+        let chunk_start = writer.written();
+        let mut header_buf = [0u8; 512];
+        let mut header_len = 0usize;
+        let mut headers_done = false;
+        let mut bad = false;
+        loop {
+            if tick() {
+                log::warn!("smol OTA: aborted by long-press (slot untouched)");
+                return false;
+            }
+            iface.poll(smoltcp_now(), device, &mut sockets);
+            let mut closed = false;
+            {
+                let s = sockets.get_mut::<tcp::Socket>(tcp_handle);
+                if s.can_recv() {
+                    let outcome = s.recv(|data| {
+                        if !headers_done {
+                            let take = core::cmp::min(header_buf.len() - header_len, data.len());
+                            if take == 0 {
+                                bad = true;
+                                return (0, false); // headers exceed the buffer → give up
+                            }
+                            header_buf[header_len..header_len + take]
+                                .copy_from_slice(&data[..take]);
+                            header_len += take;
+                            if let Some(bstart) = crate::ota::header_end(&header_buf[..header_len]) {
+                                match crate::ota::status_code(&header_buf[..header_len]) {
+                                    Some(206) => {} // Partial Content — Range honoured
+                                    Some(200) if off == 0 => {
+                                        // Server ignored Range → full-body fallback (the old
+                                        // single-GET path). Validate Content-Length == size as
+                                        // before; this GET is NOT resumable (checked after drain).
+                                        range_ok = false;
+                                        if let Some(cl) =
+                                            crate::ota::content_length(&header_buf[..header_len])
+                                        {
+                                            if cl != announce.size {
+                                                bad = true;
+                                                return (take, false); // length mismatch → abort
+                                            }
+                                        }
+                                    }
+                                    _ => {
+                                        bad = true; // non-206 range reply (or 200 mid-stream)
+                                        return (take, false);
+                                    }
+                                }
+                                headers_done = true;
+                                let fed = writer.feed(&header_buf[bstart..header_len]);
+                                if !fed {
+                                    bad = true; // flash write error
+                                }
+                                return (take, fed);
+                            }
+                            (take, true) // headers still arriving
+                        } else {
+                            let fed = writer.feed(data);
+                            if !fed {
+                                bad = true; // flash write error
+                            }
+                            (data.len(), fed)
+                        }
+                    });
+                    match outcome {
+                        Ok(true) => {}
+                        Ok(false) => closed = true, // bad header / flash error → end this chunk
+                        Err(_) => closed = true,
+                    }
+                } else if !s.may_recv() {
+                    closed = true; // peer closed (Connection: close) + rx drained → chunk complete
+                }
+            }
+            // Poll AGAIN right after draining so the reopened window (+ its ACK) hits the wire
+            // this iteration — halves the window-closed gap that made the transfer RTT-bound.
+            iface.poll(smoltcp_now(), device, &mut sockets);
+            if writer.written() >= announce.size {
+                break; // whole image done
+            }
+            if closed {
+                break; // this chunk's connection ended → outer loop resumes from written()
+            }
+            if Instant::now() > deadline {
+                log::warn!("smol OTA: download timed out (slot untouched)");
+                return false;
+            }
+        }
+
+        if bad {
+            log::error!("smol OTA: bad HTTP status/length on range {off}-{end} (slot untouched)");
+            return false;
+        }
+        if !range_ok && writer.written() < announce.size {
+            // A 200 server re-sends from 0, so an incomplete full-body GET can't be resumed
+            // (that's the OLD failure mode). Fail cleanly rather than double-write.
+            log::error!(
+                "smol OTA: server ignored Range (200) and the single GET died mid-body — not resumable"
+            );
+            return false;
+        }
+        // Progress accounting: a chunk that advanced resets the stall guard; a chunk that
+        // delivered fewer bytes than requested (broke early) forces re-requesting the remainder.
+        if writer.written() > chunk_start {
+            stall = 0;
+            if range_ok && writer.written() <= end && writer.written() < announce.size {
+                chunk_retries += 1; // short chunk → remainder re-requested next iteration
+            }
+        } else {
+            chunk_retries += 1;
+            stall += 1;
+            if stall >= OTA_MAX_STALL {
+                log::error!(
+                    "smol OTA: {OTA_MAX_STALL} zero-progress attempts at offset {off} — aborting (slot untouched)"
+                );
+                return false;
+            }
+        }
     }
+
+    log::info!(
+        "smol OTA: image received — {} B over Range chunks ({} chunk retries)",
+        writer.written(),
+        chunk_retries
+    );
 
     // Integrity gate (exact size + SHA-256) AND #32 authenticity gate (Ed25519 over the
     // signed manifest "build|size|sha256hex"). BOTH must pass before otadata is touched;

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -752,6 +752,7 @@ pub fn run_ntp_burst(
         &mut None, // #40: boot burst has no persistent staged to carry
         &mut None, // #40: boot burst has no relay diag to publish
         &mut None, // #3: boot burst has no relay RX-diag to publish
+        &mut None, // #139-followup: boot/NTP burst is never a self-OTA fetch
         mqtt_deadline,
         tick,
     );
@@ -1644,6 +1645,9 @@ fn mqtt_session(
     // #3 RELAY RX-DIAG: the last relay's `(leaf_id, rx_any, otan_valid, last_wb, total)`.
     // PUBLISHED to retained `smol/<leaf>/ota/relaydiag` here, consumed after. `&mut None` off-gw.
     leaf_relay_rx: &mut Option<RelayDiag>,
+    // #139-followup: on a failed SELF-fetch, `(chunk_k, chunk_n, retries, stalls)` → formatted +
+    // published retained to `smol/<id>/ota/diag` (gateway-only; consumed once). `&mut None` otherwise.
+    ota_self_fail: &mut Option<(u32, u32, u32, u32)>,
     deadline: Instant,
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
@@ -2634,6 +2638,29 @@ fn mqtt_session(
         *leaf_diag = None; // consumed — published once
     }
 
+    // #139-followup: publish this node's OWN failed-self-fetch record to retained
+    // `smol/<id>/ota/diag` (#135 armdiag pattern). Release images are serial-silent, so a self-OTA
+    // that dies mid-download is otherwise INVISIBLE on the fleet — the blindness that turned
+    // tonight's mid-body deaths into a three-hour diagnosis. `chunk=k/n` = how far the download got
+    // (0/0 ⇒ died before the download: assoc/DHCP/slot); `retry`/`stall` = transfer trouble.
+    // Consumed after publish (set None) so it isn't re-emitted every flush.
+    if let Some((k, n, r, s)) = *ota_self_fail {
+        let mut dtopic = MqttScratch::new();
+        let _ = write!(dtopic, "smol/{}/ota/diag", node_id);
+        let mut dval = MqttScratch::new();
+        let _ = write!(dval, "self-fetch-failed chunk={}/{} retry={} stall={}", k, n, r, s);
+        if let Some(np) =
+            crate::net::mqtt::encode_publish(&mut pkt, dtopic.as_bytes(), dval.as_bytes(), true)
+        {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..np], deadline, tick);
+        }
+        log::info!(
+            "smol #139: published smol/{}/ota/diag = self-fetch-failed chunk={}/{} retry={} stall={}",
+            node_id, k, n, r, s
+        );
+        *ota_self_fail = None; // consumed — published once
+    }
+
     // #111: CROWN-PORTABLE install cleanup — clear a leaf's retained `ota/install` once its FRESH
     // STAT confirms the version-flip (reported build >= the staged build). This is the SUCCESS
     // clear that survives a crown handover: the old design cleared only on the RELAY outcome
@@ -3233,6 +3260,9 @@ pub fn run_mqtt_burst(
     // #3: last relay attempt's RX evidence → published to `smol/<leaf>/ota/relaydiag` (see
     // `mqtt_session`). `&mut None` on boot/leaf bursts.
     leaf_relay_rx: &mut Option<RelayDiag>,
+    // #139-followup: on a failed SELF-fetch, `(chunk_k, chunk_n, retries, stalls)` → formatted +
+    // published retained to `smol/<id>/ota/diag` (see `mqtt_session`). `&mut None` otherwise.
+    ota_self_fail: &mut Option<(u32, u32, u32, u32)>,
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
     let mut iface = create_interface(device);
@@ -3422,6 +3452,7 @@ pub fn run_mqtt_burst(
         staged_raw, // #40: forward the persistent staged announce (or &mut None)
         leaf_diag, // #40: forward the diag/clear state (or &mut None)
         leaf_relay_rx, // #3: forward the relay RX-diag (or &mut None)
+        ota_self_fail, // #139-followup: forward the self-fetch-fail snapshot (or &mut None)
         deadline,
         tick,
     );
@@ -3590,6 +3621,7 @@ fn parse_ipv4(host: &str) -> Option<smoltcp::wire::Ipv4Address> {
 /// (failure/abort, good slot untouched); on SUCCESS it reboots inside `ota::activate`
 /// and never returns.
 #[cfg(feature = "espnow")]
+#[allow(clippy::too_many_arguments)] // +fail diag (#139-followup) tips this to 8 params
 pub fn run_ota_fetch(
     controller: &mut esp_wifi::wifi::WifiController<'static>,
     device: &mut esp_wifi::wifi::WifiDevice<'static>,
@@ -3602,6 +3634,12 @@ pub fn run_ota_fetch(
     // body is byte-identical, only the terminal action differs (activate-reboot vs return).
     relay_mode: bool,
     staged_slot: &mut Option<esp_bootloader_esp_idf::ota::Slot>,
+    // #139-followup observability: on a genuine self-fetch FAILURE (not a user abort), set to
+    // `(chunk_k, chunk_n, retries, stalls)` — how far the download got + the transfer-trouble
+    // counters. The self-OTA caller (`run_ota_update`) formats + publishes it retained to
+    // `smol/<id>/ota/diag` (#135 armdiag pattern); release images are serial-silent, so this is
+    // the ONLY fleet-visible signal of WHY a self-fetch failed.
+    fail: &mut Option<(u32, u32, u32, u32)>,
 ) -> bool {
     let Some((host, port, path)) = crate::ota::split_url(announce.url()) else {
         log::error!("smol OTA: malformed announce URL — aborting fetch");
@@ -3656,6 +3694,7 @@ pub fn run_ota_fetch(
             return false;
         }
         if Instant::now() > deadline {
+            *fail = Some((0, 0, 0, 0)); // #139-followup: died before the download (association)
             log::warn!("smol OTA: WiFi association timed out");
             return false;
         }
@@ -3680,6 +3719,7 @@ pub fn run_ota_fetch(
             break;
         }
         if Instant::now() > deadline {
+            *fail = Some((0, 0, 0, 0)); // #139-followup: died before the download (DHCP)
             log::warn!("smol OTA: DHCP timed out");
             return false;
         }
@@ -3688,6 +3728,7 @@ pub fn run_ota_fetch(
     // Open the inactive-slot writer ONCE (image is streamed here across chunks, never buffered
     // whole). `writer.written()` doubles as the RESUME cursor and the running-SHA position.
     let Some(mut writer) = crate::ota::ImageWriter::begin() else {
+        *fail = Some((0, 0, 0, 0)); // #139-followup: died before the download (slot open)
         log::error!("smol OTA: cannot open inactive slot (no OTA partition table?)");
         return false;
     };
@@ -3730,8 +3771,13 @@ pub fn run_ota_fetch(
     let mut range_ok = true; // flips false if chunk 0 returns 200 (server ignored Range)
     let mut chunk_retries: u32 = 0; // re-requests forced by a short/failed chunk
     let mut stall: u32 = 0; // consecutive zero-progress attempts
+    let chunk_n = announce.size.div_ceil(OTA_CHUNK); // total chunks (for the #139-followup fail diag)
 
     while writer.written() < announce.size {
+        // #139-followup: keep the fail-diag snapshot current so ANY failure return below carries
+        // how far the download got + the trouble counters (the self-OTA caller publishes it retained
+        // to smol/<id>/ota/diag — release images are serial-silent, so this is the fleet-visible why).
+        *fail = Some((writer.written() / OTA_CHUNK, chunk_n, chunk_retries, stall));
         if tick() {
             log::warn!("smol OTA: aborted by long-press (slot untouched)");
             return false;
@@ -3961,6 +4007,10 @@ pub fn run_ota_fetch(
         crate::ota::activate(target, announce.build, false); // self-OTA → confirm via DHCP
         false // reached only if the otadata write failed
     } else {
+        // #139-followup: the download COMPLETED but the integrity/authenticity gate rejected it
+        // (corrupt/truncated/bad-sig). Record K=N (all chunks fetched) so the fleet diag
+        // distinguishes a verify failure from a mid-download death.
+        *fail = Some((chunk_n, chunk_n, chunk_retries, stall));
         log::error!("smol OTA: verify FAILED (size/SHA-256 or ed25519 signature) — discarded (good slot intact)");
         false
     }


### PR DESCRIPTION
⛔ **MERGE GATE: HW canary pending hardware.** Both changes are release + full-profile-bar green and reasoned from nebula's WiFi research, but NEITHER is validated on a live board — the fleet is converged/settled and was NOT touched. Do not merge until the (a)-(d) canary checks below pass.

The OTA transfer-reliability pair — they compose (both on `net/wifi.rs`'s association + fetch path). From nebula's findings 1b + 2 (`scratch/smol-ha-batt/nebula-c3-wifi-research.md`).

## #139 — PowerSaveMode::None at init + before association (`213297c`)
esp-wifi/IDF default is `WIFI_PS_MIN_MODEM`; `connect()` resets ps to it; we asserted `None` only AFTER `is_connected()` (@3330 MQTT flush, @3663 OTA) — so every association/auth handshake ran under modem-sleep (AP buffers UNICAST at DTIM → the re-ARP-after-reply / forwarded-NTP-never-arrives / TX-fine-RX-deaf class). Now asserted in the **shared espnow path**: at radio init (baseline, after `esp_wifi::wifi::new`) and in `switch()`'s WifiSta arm right after `connect()` (before the handshake completes, since connect() just reset it). Post-`is_connected()` re-asserts kept as belt-and-suspenders. Covers every espnow association (NTP / MQTT / OTA / re-election), not only `run_ota_fetch`.

## #138 — chunked HTTP Range OTA fetch (`5b90cb2`)
`run_ota_fetch`'s single minutes-long GET died mid-body 40–90 s in — untunable esp-wifi driver fragility (esp-idf #12091 closed "Not Applicable"; esp-wifi #215, esp-hosted #184), while seconds-long MQTT/DHCP on the same association are rock-solid. Now **sequential 48 KB Range chunks** — each a short `GET`+`Range: bytes=<off>-<end>` on a FRESH `Connection: close` socket, inside the window that demonstrably works. The `ImageWriter` accumulates across chunks → the running SHA-256 and the size + ed25519 verify gate are **UNCHANGED**.
- **Resume** from `writer.written()` on a broken chunk (no whole-image restart — resume falls out of the accumulator: flash offset + SHA position advance together).
- **206** happy path; a **200 on chunk 0** (server ignored Range) falls back to the old full-body single-GET semantics (`Content-Length==size` checked; not resumable → an incomplete 200 fails cleanly rather than double-writing).
- `OTA_FETCH_BUDGET` stays the overall cap; `OTA_MAX_STALL` (6 zero-progress attempts) guards livelock; `chunk_retries` → serial (the fetch reboots on success, so a persisted diag counter wouldn't survive — serial `ESP_LOG=info` is the rig's sink).
- Server precondition: Range + Content-Length (python http.server 3.7+ ✓; the 200-fallback covers servers that don't).

## Verification (host — the HW rig is the remaining gate)
Full profile bar GREEN: `clippy -D warnings` on default / espnow / espnow,cast,io / espnow,wled / espnow,mesh-test + release build (`espnow,cast,io`) links. NO flash / MQTT / mesh touched (fleet converged/settled).

## ⛔ HW canary checks (must pass before merge)
- **(a)** a full ~1 MB image fetch COMPLETES over N Range chunks on a live board where the single-GET died mid-body.
- **(b)** a mid-chunk connection kill RESUMES from bytes-written (serial "chunk retries" climbs) instead of restarting the whole image.
- **(c)** SHA-256 + ed25519 verify still GATES activation (a corrupted/short image is rejected, good slot intact).
- **(d)** #139: the association-window ARP/DHCP/unicast-loss signature is GONE — DIAG `tage` stops growing fleet-wide over a multi-hour soak.

Refs #138 #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)