### PR TITLE
feat(fw): #142 — single-network operation (retire #100 dual-slot fallback) [HW-GATE-HELD]

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -368,7 +368,7 @@ firmware predates is DROPPED (forward-compat, #46). Parse is panic-free/heap-fre
 | `U` | #43 | **display units** — °F/°C + 12/24h (fleet-global via `CFG_TARGET_ALL`) | yes | live |
 | `P` | #55 | **plugin visibility** bitmask per node | yes | live |
 | `Y` | #45 | **Custom screen** layout (the largest value → drives `CFG_VALUE_MAX = 64`) | yes | live |
-| `N` | #100 S1b | active **WiFi slot** index (`fd3b439`) | yes | **edge-triggered reboot** |
+| ~~`N`~~ | #100 S1b → **#142** | **RETIRED** — WiFi-slot switch removed (single-network). A received `N` is drained + ignored | (n/a) | none |
 | `B` | #100 S2 | **broker** leg override (IPv4 + port) (`b08204d`, #110) | yes | **edge-triggered reboot** |
 | `O` | #100 S3 | **OTA-host** override — one RFC1918 host appended to the fetch allowlist (`b08204d`, #110) | yes | live, **no reboot** |
 | `R` | #52 | **remote reboot** | **NO** — transient, never cached/retained | reboots (that is its function) |
@@ -376,15 +376,16 @@ firmware predates is DROPPED (forward-compat, #46). Parse is panic-free/heap-fre
 | `G` | #72 | **IO pin-map** — the whole per-node driver map (see below) (`5689b1b`, #113) | yes | live, **no reboot** (edge-triggered re-bind) |
 | `g` | #72 | **IO output states** — commanded output levels (see below) (`5689b1b`, #113) | yes | live, no reboot |
 
-- **Reboot vs live.** Live-apply (no reboot): `S L U P Y O W G g`. Reboot on apply: `N` (WiFi-slot
-  switch), `B` (broker-leg change) — both **edge-triggered** (only when the value changes, so
-  the ~10 s re-arm never reboot-loops); `R` reboots by design. `O` takes effect on the next OTA
-  fetch without a reboot.
-- **Cached + re-armed vs transient.** `S L U P Y N B O G g` live in the gateway's `cfg_cache` and are
+- **Reboot vs live.** Live-apply (no reboot): `S L U P Y O W G g`. Reboot on apply: `B` (broker-leg
+  change) — **edge-triggered** (only when the value changes, so the ~10 s re-arm never
+  reboot-loops); `R` reboots by design. `O` takes effect on the next OTA fetch without a reboot.
+  (`N` was reboot-on-apply pre-#142; retired.)
+- **Cached + re-armed vs transient.** `S L U P Y B O G g` live in the gateway's `cfg_cache` and are
   **re-broadcast every ~10 s** (`broadcast_cached_configs`), so a rebooted leaf re-arms within ~10 s
-  with **no leaf-side NVS** — except the network state (`N`/`B`/`O`), which *also* persists in the
-  NVS net record below (needed to reach the broker at all before the first relay). `R`/`W` are
-  one-shot and never cached (an anti-reboot-loop / anti-off-channel invariant).
+  with **no leaf-side NVS** — except the network overrides (`B`/`O`), which *also* persist in the
+  NVS net record below (needed to reach the broker at all before the first relay). A retained `N` is
+  still relayed but **inert** (drained + ignored, #142). `R`/`W` are one-shot and never cached (an
+  anti-reboot-loop / anti-off-channel invariant).
 - **`S` default-screen value.** `<AppKind>:<page>` — `AppKind` is the exact `app.rs` spelling
   (`Menu Clock Batt Grid Snake Bench MeshSnake About`; wire `Snake` → MeshSnake on espnow); `page`
   is one digit, out-of-range clamps to 0; empty value clears → compile-time `board.rs`
@@ -420,34 +421,39 @@ cleanly, those don't). Source: `io.rs` (`PinMap`/`apply_wire`/`apply_set`), `wif
 - This is the **dollhouse per-room lamp + button foundation** (#75): a room LED on `7L`, a doll's
   button on `10B`, driven/observed entirely from HA.
 
-### The NVS net record — 28-byte v2 (#100)
+### The NVS net record — 28-byte v3 (#100 → #142)
 
-The network state set by `CFG-N/B/O` also persists in NVS **sector 5** (`0x5000`), so a leaf can
+The network override state set by `CFG-B/O` persists in NVS **sector 5** (`0x5000`), so a leaf can
 reach the broker before the first relay arrives. Brick-safe: any read failure/corruption → `None` →
-the caller defaults to slot 0 (the boot-default network).
+the caller defaults to the single baked network, no overrides. #142 retired the slot machinery;
+bytes 5–7 are now reserved-zero (same layout, so a pre-#142 v2 record still parses — see compat).
 
 | Bytes | Field | Notes |
 |---|---|---|
 | 0–3 | magic `"SMn1"` | `NET_MAGIC` |
-| 4 | version | v1 = 10-B core (slot only); **v2 = 28 B** (written today), adds the ext |
-| 5 | `active` | WiFi slot associated NOW (`<2`) |
-| 6 | `commanded` | last slot CFG-`N` asked for (differs from `active` iff auto-reverted) |
-| 7 | `fallback` | the un-brick WiFi fallback fired → DIAG `net=<slot>:fb` |
-| 8 | `active ^ 0xFF` | core complement guard |
-| 9 | `(active^commanded^fb)+0x5A` | core checksum guard *(v1 core ends here — 10 B)* |
-| 10 | broker present (1/0) | v2 ext (Stage 2) |
+| 4 | version | v1 = 10-B core; v2 = 28 B (#100 slot+overrides); **v3 = 28 B** (#142, written today) |
+| 5 | ~~`active`~~ reserved (0) | was WiFi slot; **#142: reserved-zero** (nonzero in a legacy v2 record) |
+| 6 | ~~`commanded`~~ reserved (0) | was last CFG-`N` slot; **#142: reserved-zero** |
+| 7 | ~~`fallback`~~ reserved (0) | was the un-brick fallback flag; **#142: reserved-zero** |
+| 8 | `b5 ^ 0xFF` | core complement guard (over byte 5) |
+| 9 | `(b5^b6^b7)+0x5A` | core checksum guard *(v1 core ends here — 10 B)* |
+| 10 | broker present (1/0) | ext (Stage 2) |
 | 11 | `broker_fallback` | override auto-disabled after repeated CONNACK fails → `brk=fb` |
 | 12–15 | broker IPv4 octets | RFC1918, gated at CFG apply |
 | 16–17 | broker port | u16 LE |
-| 18 | ota_host present (1/0) | v2 ext (Stage 3) |
+| 18 | ota_host present (1/0) | ext (Stage 3) |
 | 19–22 | ota_host IPv4 octets | RFC1918 |
 | 23 | ext checksum | `sum(rec[10..23]) + 0x5A` |
 | 24 | ext checksum `^ 0xFF` | ext complement guard |
 | 25–27 | zero pad | word-alignment only — esp-storage `WRITE_SIZE = 4`, so 25→**28** (`1b52456`); outside the checksum |
 
-- **v1 ↔ v2 compat.** A v2 firmware reading a v1 record treats it as "no overrides"; a v1 firmware
-  reading a v2 record rejects it (version mismatch) → slot 0 (a **safe** rollback). No forced
-  migration — the first v2 write (a CFG-`N`/`B`/`O` apply, or a fallback) upgrades the record in place.
+- **Migration (v1/v2/v3).** #142 fw reading a **v2** record MIGRATES it: keep the broker/OTA-host
+  override fields, discard the (now-meaningless) slot bytes — so a deployed board that was never
+  flash-erased keeps its overrides across the OTA. A **v1** record → no overrides. **v3** → native.
+  Unknown version / bad checksum / erased → `None` → safe defaults. No forced boot-time rewrite
+  (flash wear): the first genuine CFG-`B`/`O` change upgrades the record to v3 in place
+  (verify-after-write gated). A pre-#142 (v2-reader) fw reading a v3 record rejects it → safe default
+  (same one-way rollback posture as v1↔v2).
 - **Why 28, not 25.** A non-word-aligned write returns `NotAligned`; the swallowed error had made the
   record silently never persist (HW-canary find 2026-07-12 — the edge-trigger fired, then
   verify-after-write aborted every apply). Source: `ota.rs` `NetCfg`/`encode_net_cfg`/`parse_net_cfg`.
@@ -465,7 +471,7 @@ caches it (`diag_cache`) and republishes it retained to `smol/<id>/diag`.
 DIAG|slot=<bootslot>|rst=<reset-reason>|boot=<bootcount>|ota=<outcome>|up=<sec>|heap=<free>
     |hmin=<heap-min>|btn=<short>|btnl=<long>|fok=<flush-ok>|ffl=<flush-fail>|vok=<verify-ok>
     |vfl=<verify-fail>|loss=<pct>|rtt=<ms>|rx=<n>|tx=<n>|led=<mode>:<on|off>|tage=<sec-since-sync>
-    |tsrc=<ntp|mesh|none>|net=<slot>:<ok|fb>|brk=<baked|ovr|fb>|otah=<slot|ovr>
+    |tsrc=<ntp|mesh|none>|net=0:ok|brk=<baked|ovr|fb>|otah=<slot|ovr>
     |fwd=<uplink-fwds>|dedup=<dup-drops>|ttl=<ttl-drops>|hop=<1|2>|dlseq=<last-adopted>|dfwd=<downlink-refloods>
     [|cfg=<applied-config>][|io=<pin>:<count>,…][|deaf=<n>|ddrops=<n>]
 ```
@@ -481,7 +487,7 @@ DIAG|slot=<bootslot>|rst=<reset-reason>|boot=<bootcount>|ota=<outcome>|up=<sec>|
 | `vok`/`vfl` | OTA image verify ok/fail | #49 |
 | `loss`/`rtt`/`rx`/`tx` | mesh link-quality set (packet-loss % · RTT ms · rx/tx counts) | #49/#74 |
 | `led`/`tage`/`tsrc` | commanded LED mode:lit-state · seconds since sync · time source | #74 |
-| `net=<slot>:<ok\|fb>` | active WiFi slot + whether the un-brick fallback fired | #100 S1b (`fd3b439`) |
+| `net=0:ok` | **FROZEN** constant (#142 single-network — no slot/fallback; `0` = the historical primary baseline). Kept only so the dashboard's positional DIAG parse stays stable; a dashboard follow-up repurposes/drops it | #100 S1b → #142 |
 | `brk=<baked\|ovr\|fb>` | broker: baked-in · override active · override auto-disabled | #100 S2 (#110) |
 | `otah=<slot\|ovr>` | OTA host: slot allowlist · runtime override appended | #100 S3 (#110) |
 | `fwd` | **uplink** RELAY2 re-broadcasts forwarded by this node — the C0 byte-identical invariant: **must be 0 fleet-wide in all-hear** (increments at exactly one site, the RELAY2 forward arm) | #13 |

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -1268,53 +1268,12 @@ fn main() -> ! {
                 log::info!("smol #45: custom screen layout updated ({} B)", n);
             }
 
-            // #100: a network-switch config (key `N`) = the active WiFi-slot index. CONFIG/CACHED
-            // (retained), so it re-delivers every burst → EDGE-TRIGGERED on a change of the COMMANDED
-            // slot (NOT the active slot): a re-read of the same value is a no-op ⇒ never a reboot-loop
-            // (compare-to-commanded also means a latched fallback stays put — re-command to escape).
-            // A genuine change → persist {active=slot, commanded=slot, fallback=false} + reboot into
-            // the slot (the boot fallback then associates on it, self-healing if it's unreachable).
-            // Out-of-range / unparseable → ignored (keep current). software_reset() never returns.
-            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_NET) {
-                if let Some(slot) = core::str::from_utf8(&o.buf[..o.len])
-                    .ok()
-                    .and_then(|s| s.trim().parse::<u8>().ok())
-                {
-                    if (slot as usize) < crate::secrets::WIFI_NETWORKS.len() {
-                        let cur = crate::ota::read_net_cfg().map_or(0, |c| c.commanded);
-                        if slot != cur {
-                            log::warn!("smol #100: network slot -> {} (was commanded {}) — reboot", slot, cur);
-                            // A WiFi-slot switch resets to the new network's BAKED identity: the
-                            // broker + OTA-host overrides are cleared (they were set for the OLD
-                            // network's VLAN and would drop CONNACK cross-VLAN / point OTA off-net).
-                            // The slot IS the full network identity — re-apply an override after the
-                            // switch if still wanted.
-                            crate::ota::write_net_cfg(crate::ota::NetCfg {
-                                active: slot,
-                                commanded: slot,
-                                fallback: false,
-                                broker: None,
-                                broker_fallback: false,
-                                ota_host: None,
-                            });
-                            // #100 canary lesson: VERIFY-AFTER-WRITE before the reset. If the
-                            // record didn't persist (any flash error — all swallowed above), a
-                            // reset would boot back on the old slot, re-receive the retained
-                            // command, and loop forever (~20 s reset cycle, observed on HW).
-                            // A failed readback = abort the switch this cycle; the retained
-                            // command retries next cycle, and the failure stays VISIBLE
-                            // (commanded stays != slot) instead of becoming a reboot loop.
-                            let persisted = crate::ota::read_net_cfg()
-                                .is_some_and(|c| c.commanded == slot);
-                            if persisted {
-                                esp_hal::system::software_reset();
-                            } else {
-                                log::warn!("smol #100: net record did NOT persist — switch aborted (no reset)");
-                            }
-                        }
-                    }
-                }
-            }
+            // #142: the CFG-`N` network-slot command is RETIRED (single-network operation — no slot
+            // to select). Drain any stale/retained `N` offer so it can't linger in the tracker, but
+            // take NO action — a board never switches networks (a primary-assoc failure is a
+            // mesh-only leaf that keeps retrying the primary, not a reason to switch). The broker
+            // (`B`) and OTA-host (`O`) overrides below are independent and remain. See docs/protocol.md.
+            let _ = r.take_cfg_offer(crate::net::CFG_KEY_NET);
 
             // #100 Stage 2: a broker-override config (key `B`) = the MQTT broker leg (`ip` or
             // `ip:port`). CONFIG/CACHED (retained) — EDGE-TRIGGERED on a change of the COMMANDED

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2625,20 +2625,14 @@ impl RadioManager {
         let tx = self.bench.tx_count;
         let e = self.diag_extra;
         let led_state = if e.led_on { "on" } else { "off" };
-        // #100: active WiFi slot + fallback state (net=<slot>:<ok|fb>). `fb` = we auto-reverted off
-        // the commanded slot (the un-brick fallback fired) — HA surfaces "the network switch failed".
-        // Stage 2/3: brk=<baked|ovr|fb> (broker override state — `fb` = the override was auto-disabled
-        // after repeated CONNACK failures, running the baked broker) + otah=<slot|ovr> (an OTA-host
-        // override is appended to the allowlist). All read live from the one NVS net-record.
-        let net = crate::ota::read_net_cfg().unwrap_or(crate::ota::NetCfg {
-            active: 0,
-            commanded: 0,
-            fallback: false,
-            broker: None,
-            broker_fallback: false,
-            ota_host: None,
-        });
-        let net_fb = if net.fallback { "fb" } else { "ok" };
+        // #142: single-network operation — the #100 slot/fallback state is retired, so `net=` is
+        // FROZEN to the constant `0:ok` (slot 0 was always the primary — every healthy board's
+        // historical baseline is net=0:ok; the removed roam network was slot 1). Kept (not dropped) ONLY to preserve the HA dashboard's
+        // POSITIONAL DIAG parse; a dashboard follow-up repurposes or drops it. Stage 2/3 override
+        // state is still LIVE from the NVS net-record: brk=<baked|ovr|fb> (broker override — `fb` =
+        // auto-disabled after repeated CONNACK failures, running the baked broker) + otah=<slot|ovr>.
+        let net = crate::ota::read_net_cfg().unwrap_or_default();
+        let net_fb = "ok"; // #142: frozen (no slot fallback in single-network mode)
         let brk = match (net.broker.is_some(), net.broker_fallback) {
             (true, false) => "ovr",
             (true, true) => "fb",
@@ -2673,7 +2667,7 @@ impl RadioManager {
             led_state,
             e.tage_s,
             e.tsrc,
-            net.active,
+            0, // #142: net= frozen to slot 0 (the historical primary baseline); dashboard parse stays positional
             net_fb,
             brk,
             otah,

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -48,8 +48,8 @@ use smoltcp::{
 // Configuration (compile-time placeholders — set before flashing).
 // -------------------------------------------------------------------------
 
-// #100 Stage 1b: WiFi creds are read PER-SLOT at runtime (`WIFI_NETWORKS[active].ssid/pass`) inside
-// `associate_slot`, selected by the NVS net-record + the un-brickable fallback — no fixed SSID const.
+// #142: WiFi creds are read at runtime from the single baked `WIFI_NETWORK` (ssid/pass) inside
+// `associate` — no fixed SSID const, and (post-#142) no slot selection or un-brickable fallback.
 
 /// NTP server IPv4. We hardcode an anycast IP so we need no DNS resolver in
 /// the smoltcp build. time.cloudflare.com's NTP anycast address:
@@ -415,17 +415,16 @@ enum AssocResult {
     Aborted,
 }
 
-/// #100: one association attempt on `WIFI_NETWORKS[slot]`. Disconnect-then-(re)configure so a
-/// slot SWITCH (different SSID) re-associates cleanly, then wait for `is_connected` within
-/// `SYNC_BUDGET`. Extracted from `run_ntp_burst` so the fallback loop can retry PER-SLOT and
-/// revert on `TimedOut` ONLY (never on a long-press abort or a later DHCP/SNTP failure).
+/// #142: one association attempt on the single baked `WIFI_NETWORK`. Disconnect-then-(re)configure
+/// so a re-association is clean, then wait for `is_connected` within `SYNC_BUDGET`. `TimedOut` just
+/// means retry next burst (never a network switch — #100's slot revert is retired); a `#20 long-press
+/// Aborted` unwinds the burst.
 #[cfg(feature = "wifi")]
-fn associate_slot(
+fn associate(
     controller: &mut esp_wifi::wifi::WifiController<'static>,
-    slot: u8,
     tick: &mut dyn FnMut() -> bool,
 ) -> AssocResult {
-    let net = &crate::secrets::WIFI_NETWORKS[slot as usize];
+    let net = &crate::secrets::WIFI_NETWORK;
     // Drop any prior association before reconfiguring (harmless if not connected) so switching
     // SSIDs between slots doesn't leave a stale config. Errors are non-fatal → treated as a miss.
     let _ = controller.disconnect();
@@ -454,11 +453,11 @@ fn associate_slot(
             return AssocResult::Aborted; // #20 long-press mid-sync
         }
         if Instant::now() > deadline {
-            log::warn!("smol #100: assoc timed out on slot {} ('{}')", slot, net.ssid);
+            log::warn!("smol #142: assoc timed out on '{}' — retry next burst (mesh-only leaf)", net.ssid);
             return AssocResult::TimedOut;
         }
     }
-    log::info!("smol #100: associated to slot {} ('{}')", slot, net.ssid);
+    log::info!("smol #142: associated to '{}'", net.ssid);
     AssocResult::Associated
 }
 
@@ -475,8 +474,7 @@ fn active_broker() -> (Ipv4Addr, u16) {
     if let Some((ip, port)) = cfg.and_then(|c| c.broker.filter(|_| !c.broker_fallback)) {
         return (Ipv4Addr::new(ip[0], ip[1], ip[2], ip[3]), port);
     }
-    let active = cfg.map_or(0usize, |c| c.active as usize);
-    let net = &crate::secrets::WIFI_NETWORKS[active.min(crate::secrets::WIFI_NETWORKS.len() - 1)];
+    let net = &crate::secrets::WIFI_NETWORK;
     (
         Ipv4Addr::new(net.broker_ip[0], net.broker_ip[1], net.broker_ip[2], net.broker_ip[3]),
         net.broker_port,
@@ -612,50 +610,28 @@ pub fn run_ntp_burst(
     );
     let tcp_handle = sockets.add(tcp_socket);
 
-    // --- #100 WiFi connect with the UN-BRICKABLE slot fallback -----------
-    // Associate on the NVS-selected slot (default 0 if the record is erased/corrupt). A wrong or
-    // unreachable selection SELF-HEALS without USB: up to ASSOC_ATTEMPTS × SYNC_BUDGET on the
-    // active slot; all TimedOut → the ONE revert to the other slot (write NVS {active=other,
-    // fallback=1}) → retry it. BOTH slots fail → STAY PUT (return None; the boot free-runs and the
-    // next burst/boot retries). The NVS `fallback` flag GATES the cross-reboot revert: an
-    // already-reverted boot never reverts again → provably ONE revert-write per commanded
-    // selection, ZERO flash wear during a sustained total outage. Only a `TimedOut` counts toward a
-    // revert — a `#20 long-press Aborted` unwinds without ever touching NVS.
+    // --- #142 WiFi connect: single network, retry-primary-forever ---------
+    // Associate on the ONE baked network (`crate::secrets::WIFI_NETWORK`). Up to ASSOC_ATTEMPTS ×
+    // SYNC_BUDGET; all TimedOut → return None and let THIS burst end — the board free-runs as a
+    // fully-functional ESP-NOW mesh-only leaf (mesh membership + relayed telemetry + mesh time, no
+    // WiFi bursts) and the next burst/boot simply retries the primary. #142 retired #100's dual-slot
+    // revert: a board is NEVER switched onto the secondary/roam SSID (which caused AP-table
+    // pathologies) — a persistent primary-assoc failure is a placement/per-board TX issue (#141),
+    // not a reason to leave the intended network. No NVS write on failure (zero flash wear).
     const ASSOC_ATTEMPTS: u8 = 3;
-    let mut sel = crate::ota::read_net_cfg().unwrap_or(crate::ota::NetCfg {
-        active: 0,
-        commanded: 0,
-        fallback: false,
-        broker: None,
-        broker_fallback: false,
-        ota_host: None,
-    });
-    'assoc: loop {
-        let mut attempt = 0u8;
-        loop {
-            match associate_slot(controller, sel.active, tick) {
-                AssocResult::Associated => break 'assoc,
-                AssocResult::Aborted => return None, // long-press → never a revert
-                AssocResult::TimedOut => {
-                    attempt += 1;
-                    if attempt >= ASSOC_ATTEMPTS {
-                        break; // active slot exhausted → revert or stay-put
-                    }
+    let mut attempt = 0u8;
+    loop {
+        match associate(controller, tick) {
+            AssocResult::Associated => break,
+            AssocResult::Aborted => return None, // #20 long-press → unwind the burst
+            AssocResult::TimedOut => {
+                attempt += 1;
+                if attempt >= ASSOC_ATTEMPTS {
+                    log::warn!("smol #142: primary assoc unreachable — mesh-only this burst, retry next");
+                    return None; // mesh-only leaf; next burst retries the primary (never switch)
                 }
             }
         }
-        if sel.fallback {
-            // Already reverted (this boot, or a prior one — the NVS flag) and the fallback slot ALSO
-            // failed → STAY PUT. No revert, no NVS write (the anti-ping-pong / zero-wear guarantee).
-            log::warn!("smol #100: both slots unreachable (fallback latched) — staying put, no NVS write");
-            return None;
-        }
-        let other = 1 - sel.active;
-        // Preserve commanded + the broker/OTA overrides (`..sel`) — the WiFi revert only flips the
-        // active slot; a broker/OTA override survives a slot fallback (and CFG-`N` clears them).
-        sel = crate::ota::NetCfg { active: other, fallback: true, ..sel };
-        crate::ota::write_net_cfg(sel); // the ONE revert-write
-        log::warn!("smol #100: selected slot unreachable — reverted to slot {} (fallback), retrying", other);
     }
 
     // Poll the stack until DHCP yields an address. The DHCP `Event` borrows

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -53,17 +53,15 @@ pub const OTA_AUTO_INSTALL: bool = false;
 
 /// Image-host allowlist test (spec §4b-5): an announce whose URL host is not allowed is refused
 /// BEFORE any socket opens. The real LAN host(s) live in the GIT-IGNORED `crate::secrets` (this repo
-/// is PUBLIC — never commit a LAN IP). #100 Stage 3: the base allowlist is the RUNTIME-active slot's
-/// baked `ota_hosts` (was a slot-0 const), PLUS the NVS CFG-`O` override (one extra RFC1918 host,
-/// dashboard-set). Read at gate time — no reboot. A bad override can only ever REFUSE a fetch (it is
-/// merely an additional allowed host); the image itself stays monotonicity-gated, so this is
+/// is PUBLIC — never commit a LAN IP). #142: the base allowlist is the single baked network's
+/// `ota_hosts` (`crate::secrets::WIFI_NETWORK`), PLUS the NVS CFG-`O` override (one extra RFC1918
+/// host, dashboard-set). Read at gate time — no reboot. A bad override can only ever REFUSE a fetch
+/// (it is merely an additional allowed host); the image itself stays monotonicity-gated, so this is
 /// defense-in-depth, never a brick surface.
 #[cfg(feature = "wifi")]
 fn host_allowed(host: &str) -> bool {
     let cfg = read_net_cfg();
-    let active = cfg.map_or(0usize, |c| c.active as usize);
-    let slot = &crate::secrets::WIFI_NETWORKS[active.min(crate::secrets::WIFI_NETWORKS.len() - 1)];
-    if slot.ota_hosts.contains(&host) {
+    if crate::secrets::WIFI_NETWORK.ota_hosts.contains(&host) {
         return true;
     }
     // Stage 3: the CFG-`O` override — one extra RFC1918 host, matched by parsing the URL host.
@@ -1514,12 +1512,19 @@ pub fn reset_reason_token() -> &'static str {
 #[cfg(feature = "wifi")]
 const NET_MAGIC: [u8; 4] = *b"SMn1";
 /// Record version WRITTEN by this firmware. v1 (Stage 1) = the 10-byte core (slot selection only);
-/// v2 (Stage 2/3) appends the broker + OTA-host overrides. `parse_net_cfg` accepts BOTH: a v2 fw
-/// reading a Stage-1 v1 record treats it as "no overrides"; a v1 fw reading a v2 record rejects it
-/// (version mismatch) → slot 0 (a SAFE rollback default). No forced migration — the first v2 write
-/// (CFG-`N`/`B`/`O` apply or a fallback) upgrades the record in place.
-#[cfg(feature = "wifi")]
-const NET_VERSION: u8 = 2;
+/// v2 (#100 Stage 2/3) added the broker + OTA-host overrides alongside the slot bytes; v3 (#142)
+/// RETIRES the slot machinery — same on-flash layout, but the former slot bytes [5..8] are
+/// reserved-zero and carry no meaning. `parse_net_cfg` MIGRATES on read: v2 → keep the override
+/// fields, discard the slot bytes; v1 → no overrides; v3 → native. An unknown version / bad checksum
+/// / erased flash → `None` → safe defaults (single baked network, no overrides). Deployed boards that
+/// were never flash-erased carry a v2 record, so this migration is REQUIRED — it preserves their
+/// broker/OTA-host overrides across the #142 OTA. No forced boot-time rewrite (flash wear): the first
+/// genuine CFG-`B`/`O` change upgrades the record to v3 in place, verify-after-write gated. A pre-#142
+/// (v2-reader) fw reading a v3 record rejects it → slot 0 (a SAFE rollback default), same as v1↔v2.
+// #142: written only by the CFG-`B`/`O` apply (espnow tier) — the wifi-tier writer (the retired
+// slot-fallback revert) is gone, so gate to `espnow` to stay dead-code-clean in a wifi-only build.
+#[cfg(feature = "espnow")]
+const NET_VERSION: u8 = 3;
 /// nvs sector 5 = 0x5000 = 20480 (the one free sector; see the segregation note above).
 #[cfg(feature = "wifi")]
 const NET_REC_OFF: u32 = 5 * 4096;
@@ -1535,20 +1540,20 @@ const NET_REC_OFF: u32 = 5 * 4096;
 #[cfg(feature = "wifi")]
 const NET_REC_LEN: usize = 28;
 
-/// The persisted network identity. `active` = the WiFi slot we associate on NOW; `commanded` = the
-/// last slot HA asked for via CFG-`N` (differs from `active` iff we auto-reverted); `fallback` = the
-/// WiFi assoc fallback fired (surfaced as `net=<slot>:fb`). #100 Stage 2/3 overrides (all runtime,
-/// NVS-persisted, RFC1918-gated at the CFG apply): `broker` = the COMMANDED broker leg override (the
-/// slot's baked broker is used when `None`); `broker_fallback` = the override was auto-disabled after
-/// repeated CONNACK failures — `broker` is KEPT (for DIAG + the edge-trigger) but ignored at runtime,
-/// mirroring the WiFi `fallback`; `ota_host` = one extra RFC1918 host appended to the OTA allowlist.
+/// The persisted network overrides. #142: the #100 dual-slot fields (`active`/`commanded`/`fallback`)
+/// are RETIRED — boards run the single baked network (`crate::secrets::WIFI_NETWORK`), so there is no
+/// slot to select or revert. The on-flash record FORMAT is unchanged (see `encode_net_cfg`): the
+/// former slot bytes `[5..10]` are reserved-zero, so a pre-#142 record still parses and its overrides
+/// (below) SURVIVE the OTA — the migration is brick-safe with no version bump. #100 Stage 2/3 overrides
+/// (all runtime, NVS-persisted, RFC1918-gated at the CFG apply; independent of the slot machinery and
+/// load-bearing per #116): `broker` = the COMMANDED broker leg override (the baked broker is used when
+/// `None`); `broker_fallback` = the override was auto-disabled after repeated CONNACK failures —
+/// `broker` is KEPT (for DIAG + the edge-trigger) but ignored at runtime; `ota_host` = one extra
+/// RFC1918 host appended to the OTA allowlist.
 #[cfg(feature = "wifi")]
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, PartialEq)]
 pub struct NetCfg {
-    pub active: u8,
-    pub commanded: u8,
-    pub fallback: bool,
-    /// Stage 2: broker leg override (IPv4 octets + port). `None` = use the active slot's baked broker.
+    /// Stage 2: broker leg override (IPv4 octets + port). `None` = use the baked network's broker.
     pub broker: Option<([u8; 4], u16)>,
     /// Stage 2: the `broker` override was auto-disabled (N failed CONNACKs). Runtime uses the baked
     /// broker; `broker` is retained so DIAG shows `brk=fb` and CFG-`B` edge-triggers correctly.
@@ -1577,30 +1582,26 @@ fn parse_net_cfg(rec: &[u8]) -> Option<NetCfg> {
         return None;
     }
     let ver = rec[4];
-    if ver != 1 && ver != 2 {
+    // #142: accept v1 (Stage-1 core), v2 (#100 slot+overrides — MIGRATED), and v3 (#142 native).
+    // Anything else (or a rollback-written future version) → None → safe defaults.
+    if ver != 1 && ver != 2 && ver != 3 {
         return None;
     }
-    let (active, commanded, fb) = (rec[5], rec[6], rec[7]);
-    // Core complement + checksum guards (mirror the identity record) — present in v1 AND v2.
-    if rec[8] != active ^ 0xFF || rec[9] != (active ^ commanded ^ fb).wrapping_add(0x5A) {
+    // rec[5..8]: the slot bytes (active/commanded/fallback) in v1/v2, reserved-zero in v3. Read only
+    // to validate the core redundancy guards — this is what lets a PRE-#142 v2 record (nonzero slot
+    // bytes, valid checksum) still parse so its overrides survive the OTA. The values are DISCARDED
+    // (there is no slot concept any more): v2 is thereby migrated to the v3 in-RAM shape on read.
+    let (b5, b6, b7) = (rec[5], rec[6], rec[7]);
+    // Core complement + checksum guards (mirror the identity record) — present in v1, v2 AND v3.
+    if rec[8] != b5 ^ 0xFF || rec[9] != (b5 ^ b6 ^ b7).wrapping_add(0x5A) {
         return None;
     }
-    // Slot indices MUST be valid (< 2) and fallback a clean bool — else treat as corrupt.
-    if active > 1 || commanded > 1 || fb > 1 {
-        return None;
-    }
-    let core = NetCfg {
-        active,
-        commanded,
-        fallback: fb != 0,
-        broker: None,
-        broker_fallback: false,
-        ota_host: None,
-    };
     if ver == 1 {
-        return Some(core); // Stage-1 record: no overrides.
+        return Some(NetCfg::default()); // Stage-1 record: no overrides.
     }
-    // v2 ext: require the full record + a matching checksum/complement before trusting the overrides.
+    // v2/v3 ext: require the full record + a matching checksum/complement before trusting the
+    // overrides. (Identical ext layout in v2 and v3 — only the version byte + zeroed slots differ,
+    // so the same extraction migrates a v2 record and reads a v3 one.)
     if rec.len() < NET_REC_LEN || rec[23] != net_ext_checksum(rec) || rec[24] != rec[23] ^ 0xFF {
         return None;
     }
@@ -1615,22 +1616,27 @@ fn parse_net_cfg(rec: &[u8]) -> Option<NetCfg> {
         broker,
         broker_fallback: rec[11] == 1,
         ota_host,
-        ..core
     })
 }
 
-/// Encode the v2 net record (always written at [`NET_VERSION`] = 2). Absent overrides zero their
-/// present-flag + bytes so the record is deterministic; the ext checksum + complement close it.
-#[cfg(feature = "wifi")]
+/// Encode the v3 net record (#142 — always written at [`NET_VERSION`] = 3; slot bytes reserved-zero).
+/// Absent overrides zero their present-flag + bytes so the record is deterministic; the ext checksum
+/// + complement close it. Length stays 28 B (word-aligned; [25..28] pad outside the checksum).
+///
+/// #142: espnow-gated — only the CFG-`B`/`O` apply (mesh tier) writes the record now.
+#[cfg(feature = "espnow")]
 fn encode_net_cfg(c: NetCfg) -> [u8; NET_REC_LEN] {
     let mut r = [0u8; NET_REC_LEN];
     r[0..4].copy_from_slice(&NET_MAGIC);
     r[4] = NET_VERSION;
-    r[5] = c.active;
-    r[6] = c.commanded;
-    r[7] = c.fallback as u8;
-    r[8] = c.active ^ 0xFF;
-    r[9] = (c.active ^ c.commanded ^ c.fallback as u8).wrapping_add(0x5A);
+    // #142: the retired slot bytes [5..8] are reserved-zero; the core guards still checksum over
+    // them (0^0xFF at [8], (0^0^0)+0x5A at [9]) so the on-flash format is byte-identical to a
+    // pre-#142 record and `parse_net_cfg` accepts both without a version bump.
+    r[5] = 0;
+    r[6] = 0;
+    r[7] = 0;
+    r[8] = 0xFF;
+    r[9] = 0x5A;
     if let Some((ip, port)) = c.broker {
         r[10] = 1;
         r[12..16].copy_from_slice(&ip);
@@ -1663,12 +1669,15 @@ pub fn read_net_cfg() -> Option<NetCfg> {
     parse_net_cfg(&rec)
 }
 
-/// Persist the net selection (erase + write nvs sector 5). Best-effort — any error is swallowed
-/// (the in-RAM selection still governs THIS boot; the next boot retries). Sector 5 is the net
-/// record's OWN sector (segregated), so the erase+write can never touch identity/floor/boot-count.
-/// Called ONLY on a genuine change (CFG-`N` apply, or the ONE-per-boot fallback revert) — never in
-/// a retry loop, so no flash wear / NVS ping-pong even during a total-outage stay-put.
-#[cfg(feature = "wifi")]
+/// Persist the net overrides (erase + write nvs sector 5). Best-effort — any error is swallowed
+/// (the in-RAM value still governs THIS boot; the next boot retries). Sector 5 is the net record's
+/// OWN sector (segregated), so the erase+write can never touch identity/floor/boot-count. #142:
+/// called ONLY on a genuine CFG-`B`/`O` override change (the slot-switch + un-brick-fallback callers
+/// are retired) — never in a retry loop, so no flash wear / NVS ping-pong. This is also what upgrades
+/// a legacy v2 record to v3 in place, on the first real override change.
+/// #142: espnow-gated — only the CFG-`B`/`O` apply (mesh tier) writes; the wifi-tier writer (the
+/// retired #100 slot-fallback revert) is gone, so a wifi-only build carries no writer (dead-code-clean).
+#[cfg(feature = "espnow")]
 pub fn write_net_cfg(c: NetCfg) {
     use embedded_storage::nor_flash::NorFlash;
     let mut flash = FlashStorage::new();

--- a/rust/clock/src/secrets.rs.example
+++ b/rust/clock/src/secrets.rs.example
@@ -11,21 +11,22 @@
 //! repo is PUBLIC — real credentials must never be committed. Only the `wifi`
 //! and `espnow` feature builds read these (Phase 1 needs no WiFi).
 
-// --- #100 dual network slots (dashboard-switchable, un-brickable fallback) ----
-// Each slot is a full network identity: WiFi creds + the MQTT broker leg + the OTA
-// image-host allowlist. The ACTIVE slot is selected at RUNTIME (CFG key `N`, persisted
-// in NVS) and a failed association auto-reverts to the other slot (the un-brickable
-// fallback — a wrong selection self-heals without USB). Secrets NEVER cross MQTT; only
-// the slot INDEX is relayed. Slot 0 is the boot default.
+// --- #142 single network -------------------------------------------------------
+// The board runs ONE baked network: WiFi creds + the MQTT broker leg + the OTA
+// image-host allowlist. (#100's dual-slot machinery + the un-brickable slot fallback
+// were retired in #142 — a failed association just keeps retrying the primary; the
+// board is a fully-functional ESP-NOW mesh leaf meanwhile, never switched onto an
+// unwanted network.) Secrets NEVER cross MQTT. Runtime broker / OTA-host OVERRIDES
+// (CFG keys `B` / `O`, NVS-persisted) remain — they are independent of the network.
 
-/// One bakeable network slot. `broker_ip` MUST be the broker leg that is SAME-SUBNET as
+/// The bakeable network identity. `broker_ip` MUST be the broker leg that is SAME-SUBNET as
 /// this network's DHCP lease (the quad-homed-broker rule — a cross-VLAN leg drops CONNACK).
 /// `ota_hosts` is the OTA fetch allowlist for this network (defense-in-depth; the image is
 /// itself ed25519-gated). Plain-TCP Mosquitto (no TLS in no_std).
 pub struct NetSlot {
     pub ssid: &'static str,
     pub pass: &'static str,
-    /// Broker IPv4 as four octets (own-VLAN leg for THIS network).
+    /// Broker IPv4 as four octets (own-VLAN leg for this network).
     pub broker_ip: [u8; 4],
     /// Broker TCP port (Mosquitto default 1883, plain).
     pub broker_port: u16,
@@ -33,24 +34,14 @@ pub struct NetSlot {
     pub ota_hosts: &'static [&'static str],
 }
 
-/// The two baked network slots. Slot 0 = boot default; slot 1 = the alternate (e.g. the
-/// migration target). Real values live ONLY in the git-ignored `secrets.rs` — never commit them.
-pub const WIFI_NETWORKS: [NetSlot; 2] = [
-    NetSlot {
-        ssid: "YOUR_WIFI_SSID_0",
-        pass: "YOUR_WIFI_PASSWORD_0",
-        broker_ip: [10, 0, 0, 0],
-        broker_port: 1883,
-        ota_hosts: &["10.0.0.0"],
-    },
-    NetSlot {
-        ssid: "YOUR_WIFI_SSID_1",
-        pass: "YOUR_WIFI_PASSWORD_1",
-        broker_ip: [10, 0, 0, 0],
-        broker_port: 1883,
-        ota_hosts: &["10.0.0.0"],
-    },
-];
+/// The single baked network. Real values live ONLY in the git-ignored `secrets.rs` — never commit them.
+pub const WIFI_NETWORK: NetSlot = NetSlot {
+    ssid: "YOUR_WIFI_SSID",
+    pass: "YOUR_WIFI_PASSWORD",
+    broker_ip: [10, 0, 0, 0],
+    broker_port: 1883,
+    ota_hosts: &["10.0.0.0"],
+};
 
 // --- MQTT broker auth (shared across slots — same Mosquitto, same credentials) ----
 /// Broker username (anonymous auth is expected OFF → username + password required).


### PR DESCRIPTION
> **⚠️ HW-GATE-HELD** — do not merge until the canary checks below pass on the rig. Closes #142. Branch off main `3040b8c`. No flash/MQTT/mesh performed (fleet converged + asleep).

## What
Retire the #100 dual-slot network machinery (slot 1 + the assoc-fallback revert). Boards operate on the **single** baked network. A board whose primary association fails is a fully-functional **ESP-NOW mesh-only leaf** (mesh membership + relayed telemetry + mesh time) that keeps retrying the primary — it is **never** switched onto the secondary/roam SSID. Owner's call 2026-07-14; a persistent primary-assoc failure is a per-board TX/placement issue (#141), not a reason to leave the intended network.

## Changes
- **secrets.rs(.example):** `WIFI_NETWORKS[2]` → single `WIFI_NETWORK` (per-network `ota_hosts` kept).
- **net/wifi.rs:** `associate_slot`→`associate` (no slot); the assoc-fallback loop → retry-primary `ASSOC_ATTEMPTS`, then `None` = mesh-only this burst, retry next (no NVS write → zero flash wear); broker leg resolves the single network.
- **ota.rs `NetCfg`:** drop `active`/`commanded`/`fallback`; **KEEP** `broker`/`broker_fallback`/`ota_host` overrides (#100 S2/3, #116 — independent + load-bearing).
- **CFG `N`** (net-slot) retired — the apply handler drains + ignores a stale/retained `N`.
- **DIAG `net=`** frozen to the constant `1:ok` (keeps the HA dashboard's *positional* DIAG parse stable — **dashboard follow-up** needed to repurpose/drop the field).
- **docs/protocol.md:** CFG-`N` row, the NVS v3 record + migration table, DIAG `net=`.

## NVS migration (the load-bearing part)
The `NetCfg` NVS record is bumped **v2 → v3** (record stays 28 B, word-aligned; slot bytes `[5..8]` reserved-zero). `parse_net_cfg` migrates on read:
| stored record | → in-RAM |
|---|---|
| **v2** (pre-#142, slot bytes + overrides) | **keep broker/broker_fallback/ota_host; discard slot bytes** |
| v1 (Stage-1 core) | no overrides |
| v3 (native) | as written |
| unknown version / bad checksum / erased | `None` → safe defaults (single network, no overrides) |

No forced boot-time rewrite (flash wear): the **first genuine CFG-`B`/`O` change** upgrades a v2 record to v3 in place (verify-after-write gated). **This is required** — id7/id9 were never flash-erased tonight, so they carry v2 records that must keep their overrides across this OTA. Rollback posture preserved: a pre-#142 (v2-reader) fw reading a v3 record rejects it → safe default (same one-way as v1↔v2). `write_net_cfg`/`encode_net_cfg` are now `espnow`-gated (only the CFG-`B`/`O` apply writes).

## Canary checks (must pass before un-gating)
1. **v2-record board upgrades cleanly, overrides intact** — a board that was NOT flash-erased (id7/id9, carrying a v2 NetCfg) takes the OTA and its broker/OTA-host overrides still apply (DIAG `brk=`/`otah=` unchanged); no reset loop.
2. **Primary-assoc-fail board stays mesh-only + retries** — a board whose primary association fails at its spot (id5) keeps retrying the primary, never falls back to a second network, and remains a functional mesh leaf (relayed telemetry, mesh time) — no crash loop, no fallback write.
3. **Normal boards unaffected** across reboot + OTA + election cycles (single-legged broker selection).

## Verification (static)
- Full profile bar `clippy -D warnings` clean: default / wifi / espnow / cast / io / wled / espnow,cast,io.
- `cargo build --release --features espnow,cast,io` green — valid RISC-V ELF.

## Merge-order note
124b is concurrently on `feat/138-range-fetch` touching net/wifi.rs (fetch loop) — my regions (assoc/slot selection + NetCfg) are disjoint; coordinate merge order with the team-lead at merge time.

Refs #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
