### PR TITLE
feat(wifi): #140 grow heap 72→128 KiB + tune esp-wifi RX buffers (HW-gate held)

### DIFF
--- a/rust/clock/.cargo/config.toml
+++ b/rust/clock/.cargo/config.toml
@@ -39,3 +39,21 @@ build-std = ["core", "alloc"]
 
 [registries.crates-io]
 protocol = "sparse"
+
+# #140 esp-wifi RX-buffer tuning (heap-gated — see scratch/smol-ha-batt/140-heap-audit.md).
+# We ran esp-wifi 0.15's stock-low defaults (rx_queue 5 / static_rx 10 / dynamic_rx 32 / rx_ba_win 6),
+# which starve sustained RX and were a co-cause of the mid-body OTA-fetch stalls (nebula finding 3 /
+# esp-hosted #184). The bump is UNLOCKED by growing the heap 72→128 KiB (net::init_heap) — the audit
+# showed ~120 KB of DRAM free and only ~5.9 KB heap headroom at the old size, so tuning buffers on the
+# 72 KiB heap would OOM. Keys/ranges verified against esp-wifi 0.15's generated config table; each
+# static RX buffer ≈ 1.6 KB, allocated at esp_wifi::init from the (now-grown) esp-alloc heap.
+# HW-GATE-HELD: throughput/stability win only provable on the deaf-list/fetch rig (pairs with #143).
+[env]
+# 10→16: more 802.11 RX headroom (IDF throughput profile uses 16–25). +~9.6 KB permanent at init.
+ESP_WIFI_CONFIG_STATIC_RX_BUF_NUM = "16"
+# 32→40: on-demand ceiling; must be ≥ static_rx_buf_num. Freed as the TCP stack drains each frame.
+ESP_WIFI_CONFIG_DYNAMIC_RX_BUF_NUM = "40"
+# 5→8: deeper RX frame queue to ride short bursts without drop.
+ESP_WIFI_CONFIG_RX_QUEUE_SIZE = "8"
+# 6→12: bigger Block-Ack RX window for AMPDU throughput. MUST stay ≤ static_rx_buf_num (16). iperf 9–12.
+ESP_WIFI_CONFIG_RX_BA_WIN = "12"

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -117,13 +117,20 @@ pub use wifi::CFG_KEY_SCAN;
 pub use wifi::try_time_sync;
 
 /// Install esp-wifi's heap ONCE. esp-alloc declares the `#[global_allocator]`
-/// inside its own crate; this macro just adds a 72 KiB internal-RAM region to
-/// it (the size the esp-wifi C3 examples use). Defined here so both the Phase 2
-/// (`wifi`) and Phase 3 (`espnow`) code paths share a single heap region rather
-/// than each reserving their own.
+/// inside its own crate; this macro just adds an internal-RAM region to it.
+/// Defined here so both the Phase 2 (`wifi`) and Phase 3 (`espnow`) code paths
+/// share a single heap region rather than each reserving their own.
+///
+/// #140: grown 72 → 128 KiB. The gateway free-heap low-watermark bottomed at ~5.9 KB during crown
+/// duty (esp-wifi's static RX pool ≈16 KB + dynamic RX churn draw from THIS region), leaving no room
+/// to raise the RX buffers that fix the sustained-fetch stalls. The heap audit
+/// (scratch/smol-ha-batt/140-heap-audit.md) showed ~120 KB of the C3's 313 KiB DRAM window unused —
+/// so growing the heap is the safe unlock: it lifts the low-watermark to ~52 KB even after the
+/// #140 static-RX bump (.cargo/config.toml [env]). The region is uninit `.bss` in DMA-capable
+/// internal SRAM; 128 KiB keeps `.data`+`.bss` (~191 KB) well under the DRAM window before stack.
 #[cfg(feature = "wifi")]
 pub fn init_heap() {
-    esp_alloc::heap_allocator!(size: 72 * 1024);
+    esp_alloc::heap_allocator!(size: 128 * 1024);
 }
 
 /// Phase-1 (default) placeholder used when no radio features are enabled: the


### PR DESCRIPTION
Closes #140. Full audit: `scratch/smol-ha-batt/140-heap-audit.md`.

## Problem

The gateway free-heap low-watermark bottomed at **~5.9 KB** during crown duty. esp-wifi's static RX
pool (~16 KB) + dynamic RX churn draw from the single **72 KiB** esp-alloc region, so a sustained RX
burst (the OTA fetch, a heavy flush) starves the heap → dropped frames → stalled TCP (nebula's
research finding 3 / esp-hosted #184) — a co-cause of the mid-body fetch deaths (#138). Raising the
stock-low RX buffers is the fix, but on the 72 KiB heap it would OOM.

## Audit findings (what changed the plan)

- **Freeing mesh RAM pre-fetch is a non-lever** (the originally-hypothesised approach): ESP-NOW and
  WiFi share **one** `esp_wifi::init` controller (`Box::leak`'d; mode-switch only drops the
  association, never tears down); the relay caches are **stack-resident** (`RadioManager` is a stack
  local, not heap/`.bss`); the ESP-NOW peer table is a few hundred bytes. Net freeable heap ≈ **0 KB**.
- **~120 KB of the C3's 313 KiB DRAM window is unused.** The 72 KiB heap is conservative. **Growing
  the heap is the safe unlock.**

## Changes

- **`net::init_heap`: heap `72 → 128 KiB`** (+56 KiB). Lifts the low-watermark from ~5.9 KB to
  **~52 KB** even after the static-RX bump below. Uninit `.bss` in DMA-capable internal SRAM;
  measured `.data`+`.bss` ≈ **190 KB**, ~123 KB under the DRAM window before stack.
- **`.cargo/config.toml` `[env]`** — esp-wifi 0.15 esp-config (keys/ranges verified against the
  crate's generated config table):
  | key | default → new | note |
  |---|---|---|
  | `ESP_WIFI_CONFIG_STATIC_RX_BUF_NUM` | 10 → **16** | +~9.6 KB permanent at init (IDF profile 16–25) |
  | `ESP_WIFI_CONFIG_DYNAMIC_RX_BUF_NUM` | 32 → **40** | on-demand ceiling; ≥ static |
  | `ESP_WIFI_CONFIG_RX_QUEUE_SIZE` | 5 → **8** | deeper RX frame queue |
  | `ESP_WIFI_CONFIG_RX_BA_WIN` | 6 → **12** | AMPDU BA window; ≤ static_rx_buf_num (per the rec) |
- **No pre-fetch free-up code** — the audit shows it would free nothing (documented, not omitted).

## Verification (host + build only)

- `cargo build --release` on **default**, **espnow**, **espnow,cast,io** — all link clean.
- `cargo clippy --release --features espnow,cast,io -- -D warnings` — clean.
- ELF `.bss` grew **+56 KB** exactly as predicted (heap growth confirmed); total static RAM ≈ 190 KB,
  comfortably within the 313 KiB DRAM window on every profile (the base-RAM regression check nebula
  flagged).

## ⛔ MERGE GATE: HW rig canary pending hardware

Heap growth touches **every profile's base RAM**, and the RX-buffer win is only provable on air. Do
not merge on green alone. Canary one board:

1. A sustained OTA fetch completes with heap margin — DIAG `hmin` stays well above 0 through the
   whole transfer (the win: it used to bottom at ~5.9 KB).
2. No RAM regression / boot failure on `default` and `espnow,cast,io` (measure `hmin` on each).
3. **Instrument/observe the main-stack high-water alongside `hmin`** — growing the heap shrank the
   linker's main-stack region ~144 → ~88 KiB, so confirm peak stack depth stays comfortably inside
   88 KiB on the canary (the one budget residual that isn't build-measurable; see audit §6).
4. Pairs with **#143** (chunked HTTP-Range fetch) — together they should end the mid-body stalls.

## Review question

Heap growth is a broader change than the issue's "free mesh RAM before OTA" framing. The audit shows
that framing frees nothing here, so heap growth is the correct lever — but it's a base-RAM change to
every board. Comfortable with 128 KiB, or prefer a smaller step (e.g. 96 KiB) for the first canary?

Refs #138, #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
