### PR TITLE
fix(fw): #146 abdicate-on-flush-fail — a flush-incapable owner can no longer hold/drag the mesh [HW-GATE-HELD]

### DIFF
--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1440,6 +1440,17 @@ struct Relay {
     /// Consecutive failed flushes; past `FLUSH_FAILS_BEFORE_DROP` we shed the
     /// queue's oldest each failure so a dead-AP gateway drains + stops re-bursting.
     flush_fails: u8,
+    /// #146 CLAIM guard (abdicate-on-flush-fail latch): set when this board R-DEMOTES on
+    /// sustained flush failure (its WiFi uplink is PROVEN unable to complete a broker flush),
+    /// cleared only when a flush actually SUCCEEDS or this board adopts a live FOREIGN owner
+    /// (the mesh is healthy again). While set, the election resolver refuses to (re)claim the
+    /// crown — even this board's own stale retained `MC` record — so a marginal/RF-impaired
+    /// owner that can squeak a tiny election-burst CONNACK through (but never a full flush)
+    /// can NO LONGER perpetually re-grab its frozen `MC` after every R-DEMOTE (which reset
+    /// `flush_fails` and dragged the mesh across channels — issue #146). Leaf participation
+    /// stays fully intact; only the CLAIM is suppressed, so the H1/H2 machinery elects a
+    /// flush-capable board off the abdicated owner's frozen seq.
+    flush_fail_latch: bool,
     /// Recently-completed `(src_mac, msgid)` ring — dedup post-completion
     /// retransmits so a message is never enqueued (UDP-delivered) twice (finding 3).
     done: [Option<([u8; 6], u16)>; DONE_RING],
@@ -1476,6 +1487,7 @@ impl Relay {
             queue: [GwMsg::new(); GATEWAY_QUEUE],
             last_flush_ms: 0,
             flush_fails: 0,
+            flush_fail_latch: false, // #146: no abdication yet
             done: [None; DONE_RING],
             done_cursor: 0,
             seen: crate::net::flood::SeenSet::new(),
@@ -2136,6 +2148,12 @@ impl RadioManager {
         // budget is defined in whole seconds, so it's exact — and clippy-clean under -D warnings.
         elect.recovery_stale_floor_ms =
             RELAY_FLUSH_INTERVAL_MS + crate::net::wifi::RELAY_FLUSH_BUDGET.as_secs() * 1000;
+        // #146 CLAIM guard: if we abdicated on sustained flush failure, tell the resolver to
+        // participate as LEAF ONLY — never (re)claim the crown, not even our own stale retained
+        // `MC`. This is what makes R-DEMOTE STICK: without it, this very recovery burst would
+        // re-read `MC|<self>|…` (frozen seq) and re-grab ownership on a CONNACK that a tiny
+        // election publish can pass but a full flush cannot — the #146 churn/channel-drag loop.
+        elect.flush_incapable = self.relay.flush_fail_latch;
         // #6 OTA / #21 config / #33 install: a leaf's recovery burst can also surface these.
         let mut ota_offer: Option<crate::ota::Announce> = None;
         let mut config_offer: Option<crate::app::DefaultScreen> = None;
@@ -2225,6 +2243,16 @@ impl RadioManager {
         } else {
             // A LIVE owner holds the mesh (possibly a new lower id): stay leaf, re-scan.
             self.relay.is_gateway = false;
+            // #146 CLAIM guard clear: adopting a LIVE FOREIGN owner means the mesh is healthy
+            // again under a flush-capable board (it proved its uplink by publishing a fresh MC).
+            // Lift the abdication latch so we may compete normally if that owner later dies —
+            // the RSSI-weighted recovery stagger then de-prioritizes a weak-uplink survivor, and
+            // if we win again but still can't flush, R-DEMOTE simply re-latches us. Guarded on a
+            // DIFFERENT, ALIVE owner so our own suppressed self-record (owner_id == id) never
+            // clears the latch (that would re-open the loop).
+            if elect.owner_id != id && elect.owner_alive {
+                self.relay.flush_fail_latch = false;
+            }
             // #51 speed-up: grace-reset the owner-silence clock ONLY for a GENUINELY LIVE
             // owner (give the scan time to re-lock it). A dead-but-inside-our-backoff owner
             // (owner_alive == false) gets NO reset, so the next recovery burst fires on
@@ -4115,6 +4143,10 @@ impl RadioManager {
                 q.used = false;
             }
             self.relay.flush_fails = 0;
+            // #146 CLAIM guard: a flush SUCCEEDED → our uplink is proven able to reach the
+            // broker, so lift the abdication latch. Ownership is claimable again (this is the
+            // literal "no re-claim until a flush succeeds" clear).
+            self.relay.flush_fail_latch = false;
             log::info!("smol: relay flush done");
         } else {
             self.relay.flush_fails = self.relay.flush_fails.saturating_add(1);
@@ -4138,6 +4170,14 @@ impl RadioManager {
                 // HELLO-silent until we re-lock a new owner — otherwise our stale HELLO
                 // keeps the leaves pinned to us and no successor can ever be elected.
                 self.silent_until_relock = true;
+                // #146 CLAIM guard: LATCH the abdication. Going HELLO-silent alone was NOT
+                // enough — the next leaf recovery burst re-read our OWN stale retained `MC`
+                // (owner == node_id) and RE-CLAIMED the crown (resetting flush_fails, resuming
+                // HELLO, dragging the mesh across channels). The latch makes the election
+                // resolver refuse that self-reclaim until a flush actually succeeds or we adopt
+                // a live foreign owner — so a flush-incapable board stays leaf-only and the
+                // H1/H2 machinery elects a capable owner off our now-frozen `MC` seq.
+                self.relay.flush_fail_latch = true;
                 let _ = self.switch(Mode::EspNow);
                 log::warn!(
                     "smol: gateway DEMOTED after {} failed flushes — AP unreachable, HELLO-silent + leaf-scanning",

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -138,6 +138,14 @@ pub struct MeshElect {
     /// boot when the MC is empty or already names THIS board. Gateway-flush keeps `boot=false`
     /// so a running gateway's lowest-id split-brain resolution (#2) is unchanged.
     pub boot: bool,
+    /// #146 CLAIM guard: true iff the caller has LATCHED this board out of ownership because it
+    /// abdicated on sustained flush failure (`mode.rs` `flush_fail_latch`). When set, the resolver
+    /// refuses to (re)claim the crown in ANY arm — including re-grabbing this board's own stale
+    /// retained `MC` (the `owner == node_id` self-reclaim that defeated R-DEMOTE in issue #146) —
+    /// and leaves the record to freeze so a flush-capable board takes over. Leaf adoption of a live
+    /// owner is unaffected. Always false on boot/gateway-flush and for a healthy fleet (a board that
+    /// can flush is never latched), so this is a no-op on every path except a proven-incapable owner.
+    pub flush_incapable: bool,
     // --- outputs (applied to the live role by the caller) ---
     /// True iff I claimed / hold ownership (I am the coexist gateway).
     pub i_am_owner: bool,
@@ -164,6 +172,7 @@ impl MeshElect {
             owner_never_heard: false,
             recovery_stale_floor_ms: 0, // #136: seeded by the caller on a recovery election
             boot: false,
+            flush_incapable: false, // #146: seeded by the caller from the flush-fail abdication latch
             i_am_owner: false,
             owner_id: my_id,
             owner_alive: false,
@@ -2951,6 +2960,25 @@ fn mqtt_session(
             elect.owner_id = node_id;
             Some(1)
         }
+    };
+    // #146 CLAIM guard: a board that abdicated on sustained flush failure (its WiFi uplink is
+    // PROVEN unable to complete a broker flush) must participate as LEAF ONLY — it may adopt an
+    // owner but must never (re)claim the crown, not even its own stale retained `MC`. Suppress the
+    // claim HERE, before any MC publish, so the retained record is left to FREEZE and the H1/H2
+    // takeover machinery elects a flush-capable board off that frozen seq. `i_am_owner == true`
+    // iff `claim_seq.is_some()` on every arm above, so clearing it here is exactly the claim set.
+    // Composes with #137: a live, actively-FLUSHING owner is never latched (its flushes succeed →
+    // the latch is clear), so this is a no-op for a healthy fleet — zero behavior change.
+    let claim_seq = if elect.flush_incapable {
+        if claim_seq.is_some() {
+            elect.i_am_owner = false;
+            log::warn!(
+                "smol: #146 election — flush-incapable, refusing to claim (leaf-only until a flush succeeds)"
+            );
+        }
+        None
+    } else {
+        claim_seq
     };
     if let Some(newseq) = claim_seq {
         // Record my own ownership locally so my seq counts as "fresh" next read, then


### PR DESCRIPTION
Closes #146.

## Problem
A WiFi-incapable / RF-impaired board could **claim** mesh ownership and **hold** it while never completing a single broker flush (`fok=0`): the mesh lost its uplink and its broker→mesh command path, and the crown **dragged the fleet across channels** (live rig incident, 2026-07-15).

## Root cause
The **HOLD guard already existed** — R-DEMOTE abdicates a gateway after `FLUSH_FAILS_BEFORE_DEMOTE` (3) failed flushes (`is_gateway=false`, HELLO-silent). But abdication **did not stick**. The `#51-A2` CLAIM-AFTER-PUBLISH gate only requires a *tiny* retained-`MC` publish to reach the broker — which a marginal board can pass even when a *full* telemetry flush cannot. So the abdicated board re-read its **own frozen `MC`** (`owner == node_id` arm) on the very next leaf recovery burst and **re-claimed**, resetting `flush_fails`, resuming HELLO, and re-dragging the channel. A tight self-reclaim loop no HOLD guard alone can break.

## Fix — the missing CLAIM guard, composed with the existing machinery
- **`mode.rs`**: new `Relay.flush_fail_latch`.
  - **SET** in the R-DEMOTE branch (alongside `silent_until_relock`).
  - **CLEAR** when a flush **succeeds** (the literal *"no re-claim until a flush succeeds"*), or when a leaf recovery **adopts a live foreign owner** (mesh healthy again under a capable board).
  - Seeded into the recovery `MeshElect`.
- **`wifi.rs`**: new `MeshElect.flush_incapable`. The election resolver **suppresses the claim in every arm, before any `MC` publish**, when latched → the retained record is left to **freeze**, and the existing H1/H2 takeover machinery elects a flush-capable board off that frozen seq.

Leaf participation is fully intact — only the **claim** is suppressed.

### Composition / safety
- **#137 floor intact**: a live, actively-*flushing* owner is never latched (its flushes succeed → latch clears), so "live owner" now means **flushing**, not merely HELLOing.
- **Zero behavior change for a healthy fleet (by construction)**: every new branch is gated on the latch, which a board that can flush never sets.
- **#142-aware**: composes with the mesh-only-leaf posture; the latch is runtime-only (no NVS write, zero flash wear) → a reboot/reflash of a cured board re-enables claiming.

## Bar (green)
- `cargo clippy --release --features espnow,cast,io -- -D warnings` — clean
- `cargo build --release --features espnow,cast,io` — green (2.24 MB ELF)
- default feature-free `cargo build --release` — green

## ⚠️ HW-GATE-HELD — HW canary (do NOT merge until run on the rig)
- [ ] **(a) Abdication sticks + capable takeover, no drag** — force an owner into flush-failure (deaf-to-AP rig or unplugged AP). It abdicates within ~N flush intervals, a **capable board takes over**, and there is **no channel drag** (no ch6→ch11 hunt). The abdicated board stays leaf-only and does **not** re-grab its own frozen `MC`.
- [ ] **(b) Healthy fleet unchanged** — a healthy fleet shows **zero behavior change** across reboots/elections (never latches).
- [ ] **(c) Composes with #137** — a live owner at a budget-edge re-assoc flush (seq still advancing) is **not** taken over and is **never** latched.

## Blast radius
- `rust/clock/src/net/mode.rs` — `Relay` struct + ctor; `maybe_leaf_reelect` (seed + clear); `flush_result` (set on R-DEMOTE, clear on success). Callers: the leaf recovery + gateway flush paths.
- `rust/clock/src/net/wifi.rs` — `MeshElect` struct + ctor; the `mqtt_session` election resolver (one suppression gate before the publish block). Gateway-flush/boot paths pass `flush_incapable=false` → unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)