### PR TITLE
feat(fw): #153 retire the syncing overlay — live screen persists, 1-px OTA progress edge [HW-GATE-HELD]

### DIFF
--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -511,25 +511,18 @@ fn main() -> ! {
 
     #[cfg(feature = "espnow")]
     let (mut radio, synced) = {
-        // #20 (1b): responsive BOOT tick — runs inside every busy-wait loop of the
-        // NTP/MQTT burst. LED fast-blink (as before) + a throttled "Syncing…"
-        // spinner (only AFTER the splash minimum, so the identity splash still
-        // shows) + a LONG-PRESS abort that LATCHES (once `boot_abort` is set the
-        // closure returns true forever, so the burst unwinds fast and boot proceeds
-        // straight to the Menu). Built here so the radio module stays UI-agnostic.
-        let mut boot_draw_ms = 0u64;
+        // #20 (1b) / #153: responsive BOOT tick — runs inside every busy-wait loop of the
+        // NTP/MQTT burst. LED fast-blink (as before) + a LONG-PRESS abort that LATCHES (once
+        // `boot_abort` is set the closure returns true forever, so the burst unwinds fast and
+        // boot proceeds straight to the Menu). #153 retired the "Syncing…" spinner: at boot
+        // there is no app frame yet, so the identity SPLASH simply persists on the glass for
+        // the burst (nothing overdraws it). Built here so the radio module stays UI-agnostic.
         let mut boot_abort = false;
         let mut boot_tick = || {
             let now = millis();
             led.apply(led::LedState::WifiSync, now);
             if matches!(button.poll(now), Some(input::Press::Long)) {
                 boot_abort = true;
-            }
-            if now.saturating_sub(splash_start) >= SPLASH_MIN_MS
-                && now.saturating_sub(boot_draw_ms) >= SYNC_REDRAW_MS
-            {
-                boot_draw_ms = now;
-                draw_syncing(&mut display, (now / SYNC_REDRAW_MS) as u8);
             }
             boot_abort
         };
@@ -760,17 +753,14 @@ fn main() -> ! {
             // blocks for the association, so it drives the SAME responsive tick as a
             // flush (LED + throttled spinner + latching long-press abort).
             {
-                let mut reelect_draw_ms = 0u64;
                 let mut reelect_abort = false;
+                // #153: re-election is a routine burst → draw NOTHING; the last app frame
+                // stays frozen on the glass (a still clock beats a spinner). LED + abort only.
                 if r.maybe_leaf_reelect(&mut batt_cache, &mut grid_cache, now, &mut || {
                     let t = millis();
                     led.apply(led::LedState::WifiSync, t);
                     if matches!(button.poll(t), Some(input::Press::Long)) {
                         reelect_abort = true;
-                    }
-                    if t.saturating_sub(reelect_draw_ms) >= SYNC_REDRAW_MS {
-                        reelect_draw_ms = t;
-                        draw_syncing(&mut display, (t / SYNC_REDRAW_MS) as u8);
                     }
                     reelect_abort
                 }) {
@@ -802,6 +792,10 @@ fn main() -> ! {
                 if let Some(announce) = r.take_ota_offer() {
                     let mut ota_draw_ms = 0u64;
                     let mut ota_abort = false;
+                    // #153: OTA self-install is minutes-scale → keep the frozen app frame and
+                    // paint only a 1-px bottom progress edge from the live byte counts the
+                    // fetch writes into `ota_prog` (throttled to SYNC_REDRAW_MS like the old spinner).
+                    let ota_prog = core::cell::Cell::new(ota::OtaProgress::default());
                     r.run_ota_update(&announce, &mut || {
                         let t = millis();
                         led.apply(led::LedState::WifiSync, t);
@@ -810,10 +804,11 @@ fn main() -> ! {
                         }
                         if t.saturating_sub(ota_draw_ms) >= SYNC_REDRAW_MS {
                             ota_draw_ms = t;
-                            draw_syncing(&mut display, (t / SYNC_REDRAW_MS) as u8);
+                            let p = ota_prog.get();
+                            draw_ota_edge(&mut display, p.done, p.total);
                         }
                         ota_abort
-                    });
+                    }, &ota_prog);
                     redraw = true;
                 }
             }
@@ -1113,18 +1108,12 @@ fn main() -> ! {
                     #[cfg(feature = "coexist-soak")]
                     let (_, soak_rx0, soak_lost0, _) = r.soak_counts();
                     let mut flush_abort = false;
-                    let mut flush_draw_ms = 0u64;
-                    // #30: draw the sync spinner ONLY on the idle Clock face. The flush is
-                    // sub-second and already deferred until >= FLUSH_IDLE_MS of no input (the #20
-                    // idle-defer above), so the user is never mid-navigation when it fires — the
-                    // one residual is the overlay flashing over whatever screen was LEFT on display
-                    // (e.g. a static Home menu). Suppressing it everywhere but the Clock lets that
-                    // frame simply hold for the sub-second flush (the render loop repaints after),
-                    // while the Clock — the ambient idle face — keeps its expected brief sync glyph.
-                    // The LED WifiSync cue below still fires on every screen (non-disruptive). This
-                    // retires the visible #20/#30 residual WITHOUT touching the HW-proven flush poll
-                    // (the cooperative/non-blocking-poll rewrite is filed separately, HW-canary-gated).
-                    let show_sync = matches!(app, App::Clock(_));
+                    // #153: telemetry flush is a routine sub-second burst → draw NOTHING; the
+                    // last app frame (any screen) simply holds for its duration and the render
+                    // loop repaints after. Retires the #20/#30 residual overlay entirely (the
+                    // old Clock-only `show_sync` heuristic is gone). LED WifiSync cue + latching
+                    // long-press abort below are unchanged. The HW-proven flush poll is untouched
+                    // (the cooperative/non-blocking-poll rewrite stays filed separately, #89).
                     // #40: a flush that hears a leaf's retained OTA install surfaces
                     // `(leaf_id, staged announce)` here → relayed below.
                     let mut leaf_ota: Option<(u8, ota::Announce)> = None;
@@ -1133,10 +1122,6 @@ fn main() -> ! {
                         led.apply(led::LedState::WifiSync, t);
                         if matches!(button.poll(t), Some(input::Press::Long)) {
                             flush_abort = true;
-                        }
-                        if show_sync && t.saturating_sub(flush_draw_ms) >= SYNC_REDRAW_MS {
-                            flush_draw_ms = t;
-                            draw_syncing(&mut display, (t / SYNC_REDRAW_MS) as u8);
                         }
                         flush_abort
                     });
@@ -1164,6 +1149,10 @@ fn main() -> ! {
                         if let Some(mac) = r.mac_for_id_sticky(leaf_id) {
                             let mut relay_draw_ms = 0u64;
                             let mut relay_abort = false;
+                            // #153: leaf-feed relay is minutes-scale → keep the frozen app frame
+                            // and paint the 1-px bottom progress edge (fetch bytes then ESP-NOW
+                            // chunk windows, both written into `relay_prog` by run_leaf_ota_relay).
+                            let relay_prog = core::cell::Cell::new(ota::OtaProgress::default());
                             let outcome = r.run_leaf_ota_relay(leaf_id, mac, &ann, &mut || {
                                 let t = millis();
                                 led.apply(led::LedState::WifiSync, t);
@@ -1172,10 +1161,11 @@ fn main() -> ! {
                                 }
                                 if t.saturating_sub(relay_draw_ms) >= SYNC_REDRAW_MS {
                                     relay_draw_ms = t;
-                                    draw_syncing(&mut display, (t / SYNC_REDRAW_MS) as u8);
+                                    let p = relay_prog.get();
+                                    draw_ota_edge(&mut display, p.done, p.total);
                                 }
                                 relay_abort
-                            });
+                            }, &relay_prog);
                             // #40: record the phase → published to smol/<leaf>/ota/diag on the
                             // next burst + drives the install clear/retry policy.
                             r.record_leaf_ota(leaf_id, outcome);
@@ -1629,40 +1619,36 @@ where
 }
 
 /// #20: the "Syncing WiFi" indicator shown while a WiFi burst blocks the loop
-/// (boot NTP burst + gateway flush). An animated spinner (`|/-\`) so the freeze
-/// reads as intentional progress, plus a `hold=menu` hint for the long-press
-/// abort. Takes the concrete [`app::Oled`] and flushes itself (unlike
-/// `draw_splash`). espnow-only — the only builds with the blocking flush + abort
-/// path, so default/wifi stay untouched.
+/// #153: the 1-px OTA progress edge along the display's BOTTOM row — the minimal feedback
+/// that replaced the retired full-screen `draw_syncing` spinner. Unlike the spinner it does
+/// NOT clear the framebuffer: the frozen last app frame stays visible above, and only row
+/// `y = H-1` is repainted (Off across the full width, then On for the completed fraction)
+/// before flushing. `done`/`total` are the transfer counts the fetch/relay writes into the
+/// shared [`ota::OtaProgress`] cell — bytes for a self-fetch, chunks for a leaf relay; only
+/// the ratio is rendered. `total == 0` (op just armed) → an empty edge. The long-press abort
+/// is unadvertised now (issue #153) but still live. espnow-only, matching the blocking OTA
+/// path, so default/wifi builds stay untouched.
 #[cfg(feature = "espnow")]
-fn draw_syncing(display: &mut app::Oled, frame: u8) {
-    let big = MonoTextStyleBuilder::new()
-        .font(&FONT_6X10)
-        .text_color(BinaryColor::On)
-        .build();
-    let small = MonoTextStyleBuilder::new()
-        .font(&FONT_5X8)
-        .text_color(BinaryColor::On)
-        .build();
-    display.clear(BinaryColor::Off).ok();
-    // "Sync <spinner>" — motion is visible even while the single radio is busy and
-    // the rest of the UI can't advance.
-    let spin = [b'|', b'/', b'-', b'\\'][(frame & 3) as usize];
-    let head = [b'S', b'y', b'n', b'c', b' ', spin];
-    Text::with_baseline(
-        core::str::from_utf8(&head).unwrap_or("Sync"),
-        Point::new(2, 3),
-        big,
-        Baseline::Top,
-    )
-    .draw(display)
-    .ok();
-    Text::with_baseline("WiFi...", Point::new(2, 16), big, Baseline::Top)
+fn draw_ota_edge(display: &mut app::Oled, done: u32, total: u32) {
+    use embedded_graphics::primitives::{Line, PrimitiveStyle};
+    let bb = display.bounding_box();
+    let w = bb.size.width as i32;
+    let y = bb.size.height as i32 - 1;
+    // Erase the bottom row only (the app frame above is left intact), then paint the
+    // completed fraction. The erase keeps it correct even if a resume lowers the count.
+    Line::new(Point::new(0, y), Point::new(w - 1, y))
+        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::Off, 1))
         .draw(display)
         .ok();
-    Text::with_baseline("hold=menu", Point::new(2, 31), small, Baseline::Top)
-        .draw(display)
-        .ok();
+    if total > 0 && done > 0 {
+        let filled = ((done.min(total) as u64 * w as u64) / total as u64) as i32;
+        if filled > 0 {
+            Line::new(Point::new(0, y), Point::new(filled - 1, y))
+                .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+                .draw(display)
+                .ok();
+        }
+    }
     display.flush().ok();
 }
 

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -3283,6 +3283,8 @@ impl RadioManager {
         &mut self,
         announce: &crate::ota::Announce,
         tick: &mut dyn FnMut() -> bool,
+        // #153: forwarded to the fetch so `main`'s tick can paint the OTA progress edge.
+        progress: &core::cell::Cell<crate::ota::OtaProgress>,
     ) -> bool {
         log::info!("smol OTA: opening update burst (mesh deaf for the whole download)");
         let _ = self.switch(Mode::WifiSta);
@@ -3295,6 +3297,7 @@ impl RadioManager {
                 // unused since a successful self-fetch reboots inside `activate`).
                 crate::net::wifi::run_ota_fetch(
                     &mut self.controller, sta, rng, announce, tick, false, &mut None, &mut fail,
+                    progress,
                 )
             }
         };
@@ -3397,6 +3400,9 @@ impl RadioManager {
         leaf_mac: [u8; 6],
         announce: &crate::ota::Announce,
         tick: &mut dyn FnMut() -> bool,
+        // #153: written during the fetch (bytes) then the ESP-NOW push (chunks) so `main`'s
+        // relay tick can paint the 1-px bottom progress edge over the frozen app frame.
+        progress: &core::cell::Cell<crate::ota::OtaProgress>,
     ) -> crate::ota_mesh::LeafOtaOutcome {
         use crate::ota_mesh::{
             self as om, LeafOtaOutcome, CHUNK_PAYLOAD, WINDOW_BYTES, WINDOW_CHUNKS,
@@ -3501,6 +3507,7 @@ impl RadioManager {
         let fetched = match self.sta.as_mut() {
             Some(sta) => crate::net::wifi::run_ota_fetch(
                 &mut self.controller, sta, rng, announce, tick, true, &mut staged, &mut None,
+                progress,
             ),
             None => false,
         };
@@ -3636,6 +3643,8 @@ impl RadioManager {
             if tick() {
                 return LeafOtaOutcome::Aborted;
             }
+            // #153: surface leaf-feed chunk progress for the UI tick's bottom edge.
+            progress.set(crate::ota::OtaProgress { done: wb, total });
             let wlen_chunks = core::cmp::min(WINDOW_CHUNKS as u32, total - wb);
             let window_off = wb * CHUNK_PAYLOAD as u32;
             let window_bytes = core::cmp::min(WINDOW_BYTES as u32, size - window_off) as usize;

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -3736,6 +3736,10 @@ pub fn run_ota_fetch(
     // the ONLY fleet-visible signal of WHY a self-fetch failed.
     // #147: 5th field = the `ota_fail::*` code pinning the exact stage that died.
     fail: &mut Option<(u32, u32, u32, u32, u32)>,
+    // #153: written each chunk so `main`'s OTA tick can paint the 1-px bottom progress
+    // edge (bytes downloaded / image size). UI-agnostic: net/ only sets the counts, the
+    // display lives in `main`. Shared by self-OTA and the gateway's relay-fetch phase.
+    progress: &core::cell::Cell<crate::ota::OtaProgress>,
 ) -> bool {
     let Some((host, port, path)) = crate::ota::split_url(announce.url()) else {
         log::error!("smol OTA: malformed announce URL — aborting fetch");
@@ -3886,6 +3890,8 @@ pub fn run_ota_fetch(
         // caller publishes it retained to smol/<id>/ota/diag — release images are serial-silent, so
         // this is the fleet-visible why).
         *fail = Some((writer.written() / OTA_CHUNK, chunk_n, chunk_retries, stall, fail_point));
+        // #153: surface live byte progress for the UI tick's bottom edge.
+        progress.set(crate::ota::OtaProgress { done: writer.written(), total: announce.size });
         if tick() {
             log::warn!("smol OTA: aborted by long-press (slot untouched)");
             return false;

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -112,6 +112,17 @@ const fn parse_u32(s: &str) -> u32 {
 /// A parsed retained OTA announce: `OTA|build|size|sha256hex|url`. OWNED (the URL is
 /// copied into a fixed buffer) so it can be stashed between the burst that READS it
 /// and the burst that FETCHES it, without borrowing the MQTT receive buffer.
+/// #153: OTA transfer progress surfaced to the UI so `main`'s tick can paint the 1-px
+/// bottom progress edge that replaced the retired full-screen syncing overlay. `done`/
+/// `total` are bytes (self-fetch) or chunks (leaf relay) — the renderer only needs the
+/// ratio. Threaded as a `&Cell<OtaProgress>` into the fetch/relay so the UI-agnostic
+/// `net/` layer writes the counts without ever touching the display.
+#[derive(Clone, Copy, Default)]
+pub struct OtaProgress {
+    pub done: u32,
+    pub total: u32,
+}
+
 #[derive(Clone, Copy)]
 pub struct Announce {
     pub build: u32,


### PR DESCRIPTION
Closes #153.

The full-screen "Syncing WiFi" spinner that took over the display during every radio burst is retired (JP directive 2026-07-15). Boards keep showing their normal screen during routine bursts; only minutes-scale OTA gets minimal feedback.

## Behaviour
| Burst | Before | After |
|---|---|---|
| Boot NTP (~529) | spinner | **identity splash persists** (no app frame yet) |
| Re-election (~771) | spinner | **draw nothing** — last app frame frozen |
| Telemetry flush (~1137) | spinner (Clock only) | **draw nothing** — any screen frozen |
| Self-OTA install (~811) | spinner | **1-px bottom progress edge** over the frozen frame |
| Leaf-relay feed (~1173) | spinner | **1-px bottom progress edge** (fetch bytes → relay chunks) |

A clock frozen for a sub-second flush beats a spinner flashing five times a minute; the minutes-scale OTA is the only thing that earns feedback, and it's one pixel tall.

## How the progress edge works
- **Side-channel**: a `Cell<OtaProgress { done, total }>` (in `ota.rs`) threaded UI-agnostically into `run_ota_fetch` (bytes downloaded) and `run_leaf_ota_relay`'s window feed (chunks pushed). `net/` only ever writes the counts; the display stays in `main`.
- **`draw_ota_edge`** (replaces `draw_syncing`): erases *only* the bottom row (the frozen app frame above is untouched), then fills the completed fraction along `y = H-1`. `total == 0` (op just armed) → empty edge (idle sentinel).
- **Reset semantics**: a fresh per-op `Cell` = reset-at-start is inherent; at terminal the resuming render loop repaints over the edge. No global mutable state.
- Throttled to the same `SYNC_REDRAW_MS` cadence the old spinner used, so the OTA-path timing is unchanged.

## Scope / relation to #89
UX retirement only — the bursts still **block** (the frame freezes rather than animating). #89 (non-blocking flush state machine) remains the structural fix and stays deferred; this issue deliberately does not touch scheduling. Long-press abort during OTA is unchanged (just no longer advertised by a spinner).

## Provenance
Originated by morpheus-ops (the `Cell` out-param design + all five call sites) before it hit its session limit; **completed and bar-verified** in this lane. Kept the `Cell` approach over a global `AtomicU16` static — identical behaviour, cleaner (no global state, per-op reset). Reconciliation flagged to the team-lead.

## Bar (green)
- `cargo clippy --release --features espnow,cast,io -- -D warnings` — clean
- `cargo build --release --features espnow,cast,io` — green (2.24 MB ELF)
- default feature-free `cargo build --release` — green

## ⚠️ HW-GATE-HELD — HW canary (do NOT merge until run on the rig)
- [ ] **Clock face persists through a flush** — trigger a telemetry flush; the clock (or whatever screen is up) stays frozen on the glass, **no spinner**, and repaints normally after.
- [ ] **OTA shows only the bottom edge** — a self-OTA install (and a leaf-relay feed) shows the app frame frozen with a 1-px bottom edge that grows toward full width as the transfer progresses.
- [ ] **Abort still works** — a long-press during an OTA still aborts (unadvertised).
- [ ] **No burst-duration regression** — flush/OTA timings unchanged vs the spinner build.

## Blast radius
- `main.rs` — 5 call sites (3 draw-nothing, 2 progress-edge) + `draw_syncing`→`draw_ota_edge`.
- `net/wifi.rs` `run_ota_fetch` + `net/mode.rs` `run_ota_update`/`run_leaf_ota_relay` — one `progress` param each + logic-free `.set()` taps (the OTA download path; no behavior change).
- `ota.rs` — the `OtaProgress` struct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)