### PR TITLE
fix(fw): #172 bare-wifi tier passes clippy -D warnings (silence espnow-only dead code)

### DIFF
--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -17,6 +17,10 @@ mod wifi;
 /// WiFi driver — called at radio init and re-asserted beside every #139 `PowerSaveMode::None`
 /// assert (a driver stop/start resets it; connect() does not).
 #[cfg(feature = "wifi")]
+// #172: a wifi-layer TX-power clamp, but every caller today is on an espnow-gated path
+// (run_mqtt_burst / run_ota_fetch / mode). Keep it available in wifi builds; silence
+// dead-code in a wifi-without-espnow build so `clippy --features wifi -D warnings` passes.
+#[cfg_attr(not(feature = "espnow"), allow(dead_code))]
 pub(crate) fn assert_max_tx_power() {
     const MAX_TX_POWER_QDBM: i8 = 34; // 8.5 dBm x 4 (quarter-dBm units)
     let err = unsafe { esp_wifi_sys::include::esp_wifi_set_max_tx_power(MAX_TX_POWER_QDBM) };

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -117,6 +117,11 @@ const fn parse_u32(s: &str) -> u32 {
 /// `total` are bytes (self-fetch) or chunks (leaf relay) — the renderer only needs the
 /// ratio. Threaded as a `&Cell<OtaProgress>` into the fetch/relay so the UI-agnostic
 /// `net/` layer writes the counts without ever touching the display.
+// #172: constructed only on the espnow OTA fetch/relay paths (run_ota_fetch / mode /
+// main's OTA closures — all cfg(espnow)); keep the type in every build but silence
+// dead-code in a wifi-without-espnow build, matching the `Announce` field idiom below.
+// Lets `clippy --features wifi -D warnings` pass on all tiers.
+#[cfg_attr(not(feature = "espnow"), allow(dead_code))]
 #[derive(Clone, Copy, Default)]
 pub struct OtaProgress {
     pub done: u32,


### PR DESCRIPTION
Closes #172.

## Problem
`cargo clippy --features wifi -- -D warnings` failed on main: `assert_max_tx_power` (#141) and `OtaProgress` (#153) are constructed/used only on **espnow-gated** paths (`run_mqtt_burst` / `run_ota_fetch` / `net/mode` / main's OTA closures — all `cfg(espnow)`), so a wifi-**without**-espnow build reports them dead. Pre-existing (confirmed on pristine 431bd5b); surfaced during #89 Stage 1 gating.

## Fix
`#[cfg_attr(not(feature = "espnow"), allow(dead_code))]` on both defs — the **same idiom the adjacent `Announce` struct already uses** (ota.rs) for its espnow-only-read fields. Keeps the items present in every build (no broken type-refs / derives / doc-links); silences the lint only in a wifi-without-espnow build. Clippy itself suggested this form.

## Zero runtime impact
In an espnow build the `cfg_attr` predicate is false → no attribute applied → the **deployed fleet image is unaffected** (cfg-identical). This is a CI/hygiene fix only — **not HW-gated**, safe to merge without a canary.

## Gate (pinned rustc 1.96.1, katana)
clippy `-D warnings` now **green on all tiers**: `wifi` (the previously-failing one), `espnow,cast,io`, and default; default + wifi release builds green. Diff: 2 files, +9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)