### PR TITLE
fix: #159 sync mesh-model to meshscope's raw-u8 RSSI decode (+ HA-parity consts)

### DIFF
--- a/rust/viz/mesh-model/src/model.rs
+++ b/rust/viz/mesh-model/src/model.rs
@@ -1,15 +1,31 @@
-//! The shared world model. The MQTT thread folds every retained/live `smol/#`
-//! payload into this via [`Model::ingest`]; the egui frame reads it under the lock.
-//! `ingest` is pure w.r.t. the clock — it takes `now_s` — so it is unit-testable and
-//! demo-seedable with synthetic timelines.
+//! The shared world model — the **liftable `mesh-model` core**. Together with
+//! `parse.rs` + `names.rs` this is a closed, UI-free / MQTT-free module set (it
+//! references only `crate::parse` / `crate::names`, and no eframe/rumqttc type
+//! crosses this boundary), so it lifts VERBATIM into a standalone `mesh-model` lib
+//! crate that #159 (observatory) can also depend on — per
+//! docs/superpowers/specs/2026-07-18-mesh-visualizers-design.md ("one model, two
+//! faces"). Inlined here per team-lead direction; structured to lift.
+//!
+//! The MQTT thread folds every retained/live `smol/#` payload in via
+//! [`Model::ingest`]; a frontend reads the state each frame. `ingest` is pure w.r.t.
+//! the clock (takes `now_s`), so it is unit-testable and demo-seedable.
 
 use std::collections::{BTreeMap, VecDeque};
 
 use crate::names;
 use crate::parse::{self, Diag, OtaState, PeerLink};
 
-/// Node considered stale (dimmed) after this many seconds without any message.
-pub const STALE_S: f64 = 90.0;
+// --- Semantic thresholds — the SINGLE SOURCE OF DERIVATION TRUTH (HA parity) ---
+// Every derived signal is defined ONCE here; the HA dashboard mirrors these (and
+// vice-versa) — the bidirectional-parity rule in the spec. Change a threshold here
+// → update HA to match.
+/// A node fades to "stale" after this long without any message (~1.5 flush cycles).
+pub const STALE_S: f64 = 45.0;
+/// A link at or weaker than this dBm is a "weak link" (dashed in the graph).
+pub const WEAK_LINK_DBM: i32 = -80;
+/// Free heap at or below this many bytes is "low heap" (flagged).
+pub const LOW_HEAP_B: u64 = 20_000;
+
 const HIST_CAP: usize = 240; // ~ retained cadence * this = tens of minutes of trail
 const EVENT_CAP: usize = 300;
 

--- a/rust/viz/mesh-model/src/parse.rs
+++ b/rust/viz/mesh-model/src/parse.rs
@@ -52,6 +52,20 @@ pub fn split_node_topic(topic: &str) -> Option<(u8, &str)> {
     Some((id, suffix))
 }
 
+/// The firmware serializes a peer's ESP-NOW RSSI as the **raw `u8`** byte from
+/// `rx_control.rssi` (esp-wifi reports it unsigned), so a real `-41 dBm` arrives on
+/// the wire as `215`. Reinterpret any 128..=255 value as the signed byte it is;
+/// genuine negatives / zero / small values pass through. RSSI in dBm is never
+/// positive, so this is lossless for every real reading (-128..-1 ↔ 128..255).
+/// Confirmed against live `smol/5/peers` = `8,215,…` (id8 at -41 dBm).
+pub fn normalize_rssi(v: i32) -> i32 {
+    if (128..=255).contains(&v) {
+        v - 256
+    } else {
+        v
+    }
+}
+
 /// Parse `PEERS|<role>|<ch>|id,rssi,age,ch,flags;...`. An empty payload (retained
 /// clear on demotion) yields `None`; the caller treats that as "drop this node's edges".
 pub fn parse_peers(payload: &str) -> Option<PeersRecord> {
@@ -65,7 +79,7 @@ pub fn parse_peers(payload: &str) -> Option<PeersRecord> {
     for rec in body.split(';').filter(|s| !s.is_empty()) {
         let mut f = rec.split(',');
         let id: u8 = f.next()?.parse().ok()?;
-        let rssi: i32 = f.next()?.parse().ok()?;
+        let rssi: i32 = normalize_rssi(f.next()?.parse().ok()?);
         let age_s: u32 = f.next()?.parse().ok()?;
         let ch: u8 = f.next()?.parse().ok()?;
         let flags: u8 = f.next()?.parse().ok()?;
@@ -180,6 +194,20 @@ mod tests {
         assert_eq!(p.links.len(), 2);
         assert_eq!(p.links[0], PeerLink { id: 8, rssi: -55, age_s: 2, channel: 6, connected: true, has_mesh_time: true });
         assert_eq!(p.links[1], PeerLink { id: 9, rssi: -72, age_s: 14, channel: 6, connected: true, has_mesh_time: false });
+    }
+
+    #[test]
+    fn rssi_raw_u8_is_decoded_to_dbm() {
+        // Live ground truth: smol/5/peers = "PEERS|G|1|8,215,0,1,3;7,214,0,1,3;9,194,0,1,3".
+        assert_eq!(normalize_rssi(215), -41);
+        assert_eq!(normalize_rssi(214), -42);
+        assert_eq!(normalize_rssi(194), -62);
+        assert_eq!(normalize_rssi(-55), -55); // already-signed passes through
+        assert_eq!(normalize_rssi(0), 0);
+        let p = parse_peers("PEERS|G|1|8,215,0,1,3;7,214,0,1,3;9,194,0,1,3").unwrap();
+        assert_eq!(p.channel, 1);
+        assert_eq!(p.links[0].rssi, -41);
+        assert_eq!(p.links[2].rssi, -62);
     }
 
     #[test]

--- a/rust/viz/observatory/src/mesh.rs
+++ b/rust/viz/observatory/src/mesh.rs
@@ -78,27 +78,39 @@ fn ev(t: f64, topic: &str, payload: impl AsRef<[u8]>) -> ScriptEvent {
     ScriptEvent { t, topic: topic.to_string(), payload: payload.as_ref().to_vec() }
 }
 
+/// Encode a dBm reading the way the firmware puts it on the wire: ESP-NOW RSSI is a
+/// **raw `u8`**, so a negative dBm ships as its unsigned byte (e.g. -46 dBm -> 210).
+/// mesh-model's `normalize_rssi` decodes it back. Emitting raw here makes the demo a
+/// faithful `smol/<id>/peers` replay and exercises the decode end-to-end.
+fn raw_rssi(dbm: i32) -> i32 {
+    if dbm < 0 {
+        dbm + 256
+    } else {
+        dbm
+    }
+}
+
 /// A star roster centred on `owner` at channel `ch`: owner is gateway 'G' linking to
 /// every leaf; each leaf is 'L' linking back. RSSI falls off by list position so the
-/// filaments vary. Returns the peers events to publish.
+/// filaments vary. Returns the peers events to publish (raw-u8 RSSI, like the fleet).
 fn peers_star(owner: u8, fleet: &[u8], ch: u8, t: f64) -> Vec<ScriptEvent> {
     let leaves: Vec<u8> = fleet.iter().copied().filter(|&i| i != owner).collect();
     let mut out = Vec::new();
     // Owner sees all leaves.
     let mut body = String::new();
     for (k, &l) in leaves.iter().enumerate() {
-        let rssi = -46 - (k as i32) * 9; // -46, -55, -64, -73 ...
+        let rssi = raw_rssi(-46 - (k as i32) * 9); // -46, -55, -64, -73 dBm on the wire
         let age = 1 + k as u32;
         body.push_str(&format!("{l},{rssi},{age},{ch},3;"));
     }
     out.push(ev(t, &format!("smol/{owner}/peers"), format!("PEERS|G|{ch}|{body}")));
     // Each leaf sees the owner (+ a cross-link to its neighbour for a richer graph).
     for (k, &l) in leaves.iter().enumerate() {
-        let rssi = -48 - (k as i32) * 9;
+        let rssi = raw_rssi(-48 - (k as i32) * 9);
         let mut lb = format!("{owner},{rssi},{},{ch},3;", 1 + k as u32);
         if let Some(&nb) = leaves.get((k + 1) % leaves.len()) {
             if nb != l {
-                lb.push_str(&format!("{nb},{},{},{ch},1;", -70 - (k as i32) * 3, 8 + k as u32));
+                lb.push_str(&format!("{nb},{},{},{ch},1;", raw_rssi(-70 - (k as i32) * 3), 8 + k as u32));
             }
         }
         out.push(ev(t, &format!("smol/{l}/peers"), format!("PEERS|L|{ch}|{lb}")));


### PR DESCRIPTION
**Correctness hotfix** to the `rust/viz/mesh-model` that merged with #171.

#171 lifted `mesh-model` from meshscope **@81ebb14** — one commit before meshscope's
RSSI-decode fix landed (`982cbaf` on main). So main's `rust/viz/mesh-model` shipped
with the raw-u8 RSSI bug while `rust/meshscope` has the fix. Caught by **@morpheus-158**
(live-verified on the fleet).

### The bug
The firmware serializes a peer's ESP-NOW RSSI as a **raw `u8`** (`rx_control.rssi` is
unsigned), so a real **-41 dBm arrives on the wire as 215**. Without `normalize_rssi`,
`PeerLink.rssi` is `+215`, and every observatory edge metric — brightness, spring
tightness, color — **inverts** on live broker data. The `--demo` used signed dBm
directly, so it masked the bug (demo-only testing wouldn't catch it).

### The fix
Syncs `rust/viz/mesh-model/{parse,model}.rs` **byte-for-byte** to meshscope's corrected
core:
- `parse::normalize_rssi` (`128..=255 → v-256`; lossless — dBm is never positive),
  applied in `parse_peers`
- `model.rs`: `STALE_S 90→45` (~1.5 flush cycles) + `WEAK_LINK_DBM = -80` +
  `LOW_HEAP_B = 20_000` — the HA-parity single-source-of-derivation-truth thresholds

Also makes `observatory --demo` emit **raw-u8 RSSI** (like the fleet), so the demo
faithfully replays the wire format and exercises the decode end-to-end.

`mesh-model` is byte-identical to meshscope's core again → the coming **convergence PR**
(meshscope depends on `rust/viz/mesh-model`, delete its inlined copy) stays a pure dedup.

### Verified on familiar
- `cargo test -p mesh-model` ✅ **17 tests** — incl. new `rssi_raw_u8_is_decoded_to_dbm`
  (`normalize_rssi(215) == -41`; `parse_peers("...8,215,...").links[0].rssi == -41`) + doctest
- `cargo build -p observatory` ✅ · `cargo clippy` ✅ clean · `--selftest` ✅ (crown Aegis, 8 edges)

Demo visuals are unchanged (decoded dBm == the values the old demo used); the payload
is correctness on **live** data. No secrets, additive to `rust/viz/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)