### PR TITLE
feat(fw): #155 channel_hint — operator lever for the mesh channel (option 3)

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -67,6 +67,14 @@ CONFIG topic). Operator guide: **[`docs/relay.md`](docs/relay.md)**.
   the broker** — a retained `smol/mesh/channel` = `MC|owner|channel|seq` record — so it can't
   fragment (gateways on different channels still share one broker). The `seq`/liveness field is
   load-bearing: a stale record → the next-best board takes over.
+- **Operator channel lever** (#155): publish a **retained** `smol/mesh/channel_hint` = a decimal
+  channel (e.g. `6`) and the crown **honors it at claim time** — a board whose AP channel ≠ the
+  hint refuses the crown, so the mesh converges onto a board already on that channel (the coexist
+  radio can only park the mesh on the crown's *own* AP channel, so the lever steers *which* board
+  is crown). A sitting crown on the wrong channel yields (goes HELLO-silent) so a hinted-channel
+  board takes over. **Clear it** by publishing an empty retained payload → normal election resumes.
+  This replaces the old manual seq-forged `MC` plant. ⚠️ A hint no board can satisfy leaves the
+  mesh crownless until you clear it — it's a deliberate operator control, not automatic.
 - **No-burst coexist** (#23): the gateway stays associated and runs ESP-NOW + WiFi concurrently on
   one channel, so a telemetry flush no longer tears the radio down (no multi-second mesh-deaf
   window). Leaves scan 1/6/11 to find the gateway's channel + re-lock on silence.

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -4134,10 +4134,22 @@ impl RadioManager {
                 self.relay.is_gateway = false;
                 self.scan_locked = false;
                 self.last_owner_heard_ms = now;
+                // #155: a HINT-DRIVEN yield (our channel != the operator's channel_hint) is an
+                // abdication, not an adopt-a-live-owner demote — go HELLO-silent like an R-DEMOTE
+                // so leaves stop following us on the wrong channel and re-elect a hinted-channel
+                // crown promptly. We DON'T latch flush_fail_latch: our uplink is fine (we flush),
+                // we're merely on the wrong channel — so we may reclaim once on a hinted-channel AP.
+                if elect.hint_blocked {
+                    self.silent_until_relock = true;
+                }
                 let _ = self.switch(Mode::EspNow);
                 log::info!(
-                    "smol: gateway DEMOTED — live owner id{} holds the mesh; leaf-scanning",
-                    self.elected_owner
+                    "smol: gateway DEMOTED — {} (leaf-scanning)",
+                    if elect.hint_blocked {
+                        "yielded on channel_hint, HELLO-silent"
+                    } else {
+                        "live owner holds the mesh"
+                    }
                 );
             }
         }

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -77,6 +77,20 @@ const GRID_TOPIC: &[u8] = b"smol/display/grid";
 #[cfg(feature = "wifi")]
 const MESH_CHANNEL_TOPIC: &[u8] = b"smol/mesh/channel";
 
+/// #155 channel-drag OPERATOR LEVER: a retained hint the crown HONORS at claim time.
+/// Payload = a decimal 2.4 GHz channel (the fleet uses `1`/`6`/`11`); an EMPTY payload (the
+/// retain-clear) restores un-hinted behavior. The mesh channel is PHYSICALLY the crown's AP
+/// channel (coexist single-radio: while associated the PHY sits on the AP's channel), so a hint
+/// can only steer WHICH board holds the crown — a candidate whose LEARNED channel != the hint
+/// refuses to claim (see the claim gate in `mqtt_session`), so the (re)election converges onto a
+/// board already on the hinted channel and the fleet stops being dragged onto a weak AP. This
+/// replaces JP's manual seq-forged `MC` plant with a first-class, documented control. Absent/empty
+/// ⇒ the election is byte-identical to pre-#155. See issue #155 (option 3). SAFETY: an
+/// unsatisfiable hint (no capable board on that channel) leaves the mesh crownless until the
+/// operator clears the topic — the lever is deliberate, not automatic.
+#[cfg(feature = "wifi")]
+const MESH_CHANNEL_HINT_TOPIC: &[u8] = b"smol/mesh/channel_hint";
+
 /// #23 stage 3-4 boot ELECTION result, filled by [`mqtt_session`] from the retained
 /// `smol/mesh/channel`. A board that reached DHCP is a candidate; the lowest-id
 /// candidate is the OWNER (coexist gateway). Non-owners demote to leaf + scan for the
@@ -146,6 +160,15 @@ pub struct MeshElect {
     /// owner is unaffected. Always false on boot/gateway-flush and for a healthy fleet (a board that
     /// can flush is never latched), so this is a no-op on every path except a proven-incapable owner.
     pub flush_incapable: bool,
+    /// #155 channel-drag operator lever: the retained `smol/mesh/channel_hint` value (a decimal
+    /// 2.4 GHz channel), or `None` when the topic is absent/empty/garbage. Seeded by
+    /// [`mqtt_session`] from the broker each burst. When `Some(h)`, this board's own channel
+    /// (`my_channel`) is KNOWN (non-zero) and != `h`, the claim gate refuses to (re)claim the crown
+    /// — so the mesh converges onto a crown actually on the hinted channel and the drag heals.
+    /// FAIL-OPEN on an unknown own-channel (`my_channel == 0`): a not-yet-learned board claims as
+    /// before, so a mesh is never left crownless while a channel is still being learned. `None` ⇒
+    /// no gate ⇒ election unchanged. Same claim-guard shape as `flush_incapable` (#146).
+    pub channel_hint: Option<u8>,
     // --- outputs (applied to the live role by the caller) ---
     /// True iff I claimed / hold ownership (I am the coexist gateway).
     pub i_am_owner: bool,
@@ -156,6 +179,12 @@ pub struct MeshElect {
     /// its owner-silence clock ONLY for a genuinely-live owner — a dead-deferred owner
     /// gets no reset, so the next recovery burst fires on cadence (faster failover).
     pub owner_alive: bool,
+    /// #155: true iff the CHANNEL-HINT claim gate fired this burst — i.e. we would have claimed /
+    /// held the crown but our channel != the operator's `channel_hint`, so we yielded. The caller
+    /// uses this on the gateway-flush path to go HELLO-silent on a hint-driven demote (like an
+    /// R-DEMOTE abdication), so a sitting crown vacates promptly and leaves re-elect a
+    /// hinted-channel board instead of staying pinned to our now-wrong-channel HELLO.
+    pub hint_blocked: bool,
 }
 
 #[cfg(feature = "wifi")]
@@ -173,9 +202,11 @@ impl MeshElect {
             recovery_stale_floor_ms: 0, // #136: seeded by the caller on a recovery election
             boot: false,
             flush_incapable: false, // #146: seeded by the caller from the flush-fail abdication latch
+            channel_hint: None, // #155: seeded by the caller from the retained smol/mesh/channel_hint
             i_am_owner: false,
             owner_id: my_id,
             owner_alive: false,
+            hint_blocked: false, // #155: set by the claim gate on a channel-hint yield
         }
     }
 }
@@ -258,6 +289,22 @@ fn parse_mesh_channel(payload: &[u8]) -> Option<(u8, u8, u32)> {
     let ch: u8 = it.next()?.parse().ok()?;
     let seq: u32 = it.next()?.parse().ok()?;
     Some((owner, ch, seq))
+}
+
+/// #155: parse a retained `smol/mesh/channel_hint` payload → the hinted 2.4 GHz channel.
+/// A single decimal `u8` (the operator publishes `1`/`6`/`11`); surrounding ASCII whitespace is
+/// tolerated. An EMPTY payload (the retain-clear) or any malformed / out-of-range value → `None`
+/// (no hint) — so clearing the topic restores the un-hinted election, and a typo (e.g. `99`) can
+/// never wedge the mesh onto a channel no board can be on (fail-open). Panic-free (checked parse,
+/// no indexing). Accepts only 1..=13 (real 2.4 GHz channels); 0 is the advisory sentinel elsewhere.
+#[cfg(feature = "wifi")]
+fn parse_channel_hint(payload: &[u8]) -> Option<u8> {
+    let ch: u8 = core::str::from_utf8(payload).ok()?.trim().parse().ok()?;
+    if (1..=13).contains(&ch) {
+        Some(ch)
+    } else {
+        None
+    }
 }
 
 /// #21/#48/#55 leaf-relay: extract the leaf id `N` from a `smol/<N><suffix>` topic (the shape
@@ -2118,6 +2165,13 @@ fn mqtt_session(
     if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 3, MESH_CHANNEL_TOPIC) {
         let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
     }
+    // #155 channel-drag operator lever: subscribe the retained channel-hint (packet-id 13 — the
+    // first free id; 9 is `smol/+/ota/install`). Sent right after the election topic so its retained
+    // value rides the SAME broker burst as `MC` and is captured before the resolver runs (the settle
+    // window after the primary downlinks catches it, exactly like the OTA/config retained topics).
+    if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 13, MESH_CHANNEL_HINT_TOPIC) {
+        let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+    }
 
     // --- PUBLISH telemetry (transient) + discovery config (retained) per node ---
     for &(id, line) in telemetry {
@@ -2432,6 +2486,14 @@ fn mqtt_session(
                     } else if topic == MESH_CHANNEL_TOPIC {
                         mc = parse_mesh_channel(payload); // #23 election record
                         got_mc = true; // present (unparseable → treated as claimable below)
+                    } else if topic == MESH_CHANNEL_HINT_TOPIC {
+                        // #155: capture the operator's retained channel hint into the election
+                        // record; the claim gate (below, next to the #146 guard) honors it. An
+                        // empty/garbage payload parses to None → no hint → unchanged election.
+                        elect.channel_hint = parse_channel_hint(payload);
+                        if let Some(h) = elect.channel_hint {
+                            log::info!("smol: #155 channel_hint = ch{} (retained)", h);
+                        }
                     } else if topic == OTA_STAGED_TOPIC {
                         // #33 Model-A: parse + GATE the retained STAGED line (monotonicity +
                         // host allowlist + size). A gate-passing staged build becomes the
@@ -3205,6 +3267,29 @@ fn mqtt_session(
         None
     } else {
         claim_seq
+    };
+    // #155 channel-drag OPERATOR LEVER: honor the retained `smol/mesh/channel_hint`. The mesh
+    // channel is PHYSICALLY the crown's AP channel (coexist single-radio), so a hint can only steer
+    // WHICH board holds the crown: a candidate whose OWN channel is KNOWN (non-zero) and != the
+    // hint must not claim, so the (re)election converges onto a board already on the hinted channel
+    // and the fleet stops being dragged onto a weak AP. Same claim-guard SHAPE as #146 above —
+    // suppress the claim HERE, before the MC publish, so the retained record is left to freeze and
+    // a hinted-channel board takes over off that frozen seq. `hint_blocked` tells the caller
+    // (mode.rs flush) to go HELLO-silent on a hint-driven yield so a SITTING crown vacates promptly.
+    // FAIL-OPEN on an unknown own-channel (`my_channel == 0`): a not-yet-learned board claims as
+    // before (never a crownless mesh while a channel is still being learned). No hint ⇒ no-op.
+    let claim_seq = match (claim_seq, elect.channel_hint) {
+        (Some(_), Some(h)) if elect.my_channel != 0 && elect.my_channel != h => {
+            elect.i_am_owner = false;
+            elect.hint_blocked = true;
+            log::info!(
+                "smol: #155 channel_hint ch{} != my ch{} — yielding crown (leaf until on-hint)",
+                h,
+                elect.my_channel
+            );
+            None
+        }
+        (cs, _) => cs,
     };
     if let Some(newseq) = claim_seq {
         // Record my own ownership locally so my seq counts as "fresh" next read, then


### PR DESCRIPTION
## What
Implements **option 3 of #155**: a retained `smol/mesh/channel_hint` topic the crown **honors at claim time** — a first-class, documented replacement for JP's manual seq-forged `MC` plant. Scoped to the isolated operator-lever lane (NOT the crown-side election-resolver rewrite).

## Why this shape (the physical constraint)
Under coexist the mesh runs on a **single radio**, so while a crown is associated its PHY sits on its AP's channel — the mesh channel **is** the crown's AP channel. You therefore cannot put the mesh on channel Y while the crown's AP is on X. The only physically-sound way a hint can move the mesh is to steer **which board holds the crown**:

- A candidate whose **learned channel != the hint refuses to claim** (same guard shape as the #146 `flush_incapable` lever), so the (re)election converges onto a board already on the hinted channel.
- A **sitting crown** that mismatches **yields** (goes HELLO-silent via the existing `!i_am_owner` flush-demote path) so a hinted-channel board takes over off the frozen `MC` seq → the fleet stops being dragged onto a weak AP.
- **Fail-open** on an unknown own-channel (`my_channel == 0`) — a not-yet-learned board claims as before, never a crownless mesh mid-learn.
- **Empty/garbage payload → no hint → byte-identical to pre-#155.** Clearing the topic restores normal election.
- ⚠️ An unsatisfiable hint (no capable board on that channel) leaves the mesh crownless until the operator clears it — deliberate, not automatic (documented in ONBOARDING).

## Footprint (additive, +107 / -2 across 3 files)
- `net/wifi.rs`: new `MESH_CHANNEL_HINT_TOPIC` const · `parse_channel_hint()` · two `MeshElect` fields (`channel_hint` in, `hint_blocked` out) · a subscribe arm (pid 9, rides the retained burst with `MC`) · a handler arm · **the claim gate placed directly beside the #146 guard, before the MC publish**.
- `net/mode.rs`: a HELLO-silent hook on a hint-driven demote in the gateway-flush `!i_am_owner` branch (no `flush_fail_latch` — the uplink is fine, only the channel is wrong, so the board may reclaim on a hinted-channel AP).
- `ONBOARDING.md`: operator doc for the lever.

## Coordination + rebase
Coordinated line-boundaries with **morpheus-89** before writing (per collision discipline). **89's PR #170 merged first**; this branch is **rebased onto it (f365f9d) with zero conflicts** — all integration anchors (MeshElect struct, election resolver, #146 guard, subscribe block, MC handler, `parse_mesh_channel`) survived 89's boot-burst rewrite intact. The gate composes with 89's election code; it does not touch `maybe_leaf_reelect` or the resolver's decision arms.

## Build / clippy (KATANA, pinned 1.96.1 per rust-toolchain.toml)
- ✅ `cargo build --release --features espnow` (fleet) — clean
- ✅ `cargo clippy --release --features espnow -- -D warnings` — clean
- ✅ `cargo build --release` (default no-radio) — clean; default profile unaffected (all new code is `#[cfg(feature = "wifi")]`-gated — proven via cfg, not ELF byte-equality)
- ℹ️ `--features wifi`-only clippy has TWO **pre-existing** dead-code errors (`assert_max_tx_power`, `OtaProgress`) unrelated to this diff (confirmed identical on `main`); the fleet build is `espnow`.

## 🔒 HW CANARY — GATE HELD (no flash/MQTT/mesh performed)
To be run by the HW-gate holder on the rig:
1. **No hint (regression):** with no `smol/mesh/channel_hint` retained, confirm election + crown behavior is unchanged.
2. **Steer:** publish retained `smol/mesh/channel_hint` = the strong-AP channel. Expect: a crown on a different channel yields HELLO-silent (`#155 channel_hint … yielding crown` / `yielded on channel_hint` in serial), a board on the hinted channel claims, mesh parks on that channel within ~1–2 flush cycles.
3. **Reproduce the 07-14/07-15 drag** and confirm the lever re-parks it (the manual-plant scenario).
4. **Clear:** publish empty retained payload → normal election resumes.

Closes part of #155 (option 3 lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)