### PR TITLE
fix(ota): #157 leaf finalize-ack — a complete feed no longer strands unactivated [HW-GATE HELD]

### DIFF
--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -3639,6 +3639,10 @@ impl RadioManager {
         }
 
         let mut wb: u32 = 0;
+        // #157: set when the LAST window is positively acked by the leaf's finalize-ack (an
+        // all-zero OTAN at the last window base) → delivered-CONFIRMED. Stays false if the last
+        // window only exited via the blind round-exhaustion fallthrough → delivered-UNCONFIRMED.
+        let mut last_win_acked = false;
         'windows: while wb < total {
             if tick() {
                 return LeafOtaOutcome::Aborted;
@@ -3740,6 +3744,12 @@ impl RadioManager {
                     }
                 }
                 if advanced {
+                    // #157: an all-zero OTAN at the LAST window base is the leaf's finalize-ack —
+                    // positive proof it received the whole image + is activating. (For non-last
+                    // windows it's the ordinary advance-ack.)
+                    if wb + WINDOW_CHUNKS as u32 >= total {
+                        last_win_acked = true;
+                    }
                     wb += WINDOW_CHUNKS as u32;
                     break;
                 }
@@ -3856,12 +3866,23 @@ impl RadioManager {
                 log::info!("smol #40: leaf id{} CONFIRMED at build {} — update stuck", leaf_id, b);
                 LeafOtaOutcome::Confirmed
             }
-            Some(b) => {
+            // Settled at an OLD build. #157: distinguish a genuine self-test rollback (the leaf
+            // finalize-acked → it DID complete + activate, then rolled back) from a stranded feed
+            // (NO finalize-ack → it never completed the last window, so it's on the old build
+            // because it never activated — not a rollback). The stranded case must RETRY, not clear.
+            Some(b) if last_win_acked => {
                 log::warn!(
-                    "smol #40: leaf id{} settled at OLD build {} — self-test rolled it back (HA re-offers)",
+                    "smol #40: leaf id{} settled at OLD build {} after finalize-ack — self-test rolled it back (HA re-offers)",
                     leaf_id, b
                 );
                 LeafOtaOutcome::RolledBack
+            }
+            Some(b) => {
+                log::warn!(
+                    "smol #40 #157: leaf id{} on OLD build {} + NO finalize-ack → DELIVERED-UNCONFIRMED (last-window frame lost; retrying)",
+                    leaf_id, b
+                );
+                LeafOtaOutcome::RelayUnconfirmed
             }
             None => {
                 if let Some(wrong) = mac_seen_id {
@@ -3873,12 +3894,23 @@ impl RadioManager {
                         leaf_id, wrong
                     );
                     LeafOtaOutcome::IdMismatch
-                } else {
+                } else if last_win_acked {
+                    // #157: the leaf finalize-acked (completed + activating) but never re-STATed —
+                    // it activated and went silent → a genuine possible brick (unchanged semantics).
                     log::error!(
-                        "smol #40: leaf id{} did not reappear at build {} within the confirm window — possible brick (USB recovery)",
+                        "smol #40: leaf id{} finalize-acked then did not reappear at build {} — possible brick (USB recovery)",
                         leaf_id, announce.build
                     );
                     LeafOtaOutcome::Timeout
+                } else {
+                    // #157: never finalize-acked AND never re-STATed → the feed never completed
+                    // (leaf still on the old image, mesh-silent this window) → delivered-unconfirmed,
+                    // retry rather than mislabel as a brick.
+                    log::warn!(
+                        "smol #40 #157: leaf id{} never finalize-acked + no STAT → DELIVERED-UNCONFIRMED (retrying)",
+                        leaf_id
+                    );
+                    LeafOtaOutcome::RelayUnconfirmed
                 }
             }
         }
@@ -4764,9 +4796,18 @@ impl RadioManager {
         // window; abort on a progress/hard-cap timeout). No-op unless a transfer is live.
         {
             let mut out = [0u8; crate::ota_mesh::OTAN_FRAME_MAX];
-            if let crate::ota_mesh::LeafAction::Nak(n) = self.ota_leaf.tick(self.id, now_ms(), &mut out) {
-                let gw = self.ota_leaf.gateway_mac();
-                self.send_to(&gw, &out[..n]);
+            match self.ota_leaf.tick(self.id, now_ms(), &mut out) {
+                crate::ota_mesh::LeafAction::Nak(n) => {
+                    let gw = self.ota_leaf.gateway_mac();
+                    self.send_to(&gw, &out[..n]);
+                }
+                // #157: the leaf self-activates from the finalize-ack timer (belt-and-braces) —
+                // even if the gateway never acknowledged the finalize-ack, a verified complete
+                // image must not stay stranded. `activate` reboots into the new slot on success.
+                crate::ota_mesh::LeafAction::Complete(slot, build) => {
+                    crate::ota::activate(slot, build, true);
+                }
+                crate::ota_mesh::LeafAction::None | crate::ota_mesh::LeafAction::Abort => {}
             }
         }
         label

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -341,6 +341,16 @@ const LEAF_PROGRESS_STALL_MS: u64 = 30_000;
 const LEAF_FIRST_CHUNK_GRACE_MS: u64 = 330_000;
 /// Hard total-session cap (ms) — a runaway transfer aborts → good slot boots (R1: USB).
 const LEAF_SESSION_MAX_MS: u64 = 600_000;
+/// #157: after the LAST window verifies, broadcast a finalize-ack (an all-zero OTAN at the
+/// last window base = "image complete, activating") up to this many times before
+/// self-activating. Gives the gateway a positive *delivered-confirmed* signal that survives
+/// a lost terminal frame — the crown records confirmed-vs-unconfirmed from hearing it.
+const LEAF_FINALIZE_ACK_MAX: u8 = 4;
+/// #157: max time (ms) to spend emitting finalize-acks before self-activating ANYWAY. The
+/// leaf never *waits* on the gateway — this is a short courtesy window so the ack can be
+/// heard; on expiry the leaf activates regardless (the belt-and-braces that un-strands a
+/// complete-but-unconfirmed image). ~2 OTAN cadences.
+const LEAF_FINALIZE_ACK_WINDOW_MS: u64 = 1_200;
 
 /// Outcome/phase of a GATEWAY → leaf relay attempt — published to `smol/<leaf>/ota/diag`
 /// (headless observability: the mesh-only leaf gives no serial, so the gateway reports the
@@ -355,6 +365,12 @@ pub enum LeafOtaOutcome {
     FetchFailed,
     /// The ESP-NOW relay loop exhausted its retransmit rounds (leaf not NAKing) — never confirmed.
     RelayFailed,
+    /// #157: the feed reached the leaf, but the leaf NEVER confirmed completion — no finalize-ack
+    /// was heard AND it settled on the OLD build / never re-STATed. The last-window terminal frame
+    /// was lost and the leaf stranded on the old image (the two live 07-15/07-18 occurrences).
+    /// Distinct from `RolledBack` (a completed image that self-tested then rolled back) and
+    /// `Timeout` (a completed image that went silent). Transient → the install is RE-OFFERED (retry).
+    RelayUnconfirmed,
     /// No STAT reappearance within the confirm window — possible brick (USB recovery).
     Timeout,
     /// The armed install's target leaf MAC isn't in the roster yet (never heard its HELLO).
@@ -376,6 +392,7 @@ impl LeafOtaOutcome {
             LeafOtaOutcome::RolledBack => "rolled-back",
             LeafOtaOutcome::FetchFailed => "fetch-failed",
             LeafOtaOutcome::RelayFailed => "relay-failed",
+            LeafOtaOutcome::RelayUnconfirmed => "delivered-unconfirmed",
             LeafOtaOutcome::Timeout => "leaf-timeout",
             LeafOtaOutcome::MacUnknown => "mac-unknown",
             LeafOtaOutcome::IdMismatch => "id-mismatch",
@@ -463,6 +480,18 @@ pub struct OtaLeafSession {
     /// gating decisions over an already-valid signature, tracked by `dbg_verdict`/relaydiag.
     verify_ok: u16,
     verify_fail: u16,
+    /// #157 finalize-ack phase. `> 0` while the VERIFIED last window is broadcasting
+    /// finalize-acks before the leaf self-activates; `0` = not finalizing. Set when the last
+    /// window passes readback verify (in `on_data`); cleared when the leaf activates or aborts.
+    /// The verify happens BEFORE this (unchanged brick-safety); this only defers the *reboot*
+    /// by a short courtesy window so the gateway can hear the completion.
+    finalize_since_ms: u64,
+    /// The last window's base seq — the OTAN window_base the finalize-ack carries.
+    finalize_wb: u32,
+    /// The verified target slot to activate (captured before `finalize()` consumed the writer).
+    finalize_slot: Option<Slot>,
+    /// Finalize-acks emitted so far this session (bounded by `LEAF_FINALIZE_ACK_MAX`).
+    finalize_acks_sent: u8,
 }
 
 impl OtaLeafSession {
@@ -486,6 +515,10 @@ impl OtaLeafSession {
             dbg_otan_sent: 0,
             verify_ok: 0,
             verify_fail: 0,
+            finalize_since_ms: 0,
+            finalize_wb: 0,
+            finalize_slot: None,
+            finalize_acks_sent: 0,
         }
     }
 
@@ -517,6 +550,9 @@ impl OtaLeafSession {
         self.active = false;
         self.window_recv = 0;
         self.writer = None;
+        self.finalize_since_ms = 0; // #157: abandon any pending finalize-ack phase
+        self.finalize_slot = None;
+        self.finalize_acks_sent = 0;
     }
 
     /// Handle an `OTAM` (signed announce). VERIFY-SIG-FIRST is the whole point: a frame
@@ -721,24 +757,40 @@ impl OtaLeafSession {
             return LeafAction::Nak(n);
         }
 
-        // ---- LAST window done → FINALIZE (readback verify) → activate. ------------
-        let (size, sha, build) = (self.size, self.sha256, self.build);
-        let writer = self.writer.take();
-        self.active = false;
-        match writer {
+        // ---- LAST window done → readback-VERIFY, then enter the #157 finalize-ack phase. ----
+        // Verify is UNCHANGED (brick-safety: a bad image never activates). On PASS we do NOT
+        // activate immediately — we broadcast a finalize-ack (an all-zero OTAN at the last window
+        // base) so the gateway learns we completed + is activating, and self-activate on a short
+        // timer in `tick()` REGARDLESS of whether the gateway hears it (#157 belt-and-braces:
+        // a lost terminal frame no longer strands a complete image on the old build).
+        let (size, sha) = (self.size, self.sha256);
+        match self.writer.take() {
             Some(w) => {
-                let target_slot = w.target();
+                let target_slot = w.target(); // capture BEFORE finalize() consumes the writer
                 if w.finalize(size, &sha) {
-                    log::info!("smol #40: image VERIFIED (readback SHA-256, ed25519 already ok) — activating build {}", build);
+                    log::info!("smol #40 #157: image VERIFIED — finalize-ack then activate build {}", self.build);
                     self.verify_ok = self.verify_ok.saturating_add(1); // #49: full integrity-verified
-                    LeafAction::Complete(target_slot, build)
+                    // Enter the finalize-ack phase; stay `active` so tick() drives ack + activate.
+                    self.finalize_since_ms = now.max(1); // never 0 (0 == "not finalizing")
+                    self.finalize_wb = wb;
+                    self.finalize_slot = Some(target_slot);
+                    self.finalize_acks_sent = 1;
+                    self.last_nak_ms = now;
+                    let zero = [0u8; OTAN_BITMAP_BYTES];
+                    let n = encode_otan(my_id, self.session_id, wb as u16, &zero, out);
+                    self.dbg_otan_sent = self.dbg_otan_sent.saturating_add(1);
+                    LeafAction::Nak(n) // the finalize-ack (gateway reads it as delivered-confirmed)
                 } else {
                     log::error!("smol #40: readback verify FAILED — discarded (good slot intact)");
                     self.verify_fail = self.verify_fail.saturating_add(1); // #49: readback SHA mismatch
+                    self.discard();
                     LeafAction::Abort
                 }
             }
-            None => LeafAction::Abort,
+            None => {
+                self.discard();
+                LeafAction::Abort
+            }
         }
     }
 
@@ -747,6 +799,39 @@ impl OtaLeafSession {
     pub fn tick(&mut self, my_id: u8, now: u64, out: &mut [u8]) -> LeafAction {
         if !self.active {
             return LeafAction::None;
+        }
+        // #157: finalize-ack phase — the last window is VERIFIED; re-broadcast the finalize-ack a
+        // few times so the gateway records delivered-CONFIRMED, then self-activate REGARDLESS (the
+        // leaf never waits on the gateway). Runs BEFORE the stall/NAK logic below — the transfer is
+        // already complete, so the progress-stall abort must not fire on it.
+        if self.finalize_since_ms != 0 {
+            let window_open =
+                now.saturating_sub(self.finalize_since_ms) < LEAF_FINALIZE_ACK_WINDOW_MS;
+            if window_open && self.finalize_acks_sent < LEAF_FINALIZE_ACK_MAX {
+                if now.saturating_sub(self.last_nak_ms) < LEAF_IDLE_NAK_MS {
+                    return LeafAction::None; // throttle between acks
+                }
+                self.last_nak_ms = now;
+                self.finalize_acks_sent = self.finalize_acks_sent.saturating_add(1);
+                let zero = [0u8; OTAN_BITMAP_BYTES];
+                let n = encode_otan(my_id, self.session_id, self.finalize_wb as u16, &zero, out);
+                self.dbg_otan_sent = self.dbg_otan_sent.saturating_add(1);
+                return LeafAction::Nak(n);
+            }
+            // Courtesy window elapsed or acks maxed → self-activate now (belt-and-braces).
+            let slot = self.finalize_slot.take();
+            self.finalize_since_ms = 0;
+            self.active = false;
+            return match slot {
+                Some(s) => {
+                    log::info!(
+                        "smol #40 #157: finalize-acks done ({}) — self-activating build {}",
+                        self.finalize_acks_sent, self.build
+                    );
+                    LeafAction::Complete(s, self.build)
+                }
+                None => LeafAction::Abort, // unreachable: slot is set whenever finalize_since_ms != 0
+            };
         }
         // #3b: while ARMED but still awaiting the very first chunk (window 0, nothing received),
         // allow the fetch-spanning grace — the gateway is fetching off-ch6, not dead. Once any


### PR DESCRIPTION
Closes #157. **HW-GATE HELD** — do not merge until the drop-the-finalize-ack canary passes on the rig (spec below). Code + clippy + release are green.

## Root cause
The windowed-NAK transfer is robust, but the **terminal step was best-effort**. The leaf self-finalized *only* when the last window completed in `on_data`; the crown **blind-resent the last window `GW_WINDOW_ROUNDS_MAX` rounds then declared CONFIRM with no positive signal** (`mode.rs` "leaf finalizes w/o advance-ack → CONFIRM"). A lost last-window chunk (or the silent completion) left a **complete image unactivated** on the leaf while the crown **falsely reported done** — the two live occurrences (07-15 `last_wb=4311/4311`, 07-18 `4320/4320`: leaf 100% fed, `vok=0/vfl=0`, stayed on the old build, order consumed → manual USB recovery).

## Fix — the issue's three points
1. **Leaf finalize-ack.** On last-window verify PASS the leaf emits a positive **finalize-ack** — an all-zero `OTAN` at the last window base ("image complete, activating") — retried up to `LEAF_FINALIZE_ACK_MAX` (4) times over `LEAF_FINALIZE_ACK_WINDOW_MS` (1.2 s). The crown **already** treats an all-zero OTAN at the last window as advance, so it now *hears* completion directly instead of inferring it from a blind round count → records **delivered-CONFIRMED**.
2. **Belt-and-braces leaf-side self-trigger.** The leaf **self-activates from the finalize-ack timer regardless** of whether the crown acknowledges — a verified-complete image can never stay stranded. *(Also fixed the `tick()` call site, which handled only `Nak` and would have silently **dropped** the new `Complete` — the self-activate would otherwise be dead code. This was the one non-obvious wiring trap.)*
3. **Confirmed vs unconfirmed outcome.** New `LeafOtaOutcome::RelayUnconfirmed` (`"delivered-unconfirmed"`): a leaf on the OLD build that **never finalize-acked** never completed the transfer → **RETRY**, not a misleading `RolledBack`/`CONFIRM`. It's transient + reached-leaf, so the existing bounded-retry-then-clear policy auto-retries it (no manual USB).

**Brick-safety unchanged:** verify-before-activate and the `ota::activate` path are untouched; the only new behaviour is a ~1.2 s finalize-ack window before the reboot. Worst case (all acks lost): the leaf still self-activates via the timer, and the crown still confirms via the existing build-flip Tier-2 → `Confirmed`.

## HW-gate canary (required before merge)
On the rig, artificially drop the leaf's finalize-ack (MAC-ban the leaf→crown OTAN path at last-window, or a debug drop):
- **Belt-and-braces:** the leaf **still activates** (build flips) via the `LEAF_FINALIZE_ACK_WINDOW_MS` timer — never stranded on the old build.
- **Confirmed path:** a healthy feed (no drop) → crown hears the finalize-ack → `confirmed`; leaf activates in ~1.2 s.
- **Unconfirmed path:** force a persistently-lost last-window chunk → outcome is `delivered-unconfirmed` (retry), NOT a false `confirmed`.
- **No regression:** healthy full feeds land + activate as before; `fwd=0`-class invariants unaffected (this touches only the terminal window).

## Build
Built on **katana** (pinned `1.96.1`, real `BUILD_NUMBER`): `clippy -D warnings` green for `espnow` and `espnow,cast,io`; `--release` green for `espnow`/`default`/`wifi`. *(The 2 `wifi` warnings are pre-existing `OtaProgress` dead-code in `ota.rs` — untouched here; my changes are espnow-gated. Note: clippy must run on katana not familiar — familiar has no `.git` so `BUILD_NUMBER=0` trips `absurd_extreme_comparisons` on a pre-existing line.)*

## Blast radius / coordination
`ota_mesh.rs` (leaf state machine + outcome enum) + `net/mode.rs` (`run_leaf_ota_relay` ack detection, outcome match, tick handler). All **espnow-gated**. Diag routed through the **outcome enum → `smol/<leaf>/ota/diag`**, deliberately NOT wifi.rs's `RelayDiag`, to keep @morpheus-89's wifi.rs rewrite untouched. Overlaps #161 (ota_mesh/mode accessors) at merge — additive, reconcilable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)