### PR TITLE
feat(fw): #161 rich on-board mesh-OTA progress display (HW-GATE-HELD)

### DIFF
--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -173,6 +173,13 @@ mod ota;
 #[cfg(feature = "espnow")]
 mod ota_mesh;
 
+// #161 the dedicated on-board OTA screen (receiving / feeding / self-fetch): a full-glass
+// progress display that auto-takes over while an update is in flight. Supersedes #153's 1-px
+// edge. Pure presentation over the OtaProgress cell + the leaf receive session — no radio
+// traffic, no wire change. espnow-only (the OTA-display path is likewise espnow-gated).
+#[cfg(feature = "espnow")]
+mod ota_screen;
+
 // LOCAL git-ignored WiFi credentials, used by the `wifi`/`espnow` radio bring-up.
 #[cfg(feature = "wifi")]
 mod secrets;
@@ -741,6 +748,15 @@ fn main() -> ! {
     // the plugins. Cleared at the end of every tick.
     let mut redraw = true;
 
+    // #161: state for the RECEIVING-leaf OTA takeover — an inbound mesh-OTA paints the
+    // dedicated OTA screen OVER the app frame each tick while the leaf session is live.
+    // `ota_rx_eta` estimates the ETA from block-rate; `was_ota_rx` is the edge latch that
+    // forces the app to repaint once the transfer ends (it resumes over our screen).
+    #[cfg(feature = "espnow")]
+    let mut ota_rx_eta = ota_screen::OtaEta::new();
+    #[cfg(feature = "espnow")]
+    let mut was_ota_rx = false;
+
     // Hold the boot splash for at least SPLASH_MIN_MS total. The espnow/wifi NTP
     // burst above usually already blew past this (the splash was up throughout);
     // this only adds real wait in the default build, where bring-up is instant.
@@ -830,10 +846,14 @@ fn main() -> ! {
                 if let Some(announce) = r.take_ota_offer() {
                     let mut ota_draw_ms = 0u64;
                     let mut ota_abort = false;
-                    // #153: OTA self-install is minutes-scale → keep the frozen app frame and
-                    // paint only a 1-px bottom progress edge from the live byte counts the
-                    // fetch writes into `ota_prog` (throttled to SYNC_REDRAW_MS like the old spinner).
+                    // #161: OTA self-install is minutes-scale → paint the dedicated full-glass OTA
+                    // screen (source host + big block bar + %/ETA + the incoming build's codename)
+                    // from the live byte counts the fetch writes into `ota_prog`, throttled to
+                    // SYNC_REDRAW_MS. Supersedes #153's 1-px edge for the self-fetch path.
                     let ota_prog = core::cell::Cell::new(ota::OtaProgress::default());
+                    let ota_host = ota::split_url(announce.url()).map(|(h, _, _)| h).unwrap_or("net");
+                    let ota_build = announce.build;
+                    let mut ota_eta = ota_screen::OtaEta::new();
                     r.run_ota_update(&announce, &mut || {
                         let t = millis();
                         led.apply(led::LedState::WifiSync, t);
@@ -843,7 +863,14 @@ fn main() -> ! {
                         if t.saturating_sub(ota_draw_ms) >= SYNC_REDRAW_MS {
                             ota_draw_ms = t;
                             let p = ota_prog.get();
-                            draw_ota_edge(&mut display, p.done, p.total);
+                            ota_screen::draw(&mut display, &ota_screen::OtaView {
+                                kind: ota_screen::OtaKind::SelfFetch { host: ota_host },
+                                build: ota_build,
+                                done: p.done,
+                                total: p.total,
+                                eta_s: ota_eta.sample(p.done, p.total, t),
+                                unit: ota_screen::OtaUnit::Bytes,
+                            });
                         }
                         ota_abort
                     }, &ota_prog);
@@ -1187,10 +1214,16 @@ fn main() -> ! {
                         if let Some(mac) = r.mac_for_id_sticky(leaf_id) {
                             let mut relay_draw_ms = 0u64;
                             let mut relay_abort = false;
-                            // #153: leaf-feed relay is minutes-scale → keep the frozen app frame
-                            // and paint the 1-px bottom progress edge (fetch bytes then ESP-NOW
-                            // chunk windows, both written into `relay_prog` by run_leaf_ota_relay).
+                            // #161: leaf-feed relay is minutes-scale → paint the dedicated OTA
+                            // screen ("feeding <leaf>" + big block bar + %/ETA + the incoming
+                            // build's codename) from the counts run_leaf_ota_relay writes into
+                            // `relay_prog`. That counter is BYTES during the gateway's own fetch
+                            // then BLOCKS during the ESP-NOW relay, so the unit is auto-picked per
+                            // paint (>10k ⇒ bytes) and the ETA re-anchors itself at the phase flip
+                            // (done drops → OtaEta re-seeds), keeping the readout clean throughout.
                             let relay_prog = core::cell::Cell::new(ota::OtaProgress::default());
+                            let relay_build = ann.build;
+                            let mut relay_eta = ota_screen::OtaEta::new();
                             let outcome = r.run_leaf_ota_relay(leaf_id, mac, &ann, &mut || {
                                 let t = millis();
                                 led.apply(led::LedState::WifiSync, t);
@@ -1200,7 +1233,18 @@ fn main() -> ! {
                                 if t.saturating_sub(relay_draw_ms) >= SYNC_REDRAW_MS {
                                     relay_draw_ms = t;
                                     let p = relay_prog.get();
-                                    draw_ota_edge(&mut display, p.done, p.total);
+                                    ota_screen::draw(&mut display, &ota_screen::OtaView {
+                                        kind: ota_screen::OtaKind::Feeding { leaf_id },
+                                        build: relay_build,
+                                        done: p.done,
+                                        total: p.total,
+                                        eta_s: relay_eta.sample(p.done, p.total, t),
+                                        unit: if p.total > 10_000 {
+                                            ota_screen::OtaUnit::Bytes
+                                        } else {
+                                            ota_screen::OtaUnit::Blocks
+                                        },
+                                    });
                                 }
                                 relay_abort
                             }, &relay_prog);
@@ -1592,6 +1636,44 @@ fn main() -> ! {
         // === Advance + render the active screen. Each plugin owns its update
         // cadence + its framebuffer clear/flush — the old per-mode match arms,
         // relocated VERBATIM into each `Plugin::update` (the equivalence proof).
+        // #161: while THIS board is RECEIVING a mesh-OTA, the dedicated OTA screen takes over
+        // the whole glass (auto-activated by `ota_rx_view`, not a menu item) — the app frame is
+        // frozen until the transfer ends, then repainted (forced redraw on the falling edge).
+        // The receive session is serviced in `service()` BEFORE dispatch, so skipping the app
+        // render here only pauses PAINTING, never the mesh/flash logic.
+        #[cfg(feature = "espnow")]
+        {
+            let ota_rx = ctx.radio.as_deref().and_then(|r| r.ota_rx_view());
+            match ota_rx {
+                Some(view) => {
+                    let eta = ota_rx_eta.sample(view.done, view.total, now);
+                    ota_screen::draw(
+                        ctx.display,
+                        &ota_screen::OtaView {
+                            kind: ota_screen::OtaKind::Receiving {
+                                source_id: view.source_id,
+                                hop: view.hop,
+                            },
+                            build: view.build,
+                            done: view.done,
+                            total: view.total,
+                            eta_s: eta,
+                            unit: ota_screen::OtaUnit::Blocks,
+                        },
+                    );
+                    was_ota_rx = true;
+                }
+                None => {
+                    if was_ota_rx {
+                        was_ota_rx = false;
+                        ota_rx_eta.reset();
+                        ctx.redraw = true; // transfer ended → repaint the app over our screen
+                    }
+                    app.update(&mut ctx);
+                }
+            }
+        }
+        #[cfg(not(feature = "espnow"))]
         app.update(&mut ctx);
 
         // #26 cast: snapshot the just-rendered glass image into the shared cast frame
@@ -1654,40 +1736,6 @@ where
         .ok();
     // The caller flushes — `flush` lives on the concrete `Ssd1306`, not the
     // generic `DrawTarget` (same split as `draw_clock`/`draw_snake_death`).
-}
-
-/// #20: the "Syncing WiFi" indicator shown while a WiFi burst blocks the loop
-/// #153: the 1-px OTA progress edge along the display's BOTTOM row — the minimal feedback
-/// that replaced the retired full-screen `draw_syncing` spinner. Unlike the spinner it does
-/// NOT clear the framebuffer: the frozen last app frame stays visible above, and only row
-/// `y = H-1` is repainted (Off across the full width, then On for the completed fraction)
-/// before flushing. `done`/`total` are the transfer counts the fetch/relay writes into the
-/// shared [`ota::OtaProgress`] cell — bytes for a self-fetch, chunks for a leaf relay; only
-/// the ratio is rendered. `total == 0` (op just armed) → an empty edge. The long-press abort
-/// is unadvertised now (issue #153) but still live. espnow-only, matching the blocking OTA
-/// path, so default/wifi builds stay untouched.
-#[cfg(feature = "espnow")]
-fn draw_ota_edge(display: &mut app::Oled, done: u32, total: u32) {
-    use embedded_graphics::primitives::{Line, PrimitiveStyle};
-    let bb = display.bounding_box();
-    let w = bb.size.width as i32;
-    let y = bb.size.height as i32 - 1;
-    // Erase the bottom row only (the app frame above is left intact), then paint the
-    // completed fraction. The erase keeps it correct even if a resume lowers the count.
-    Line::new(Point::new(0, y), Point::new(w - 1, y))
-        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::Off, 1))
-        .draw(display)
-        .ok();
-    if total > 0 && done > 0 {
-        let filled = ((done.min(total) as u64 * w as u64) / total as u64) as i32;
-        if filled > 0 {
-            Line::new(Point::new(0, y), Point::new(filled - 1, y))
-                .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
-                .draw(display)
-                .ok();
-        }
-    }
-    display.flush().ok();
 }
 
 /// Write `"v<build_num> <ver_noun>"` into `out` (heap-free — the splash runs in the

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -936,6 +936,19 @@ impl Roster {
         None
     }
 
+    /// #161: the KNOWN logical id last learned for `mac` (inverse of [`mac_for_id`]), for the
+    /// on-board OTA screen's "from <noun>" source line. `None` if that MAC isn't in the roster
+    /// or hasn't announced an id yet — the screen then falls back to "from mesh".
+    #[cfg(feature = "espnow")]
+    fn id_for_mac(&self, mac: [u8; 6]) -> Option<u8> {
+        for n in &self.nodes {
+            if n.used && n.id_known && n.mac == mac {
+                return Some(n.id);
+            }
+        }
+        None
+    }
+
     /// #28: eviction value-key for a MAC — LOWER is LESS valuable (evicted first). Orders by
     /// usability (`id_known` — a MAC we can't place in HA / can't relay to is worthless), then
     /// liveness (`connected` = a fresh ACK within `PEER_STALE_MS`), then signal (`rssi`), then
@@ -4956,6 +4969,24 @@ impl RadioManager {
     #[cfg(feature = "espnow")]
     pub fn ota_leaf_dbg(&self) -> (u16, u8, u16) {
         self.ota_leaf.dbg()
+    }
+
+    /// #161: a read-only snapshot of a mesh-OTA THIS leaf is RECEIVING, for the dedicated
+    /// on-board OTA screen — `main` paints [`crate::ota_screen`] over the frozen app frame while
+    /// this is `Some`, so an inbound transfer AUTO-takes the glass (not a menu item). `None` in
+    /// steady state. Resolves the feeding gateway's MAC → a roster id for the "from <noun>" line.
+    /// READ-ONLY: reads the leaf receive session + roster, mutates neither. `espnow`-scoped like
+    /// `ota_leaf_dbg` (the `ota_leaf` receive session only exists in the mesh build).
+    #[cfg(feature = "espnow")]
+    pub fn ota_rx_view(&self) -> Option<crate::ota::OtaRxView> {
+        let (done, total, build, gw_mac) = self.ota_leaf.rx_progress()?;
+        Some(crate::ota::OtaRxView {
+            source_id: self.roster.id_for_mac(gw_mac),
+            hop: 1, // leaf-mesh-OTA is single-hop (gateway→leaf) today
+            build,
+            done,
+            total,
+        })
     }
 
     /// Current peer-link state as an [`LedState`], evaluated at `now_ms`.

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -128,6 +128,31 @@ pub struct OtaProgress {
     pub total: u32,
 }
 
+/// #161: a read-only snapshot of the mesh-OTA a RECEIVING leaf is currently taking, for the
+/// dedicated on-board OTA screen (`crate::ota_screen`). `main` reads it each tick via
+/// [`crate::net::mode::RadioManager::ota_rx_view`] and, while it is `Some`, paints the OTA
+/// screen OVER the frozen app frame — auto-activated by an inbound transfer, never a menu
+/// item. Pure PRESENTATION of state the leaf receive session (`OtaLeafSession`) already
+/// tracks: no new telemetry, no wire/format change. Copy + tiny so it crosses the borrow
+/// (read `ctx.radio`, release, then draw with `ctx.display`) as a value. espnow-only — the
+/// leaf receive path only exists in the mesh build.
+#[cfg(feature = "espnow")]
+#[derive(Clone, Copy)]
+pub struct OtaRxView {
+    /// The feeding gateway's logical id when the roster can place its MAC (`None` = a MAC we
+    /// can't name yet → the screen says "from mesh" rather than inventing an id).
+    pub source_id: Option<u8>,
+    /// ESP-NOW hops from the source. Leaf-mesh-OTA is single-hop today (gateway→leaf), so this
+    /// is 1; kept a field so a future multi-hop relay can surface the true distance unchanged.
+    pub hop: u8,
+    /// The incoming image's monotonic build number (from the SIGNED manifest) — drives the
+    /// "→ v<n>" line + its deterministic FORGE codename ("what you're becoming").
+    pub build: u32,
+    /// Image blocks committed so far / total blocks (the `k/n` readout + the bar fill ratio).
+    pub done: u32,
+    pub total: u32,
+}
+
 #[derive(Clone, Copy)]
 pub struct Announce {
     pub build: u32,

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -512,6 +512,19 @@ impl OtaLeafSession {
         self.gateway_mac
     }
 
+    /// #161: a live snapshot for the on-board OTA screen — `(done, total, build, gateway_mac)`
+    /// where `done`/`total` are BLOCKS: fully-committed windows (`window_base`) plus the current
+    /// window's received chunks (`window_recv` popcount), clamped to `total_chunks`. `None` when
+    /// idle. READ-ONLY — touches no flash/otadata and does not perturb the transfer; the caller
+    /// resolves `gateway_mac` → a source id for the "from <noun>" line.
+    pub fn rx_progress(&self) -> Option<(u32, u32, u32, [u8; 6])> {
+        if !self.active {
+            return None;
+        }
+        let done = self.window_base.saturating_add(self.window_recv.count_ones());
+        Some((done.min(self.total_chunks), self.total_chunks, self.build, self.gateway_mac))
+    }
+
     /// Discard the session (drop the writer WITHOUT activating → otadata untouched).
     fn discard(&mut self) {
         self.active = false;

--- a/rust/clock/src/ota_screen.rs
+++ b/rust/clock/src/ota_screen.rs
@@ -1,0 +1,311 @@
+//! #161 OTA screen — the dedicated "an update is crossing the mesh" display.
+//!
+//! Beyond #153's minimal 1-px bottom edge: when an OTA is in flight this takes the WHOLE
+//! glass with a purpose-built screen so you can watch a board *become* its next image.
+//! Three surfaces, one layout (72×40, 1-bit):
+//!   * **Receiving** — a leaf pulling an image over ESP-NOW: `from <gateway> · N hop`.
+//!   * **Feeding** — the crown relaying to a leaf: `feeding <leaf>`.
+//!   * **SelfFetch** — a gateway fetching its own image over WiFi/HTTP: `from <host>`.
+//!
+//! Layout (top→bottom):
+//! ```text
+//!   y=0   FONT_6X10   incoming build's FORGE codename  ("Molten Engine")   ← the hero
+//!   y=11  FONT_5X8    source / path                    ("from Forge id8")
+//!   y=20  FONT_5X8    incoming build + count           ("v339  42/128")
+//!   y=29  h=11        big dithered BLOCK bar: fill + segment dividers + leading cap,
+//!                     with "NN%" (left) and "~ETA" (right) boxed-overlaid ON the bar
+//! ```
+//!
+//! Pure PRESENTATION — no radio traffic, no flash, no wire change. `main` paints it over the
+//! frozen app frame while an OTA is live (auto-activated by [`crate::net::mode::RadioManager::ota_rx_view`]
+//! for the receive path, or the fetch/relay burst closures for the gateway paths).
+//!
+//! ## The codename caveat (parity)
+//! The firmware's true FORGE version name (About/splash) is seeded from the git short HASH
+//! (`BUILD_HASH`), which a receiving board can't know mid-transfer — the signed manifest
+//! carries only the monotonic build *number*. So this codename is seeded from the build
+//! NUMBER: deterministic + delightful + identical on every on-board surface, but it will NOT
+//! match the hash-seeded name the board shows after it reboots. Threading the true target
+//! name through the announce/OTAM is a future (viz/HA-parity) enhancement.
+
+use core::fmt::Write;
+
+use embedded_graphics::{
+    mono_font::{ascii::FONT_5X8, ascii::FONT_6X10, MonoTextStyle, MonoTextStyleBuilder},
+    pixelcolor::BinaryColor,
+    prelude::*,
+    primitives::{PrimitiveStyle, Rectangle},
+    text::{Baseline, Text},
+};
+
+use crate::app::Oled;
+use crate::net::names::{name_for_seed, FORGE};
+use crate::rssi::{clip, Line};
+
+/// Panel geometry (matches the other screens).
+const PANEL_W: i32 = 72;
+const PANEL_H: i32 = 40;
+/// Conservative per-glyph advance used for right-alignment + the boxed-label backgrounds.
+/// FONT_6X10 is exactly 6; FONT_5X8 is 5 — using 6 for both over-reserves ≤1 px/char, which
+/// only ever nudges a right-aligned label LEFT (never off the right edge) → always safe.
+const CHAR_W: i32 = 6;
+/// How many block dividers segment the progress bar (the "block k/n" texture).
+const BAR_SEGMENTS: i32 = 8;
+
+/// What kind of OTA this board is part of — picks the source/direction line.
+pub enum OtaKind<'a> {
+    /// This board is RECEIVING an image over the mesh from `source_id` (`None` = the feeding
+    /// MAC isn't in the roster yet), `hop` ESP-NOW hops away.
+    Receiving { source_id: Option<u8>, hop: u8 },
+    /// This gateway (crown) is FEEDING the image to leaf `leaf_id` over ESP-NOW.
+    Feeding { leaf_id: u8 },
+    /// This gateway is fetching its OWN image directly over WiFi/HTTP from `host`.
+    SelfFetch { host: &'a str },
+}
+
+/// The transfer's counting unit — drives the `k/n` readout (`Blocks`) vs a `KB` readout
+/// (`Bytes`). ETA is unit-agnostic (computed from the ratio over time).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum OtaUnit {
+    Blocks,
+    Bytes,
+}
+
+/// A fully-specified on-board OTA screen. `build` = the incoming image's build number;
+/// `done`/`total` = the transfer counts in `unit`; `eta_s` = the display-computed ETA in
+/// seconds (`None` until a rate is measurable).
+pub struct OtaView<'a> {
+    pub kind: OtaKind<'a>,
+    pub build: u32,
+    pub done: u32,
+    pub total: u32,
+    pub eta_s: Option<u32>,
+    pub unit: OtaUnit,
+}
+
+/// Display-side ETA estimator (no float — the C3 is soft-float). Averages the transfer rate
+/// since the moment real progress began (re-anchoring through any pre-progress wait, e.g. the
+/// gateway's off-channel fetch), so the ETA is stable and never depressed by the armed idle.
+/// One per in-flight transfer, reset when it ends.
+pub struct OtaEta {
+    /// `(done, now_ms)` anchor — moved forward while `done` is unchanged, then frozen once
+    /// blocks start flowing so the average rate is measured over the ACTIVE window only.
+    anchor: Option<(u32, u64)>,
+}
+
+impl Default for OtaEta {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OtaEta {
+    pub const fn new() -> Self {
+        Self { anchor: None }
+    }
+
+    /// Drop the anchor (call when a transfer ends) so the next one starts fresh.
+    pub fn reset(&mut self) {
+        self.anchor = None;
+    }
+
+    /// Feed the latest `(done, total, now_ms)`; returns the ETA in seconds to reach `total`,
+    /// or `None` until there is measurable progress. Integer-only, overflow-safe (`u64` math).
+    pub fn sample(&mut self, done: u32, total: u32, now_ms: u64) -> Option<u32> {
+        match self.anchor {
+            // Real progress since the anchor → average rate = Δdone / Δt.
+            Some((d0, t0)) if done > d0 && total > done => {
+                let dd = (done - d0) as u64;
+                let dt = now_ms.saturating_sub(t0).max(1);
+                let remaining = (total - done) as u64;
+                Some((remaining.saturating_mul(dt) / dd / 1000) as u32)
+            }
+            // No progress yet (first call, or still awaiting the first block) → (re)anchor at
+            // NOW so the pre-progress wait never enters the average.
+            _ => {
+                self.anchor = Some((done, now_ms));
+                None
+            }
+        }
+    }
+}
+
+fn style_5x8() -> MonoTextStyle<'static, BinaryColor> {
+    MonoTextStyleBuilder::new().font(&FONT_5X8).text_color(BinaryColor::On).build()
+}
+fn style_6x10() -> MonoTextStyle<'static, BinaryColor> {
+    MonoTextStyleBuilder::new().font(&FONT_6X10).text_color(BinaryColor::On).build()
+}
+
+/// Draw `text` at `(x, y)` on a cleared (Off) background box so it stays crisp when overlaid on
+/// the dithered bar. The box is sized from the (already-clipped) text and kept 9 px tall so it
+/// never nicks the bar's 1-px top/bottom outline. Bounded to the panel — panic-free.
+fn boxed_label<D>(display: &mut D, text: &str, x: i32, y: i32)
+where
+    D: DrawTarget<Color = BinaryColor>,
+{
+    let w = text.chars().count() as i32 * CHAR_W;
+    if w <= 0 {
+        return;
+    }
+    let bx = (x - 1).max(0);
+    let bw = (w + 2).min(PANEL_W - bx);
+    Rectangle::new(Point::new(bx, y - 1), Size::new(bw.max(0) as u32, 9))
+        .into_styled(PrimitiveStyle::with_fill(BinaryColor::Off))
+        .draw(display)
+        .ok();
+    Text::with_baseline(text, Point::new(x, y), style_5x8(), Baseline::Top)
+        .draw(display)
+        .ok();
+}
+
+/// The big BLOCK progress bar: full-width outlined track, checkerboard-dithered fill
+/// proportional to `done/total`, `BAR_SEGMENTS` divider ticks (the "blocks"), and a crisp
+/// 1-px leading-edge cap. Mirrors the Finder's dither aesthetic so the fleet reads as one UI.
+/// Bounded (≤ track) + panic-free.
+fn draw_block_bar<D>(display: &mut D, y: i32, h: i32, done: u32, total: u32)
+where
+    D: DrawTarget<Color = BinaryColor>,
+{
+    // Outlined full-width track.
+    Rectangle::new(Point::new(0, y), Size::new(PANEL_W as u32, h as u32))
+        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+        .draw(display)
+        .ok();
+
+    let inner_w = PANEL_W - 2; // inside the 1-px border
+    let fill_w = if total > 0 {
+        ((done.min(total) as u64 * inner_w as u64) / total as u64) as i32
+    } else {
+        0
+    };
+
+    // Checkerboard dither of the filled region (inside the border).
+    let x_end = 1 + fill_w.clamp(0, inner_w);
+    for yy in (y + 1)..(y + h - 1) {
+        for xx in 1..x_end {
+            if (xx + yy) & 1 == 0 {
+                Pixel(Point::new(xx, yy), BinaryColor::On).draw(display).ok();
+            }
+        }
+    }
+
+    // Segment dividers: 1-px vertical ticks at each block boundary. On in the UNFILLED part
+    // (faint ruler) and Off in the FILLED part (a clean gap in the dither) → reads as blocks.
+    for k in 1..BAR_SEGMENTS {
+        let xx = 1 + (k * inner_w) / BAR_SEGMENTS;
+        if xx <= 0 || xx >= PANEL_W - 1 {
+            continue;
+        }
+        let color = if xx < x_end { BinaryColor::Off } else { BinaryColor::On };
+        // Faint: only the middle rows, so the outline stays intact.
+        for yy in (y + 2)..(y + h - 2) {
+            Pixel(Point::new(xx, yy), color).draw(display).ok();
+        }
+    }
+
+    // Crisp leading-edge cap so the moving front is unambiguous.
+    if fill_w > 0 {
+        let cap_x = x_end.clamp(1, PANEL_W - 2);
+        Rectangle::new(Point::new(cap_x, y + 1), Size::new(1, (h - 2).max(1) as u32))
+            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
+            .draw(display)
+            .ok();
+    }
+}
+
+/// Format the ETA compactly (≤5 chars): `~45s` under 100 s, else `~Nm` minutes.
+fn fmt_eta(line: &mut Line, eta_s: u32) {
+    if eta_s < 100 {
+        let _ = write!(line, "~{}s", eta_s);
+    } else {
+        let _ = write!(line, "~{}m", eta_s.div_ceil(60));
+    }
+}
+
+/// Paint the full OTA screen. `display` is the concrete panel (we own the clear + flush, like
+/// the other full-screen draws). Alloc-free; every string is clipped to the 1-bit glass.
+pub fn draw(display: &mut Oled, v: &OtaView) {
+    display.clear(BinaryColor::Off).ok();
+
+    // --- y=0: incoming build's FORGE codename (the hero — "what you're becoming"). --------
+    // Build-NUMBER-seeded (see the module caveat), so it is identical on every on-board surface.
+    let (adj, noun) = name_for_seed(v.build, &FORGE);
+    let mut hero = Line::new();
+    let _ = write!(hero, "{} {}", adj, noun);
+    Text::with_baseline(clip(hero.as_str(), 12), Point::new(0, 0), style_6x10(), Baseline::Top)
+        .draw(display)
+        .ok();
+
+    // --- y=11: source / path line (kind-specific). ----------------------------------------
+    let mut src = Line::new();
+    match &v.kind {
+        OtaKind::Receiving { source_id, hop } => {
+            match source_id {
+                Some(id) => {
+                    let _ = write!(src, "from {} i{}", name_for_seed_id_noun(*id), id);
+                }
+                None => {
+                    let _ = write!(src, "from mesh");
+                }
+            }
+            // Single-hop today (gateway→leaf); surface the distance only if a future multi-hop
+            // relay ever feeds from farther out.
+            if *hop > 1 {
+                let _ = write!(src, " {}h", hop);
+            }
+        }
+        OtaKind::Feeding { leaf_id } => {
+            let _ = write!(src, "feed {} i{}", name_for_seed_id_noun(*leaf_id), leaf_id);
+        }
+        OtaKind::SelfFetch { host } => {
+            let _ = write!(src, "from {}", host);
+        }
+    }
+    Text::with_baseline(clip(src.as_str(), 14), Point::new(0, 11), style_5x8(), Baseline::Top)
+        .draw(display)
+        .ok();
+
+    // --- y=20: incoming build + count. ----------------------------------------------------
+    let mut stat = Line::new();
+    match v.unit {
+        OtaUnit::Blocks => {
+            let _ = write!(stat, "v{} {}/{}", v.build, v.done, v.total);
+        }
+        OtaUnit::Bytes => {
+            let _ = write!(stat, "v{} {}/{}K", v.build, v.done / 1024, v.total / 1024);
+        }
+    }
+    Text::with_baseline(clip(stat.as_str(), 14), Point::new(0, 20), style_5x8(), Baseline::Top)
+        .draw(display)
+        .ok();
+
+    // --- y=29: the big block bar + boxed % (left) and ETA (right) overlays. ----------------
+    let bar_y = 29;
+    let bar_h = PANEL_H - bar_y; // 11 → fills to the bottom row
+    draw_block_bar(display, bar_y, bar_h, v.done, v.total);
+
+    let pct = if v.total > 0 {
+        (v.done.min(v.total) as u64 * 100 / v.total as u64) as u32
+    } else {
+        0
+    };
+    let mut pl = Line::new();
+    let _ = write!(pl, "{}%", pct);
+    boxed_label(display, pl.as_str(), 2, bar_y + 2);
+
+    if let Some(eta) = v.eta_s {
+        let mut el = Line::new();
+        fmt_eta(&mut el, eta);
+        let w = el.as_str().chars().count() as i32 * CHAR_W;
+        boxed_label(display, el.as_str(), (PANEL_W - w - 2).max(0), bar_y + 2);
+    }
+
+    display.flush().ok();
+}
+
+/// The magical NOUN for a node id (the on-screen handle used across the UI). A thin wrapper so
+/// the source-line formatter reads cleanly.
+fn name_for_seed_id_noun(id: u8) -> &'static str {
+    crate::net::names::name_for_id(id).1
+}


### PR DESCRIPTION
## #161 — rich on-board mesh-OTA progress display

Beyond #153's 1-px edge: a dedicated full-glass OTA screen that **auto-takes over** while an update is in flight, so you can watch a board *become* its next image.

### On-board (this PR — firmware, HW-gated)
Three surfaces, one 72×40 layout:

| Surface | When | Shows |
|---|---|---|
| **Receiving** | a leaf pulling an image over ESP-NOW | `from <gateway> i<id>`, big dithered **block bar** (k/n + %), **ETA**, incoming build **codename** |
| **Feeding** | the crown relaying to a leaf | `feed <leaf> i<id>` + the same bar/%, ETA |
| **SelfFetch** | a gateway fetching its own image over WiFi/HTTP | `from <host>` + bytes/KB + ETA |

Layout (top→bottom): codename hero (FONT_6X10) · source/path · `v<build>  k/n` · big dithered block bar with `%` (left) and `~ETA` (right) boxed-overlaid on the fill, plus segment dividers + a crisp leading-edge cap (Finder's dither aesthetic, so the fleet reads as one UI).

**Auto-activation**: the receive screen is painted by `main` over the frozen app frame whenever `RadioManager::ota_rx_view()` returns `Some` (an inbound transfer) — not a menu item you navigate to. The receive session is serviced *before* dispatch, so skipping the app render only pauses PAINTING, never mesh/flash logic; a falling-edge forced redraw repaints the app when the transfer ends. Completion → the existing verify → activate → reboot-into-new-splash flourish.

### Why it's cheap
Pure **presentation** over data that already exists (the `OtaProgress` cell + the leaf receive session). **No radio traffic, no wire/format change.** New surface area is all read-only:
- `ota::OtaRxView` — Copy display contract (`source_id`/`hop`/`build`/`done`/`total`).
- `OtaLeafSession::rx_progress` + `Roster::id_for_mac` + `RadioManager::ota_rx_view` — pure reads.
- `ota_screen.rs` — the renderer + a soft-float-free (integer) ETA estimator (re-anchors through the armed pre-progress wait, so ETA is stable and never depressed by the idle).

All **espnow-gated**; `default`/`wifi` builds are byte-clean of it (default-build invariant verified). `draw_ota_edge` (#153) retired — fully superseded.

### ⚠️ Codename caveat (design decision — wants JP's blessing)
The incoming build's FORGE codename is seeded from the build **NUMBER** (all a receiving board knows mid-transfer — the signed manifest carries no git hash), so it's deterministic + identical on every on-board surface, but it will **NOT match** the hash-seeded name the board shows in About/splash after it reboots. Options:
- **(a) ship as-is** — delightful, flagged in code (chosen).
- (b) show `v<build>` only, no name — one-line change.
- (c) thread the true target name through the announce/OTAM — bigger, touches the transport layer; a natural future viz/HA-parity item.

### PARITY (what the other lanes mirror)
Same event class + fields, from the same `ota/*` topics + mesh-model:
- **Viz (#158 meshscope / #159 observatory)**: per-node OTA bar (k/n + %), a highlighted crown→leaf feed edge, and the incoming build's codename label. `source_id` + `done/total` + `build` are exactly the on-board fields.
- **HA**: an "Update in progress" card — board, source, %, ETA — from `ota/state` + `ota/relaydiag`. ETA is display-computed on-board; HA can derive the same from the block rate.

### Gate — **HW-GATE-HELD** (do not merge)
Canary on real hardware first: a **receiving leaf** shows source + progress + ETA during a live mesh feed, and the **crown** shows `feed <leaf>`.

### Verification
- `clippy -D warnings` green on **espnow,cast,io** · **bare-wifi** (#172 gate) · **default**.
- Release build (espnow,cast,io) links; **default** + **wifi** release builds green (cfg-gating / default-build invariant).
- Rebased clean onto origin/main (`1a18972`), clear of #89 (boot-burst) and #172 (bare-wifi clippy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
