### PR TITLE
fix(fw): #192 periodic NTP re-sync — retire the boot-only sync gap [HW-GATE-HELD]

### DIFF
--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -1191,6 +1191,41 @@ fn main() -> ! {
                         flush_abort
                     });
                     flush_defer_since_ms = 0;
+                    // #192: opportunistic NTP RE-SYNC riding the flush cadence. `try_time_sync`
+                    // runs ONLY at boot, so without this the wall-clock free-runs on the C3
+                    // oscillator forever (tage climbs unbounded → fleet drift). The gateway is
+                    // WiFi-active here (just flushed); if our last true sync is stale
+                    // (> NTP_RESYNC_AGE_S ≈ 1 h), run a lightweight SNTP-only burst (reuses the
+                    // #89 NtpMachine; NO MQTT tail; does NOT tear coexist — step_assoc skips the
+                    // reconnect when already associated) and re-anchor the clock. Leaves refresh
+                    // via mesh time adoption once the crown re-broadcasts the fresh time.
+                    {
+                        let unix_now = base_unix + (now.saturating_sub(anchor_ms) / 1000) as u32;
+                        let stale_s = unix_now.saturating_sub(my_synced_at);
+                        if stale_s > net::NTP_RESYNC_AGE_S && r.is_gateway() {
+                            let mut resync_abort = false;
+                            let fresh = r.resync_ntp(&mut || {
+                                let t = millis();
+                                led.apply(led::LedState::WifiSync, t);
+                                if matches!(button.poll(t), Some(input::Press::Long)) {
+                                    resync_abort = true;
+                                }
+                                resync_abort
+                            });
+                            if let Some(unix) = fresh {
+                                // Re-anchor the free-running clock to the fresh SNTP time. The next
+                                // broadcast_time carries the new my_synced_at → leaves adopt it.
+                                base_unix = unix;
+                                anchor_ms = millis();
+                                my_synced_at = unix;
+                                time_source = app::TimeSource::NtpRoot;
+                                log::info!(
+                                    "smol #192: NTP re-synced -> Unix {} (was {}s stale)",
+                                    unix, stale_s
+                                );
+                            }
+                        }
+                    }
                     // #40 leaf-mesh-OTA orchestration: the flush surfaced a leaf install →
                     // relay the staged image to that leaf over ESP-NOW (canary-one-leaf; the
                     // relay does its own WiFi fetch then an ESP-NOW relay, minutes-scale +

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -1202,7 +1202,13 @@ fn main() -> ! {
                     {
                         let unix_now = base_unix + (now.saturating_sub(anchor_ms) / 1000) as u32;
                         let stale_s = unix_now.saturating_sub(my_synced_at);
-                        if stale_s > net::NTP_RESYNC_AGE_S && r.is_gateway() {
+                        // #192 N1 (155 review): ALSO fire when NEVER-synced (my_synced_at == 0).
+                        // 3/4 boards failed boot SNTP (tsrc=mesh) tonight, so post-#204-heal a
+                        // gateway with my_synced_at==0 would otherwise free-run a full
+                        // NTP_RESYNC_AGE_S (~1h) before its FIRST correction. Fires each flush
+                        // until the first successful sync sets my_synced_at nonzero → then the
+                        // normal ~1h staleness cadence resumes (airtime-conscious once synced).
+                        if (my_synced_at == 0 || stale_s > net::NTP_RESYNC_AGE_S) && r.is_gateway() {
                             let mut resync_abort = false;
                             let fresh = r.resync_ntp(&mut || {
                                 let t = millis();

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -136,6 +136,11 @@ pub use wifi::CFG_KEY_SCAN;
 #[cfg(all(feature = "wifi", not(feature = "espnow")))]
 pub use wifi::try_time_sync;
 
+// #192: the NTP re-sync staleness threshold — read by `main`'s flush-cadence re-sync trigger.
+// `wifi` is a private submodule, so main reaches the const only via this re-export.
+#[cfg(feature = "espnow")]
+pub(crate) use wifi::NTP_RESYNC_AGE_S;
+
 /// Install esp-wifi's heap ONCE. esp-alloc declares the `#[global_allocator]`
 /// inside its own crate; this macro just adds an internal-RAM region to it.
 /// Defined here so both the Phase 2 (`wifi`) and Phase 3 (`espnow`) code paths

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2337,6 +2337,17 @@ impl RadioManager {
         (reached_dhcp, synced)
     }
 
+    /// #192: run a periodic NTP RE-SYNC burst (SNTP-only, NO MQTT tail) on the STA device,
+    /// reusing the boot `NtpMachine` substrate. Called from the main loop on the GATEWAY when
+    /// `my_synced_at` goes stale (> `NTP_RESYNC_AGE_S`). Returns the fresh Unix time, or `None`
+    /// on failure/abort. Does NOT tear the coexist association (`NtpMachine::step_assoc` skips
+    /// the reconnect when already connected). `rng` is `Copy`; `sta` borrows disjoint from
+    /// `self.controller`. Leaves never call this (mesh time adoption refreshes their freshness).
+    pub fn resync_ntp(&mut self, tick: &mut dyn FnMut() -> bool) -> Option<u32> {
+        let sta = self.sta.as_mut()?;
+        crate::net::wifi::run_ntp_resync(&mut self.controller, sta, self.rng, tick)
+    }
+
     /// Current radio mode. Part of the public API (a caller may inspect which
     /// stack is live before choosing to broadcast); not used by `main` today.
     #[allow(dead_code)]

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -692,6 +692,17 @@ impl NtpMachine {
     /// waiting → yield).
     fn step_assoc(&mut self, controller: &mut esp_wifi::wifi::WifiController<'static>) -> bool {
         let net = &crate::secrets::WIFI_NETWORK;
+        // #192: an ALREADY-associated caller (the periodic NTP re-sync burst on a coexist
+        // gateway) skips the disconnect/reconfigure/connect FFI — issuing it would TEAR a live
+        // coexist association (mesh-deaf + re-election churn) for no reason. Go straight to DHCP.
+        // Boot is NOT yet connected here, so the boot burst still runs the full setup below →
+        // boot behaviour is byte-identical.
+        if !self.assoc_configured && matches!(controller.is_connected(), Ok(true)) {
+            self.assoc_configured = true;
+            self.deadline = Instant::now() + SYNC_BUDGET; // shared DHCP+SNTP budget
+            self.phase = NtpPhase::Dhcp;
+            return true;
+        }
         if !self.assoc_configured {
             // Drop any prior association before reconfiguring (harmless if not connected).
             let _ = controller.disconnect();
@@ -900,6 +911,50 @@ pub fn note_broker_connect(connected: bool) {
             "smol #100: broker override unreachable x{} — disabled, reverting to the slot's baked broker",
             streak
         );
+    }
+}
+
+/// #192: re-sync NTP when the last true sync (`my_synced_at`) is older than this. try_time_sync
+/// runs ONLY at boot, so without a periodic re-sync the wall-clock free-runs on the ESP32-C3
+/// oscillator forever (~10–40 ppm drift → seconds/day, unbounded). 1 h caps the accumulated
+/// error before correction while keeping the extra WiFi bursts rare (≈1/120 flushes).
+/// ⚠️ HARDWARE-WATCH tuning knob.
+#[cfg(feature = "espnow")]
+pub(crate) const NTP_RESYNC_AGE_S: u32 = 3600;
+
+/// #192: periodic NTP re-sync — a lightweight SNTP-only burst that reuses the #89 Stage-1
+/// `NtpMachine` substrate. UNLIKE `run_ntp_burst` it runs NO MQTT tail (no election, no downlink,
+/// no discovery): it exists solely to refresh the clock when `my_synced_at` goes stale
+/// (main-loop trigger, GATEWAY only — leaves refresh via mesh time adoption). On an already-
+/// associated coexist gateway, `NtpMachine::step_assoc` skips the disconnect/reconnect, so this
+/// does NOT tear the coexist association — it rebuilds the smoltcp stack (fresh interface) →
+/// DHCP → one SNTP exchange → returns the Unix time (`None` on timeout/abort/assoc-DHCP fail).
+///
+/// Reuses the same module `static mut` NTP buffers as the boot burst — alias-safe for the F2
+/// reason: the boot burst completes BEFORE the main loop, and re-syncs are sequential (only one
+/// flush/burst is ever in flight in the single-threaded main loop), so the borrows never overlap.
+#[cfg(feature = "espnow")]
+pub fn run_ntp_resync(
+    controller: &mut esp_wifi::wifi::WifiController<'static>,
+    device: &mut esp_wifi::wifi::WifiDevice<'static>,
+    mut rng: Rng,
+    tick: &mut dyn FnMut() -> bool,
+) -> Option<u32> {
+    let sntp_src_port = 49152 + (rng.random() % 16384) as u16;
+    let mut machine = NtpMachine::new(device, sntp_src_port);
+    loop {
+        match machine.poll(controller, device) {
+            NtpPoll::Pending => {
+                if tick() {
+                    return None; // #20 long-press abort → give up this re-sync, retry when due again
+                }
+            }
+            // Assoc/DHCP gave up (e.g. AP briefly unreachable) → no fresh time this cycle; the
+            // main-loop trigger re-attempts on the next flush once still stale.
+            NtpPoll::Failed => return None,
+            // Reached DHCP; carry the SNTP result. NO MQTT tail (that is run_ntp_burst / the flush).
+            NtpPoll::ReachedDhcp(t) => return t,
+        }
     }
 }
 


### PR DESCRIPTION
Closes #192. **HW-GATE-HELD** — needs bench verification before merge/rollout.

## Problem
`try_time_sync` runs ONLY at boot → the wall-clock free-runs on the C3 oscillator forever. Live fleet (v339): tage≈9h on all 4 boards, none re-synced since boot; #187 NTP-freshness dots all red. Unbounded drift (~10-40 ppm).

## Fix — isolated SNTP-only re-sync riding the flush cadence
Chosen to keep **zero blast radius** on the brick-sensitive `mqtt_session` election/drain path:
- **`NtpMachine::step_assoc`**: skip disconnect/reconnect when already connected → a coexist gateway re-sync does **not tear** the association. Boot is not-connected → full setup → **byte-identical**.
- **`run_ntp_resync`**: thin driver reusing the #89 Stage-1 `NtpMachine` (assoc-check → DHCP → SNTP), **no MQTT tail**; reuses the boot NTP_* static buffers (alias-safe: sequential, boot done before the main loop).
- **`RadioManager::resync_ntp`** lends controller+sta.
- **main flush block**: gateway + `unix_now - my_synced_at > NTP_RESYNC_AGE_S` (1h) → `resync_ntp` → re-anchor `base_unix`/`anchor_ms`/`my_synced_at` + `time_source=NtpRoot`. Leaves refresh via mesh adoption (already inherits `psynced`) once the crown re-broadcasts fresh time.

## Build tiers (katana/1.96.1)
clippy `-D warnings` + release all green: espnow,cast,io / default / wifi. **default unaffected**; wifi-only gets only the harmless `step_assoc` skip.

## Rollback
Reverting restores boot-only sync (the pre-existing drift). No shared-substrate change; `step_assoc` skip is behaviour-neutral for boot/wifi-only.

## ⚠️ HW canary (issue constraint #3 — verify BEFORE fleet)
Boot SNTP works (id8=`tsrc=ntp`) so the NTP path through gatekeeper is functional. But **must bench-confirm the SNTP reply actually ARRIVES during a coexist flush** (earlier campaign hit router-path NTP flakiness) → a gateway's tage resets, then leaves adopt fresh time (fleet tage drops, #187 dots green). If replies don't arrive on the burst path → separate gatekeeper/NTP-routing finding; re-sync is moot until fixed. Bench soak + rig queue; do NOT roll to fleet without a canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)