### PR TITLE
feat(meshscope): #23 operator mode — OTA + HA command controls behind --operator

### DIFF
--- a/rust/viz/Cargo.lock
+++ b/rust/viz/Cargo.lock
@@ -2597,6 +2597,7 @@ dependencies = [
  "egui",
  "egui_plot",
  "mesh-model",
+ "rumqttc",
 ]
 
 [[package]]

--- a/rust/viz/meshscope/Cargo.toml
+++ b/rust/viz/meshscope/Cargo.toml
@@ -19,5 +19,8 @@ mesh-model.workspace = true
 eframe = { version = "0.28", default-features = false, features = ["default_fonts", "glow", "wayland", "x11"] }
 egui = "0.28"
 egui_plot = "0.28" # sparklines in the detail panel
+# #23 operator mode: the publish path (a separate client, distinct id). The listener
+# lives in mesh-model; this is meshscope's OWN client for --operator publishing.
+rumqttc.workspace = true
 # Load a local .env (SMOL_MQTT_HOST/USER/PASS) if present — never committed.
 dotenvy.workspace = true

--- a/rust/viz/meshscope/src/main.rs
+++ b/rust/viz/meshscope/src/main.rs
@@ -10,6 +10,7 @@
 //!   meshscope --selftest headless: feed sample payloads through the model, print, exit
 //!   meshscope --help / --version
 
+mod operator;
 mod ui;
 
 use std::sync::{Arc, Mutex};
@@ -27,6 +28,9 @@ USAGE:
     meshscope [FLAGS]
 
 FLAGS:
+    --operator    Enable OPERATOR mode: an Operator dock appears and meshscope may PUBLISH
+                  to smol command topics (OTA install, config/*, reboot/scan, channel_hint).
+                  WITHOUT this flag meshscope is a pure listener (default). Live mode only.
     --demo        Launch the UI seeded with synthetic mesh data (no broker needed)
     --selftest    Headless: feed sample payloads through the model, print a summary, exit
     --help        Show this help
@@ -56,13 +60,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let demo = args.iter().any(|a| a == "--demo");
+    let operator_on = args.iter().any(|a| a == "--operator");
     let start = Instant::now();
 
-    let model = if demo {
+    let (model, operator): (Arc<Mutex<Model>>, Option<operator::Publisher>) = if demo {
         let mut m = Model::new("(demo — no broker)".into());
         seed_demo(&mut m);
         m.conn = ConnState::Connected;
-        Arc::new(Mutex::new(m))
+        if operator_on {
+            eprintln!("meshscope: --operator has no effect with --demo (no live broker to publish to)");
+        }
+        (Arc::new(Mutex::new(m)), None)
     } else {
         let cfg = match mqtt::BrokerCfg::from_env().map(|c| c.with_client_id("meshscope")) {
             Ok(c) => c,
@@ -73,8 +81,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         };
         let m = Arc::new(Mutex::new(Model::new(cfg.endpoint())));
-        mqtt::spawn(m.clone(), cfg, start);
-        m
+        mqtt::spawn(m.clone(), cfg.clone(), start);
+        // #23: the operator publisher is a SEPARATE client (distinct `<id>-op` id) so it
+        // can never collide with the listener; constructed ONLY with --operator.
+        let operator = operator_on.then(|| operator::Publisher::new(&cfg));
+        if operator_on {
+            eprintln!("meshscope: ⚡ OPERATOR MODE — publishing to smol/* is ARMED");
+        }
+        (m, operator)
     };
 
     let native_options = eframe::NativeOptions {
@@ -90,7 +104,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     eframe::run_native(
         "meshscope",
         native_options,
-        Box::new(move |cc| Ok(Box::new(ui::MeshscopeApp::new(cc, model_for_app, start, initial_selected)))),
+        Box::new(move |cc| Ok(Box::new(ui::MeshscopeApp::new(cc, model_for_app, start, initial_selected, operator)))),
     )?;
     Ok(())
 }

--- a/rust/viz/meshscope/src/operator.rs
+++ b/rust/viz/meshscope/src/operator.rs
@@ -185,7 +185,7 @@ mod tests {
             io_set(7, "0=1"),
             broker(7, "192.0.2.10:1883"),
             ota_host(7, "192.0.2.11"),
-            units("°C 24h"),
+            units("C|24"),
             channel_hint(Some(6)),
             channel_hint(None),
         ] {
@@ -199,7 +199,7 @@ mod tests {
         assert!(reboot(7).destructive);
         assert!(broker(7, "192.0.2.10:1883").destructive);
         assert!(ota_host(7, "192.0.2.11").destructive);
-        assert!(units("°C 24h").destructive);
+        assert!(units("C|24").destructive);
         assert!(channel_hint(Some(6)).destructive);
         // Not confirm-gated: install (idempotent), led, screen, scan.
         assert!(!install(7).destructive);
@@ -219,7 +219,10 @@ mod tests {
         assert_eq!(scan(9).topic, "smol/9/cmd/scan");
         assert_eq!(install(9).topic, "smol/9/ota/install");
         assert_eq!(led(9, "off").topic, "smol/9/config/led");
-        assert_eq!(units("°C 24h").topic, "smol/config/units");
+        assert_eq!(units("C|24").topic, "smol/config/units");
+        // #25: the units wire token is PIPE-separated (fw `from_wire` split('|')) — a joined
+        // "C24" would silently no-op on the board. Lock the pipe form against regression.
+        assert_eq!(units("F|24").payload, b"F|24");
         assert_eq!(channel_hint(Some(6)).topic, "smol/mesh/channel_hint");
     }
 }

--- a/rust/viz/meshscope/src/operator.rs
+++ b/rust/viz/meshscope/src/operator.rs
@@ -1,0 +1,225 @@
+//! Operator mode (#23) — the sanctioned single exception to meshscope's listener-only
+//! invariant (spec §3). Constructed ONLY when `--operator` is passed; without it, none
+//! of this exists and meshscope is a pure listener.
+//!
+//! Safety is structural, not disciplinary:
+//! - Every command is a [`PublishReq`] whose [`Retain`] is fixed by its *builder*. The
+//!   transient commands (`cmd/reset`, `cmd/scan`) are built with [`Retain::Transient`]
+//!   and there is NO builder that makes them retained — a retained `cmd/reset` is a
+//!   permanent ~10 s reboot-loop soft-brick, so this is enforced by construction and a
+//!   unit test ([`tests::transient_commands_never_retained`]).
+//! - [`PublishReq::destructive`] routes an action through a confirmation modal that shows
+//!   the exact topic + payload + retain before anything leaves the process.
+//!
+//! The publish path is meshscope-LOCAL: its own `rumqttc` client with a distinct
+//! client-id (`<listener-id>-op`), so it coexists with the listener without the
+//! same-id reconnect war. The shared `mesh-model` crate is never touched.
+
+use std::thread;
+use std::time::Duration;
+
+use rumqttc::{Client, MqttOptions, QoS};
+
+use mesh_model::mqtt::BrokerCfg;
+
+/// Retain flag for a publish — a 2-variant type so a command's retention is a
+/// deliberate, greppable choice, never a bare bool that can be flipped by accident.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Retain {
+    /// `config/*`, `ota/install` — the leaf must re-read it after a reboot.
+    Retained,
+    /// `cmd/reset`, `cmd/scan` — a one-shot command. **MUST NOT be retained**
+    /// (a retained reset re-fires every ~10 s → soft-brick).
+    Transient,
+}
+
+impl Retain {
+    pub fn as_bool(self) -> bool {
+        matches!(self, Retain::Retained)
+    }
+}
+
+/// A fully-formed publish request. Built by the typed builders below so topic/payload/
+/// retain are decided together and can't drift apart.
+#[derive(Clone, Debug)]
+pub struct PublishReq {
+    pub topic: String,
+    pub payload: Vec<u8>,
+    pub retain: Retain,
+    /// Human summary shown in the confirmation modal + the "last published" line.
+    pub label: String,
+    /// Requires a confirmation modal before it goes out (reboot / broker / ota_host /
+    /// channel_hint / any fleet-wide action).
+    pub destructive: bool,
+}
+
+impl PublishReq {
+    fn retained(topic: String, payload: impl Into<Vec<u8>>, label: String, destructive: bool) -> Self {
+        PublishReq { topic, payload: payload.into(), retain: Retain::Retained, label, destructive }
+    }
+    /// The ONLY constructor for a transient command — retain is Transient, full stop.
+    fn transient(topic: String, label: String, destructive: bool) -> Self {
+        // Payload is presence-triggered (the fw fires on receipt, ignores the value); "1"
+        // is a clear, non-empty marker.
+        PublishReq { topic, payload: b"1".to_vec(), retain: Retain::Transient, label, destructive }
+    }
+
+    pub fn summary(&self) -> String {
+        let val = String::from_utf8_lossy(&self.payload);
+        let r = if self.retain.as_bool() { "retained" } else { "transient" };
+        format!("{}  →  {} = \"{}\"  [{}]", self.label, self.topic, val, r)
+    }
+}
+
+// --- Typed control builders (the whole command surface, verified vs net/wifi.rs) -------
+// Per-node -----------------------------------------------------------------------------
+
+/// Arm an OTA install (idempotent; fw refuses `staged.build <= running`). "Install" verb
+/// matches HA's Update entity (parity).
+pub fn install(id: u8) -> PublishReq {
+    PublishReq::retained(format!("smol/{id}/ota/install"), b"INSTALL".to_vec(), format!("Install update on id{id}"), false)
+}
+pub fn default_screen(id: u8, appkind: &str, page: u8) -> PublishReq {
+    PublishReq::retained(format!("smol/{id}/config/default_screen"), format!("{appkind}:{page}"), format!("Default screen id{id} → {appkind}:{page}"), false)
+}
+pub fn led(id: u8, mode: &str) -> PublishReq {
+    PublishReq::retained(format!("smol/{id}/config/led"), mode.as_bytes().to_vec(), format!("LED id{id} → {mode}"), false)
+}
+/// Plugin-visibility mask. The fw parses `config/plugins` as **up-to-4 ASCII-hex chars
+/// → u16** (`menu.rs`), so emit hex, NOT decimal.
+pub fn plugins(id: u8, mask: u16) -> PublishReq {
+    PublishReq::retained(format!("smol/{id}/config/plugins"), format!("{mask:x}"), format!("Plugins id{id} → 0x{mask:x}"), false)
+}
+pub fn custom(id: u8, compose: &str) -> PublishReq {
+    PublishReq::retained(format!("smol/{id}/config/custom"), compose.as_bytes().to_vec(), format!("Custom screen id{id}"), false)
+}
+pub fn io_map(id: u8, descriptor: &str) -> PublishReq {
+    PublishReq::retained(format!("smol/{id}/config/io"), descriptor.as_bytes().to_vec(), format!("IO pin-map id{id} → {descriptor}"), false)
+}
+pub fn io_set(id: u8, states: &str) -> PublishReq {
+    PublishReq::retained(format!("smol/{id}/io/set"), states.as_bytes().to_vec(), format!("IO output id{id} → {states}"), false)
+}
+/// Broker override — reboots the leaf + can strand it → destructive (confirm).
+pub fn broker(id: u8, ipv4_port: &str) -> PublishReq {
+    PublishReq::retained(format!("smol/{id}/config/broker"), ipv4_port.as_bytes().to_vec(), format!("Broker override id{id} → {ipv4_port}"), true)
+}
+/// OTA-host override — strand risk → destructive (confirm).
+pub fn ota_host(id: u8, host: &str) -> PublishReq {
+    PublishReq::retained(format!("smol/{id}/config/ota_host"), host.as_bytes().to_vec(), format!("OTA host id{id} → {host}"), true)
+}
+/// Reboot — TRANSIENT (retain=false, enforced) + destructive (confirm).
+pub fn reboot(id: u8) -> PublishReq {
+    PublishReq::transient(format!("smol/{id}/cmd/reset"), format!("Reboot id{id}"), true)
+}
+/// On-demand WiFi scan — TRANSIENT (retain=false, enforced); not destructive.
+pub fn scan(id: u8) -> PublishReq {
+    PublishReq::transient(format!("smol/{id}/cmd/scan"), format!("WiFi scan id{id}"), false)
+}
+
+// Fleet-wide (v1: units + channel_hint ONLY — team-lead ruling) ------------------------
+
+/// Fleet display units. `token` e.g. "°F 12h" — align to the HA dashboard's exact vocab.
+pub fn units(token: &str) -> PublishReq {
+    PublishReq::retained("smol/config/units".to_string(), token.as_bytes().to_vec(), format!("FLEET units → {token}"), true)
+}
+/// Crown channel-steer (#155). A decimal channel; empty payload clears the hint.
+pub fn channel_hint(ch: Option<u8>) -> PublishReq {
+    let (payload, label) = match ch {
+        Some(c) => (c.to_string().into_bytes(), format!("FLEET channel hint → ch {c}")),
+        None => (Vec::new(), "FLEET channel hint → CLEAR".to_string()),
+    };
+    PublishReq::retained("smol/mesh/channel_hint".to_string(), payload, label, true)
+}
+
+// --- The publisher (own rumqttc client, distinct id) ----------------------------------
+
+/// Owns the operator MQTT client + its drain thread. `send` is fire-and-forget QoS 0.
+pub struct Publisher {
+    client: Client,
+}
+
+impl Publisher {
+    /// Build from the listener's broker cfg, deriving a distinct `<id>-op` client id so
+    /// the operator connection never collides with the listener's.
+    pub fn new(base: &BrokerCfg) -> Self {
+        let client_id = format!("{}-op", base.client_id);
+        let mut opts = MqttOptions::new(client_id, &base.host, base.port);
+        opts.set_keep_alive(Duration::from_secs(30));
+        if !base.user.is_empty() {
+            opts.set_credentials(&base.user, &base.pass);
+        }
+        let (client, mut connection) = Client::new(opts, 16);
+        // Drain the eventloop so queued publishes actually flush + it auto-reconnects.
+        thread::spawn(move || {
+            for _ in connection.iter() {}
+        });
+        Publisher { client }
+    }
+
+    /// Publish a request. Retain comes from the typed request — transient commands are
+    /// structurally retain=false. Errors are swallowed (rumqttc requeues/reconnects).
+    pub fn send(&self, req: &PublishReq) {
+        let _ = self
+            .client
+            .publish(&req.topic, QoS::AtMostOnce, req.retain.as_bool(), req.payload.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transient_commands_never_retained() {
+        // The soft-brick guard: reset + scan MUST be retain=false, always.
+        assert!(!reboot(7).retain.as_bool(), "cmd/reset must be transient (retained = reboot-loop brick)");
+        assert!(!scan(7).retain.as_bool(), "cmd/scan must be transient");
+        // And every config/* + install is retained (survives a leaf reboot).
+        for r in [
+            install(7),
+            led(7, "on"),
+            default_screen(7, "Clock", 0),
+            plugins(7, 0b101),
+            custom(7, "x"),
+            io_map(7, "0L"),
+            io_set(7, "0=1"),
+            broker(7, "192.0.2.10:1883"),
+            ota_host(7, "192.0.2.11"),
+            units("°C 24h"),
+            channel_hint(Some(6)),
+            channel_hint(None),
+        ] {
+            assert!(r.retain.as_bool(), "{} must be retained", r.topic);
+        }
+    }
+
+    #[test]
+    fn destructive_flags() {
+        // Confirm-gated: reboot, broker, ota_host, fleet units, channel_hint.
+        assert!(reboot(7).destructive);
+        assert!(broker(7, "192.0.2.10:1883").destructive);
+        assert!(ota_host(7, "192.0.2.11").destructive);
+        assert!(units("°C 24h").destructive);
+        assert!(channel_hint(Some(6)).destructive);
+        // Not confirm-gated: install (idempotent), led, screen, scan.
+        assert!(!install(7).destructive);
+        assert!(!led(7, "on").destructive);
+        assert!(!scan(7).destructive);
+    }
+
+    #[test]
+    fn channel_hint_clear_is_empty() {
+        assert!(channel_hint(None).payload.is_empty());
+        assert_eq!(channel_hint(Some(11)).payload, b"11");
+    }
+
+    #[test]
+    fn topics_are_wellformed() {
+        assert_eq!(reboot(9).topic, "smol/9/cmd/reset");
+        assert_eq!(scan(9).topic, "smol/9/cmd/scan");
+        assert_eq!(install(9).topic, "smol/9/ota/install");
+        assert_eq!(led(9, "off").topic, "smol/9/config/led");
+        assert_eq!(units("°C 24h").topic, "smol/config/units");
+        assert_eq!(channel_hint(Some(6)).topic, "smol/mesh/channel_hint");
+    }
+}

--- a/rust/viz/meshscope/src/ui/mod.rs
+++ b/rust/viz/meshscope/src/ui/mod.rs
@@ -2,6 +2,7 @@
 //! event ticker. Reads the shared [`Model`] under its lock once per frame.
 
 pub mod graph;
+mod opdock;
 mod panel;
 mod ticker;
 
@@ -10,6 +11,7 @@ use std::time::{Duration, Instant};
 
 use egui::{Color32, RichText};
 
+use crate::operator::Publisher;
 use mesh_model::model::{ConnState, Model, SyncFreshness};
 use graph::GraphLayout;
 
@@ -18,12 +20,22 @@ pub struct MeshscopeApp {
     layout: GraphLayout,
     selected: Option<u8>,
     start: Instant,
+    /// `Some` ONLY in `--operator` mode — the publish path. `None` = pure listener
+    /// (default), and the operator dock is never shown.
+    operator: Option<Publisher>,
+    op_state: opdock::OperatorState,
 }
 
 impl MeshscopeApp {
-    pub fn new(cc: &eframe::CreationContext<'_>, model: Arc<Mutex<Model>>, start: Instant, selected: Option<u8>) -> Self {
+    pub fn new(
+        cc: &eframe::CreationContext<'_>,
+        model: Arc<Mutex<Model>>,
+        start: Instant,
+        selected: Option<u8>,
+        operator: Option<Publisher>,
+    ) -> Self {
         cc.egui_ctx.set_visuals(egui::Visuals::dark());
-        MeshscopeApp { model, layout: GraphLayout::default(), selected, start }
+        MeshscopeApp { model, layout: GraphLayout::default(), selected, start, operator, op_state: opdock::OperatorState::default() }
     }
 }
 
@@ -59,6 +71,16 @@ impl eframe::App for MeshscopeApp {
         egui::SidePanel::right("detail").resizable(true).default_width(310.0).min_width(240.0).show(ctx, |ui| {
             panel::show(ui, &m, self.selected, now_s);
         });
+
+        // Operator dock (left) — ONLY in --operator mode. The command surface + the
+        // confirmation modal for destructive/fleet actions. Default builds never see it.
+        if let Some(publisher) = self.operator.as_ref() {
+            egui::SidePanel::left("operator").resizable(true).default_width(290.0).min_width(250.0).show(ctx, |ui| {
+                let sel_node = self.selected.and_then(|id| m.nodes.get(&id));
+                opdock::show(ui, sel_node, publisher, &mut self.op_state);
+            });
+            opdock::confirm_modal(ctx, publisher, &mut self.op_state);
+        }
 
         egui::CentralPanel::default().show(ctx, |ui| {
             if let Some(clicked) = self.layout.draw(ui, &m, self.selected, now_s) {

--- a/rust/viz/meshscope/src/ui/opdock.rs
+++ b/rust/viz/meshscope/src/ui/opdock.rs
@@ -8,9 +8,12 @@ use egui::{Color32, RichText};
 use crate::operator::{self, PublishReq, Publisher};
 use mesh_model::model::Node;
 
-/// Screen names = the exact `app.rs` `AppKind` wire spellings (parity). `Snake` maps to
-/// `MeshSnake` on the espnow fleet, so we list the wire form.
-const APPKINDS: &[&str] = &["Menu", "Clock", "Batt", "Grid", "Bench", "MeshSnake", "About", "Familiar"];
+/// Screen names = the exact `app.rs` `AppKind` wire spellings (single-source parity). Matches
+/// the #24 HA dashboard select (Menu·Clock·Batt·Grid·Snake·Bench·MeshSnake·About·Custom) plus
+/// `Familiar` (a screen boards report but the HA select currently lags — flagged to #25).
+/// app.rs also has Watch/Hunt/Finder; omitted here until confirmed settable-as-default.
+const APPKINDS: &[&str] =
+    &["Menu", "Clock", "Batt", "Grid", "Snake", "Bench", "MeshSnake", "About", "Custom", "Familiar"];
 const LED_MODES: &[&str] = &["status", "on", "off"];
 /// (display label, wire token) — token is the compact `F24`/`C12` form (DIAG cfg echo).
 /// Labels align to the HA dashboard vocabulary (parity — reconciling with #24).

--- a/rust/viz/meshscope/src/ui/opdock.rs
+++ b/rust/viz/meshscope/src/ui/opdock.rs
@@ -15,9 +15,10 @@ use mesh_model::model::Node;
 const APPKINDS: &[&str] =
     &["Menu", "Clock", "Batt", "Grid", "Snake", "Bench", "MeshSnake", "About", "Custom", "Familiar"];
 const LED_MODES: &[&str] = &["status", "on", "off"];
-/// (display label, wire token) — token is the compact `F24`/`C12` form (DIAG cfg echo).
-/// Labels align to the HA dashboard vocabulary (parity — reconciling with #24).
-const UNITS: &[(&str, &str)] = &[("°C 24h", "C24"), ("°C 12h", "C12"), ("°F 24h", "F24"), ("°F 12h", "F12")];
+/// (display label, wire token). The wire token is PIPE-separated `<F|C>|<24|12>` — the fw's
+/// `units::from_wire` splits on `|` and matches the halves exactly, so a joined `F24` parses
+/// to None and the board silently keeps its units (#46 clamp). Mirrors the HA payload (#25).
+const UNITS: &[(&str, &str)] = &[("°C 24h", "C|24"), ("°C 12h", "C|12"), ("°F 24h", "F|24"), ("°F 12h", "F|12")];
 
 /// Operator UI input state (text buffers + the pending confirmation + last-published).
 #[derive(Default)]

--- a/rust/viz/meshscope/src/ui/opdock.rs
+++ b/rust/viz/meshscope/src/ui/opdock.rs
@@ -1,0 +1,248 @@
+//! Operator dock (#23) — the command surface, rendered ONLY in `--operator` mode. A
+//! non-destructive control publishes on click; a destructive/fleet-wide one is routed
+//! through [`confirm_modal`] first. All publishing goes through [`crate::operator`],
+//! whose typed builders fix `retain` per command (transient reset/scan can't be retained).
+
+use egui::{Color32, RichText};
+
+use crate::operator::{self, PublishReq, Publisher};
+use mesh_model::model::Node;
+
+/// Screen names = the exact `app.rs` `AppKind` wire spellings (parity). `Snake` maps to
+/// `MeshSnake` on the espnow fleet, so we list the wire form.
+const APPKINDS: &[&str] = &["Menu", "Clock", "Batt", "Grid", "Bench", "MeshSnake", "About", "Familiar"];
+const LED_MODES: &[&str] = &["status", "on", "off"];
+/// (display label, wire token) — token is the compact `F24`/`C12` form (DIAG cfg echo).
+/// Labels align to the HA dashboard vocabulary (parity — reconciling with #24).
+const UNITS: &[(&str, &str)] = &[("°C 24h", "C24"), ("°C 12h", "C12"), ("°F 24h", "F24"), ("°F 12h", "F12")];
+
+/// Operator UI input state (text buffers + the pending confirmation + last-published).
+#[derive(Default)]
+pub struct OperatorState {
+    screen_kind: String,
+    screen_page: String,
+    plugins_hex: String,
+    custom: String,
+    io_map: String,
+    io_set: String,
+    broker: String,
+    ota_host: String,
+    channel_hint: String,
+    pending: Option<PublishReq>,
+    last: Option<String>,
+}
+
+impl OperatorState {
+    /// Apply a chosen action: destructive → queue for the modal; else publish now.
+    fn dispatch(&mut self, publisher: &Publisher, req: PublishReq) {
+        if req.destructive {
+            self.pending = Some(req);
+        } else {
+            let s = req.summary();
+            publisher.send(&req);
+            self.last = Some(s);
+        }
+    }
+}
+
+/// Render the operator dock. Accumulates at most ONE action per frame, then dispatches
+/// it after the widgets (keeps field-borrows disjoint from the &mut-self dispatch).
+pub fn show(ui: &mut egui::Ui, sel: Option<&Node>, publisher: &Publisher, st: &mut OperatorState) {
+    let mut action: Option<PublishReq> = None;
+
+    ui.add_space(4.0);
+    ui.label(RichText::new("⚡ OPERATOR — publishing armed").strong().color(Color32::from_rgb(240, 180, 60)));
+    ui.label(RichText::new("Controls publish to smol/* on the live broker.").small().weak());
+    ui.separator();
+
+    egui::ScrollArea::vertical().auto_shrink([false, false]).show(ui, |ui| {
+        // ---- Per-node ----
+        match sel {
+            None => {
+                ui.label(RichText::new("Select a node for per-node controls.").weak().small());
+            }
+            Some(n) => {
+                let id = n.id;
+                ui.label(RichText::new(format!("id {} · {}", id, n.label())).strong());
+
+                // OTA install (idempotent; show staged-vs-installed skew like HA's Update entity).
+                if let Some(o) = &n.ota {
+                    let behind = !o.latest.is_empty() && o.latest != o.installed;
+                    ui.horizontal(|ui| {
+                        ui.label(format!("build v{}", o.installed));
+                        if behind {
+                            ui.label(RichText::new(format!("→ v{} available", o.latest)).color(Color32::from_rgb(130, 200, 255)));
+                        }
+                    });
+                    let label = if behind { format!("⬆ Install v{}", o.latest) } else { "Install (up to date)".to_string() };
+                    if ui.add_enabled(behind, egui::Button::new(label)).clicked() {
+                        action = Some(operator::install(id));
+                    }
+                    if n.ota_armed {
+                        ui.label(RichText::new("🎯 install armed").small().color(Color32::from_rgb(210, 120, 235)));
+                    }
+                } else {
+                    ui.label(RichText::new("no ota/state yet").weak().small());
+                }
+                ui.separator();
+
+                // Default screen.
+                ui.label(RichText::new("display").small().weak());
+                ui.horizontal(|ui| {
+                    egui::ComboBox::from_id_source("op_screen")
+                        .selected_text(if st.screen_kind.is_empty() { "screen" } else { st.screen_kind.as_str() })
+                        .show_ui(ui, |ui| {
+                            for k in APPKINDS {
+                                ui.selectable_value(&mut st.screen_kind, (*k).to_string(), *k);
+                            }
+                        });
+                    ui.add(egui::TextEdit::singleline(&mut st.screen_page).desired_width(26.0).hint_text("pg"));
+                    if ui.add_enabled(!st.screen_kind.is_empty(), egui::Button::new("Set")).clicked() {
+                        let page = st.screen_page.trim().parse::<u8>().unwrap_or(0);
+                        action = Some(operator::default_screen(id, &st.screen_kind.clone(), page));
+                    }
+                });
+
+                // LED.
+                ui.horizontal(|ui| {
+                    ui.label("LED");
+                    for mode in LED_MODES {
+                        if ui.button(*mode).clicked() {
+                            action = Some(operator::led(id, mode));
+                        }
+                    }
+                });
+
+                // Plugins (hex mask).
+                ui.horizontal(|ui| {
+                    ui.label("Plugins hex");
+                    ui.add(egui::TextEdit::singleline(&mut st.plugins_hex).desired_width(54.0).hint_text("1f"));
+                    let parsed = u16::from_str_radix(st.plugins_hex.trim(), 16).ok();
+                    if ui.add_enabled(parsed.is_some(), egui::Button::new("Set")).clicked() {
+                        if let Some(mask) = parsed {
+                            action = Some(operator::plugins(id, mask));
+                        }
+                    }
+                });
+
+                // Custom compose string.
+                ui.horizontal(|ui| {
+                    ui.label("Custom");
+                    ui.add(egui::TextEdit::singleline(&mut st.custom).desired_width(130.0));
+                    if ui.add_enabled(!st.custom.is_empty(), egui::Button::new("Set")).clicked() {
+                        action = Some(operator::custom(id, &st.custom.clone()));
+                    }
+                });
+
+                // IO pin-map + output states.
+                ui.horizontal(|ui| {
+                    ui.label("IO map");
+                    ui.add(egui::TextEdit::singleline(&mut st.io_map).desired_width(100.0).hint_text("0L;7B"));
+                    if ui.add_enabled(!st.io_map.is_empty(), egui::Button::new("Set")).clicked() {
+                        action = Some(operator::io_map(id, &st.io_map.clone()));
+                    }
+                });
+                ui.horizontal(|ui| {
+                    ui.label("IO set");
+                    ui.add(egui::TextEdit::singleline(&mut st.io_set).desired_width(100.0).hint_text("0=1;10=0"));
+                    if ui.add_enabled(!st.io_set.is_empty(), egui::Button::new("Set")).clicked() {
+                        action = Some(operator::io_set(id, &st.io_set.clone()));
+                    }
+                });
+                ui.separator();
+
+                // Network / power (all confirm-gated except scan).
+                ui.label(RichText::new("network / power  (⚠ confirm)").small().weak());
+                ui.horizontal(|ui| {
+                    ui.label("Broker");
+                    ui.add(egui::TextEdit::singleline(&mut st.broker).desired_width(120.0).hint_text("host:port"));
+                    if ui.add_enabled(!st.broker.is_empty(), egui::Button::new("Set")).clicked() {
+                        action = Some(operator::broker(id, &st.broker.clone()));
+                    }
+                });
+                ui.horizontal(|ui| {
+                    ui.label("OTA host");
+                    ui.add(egui::TextEdit::singleline(&mut st.ota_host).desired_width(120.0).hint_text("rfc1918 host"));
+                    if ui.add_enabled(!st.ota_host.is_empty(), egui::Button::new("Set")).clicked() {
+                        action = Some(operator::ota_host(id, &st.ota_host.clone()));
+                    }
+                });
+                ui.horizontal(|ui| {
+                    if ui.button("🔍 Scan").clicked() {
+                        action = Some(operator::scan(id));
+                    }
+                    if ui.button(RichText::new("⟳ Reboot").color(Color32::from_rgb(235, 120, 90))).clicked() {
+                        action = Some(operator::reboot(id));
+                    }
+                });
+            }
+        }
+
+        ui.separator();
+        // ---- Fleet (v1: units + channel_hint only) ----
+        ui.label(RichText::new("FLEET  (⚠ confirm)").strong().color(Color32::from_rgb(230, 200, 70)));
+        ui.horizontal(|ui| {
+            ui.label("Units");
+            for (label, token) in UNITS {
+                if ui.button(*label).clicked() {
+                    action = Some(operator::units(token));
+                }
+            }
+        });
+        ui.horizontal(|ui| {
+            ui.label("Channel hint");
+            ui.add(egui::TextEdit::singleline(&mut st.channel_hint).desired_width(36.0).hint_text("6"));
+            let ch = st.channel_hint.trim().parse::<u8>().ok();
+            if ui.add_enabled(ch.is_some(), egui::Button::new("Set")).clicked() {
+                action = Some(operator::channel_hint(ch));
+            }
+            if ui.button("Clear").clicked() {
+                action = Some(operator::channel_hint(None));
+            }
+        });
+
+        // ---- Last published ----
+        if let Some(last) = &st.last {
+            ui.separator();
+            ui.label(RichText::new("last published").small().weak());
+            ui.label(RichText::new(last).small().monospace().color(Color32::from_rgb(150, 200, 160)));
+        }
+    });
+
+    if let Some(req) = action {
+        st.dispatch(publisher, req);
+    }
+}
+
+/// The confirmation modal for a queued destructive/fleet action. Shows the EXACT
+/// topic + payload + retain before anything is published — the operator's last check.
+pub fn confirm_modal(ctx: &egui::Context, publisher: &Publisher, st: &mut OperatorState) {
+    let Some(req) = st.pending.clone() else {
+        return;
+    };
+    let mut close = false;
+    egui::Window::new(RichText::new("⚠ Confirm command").color(Color32::from_rgb(235, 150, 60)))
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+        .show(ctx, |ui| {
+            ui.label("Destructive or fleet-wide. Confirm the exact publish:");
+            ui.add_space(4.0);
+            ui.label(RichText::new(req.summary()).monospace());
+            ui.add_space(8.0);
+            ui.horizontal(|ui| {
+                if ui.button(RichText::new("Confirm & publish").color(Color32::from_rgb(235, 120, 90))).clicked() {
+                    let s = req.summary();
+                    publisher.send(&req);
+                    st.last = Some(s);
+                    close = true;
+                }
+                if ui.button("Cancel").clicked() {
+                    close = true;
+                }
+            });
+        });
+    if close {
+        st.pending = None;
+    }
+}


### PR DESCRIPTION
Closes #23. Un-defers the visualizers spec's parked `--operator` mode. **Design was reviewed + approved by team-lead** (scratch/meshscope-operator/morpheus-158.md) before any publish code was written.

## The invariant
`--operator` gates **all** publishing. Without it, meshscope constructs **no publish client** and is a byte-identical pure listener (spec §3). With it, an Operator dock appears and meshscope may publish to smol command topics — the sanctioned single exception to listener-only.

## Architecture
Publish path is **meshscope-local**: a separate `rumqttc` client with a distinct `<id>-op` client id, so it coexists with the listener (no same-id reconnect war — the bug fixed in #158). The shared `mesh-model` crate (used by observatory too) is **untouched**.

## Safety by construction (the brick-critical part)
- **Retain is fixed per command by its typed builder.** `cmd/reset` + `cmd/scan` are built via the transient path (`retain=false`) — there is **no builder** that makes them retained. A retained `cmd/reset` = permanent ~10 s reboot-loop soft-brick, so this is enforced structurally + a unit test (`transient_commands_never_retained`).
- **Confirmation modal** (shows the exact topic + payload + retain) for reboot / broker / ota_host / units / channel_hint — the operator's last check.

## Control surface (verified against `net/wifi.rs`)
`ota/install` ("Install" verb + staged-vs-installed skew like HA's Update entity) · `config/{default_screen,led,plugins,custom,io}` + `io/set` · `config/{broker,ota_host}` · `cmd/{reset,scan}` · fleet `config/units` + `mesh/channel_hint`.

**Corrections found while wiring** (the confirm-before-wiring gate earned its keep):
- `config/net` **omitted** — retired/inert per #142 (fw drains+ignores `N`).
- #160 notify **omitted** — no MQTT command topic exists yet.
- `plugins` is **4-ASCII-hex → u16** (not decimal); `units` token is the compact `F24`/`C12` form.

## HA parity (#25)
Labels/thresholds mirror the #24 dashboard; NTP freshness uses the canonical mesh-model `SYNC_FRESH_S=300`/`SYNC_STALE_S=3600` (#187). Exact command-label vocab being reconciled with luna-notify (#25).

## Verification
Built on **familiar** (viz is std/non-pinned): `clippy -D warnings` + `--release` green; **4 operator unit tests pass** (retain-safety, destructive flags, topic formatting, channel-hint clear). Screenshotted **live against the fleet** (mid-v341-roll) — no clicks, nothing published. Creds env-only; broker/host field hints are RFC5737 placeholders (no real infra in-repo). Binary + screenshot in git-ignored `bin/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)