### PR TITLE
fw: #204 rung-1 — crown dead-unicast self-heal (detector + ch6-reassoc/shed ladder) [HW-GATE-HELD]

### DIFF
--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -29,6 +29,24 @@ pub(crate) fn assert_max_tx_power() {
     }
 }
 
+/// #204: the crown's CURRENT AP association — `(channel, RSSI dBm, BSSID)` — via the IDF
+/// `esp_wifi_sta_get_ap_info` FFI. `None` if not associated or the call errors. Published in the
+/// crown's DIAG so the #204 coexist-starvation hypothesis (crown deaf when its roam AP is NOT
+/// co-channel with the mesh ch6) is TESTABLE from telemetry — the forensics gap that cost ~3h of
+/// pcap tonight (the fw could not report which AP/channel/RSSI a deaf crown was on).
+#[cfg(feature = "espnow")]
+pub(crate) fn current_ap_info() -> Option<(u8, i8, [u8; 6])> {
+    // SAFETY: `esp_wifi_sta_get_ap_info` fills a caller-owned POD record (all-zero is a valid
+    // initial state); it reads current-association state only, no aliasing. Same FFI idiom as
+    // `assert_max_tx_power` above.
+    let mut rec: esp_wifi_sys::include::wifi_ap_record_t = unsafe { core::mem::zeroed() };
+    let err = unsafe { esp_wifi_sys::include::esp_wifi_sta_get_ap_info(&mut rec) };
+    if err != 0 {
+        return None;
+    }
+    Some((rec.primary, rec.rssi, rec.bssid))
+}
+
 // Hand-rolled MQTT 3.1.1 (QoS0) codec for the HA batt/telemetry bridge (v2). Pure
 // encode/decode; the socket poll-loop that drives it lives in `wifi.rs`.
 #[cfg(feature = "wifi")]

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -4212,58 +4212,67 @@ impl RadioManager {
         // downstream-dry. Streak (not one-shot): small retained frames sneak through intermittently
         // (#204 partial-heal), so a run of dry flushes is required before 2b escalates.
         if ok {
-            // #204 2b/F1: a "deaf tick" = missed our own small retained downstream (got_mc etc.) OR a
-            // recent SELF-fetch died at a bulk-RECEIVE stage. The bulk arm catches the PARTIAL-HEAL
-            // (small frames sneak through → downstream_seen=true → a got_mc-only streak would never
-            // accrue, yet the bulk download still fails — the #26 handshake-passes / body-dies split).
-            let deaf_tick = !elect.downstream_seen || bulk_fetch_deaf;
-            if deaf_tick {
-                self.relay.crown_deaf_streak = self.relay.crown_deaf_streak.saturating_add(1);
-                if bulk_fetch_deaf {
-                    self.relay.deaf_bulk_seen = true; // latch explicit bulk-inbound proof for the shed gate
-                }
-                // Self-heal ladder (GATEWAY-only — flush_telemetry is is_gateway-guarded; `ok`-gating
-                // keeps this disjoint from the !ok flush-fail / R-DEMOTE path). The reassoc rung fires
-                // on the streak (cheap); the aggressive SHED requires BULK proof (an explicit bulk-
-                // fetch failure) OR a DEEP streak — F1: never shed a partial-heal on small-frame alone.
-                if self.relay.crown_deaf_streak >= DEAF_REASSOC_N {
-                    let shed_justified = self.relay.deaf_bulk_seen
-                        || self.relay.crown_deaf_streak >= DEAF_SHED_DEEP_STREAK;
-                    if self.relay.reassoc_cycles >= DEAF_SHED_M && shed_justified {
-                        // SHED / abdicate. Mirrors the #155 channel-yield abdication shape (leaf-scan
-                        // + HELLO-silent) but tags `deaf_shed` — NOT flush_fail_latch: our UPLINK is
-                        // fine (we just flushed `ok`); we're RX-deaf, not flush-incapable. The frozen
-                        // MC lets the H1/H2 machinery elect a healthy crown; the deaf_shed backoff
-                        // (foreign-MC OR 5-min floor) damps the shed→heal-as-leaf→reclaim→re-deafen
-                        // ping-pong (the #26 loop: id9 rebooted 71→74 and re-deafened each time).
-                        self.relay.is_gateway = false;
-                        self.scan_locked = false;
-                        self.last_owner_heard_ms = now;
-                        self.silent_until_relock = true;
-                        self.relay.deaf_shed = true;
-                        self.relay.deaf_shed_ms = now;
-                        self.relay.crown_deaf_streak = 0;
-                        self.relay.reassoc_cycles = 0;
-                        self.relay.deaf_bulk_seen = false;
-                        let _ = self.switch(Mode::EspNow);
-                        log::warn!(
-                            "smol #204: crown SHED — {} ch6-reassocs still downstream-deaf; HELLO-silent + leaf-scanning",
-                            DEAF_SHED_M
-                        );
-                    } else if self.relay.reassoc_cycles < DEAF_SHED_M {
-                        // Rung 1: ch6-preferred reassociate; keep the crown, re-measure next flush.
-                        self.reassoc_ch6_prefer();
-                        self.relay.reassoc_cycles = self.relay.reassoc_cycles.saturating_add(1);
-                        self.relay.crown_deaf_streak = 0;
-                    }
-                    // else (reassoc rung exhausted but not yet shed-justified): HOLD — keep flushing;
-                    // the got_mc streak climbs toward DEEP, or a bulk-fetch failure arrives, then shed.
-                }
-            } else {
-                // FULL heal: received our own small downstream AND no bulk-fetch failure → reset all.
+            // #204 2b/F1 (155 cruxes 2+3): TWO independent deaf signals.
+            //  (a) crown_deaf_streak — the got_mc small-frame streak = the FULLY-deaf detector (small
+            //      unicast dead). Resets on ANY small downstream received.
+            //  (b) deaf_bulk_seen — a LATCHED bulk-inbound failure (a self-fetch that died RECEIVING
+            //      the body). This is the PARTIAL-HEAL signal, and the measured steady state: small
+            //      frames pass cycle after cycle (so the streak NEVER accrues) while every bulk
+            //      transfer dies. It MUST NOT be cleared by a small-frame pass (that pass IS the
+            //      partial-heal — clearing on it re-buries F1); cleared ONLY on a reassoc re-prove
+            //      (fresh evidence after a realign, bounds staleness to one cycle) or on a shed.
+            if elect.downstream_seen {
                 self.relay.crown_deaf_streak = 0;
-                self.relay.reassoc_cycles = 0;
-                self.relay.deaf_bulk_seen = false;
+            } else {
+                self.relay.crown_deaf_streak = self.relay.crown_deaf_streak.saturating_add(1);
+            }
+            if bulk_fetch_deaf {
+                self.relay.deaf_bulk_seen = true;
+            }
+            // Self-heal ladder (GATEWAY-only — flush_telemetry is is_gateway-guarded; `ok`-gating keeps
+            // it disjoint from the !ok flush-fail / R-DEMOTE path). ESCALATE on EITHER a got_mc streak
+            // (fully-deaf) OR a latched bulk failure (partial-heal — where the streak never accrues, so
+            // the bulk latch is the only driver). reassoc rung first (heal in place); SHED requires
+            // BULK proof (deaf_bulk_seen) OR a DEEP got_mc streak (the fully-deaf backstop — never
+            // fires in a small-passes partial-heal, 155 crux 4).
+            let escalate =
+                self.relay.crown_deaf_streak >= DEAF_REASSOC_N || self.relay.deaf_bulk_seen;
+            if escalate {
+                let shed_justified = self.relay.deaf_bulk_seen
+                    || self.relay.crown_deaf_streak >= DEAF_SHED_DEEP_STREAK;
+                if self.relay.reassoc_cycles >= DEAF_SHED_M && shed_justified {
+                    // SHED / abdicate. Mirrors the #155 channel-yield abdication shape (leaf-scan +
+                    // HELLO-silent) but tags `deaf_shed` — NOT flush_fail_latch: our UPLINK is fine (we
+                    // just flushed `ok`); we're RX-deaf, not flush-incapable. The frozen MC lets the
+                    // H1/H2 machinery elect a healthy crown; the deaf_shed backoff (foreign-MC OR 5-min
+                    // floor) damps the shed→heal-as-leaf→reclaim→re-deafen ping-pong (the #26 loop).
+                    self.relay.is_gateway = false;
+                    self.scan_locked = false;
+                    self.last_owner_heard_ms = now;
+                    self.silent_until_relock = true;
+                    self.relay.deaf_shed = true;
+                    self.relay.deaf_shed_ms = now;
+                    self.relay.crown_deaf_streak = 0;
+                    self.relay.reassoc_cycles = 0;
+                    self.relay.deaf_bulk_seen = false;
+                    let _ = self.switch(Mode::EspNow);
+                    log::warn!(
+                        "smol #204: crown SHED — {} ch6-reassocs still downstream-deaf; HELLO-silent + leaf-scanning",
+                        DEAF_SHED_M
+                    );
+                } else if self.relay.reassoc_cycles < DEAF_SHED_M {
+                    // Rung 1: ch6-preferred reassociate; keep the crown, re-measure next flush. RE-ARM
+                    // the bulk latch + streak so the next shed decision re-proves deafness FRESH after
+                    // the realign (155 crux 2 — never shed on pre-reassoc evidence).
+                    self.reassoc_ch6_prefer();
+                    self.relay.reassoc_cycles = self.relay.reassoc_cycles.saturating_add(1);
+                    self.relay.crown_deaf_streak = 0;
+                    self.relay.deaf_bulk_seen = false;
+                }
+                // else (reassoc rung exhausted, not yet shed-justified): HOLD — a fresh bulk failure or
+                // a DEEP got_mc streak will arrive and shed. reassoc_cycles resets only on a shed, so a
+                // repeat-offender crown (healed then deaf again in-tenure) sheds one reassoc sooner —
+                // acceptable (demonstrated deafness ⇒ hand off faster).
             }
         }
         // #6 OTA: stash any announce this flush surfaced for `main` to act on.

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1464,6 +1464,14 @@ struct Relay {
     /// stays fully intact; only the CLAIM is suppressed, so the H1/H2 machinery elects a
     /// flush-capable board off the abdicated owner's frozen seq.
     flush_fail_latch: bool,
+    /// #204 2a: consecutive gateway flushes that CONNECTED (`ok`) but received NONE of this crown's
+    /// own retained downstream (MC/batt/grid) — the crown dead-unicast-RX signal (distinct from
+    /// `flush_fails`, which counts flushes that never CONNECTED). ++ on a connected downstream-dry
+    /// flush, reset to 0 on any downstream received. Rung-1 2b escalates (reassoc → shed) on a streak.
+    crown_deaf_streak: u8,
+    /// #204 2b: ch6-preferred reassociation cycles attempted for the current deaf episode (bounded;
+    /// past M the crown is shed). Reset alongside `crown_deaf_streak` on recovery. 0 in 2a (no actions).
+    reassoc_cycles: u8,
     /// Recently-completed `(src_mac, msgid)` ring — dedup post-completion
     /// retransmits so a message is never enqueued (UDP-delivered) twice (finding 3).
     done: [Option<([u8; 6], u16)>; DONE_RING],
@@ -1501,6 +1509,8 @@ impl Relay {
             last_flush_ms: 0,
             flush_fails: 0,
             flush_fail_latch: false, // #146: no abdication yet
+            crown_deaf_streak: 0, // #204 2a: crown dead-downstream detector
+            reassoc_cycles: 0, // #204 2a/2b: reassoc attempts for the current deaf episode
             done: [None; DONE_RING],
             done_cursor: 0,
             seen: crate::net::flood::SeenSet::new(),
@@ -2858,6 +2868,15 @@ impl RadioManager {
                 ap_ch, ap_rssi, b[0], b[1], b[2], b[3], b[4], b[5]
             ));
         }
+        // #204 2a: crown dead-downstream telemetry — <deaf-streak>:<reassoc-cycles>:<shed 0/1>.
+        // Named `cdeaf` (crown-deaf) to NOT collide with the mesh-test-only `deaf=` (an ESP-NOW
+        // deaf-LIST count). Reads 0:0:0 on a healthy crown or any leaf. The shed flag is 0 in 2a
+        // (no actions yet); rung-1 2b wires the real `deaf_shed`. Appended LAST — positional parse
+        // of the fixed DIAG fields stays intact.
+        rec.push_str(&alloc::format!(
+            "|cdeaf={}:{}:0",
+            self.relay.crown_deaf_streak, self.relay.reassoc_cycles
+        ));
         rec
     }
 
@@ -4072,6 +4091,21 @@ impl RadioManager {
         // flush-success rate is the on-device #9 flush-win proof (was UART0-only). Bumped here so
         // it rides the NEXT diag record.
         self.note_flush(ok);
+        // #204 2a: crown dead-downstream detector (MEASUREMENT ONLY — no election change; 2b adds
+        // the reassoc/shed actions). Only a CONNECTED flush (`ok`) is a valid downstream probe — a
+        // flush that never reached CONNACK (`!ok`) is an uplink/AP failure (already handled by
+        // `flush_fails`/R-DEMOTE), NOT crown-RX deafness. On a connected flush, `elect.downstream_seen`
+        // (got_mc||batt||grid, set in the drain) separates healthy (received its own retained MC) from
+        // downstream-dry. Streak (not one-shot): small retained frames sneak through intermittently
+        // (#204 partial-heal), so a run of dry flushes is required before 2b escalates.
+        if ok {
+            if elect.downstream_seen {
+                self.relay.crown_deaf_streak = 0;
+                self.relay.reassoc_cycles = 0;
+            } else {
+                self.relay.crown_deaf_streak = self.relay.crown_deaf_streak.saturating_add(1);
+            }
+        }
         // #6 OTA: stash any announce this flush surfaced for `main` to act on.
         if ota_offer.is_some() {
             self.ota_offer = ota_offer;

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1326,6 +1326,16 @@ const FLUSH_FAILS_BEFORE_DROP: u8 = 2;
 /// sustained no-AP) — still safely past a transient blip / roam (R-CONNECT recovers those in
 /// seconds), but ~60 s snappier than the prior 5 for the powered-uplink-loss (R4) failover.
 const FLUSH_FAILS_BEFORE_DEMOTE: u8 = 3;
+
+/// #204 2b: consecutive downstream-dry gateway flushes (`crown_deaf_streak`) before the crown
+/// self-heal attempts its first ch6-preferred REASSOCIATE. 4 × RELAY_FLUSH_INTERVAL_MS ≈ 2 min — a
+/// confident, not-jumpy signal (a healthy crown gets its own retained MC back every flush, so 4
+/// consecutive misses is real, not a transient blip).
+const DEAF_REASSOC_N: u8 = 4;
+/// #204 2b: ch6-reassoc cycles that fail to restore downstream before the crown SHEDS (abdicates)
+/// so a healthy board takes over. 2 cycles ≈ 4-5 min total — if two ch6-reassocs don't heal it, the
+/// fabric/AP is the problem, not the association, so hand off the crown rather than churn.
+const DEAF_SHED_M: u8 = 2;
 /// Recently-completed `(src_mac, msgid)` memory. A lost RELAYACK makes a leaf
 /// retransmit an ALREADY-complete message; we must re-ACK it but NOT re-enqueue
 /// (else duplicate UDP delivery — finding 3). Ring of the last few completions.
@@ -1472,6 +1482,16 @@ struct Relay {
     /// #204 2b: ch6-preferred reassociation cycles attempted for the current deaf episode (bounded;
     /// past M the crown is shed). Reset alongside `crown_deaf_streak` on recovery. 0 in 2a (no actions).
     reassoc_cycles: u8,
+    /// #204 2b: crown-deaf ABDICATION latch — set when this board shed the crown because repeated
+    /// ch6-reassocs failed to restore downstream RX. DISTINCT from `flush_fail_latch`: a deaf crown's
+    /// UPLINK is fine (it flushes), it's RX-deaf, so it is NOT flush-incapable in the R-DEMOTE sense —
+    /// but it must still stop (re)claiming so a healthy board takes over. OR'd into the resolver's
+    /// `flush_incapable` claim-guard input; lifted when a FOREIGN owner crowns OR the 5-min floor
+    /// expires (whichever first — the ping-pong damper, since a shed board heals as a leaf and would
+    /// otherwise re-claim + re-deafen).
+    deaf_shed: bool,
+    /// #204 2b: `now_ms()` at the last deaf-shed — the 5-min re-claim-backoff floor references it.
+    deaf_shed_ms: u64,
     /// Recently-completed `(src_mac, msgid)` ring — dedup post-completion
     /// retransmits so a message is never enqueued (UDP-delivered) twice (finding 3).
     done: [Option<([u8; 6], u16)>; DONE_RING],
@@ -1511,6 +1531,8 @@ impl Relay {
             flush_fail_latch: false, // #146: no abdication yet
             crown_deaf_streak: 0, // #204 2a: crown dead-downstream detector
             reassoc_cycles: 0, // #204 2a/2b: reassoc attempts for the current deaf episode
+            deaf_shed: false, // #204 2b: crown-deaf abdication latch
+            deaf_shed_ms: 0, // #204 2b: timestamp of the last deaf-shed (5-min backoff floor)
             done: [None; DONE_RING],
             done_cursor: 0,
             seen: crate::net::flood::SeenSet::new(),
@@ -2147,6 +2169,13 @@ impl RadioManager {
         // Re-associate + run an election-ONLY burst (empty telemetry list).
         let _ = self.switch(Mode::WifiSta);
         let id = self.id;
+        // #204 2b: 5-min floor lift of the deaf-shed backoff (KNOB3 second arm). A board shed for
+        // crown deafness stays leaf-only (deaf_shed OR'd into the resolver's flush_incapable below)
+        // until EITHER a foreign owner crowns (lifted at the adopt-live-owner site) OR this floor
+        // expires — so a fleet with no other capable gateway is never permanently stranded crownless.
+        if self.relay.deaf_shed && now.saturating_sub(self.relay.deaf_shed_ms) > 300_000 {
+            self.relay.deaf_shed = false;
+        }
         let mut elect = crate::net::wifi::MeshElect::new(id);
         elect.now_ms = now;
         // #51: this is a LEAF RECOVERY election → select the WiFi-strength rule (sticky live
@@ -2177,7 +2206,11 @@ impl RadioManager {
         // `MC`. This is what makes R-DEMOTE STICK: without it, this very recovery burst would
         // re-read `MC|<self>|…` (frozen seq) and re-grab ownership on a CONNACK that a tiny
         // election publish can pass but a full flush cannot — the #146 churn/channel-drag loop.
-        elect.flush_incapable = self.relay.flush_fail_latch;
+        // #204 2b: OR-in the crown-deaf abdication — a board shed for downstream deafness (now a
+        // leaf, re-competing via THIS recovery burst) must also refuse to re-claim until it heals or
+        // hands off. Two independent latches (flush_fail_latch, deaf_shed) → two independent lift
+        // conditions → ONE resolver effect (claim suppressed).
+        elect.flush_incapable = self.relay.flush_fail_latch || self.relay.deaf_shed;
         // #6 OTA / #21 config / #33 install: a leaf's recovery burst can also surface these.
         let mut ota_offer: Option<crate::ota::Announce> = None;
         let mut config_offer: Option<crate::app::DefaultScreen> = None;
@@ -2276,6 +2309,11 @@ impl RadioManager {
             // clears the latch (that would re-open the loop).
             if elect.owner_id != id && elect.owner_alive {
                 self.relay.flush_fail_latch = false;
+                // #204 2b KNOB3 (first arm): a FOREIGN owner crowned = the goal state after a deaf-
+                // shed → lift the deaf-shed backoff so we compete normally again. Independent bool
+                // from flush_fail_latch; this is the fast lift, the 5-min floor is the no-other-
+                // gateway fallback.
+                self.relay.deaf_shed = false;
             }
             // #51 speed-up: grace-reset the owner-silence clock ONLY for a GENUINELY LIVE
             // owner (give the scan time to re-lock it). A dead-but-inside-our-backoff owner
@@ -2679,6 +2717,58 @@ impl RadioManager {
         }
     }
 
+    /// #204 2b rung-1: crown dead-downstream self-heal — REASSOCIATE, ch6-preferred. The crown-role
+    /// coexist unicast-RX deafness (#26/#204) is chronic when the crown's AP is not co-channel with
+    /// the ESP-NOW mesh (ch6). A full-band scan picks the strongest ch6 BSSID and pins the STA to it
+    /// (the known-good co-channel coexist config — retire-the-burst-coexist); with no ch6 AP in range
+    /// it falls back to the strongest overall, else a plain reconnect on the baked creds — never a
+    /// hard ch6 pin that could leave the board with NO association (worse than deaf). GATEWAY-only +
+    /// rare (deaf-streak ≥ DEAF_REASSOC_N), disruptive (the scan hops the PHY off-mesh briefly) but
+    /// bounded. Stays in WifiSta (does NOT tear down to ESP-NOW): the crown keeps its role and
+    /// re-measures downstream on the next flush; #155 channel-follow re-advertises the new channel.
+    /// ⚠️ HW-CANARY-GATED: the scan + reassociate radio path — and whether ESP-NOW coexist follows
+    /// the new STA channel — cannot be verified without hardware (same discipline as `run_scan`/OTA).
+    fn reassoc_ch6_prefer(&mut self) {
+        // COEXIST hard gate: never leave the mesh channel mid mesh-OTA transfer (mirrors run_scan).
+        if self.ota_leaf.is_active() {
+            return;
+        }
+        let net = &crate::secrets::WIFI_NETWORK;
+        // Strongest ch6 BSSID if any; else strongest overall; else None (plain reconnect on creds).
+        let (bssid, pin_ch6): (Option<[u8; 6]>, bool) = match self.controller.scan_n(16) {
+            Ok(aps) => {
+                if let Some(a) = aps
+                    .iter()
+                    .filter(|a| a.channel == 6)
+                    .max_by_key(|a| a.signal_strength)
+                {
+                    (Some(a.bssid), true)
+                } else {
+                    (aps.iter().max_by_key(|a| a.signal_strength).map(|a| a.bssid), false)
+                }
+            }
+            Err(_) => (None, false),
+        };
+        let _ = self.controller.disconnect();
+        let _ = self
+            .controller
+            .set_configuration(&esp_wifi::wifi::Configuration::Client(
+                esp_wifi::wifi::ClientConfiguration {
+                    ssid: net.ssid.into(),
+                    password: net.pass.into(),
+                    bssid,
+                    channel: if pin_ch6 { Some(6) } else { None },
+                    ..Default::default()
+                },
+            ));
+        let _ = self.controller.connect();
+        log::warn!(
+            "smol #204: crown deaf → ch6-prefer reassoc (ch6_found={}, bssid_set={})",
+            pin_ch6,
+            bssid.is_some()
+        );
+    }
+
     /// #70: sample the live free-heap and lower the min-heap watermark. Cheap (one `HEAP.free()`);
     /// `main` calls it on the ~10 s tick so the watermark tracks leak/pressure at finer resolution
     /// than the slow diag publish cadence.
@@ -2868,14 +2958,15 @@ impl RadioManager {
                 ap_ch, ap_rssi, b[0], b[1], b[2], b[3], b[4], b[5]
             ));
         }
-        // #204 2a: crown dead-downstream telemetry — <deaf-streak>:<reassoc-cycles>:<shed 0/1>.
+        // #204: crown dead-downstream telemetry — <deaf-streak>:<reassoc-cycles>:<deaf_shed 0/1>.
         // Named `cdeaf` (crown-deaf) to NOT collide with the mesh-test-only `deaf=` (an ESP-NOW
-        // deaf-LIST count). Reads 0:0:0 on a healthy crown or any leaf. The shed flag is 0 in 2a
-        // (no actions yet); rung-1 2b wires the real `deaf_shed`. Appended LAST — positional parse
-        // of the fixed DIAG fields stays intact.
+        // deaf-LIST count). Reads 0:0:0 on a healthy crown or any leaf; the shed flag latches 1 after
+        // a 2b deaf-shed until re-lock. Appended LAST — positional parse of the fixed DIAG fields intact.
         rec.push_str(&alloc::format!(
-            "|cdeaf={}:{}:0",
-            self.relay.crown_deaf_streak, self.relay.reassoc_cycles
+            "|cdeaf={}:{}:{}",
+            self.relay.crown_deaf_streak,
+            self.relay.reassoc_cycles,
+            self.relay.deaf_shed as u8
         ));
         rec
     }
@@ -4104,6 +4195,39 @@ impl RadioManager {
                 self.relay.reassoc_cycles = 0;
             } else {
                 self.relay.crown_deaf_streak = self.relay.crown_deaf_streak.saturating_add(1);
+                // #204 2b: self-heal ladder (GATEWAY-only — flush_telemetry is is_gateway-guarded at
+                // the top; `ok`-gating keeps this in the connected-flush world, disjoint from the !ok
+                // flush-fail / R-DEMOTE path). On a confident deaf streak, first try a ch6-preferred
+                // REASSOC (heal in place, keep the crown); if repeated reassocs still don't restore
+                // downstream, SHED the crown so a healthy board takes over.
+                if self.relay.crown_deaf_streak >= DEAF_REASSOC_N {
+                    if self.relay.reassoc_cycles >= DEAF_SHED_M {
+                        // SHED / abdicate. Mirrors the #155 channel-yield abdication shape (leaf-scan
+                        // + HELLO-silent) but tags `deaf_shed` — NOT flush_fail_latch: our UPLINK is
+                        // fine (we just flushed `ok`); we're RX-deaf, not flush-incapable. The frozen
+                        // MC lets the H1/H2 machinery elect a healthy crown; the deaf_shed backoff
+                        // (foreign-MC OR 5-min floor) damps the shed→heal-as-leaf→reclaim→re-deafen
+                        // ping-pong (the #26 loop: id9 rebooted 71→74 and re-deafened each time).
+                        self.relay.is_gateway = false;
+                        self.scan_locked = false;
+                        self.last_owner_heard_ms = now;
+                        self.silent_until_relock = true;
+                        self.relay.deaf_shed = true;
+                        self.relay.deaf_shed_ms = now;
+                        self.relay.crown_deaf_streak = 0;
+                        self.relay.reassoc_cycles = 0;
+                        let _ = self.switch(Mode::EspNow);
+                        log::warn!(
+                            "smol #204: crown SHED — {} ch6-reassocs still downstream-deaf; HELLO-silent + leaf-scanning",
+                            DEAF_SHED_M
+                        );
+                    } else {
+                        // Rung 1: ch6-preferred reassociate; keep the crown, re-measure next flush.
+                        self.reassoc_ch6_prefer();
+                        self.relay.reassoc_cycles = self.relay.reassoc_cycles.saturating_add(1);
+                        self.relay.crown_deaf_streak = 0;
+                    }
+                }
             }
         }
         // #6 OTA: stash any announce this flush surfaced for `main` to act on.

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2847,6 +2847,17 @@ impl RadioManager {
             let deaf_n = self.deaf.iter().flatten().count();
             rec.push_str(&alloc::format!("|deaf={}|ddrops={}", deaf_n, self.diag.ddrops));
         }
+        // #204: the crown's CURRENT AP association (channel:rssi:bssid). Makes the coexist
+        // off-ch6-starvation hypothesis testable from telemetry — the forensics gap that cost ~3h
+        // of pcap. Only meaningful while associated (a leaf isn't) → `current_ap_info` returns None
+        // off-association and the field is skipped, keeping the DIAG string byte-identical for a
+        // non-associated board. Appended LAST → positional DIAG parse of the fixed fields is intact.
+        if let Some((ap_ch, ap_rssi, b)) = crate::net::current_ap_info() {
+            rec.push_str(&alloc::format!(
+                "|ap={}:{}:{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+                ap_ch, ap_rssi, b[0], b[1], b[2], b[3], b[4], b[5]
+            ));
+        }
         rec
     }
 

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1336,6 +1336,13 @@ const DEAF_REASSOC_N: u8 = 4;
 /// so a healthy board takes over. 2 cycles ≈ 4-5 min total — if two ch6-reassocs don't heal it, the
 /// fabric/AP is the problem, not the association, so hand off the crown rather than churn.
 const DEAF_SHED_M: u8 = 2;
+
+/// #204 2b/F1: the got_mc-miss streak at which a crown SHEDS on small-frame evidence ALONE — when no
+/// explicit bulk-fetch corroboration is available (e.g. a relay-only crown with no self-OTA in flight).
+/// ~8 × RELAY_FLUSH_INTERVAL_MS ≈ 4 min of continuous downstream-dry flushes AFTER the reassoc rung is
+/// exhausted. A got_mc miss is itself bulk-dead proof (small unicast dead ⇒ bulk dead), so this is a
+/// valid — if deliberately conservative — shed path; a live bulk-fetch failure sheds sooner.
+const DEAF_SHED_DEEP_STREAK: u8 = 8;
 /// Recently-completed `(src_mac, msgid)` memory. A lost RELAYACK makes a leaf
 /// retransmit an ALREADY-complete message; we must re-ACK it but NOT re-enqueue
 /// (else duplicate UDP delivery — finding 3). Ring of the last few completions.
@@ -1492,6 +1499,11 @@ struct Relay {
     deaf_shed: bool,
     /// #204 2b: `now_ms()` at the last deaf-shed — the 5-min re-claim-backoff floor references it.
     deaf_shed_ms: u64,
+    /// #204 2b/F1: latched TRUE when a SELF-fetch failed at a bulk-RECEIVE stage during the current
+    /// deaf episode (explicit bulk-inbound proof). Gates the aggressive SHED so a partial-heal crown
+    /// (small frames pass, bulk dies) is shed on real bulk evidence, not a lucky small-frame streak.
+    /// Cleared on a full heal or a shed.
+    deaf_bulk_seen: bool,
     /// Recently-completed `(src_mac, msgid)` ring — dedup post-completion
     /// retransmits so a message is never enqueued (UDP-delivered) twice (finding 3).
     done: [Option<([u8; 6], u16)>; DONE_RING],
@@ -1533,6 +1545,7 @@ impl Relay {
             reassoc_cycles: 0, // #204 2a/2b: reassoc attempts for the current deaf episode
             deaf_shed: false, // #204 2b: crown-deaf abdication latch
             deaf_shed_ms: 0, // #204 2b: timestamp of the last deaf-shed (5-min backoff floor)
+            deaf_bulk_seen: false, // #204 2b/F1: explicit bulk-inbound-failure proof for the shed gate
             done: [None; DONE_RING],
             done_cursor: 0,
             seen: crate::net::flood::SeenSet::new(),
@@ -4076,6 +4089,15 @@ impl RadioManager {
         let _ = self.switch(Mode::WifiSta);
         let id = self.id;
         let now = now_ms();
+        // #204 2b/F1: snapshot a recent SELF-fetch's bulk-RECEIVE-stage failure BEFORE the burst
+        // consumes self.ota_self_fail (mqtt_session publishes + clears it this flush). A fetch that
+        // reached the response/body receive but couldn't complete it is the #26 downstream-bulk-deaf
+        // signature — the bulk-inbound proof that gates the crown SHED (a small-frame got_mc streak
+        // alone can't distinguish a partial-heal where small frames pass but the bulk download dies).
+        let bulk_fetch_deaf = matches!(
+            self.ota_self_fail,
+            Some((_, _, _, _, w)) if crate::net::wifi::ota_fail_is_bulk_deaf(w)
+        );
         // #27: serialize the roster into a stack buffer BEFORE the mutable-borrow burst
         // — the resulting slice is disjoint from `self` (same disjoint-borrow discipline
         // as `own_telemetry`), so it threads through with no borrow conflict. Worst case
@@ -4190,18 +4212,24 @@ impl RadioManager {
         // downstream-dry. Streak (not one-shot): small retained frames sneak through intermittently
         // (#204 partial-heal), so a run of dry flushes is required before 2b escalates.
         if ok {
-            if elect.downstream_seen {
-                self.relay.crown_deaf_streak = 0;
-                self.relay.reassoc_cycles = 0;
-            } else {
+            // #204 2b/F1: a "deaf tick" = missed our own small retained downstream (got_mc etc.) OR a
+            // recent SELF-fetch died at a bulk-RECEIVE stage. The bulk arm catches the PARTIAL-HEAL
+            // (small frames sneak through → downstream_seen=true → a got_mc-only streak would never
+            // accrue, yet the bulk download still fails — the #26 handshake-passes / body-dies split).
+            let deaf_tick = !elect.downstream_seen || bulk_fetch_deaf;
+            if deaf_tick {
                 self.relay.crown_deaf_streak = self.relay.crown_deaf_streak.saturating_add(1);
-                // #204 2b: self-heal ladder (GATEWAY-only — flush_telemetry is is_gateway-guarded at
-                // the top; `ok`-gating keeps this in the connected-flush world, disjoint from the !ok
-                // flush-fail / R-DEMOTE path). On a confident deaf streak, first try a ch6-preferred
-                // REASSOC (heal in place, keep the crown); if repeated reassocs still don't restore
-                // downstream, SHED the crown so a healthy board takes over.
+                if bulk_fetch_deaf {
+                    self.relay.deaf_bulk_seen = true; // latch explicit bulk-inbound proof for the shed gate
+                }
+                // Self-heal ladder (GATEWAY-only — flush_telemetry is is_gateway-guarded; `ok`-gating
+                // keeps this disjoint from the !ok flush-fail / R-DEMOTE path). The reassoc rung fires
+                // on the streak (cheap); the aggressive SHED requires BULK proof (an explicit bulk-
+                // fetch failure) OR a DEEP streak — F1: never shed a partial-heal on small-frame alone.
                 if self.relay.crown_deaf_streak >= DEAF_REASSOC_N {
-                    if self.relay.reassoc_cycles >= DEAF_SHED_M {
+                    let shed_justified = self.relay.deaf_bulk_seen
+                        || self.relay.crown_deaf_streak >= DEAF_SHED_DEEP_STREAK;
+                    if self.relay.reassoc_cycles >= DEAF_SHED_M && shed_justified {
                         // SHED / abdicate. Mirrors the #155 channel-yield abdication shape (leaf-scan
                         // + HELLO-silent) but tags `deaf_shed` — NOT flush_fail_latch: our UPLINK is
                         // fine (we just flushed `ok`); we're RX-deaf, not flush-incapable. The frozen
@@ -4216,18 +4244,26 @@ impl RadioManager {
                         self.relay.deaf_shed_ms = now;
                         self.relay.crown_deaf_streak = 0;
                         self.relay.reassoc_cycles = 0;
+                        self.relay.deaf_bulk_seen = false;
                         let _ = self.switch(Mode::EspNow);
                         log::warn!(
                             "smol #204: crown SHED — {} ch6-reassocs still downstream-deaf; HELLO-silent + leaf-scanning",
                             DEAF_SHED_M
                         );
-                    } else {
+                    } else if self.relay.reassoc_cycles < DEAF_SHED_M {
                         // Rung 1: ch6-preferred reassociate; keep the crown, re-measure next flush.
                         self.reassoc_ch6_prefer();
                         self.relay.reassoc_cycles = self.relay.reassoc_cycles.saturating_add(1);
                         self.relay.crown_deaf_streak = 0;
                     }
+                    // else (reassoc rung exhausted but not yet shed-justified): HOLD — keep flushing;
+                    // the got_mc streak climbs toward DEEP, or a bulk-fetch failure arrives, then shed.
                 }
+            } else {
+                // FULL heal: received our own small downstream AND no bulk-fetch failure → reset all.
+                self.relay.crown_deaf_streak = 0;
+                self.relay.reassoc_cycles = 0;
+                self.relay.deaf_bulk_seen = false;
             }
         }
         // #6 OTA: stash any announce this flush surfaced for `main` to act on.

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -185,6 +185,12 @@ pub struct MeshElect {
     /// R-DEMOTE abdication), so a sitting crown vacates promptly and leaves re-elect a
     /// hinted-channel board instead of staying pinned to our now-wrong-channel HELLO.
     pub hint_blocked: bool,
+    /// #204 2a: true iff this burst RECEIVED any of its own retained downstream (MC/batt/grid) —
+    /// the crown dead-unicast-RX liveness signal. A gateway flush that CONNECTS (`ok`) but leaves
+    /// this FALSE is a downstream-dry tick (the #204 crown-deafness: TX + broadcast fine, sustained
+    /// inbound unicast starves). Set in [`mqtt_session`]'s drain (`got_mc || got_batt || got_grid`);
+    /// the caller reads it post-burst to drive `crown_deaf_streak`. False until the drain runs.
+    pub downstream_seen: bool,
 }
 
 #[cfg(feature = "wifi")]
@@ -207,6 +213,7 @@ impl MeshElect {
             owner_id: my_id,
             owner_alive: false,
             hint_blocked: false, // #155: set by the claim gate on a channel-hint yield
+            downstream_seen: false, // #204 2a: set true in the drain on any retained downstream
         }
     }
 }
@@ -2882,6 +2889,15 @@ fn mqtt_session(
             break;
         }
     }
+
+    // #204 2a: crown dead-downstream detector (measurement only). Record whether this burst
+    // received ANY of its own retained downstream (MC/batt/grid). got_mc is the primary signal —
+    // the crown always retains its OWN MC, so a healthy crown gets it back on every flush; a
+    // downstream-deaf crown gets nothing. batt/grid strengthen confidence but aren't required. The
+    // caller (flush_telemetry) turns a CONNECTED-but-downstream-dry gateway flush into a
+    // `crown_deaf_streak` tick. ⚠️ #204 partial-heal caveat: these are small retained TCP frames,
+    // so a STREAK (not one-shot) guards a lucky small-frame while bulk stays dead (rung-2 = bulk probe).
+    elect.downstream_seen = got_mc || got_batt || got_grid;
 
     // #40 ARMDIAG: snapshot whether THIS flush caught an install (before the diag block below
     // may null `pending_leaf`) — dumped to `smol/<gw>/ota/armdiag` after the arm, so one

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1818,20 +1818,21 @@ mod ota_fail {
     }
 }
 
-/// #204 2b/F1: is a self-fetch failure stage a DOWNSTREAM-RECEIVE (bulk-deaf) signature — did the
-/// fetch get far enough to be RECEIVING the response/body but fail to complete it? These gate the
+/// #204 2b/F1: is a self-fetch failure stage a BODY-RECEPTION (bulk-deaf) signature — did the fetch
+/// reach the point of receiving the 206 response/body and then fail to complete it? These gate the
 /// aggressive crown SHED (the small-frame `got_mc` streak can false-green on a partial-heal, so the
-/// shed needs bulk-inbound proof). TRUE: handshake (no SYN-ACK) / status (bad response header) /
-/// fallback (200 body died mid-stream) / stall (zero-progress exhausted) / deadline (mid-download) /
-/// recycle (chunk never drained). FALSE: the pre-receive stages (assoc/dhcp/slot = pre-net,
-/// connect = never established, send = TX-side which is HEALTHY in the disease) and verify (body was
-/// fully RECEIVED, only the size/SHA/sig gate rejected it → downstream itself worked).
+/// shed needs bulk-inbound proof). TRUE (post-206, body-reception): status (bad 206 header /
+/// Content-Length on a chunk) / fallback (200 body died mid-stream) / stall (zero-progress exhausted
+/// = the #26 "ACKs zero downstream") / deadline (elapsed mid-download) / recycle (chunk never
+/// drained). FALSE — the PRE-206 / non-RX stages (155 crux 3): assoc/dhcp/slot (pre-net), connect
+/// (never established), handshake (TCP SYN-ACK — pre-206, and an upstream/AP blip could cause it, the
+/// R-DEMOTE lane), send (TX-side, HEALTHY in the disease), verify (body FULLY received, only the
+/// size/SHA/sig gate rejected it → downstream worked).
 #[cfg(feature = "espnow")]
 pub(crate) fn ota_fail_is_bulk_deaf(w: u32) -> bool {
     matches!(
         w,
-        ota_fail::HANDSHAKE
-            | ota_fail::STATUS
+        ota_fail::STATUS
             | ota_fail::FALLBACK
             | ota_fail::STALL
             | ota_fail::DEADLINE

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1818,6 +1818,27 @@ mod ota_fail {
     }
 }
 
+/// #204 2b/F1: is a self-fetch failure stage a DOWNSTREAM-RECEIVE (bulk-deaf) signature — did the
+/// fetch get far enough to be RECEIVING the response/body but fail to complete it? These gate the
+/// aggressive crown SHED (the small-frame `got_mc` streak can false-green on a partial-heal, so the
+/// shed needs bulk-inbound proof). TRUE: handshake (no SYN-ACK) / status (bad response header) /
+/// fallback (200 body died mid-stream) / stall (zero-progress exhausted) / deadline (mid-download) /
+/// recycle (chunk never drained). FALSE: the pre-receive stages (assoc/dhcp/slot = pre-net,
+/// connect = never established, send = TX-side which is HEALTHY in the disease) and verify (body was
+/// fully RECEIVED, only the size/SHA/sig gate rejected it → downstream itself worked).
+#[cfg(feature = "espnow")]
+pub(crate) fn ota_fail_is_bulk_deaf(w: u32) -> bool {
+    matches!(
+        w,
+        ota_fail::HANDSHAKE
+            | ota_fail::STATUS
+            | ota_fail::FALLBACK
+            | ota_fail::STALL
+            | ota_fail::DEADLINE
+            | ota_fail::RECYCLE
+    )
+}
+
 /// One short MQTT 3.1.1 QoS0 session over a fresh TCP socket to the HA broker:
 /// TCP connect → CONNECT (client-id `smol-<node_id>`, username+password) → CONNACK
 /// → SUBSCRIBE `smol/display/batt` (downlink FIRST — the retained payload every node


### PR DESCRIPTION
## What

Implements **#204 rung-1** — autonomous self-heal for the **crown-role coexist unicast-RX deafness** diagnosed in #26 (crown goes downstream-deaf minutes after crowning; TX + broadcast fine, sustained inbound unicast — OTA data, SNTP reply, MQTT downlink — starves; no remote lever works because they all ride the dead downstream). Blocks the v341/v342 fleet roll.

Three commits (each 4-tier katana/1.96.1 green: clippy -D + release espnow,cast,io / default / wifi):

1. **`97a7bea` — DIAG `ap=` (diagnosability first).** Publishes the crown's associated AP `channel:rssi:bssid` in DIAG (`current_ap_info()` FFI). Closes the forensic gap that cost ~3h of pcap in #26; makes the off-ch6 trigger testable.
2. **`483bb6a` — 2a detector (MEASUREMENT ONLY, zero election change).** `MeshElect.downstream_seen` (set in the flush drain = `got_mc||batt||grid`) → `Relay.crown_deaf_streak` (++ on a CONNECTED-but-downstream-dry gateway flush, reset on any downstream; `ok`-gated so an uplink/AP failure ≠ RX-deafness). DIAG `|cdeaf=streak:cycles:shed`. got_mc is primary (the crown always retains its own MC).
3. **`7cfac1b` — 2b self-heal ladder (ACTIONS).** On a confident deaf streak: `N=4` → ch6-preferred REASSOC (scan → strongest ch6 BSSID → pin; fallback strongest-overall, then plain reconnect — never a hard pin that risks NO association). Still deaf after `M=2` cycles → SHED the crown (leaf-scan + HELLO-silent, distinct `deaf_shed` latch OR'd into the resolver's `flush_incapable`; NOT `flush_fail_latch` — uplink is fine). Ping-pong damped by two lifts: foreign-owner-crowned (fast) OR 5-min floor (no-other-gateway fallback).

## Invariants preserved

- Election machinery **untouched** except the additive `deaf_shed` OR-in — `flush_fail_latch` (#146), `hint_blocked` (#155), the resolver arms, #136/#137 timing, #150 abdicate-on-flush-fail all unchanged. `deaf_shed` is a THIRD, independent claim-guard latch with its own lifts.
- 2a is pure measurement (no election/resolver/latch touch). 2b's escalation is `ok`-gated → disjoint from the `!ok` flush-fail/R-DEMOTE path.
- DIAG `cdeaf=` named to avoid the mesh-test-only `deaf=` list-count; format stable (3-field).

## ⚠️ HW-GATE-HELD — bench canary required before any fleet use

The scan+reassoc radio path — and whether ESP-NOW coexist follows the new STA channel — **cannot be verified without JP's rig** (same discipline as `run_scan`/OTA). Rides **#193**'s bench canary (SNTP re-sync is only verifiable once downstream RX heals). Canary matrix:

- Healthy crown → `cdeaf=0:0:0`, `ap=` shows ch6, no false action.
- Induce deafness (crown on an off-ch6 AP) → `cdeaf` streak climbs ~+1 per 30s flush → at 4 (~2min) a ch6-reassoc fires (`ap=` flips toward ch6) → downstream RX recovers → #193 SNTP re-sync succeeds → tage resets → #187 dots green → **OTA fetch completes**.
- Reassoc doesn't heal after M=2 → crown SHEDS (`cdeaf` shed-bit=1, HELLO-silent) → a healthy board crowns → NO shed→reclaim ping-pong (the #26 loop stays broken).
- NO shed on a transient single-flush blip (streak hysteresis).

## Review

Adversarial reviewer: **morpheus-155**. Reject-lines / probe checklist (authored from the #26 forensics): `scratch/ota-blackout/27-selfheal-review-checklist.md`. Focus: detector keys on SUSTAINED inbound (not ARP/tiny-frame — partial-heal false-greens those), reassoc CHANNEL-REALIGNS (not same-BSSID reconnect), shed latch STICKS without ping-pong, no #76 split-brain.

Refs #204 #27 #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
