### PR TITLE
feat(meshscope): #197 dock send-notify — type a message → toast on glass

### DIFF
--- a/rust/viz/meshscope/src/operator.rs
+++ b/rust/viz/meshscope/src/operator.rs
@@ -68,6 +68,12 @@ impl PublishReq {
         // is a clear, non-empty marker.
         PublishReq { topic, payload: b"1".to_vec(), retain: Retain::Transient, label, destructive }
     }
+    /// A value-carrying transient command (#197 notify — the message IS the payload). Like
+    /// `transient` it forces Retain::Transient: a retained notify would re-toast on every boot
+    /// (the fw's never-cached invariant), so there is no builder that can make it retained.
+    fn transient_msg(topic: String, payload: Vec<u8>, label: String, destructive: bool) -> Self {
+        PublishReq { topic, payload, retain: Retain::Transient, label, destructive }
+    }
 
     pub fn summary(&self) -> String {
         let val = String::from_utf8_lossy(&self.payload);
@@ -81,7 +87,10 @@ impl PublishReq {
     /// `retain` field blocks external struct-literal forgery — this is the wire-level backstop that
     /// also catches a future in-module builder that regresses. Enforced in [`Publisher::send`].
     fn retain_is_safe(&self) -> bool {
-        !(self.retain.as_bool() && self.topic.contains("/cmd/"))
+        // `/cmd/*` (reset/scan) AND `/notify` (#197 herald toast) must never be retained — a
+        // retained one re-fires/re-toasts on every board reconnect/boot.
+        let transient_topic = self.topic.contains("/cmd/") || self.topic.ends_with("/notify");
+        !(self.retain.as_bool() && transient_topic)
     }
 }
 
@@ -143,6 +152,91 @@ pub fn channel_hint(ch: Option<u8>) -> PublishReq {
         None => (Vec::new(), "FLEET channel hint → CLEAR".to_string()),
     };
     PublishReq::retained("smol/mesh/channel_hint".to_string(), payload, label, true)
+}
+
+// --- #197 herald: transient on-glass toast ("Send message") ---------------------------
+// Wire matches the fw `toast` module: `[~<dur>]<msg>`, wrapped to a 72 px panel.
+
+/// 72 px / (5 px glyph + 1 px advance) = 12 glyphs per line (FONT_5X8) — the fw `toast::COLS`.
+pub const NOTIFY_COLS: usize = 12;
+/// 40 px panel → 3 lines — the fw `toast::ROWS`.
+pub const NOTIFY_ROWS: usize = 3;
+/// Message chars kept, leaving room for a `~<dur>|` prefix within the fw `CFG_VALUE_MAX = 64`.
+const NOTIFY_MSG_MAX: usize = 48;
+
+/// Strip wire delimiters (`|` `;` newlines → space), collapse whitespace, trim, cap length —
+/// so the message can't corrupt the `~<dur>|<msg>` framing or overflow the CFG value.
+fn sanitize(msg: &str) -> String {
+    let mut out = String::with_capacity(msg.len());
+    let mut prev_space = false;
+    for c in msg.chars() {
+        let c = if matches!(c, '|' | ';' | '\n' | '\r' | '\t') { ' ' } else { c };
+        if c == ' ' {
+            if !prev_space && !out.is_empty() {
+                out.push(' ');
+            }
+            prev_space = true;
+        } else {
+            out.push(c);
+            prev_space = false;
+        }
+    }
+    let trimmed = out.trim_end();
+    trimmed.chars().take(NOTIFY_MSG_MAX).collect()
+}
+
+/// Build the `[~<dur>]<msg>` wire the fw `toast::parse_wire` expects.
+fn notify_wire(dur_s: Option<u16>, msg: &str) -> String {
+    let clean = sanitize(msg);
+    match dur_s {
+        Some(d) if d > 0 => format!("~{d}|{clean}"),
+        _ => clean,
+    }
+}
+
+/// A per-node transient toast. Not destructive (a single glass); retain:false (a retained
+/// notify would re-toast every boot — enforced by `transient_msg` + `retain_is_safe`).
+pub fn notify(id: u8, dur_s: Option<u16>, msg: &str) -> PublishReq {
+    let wire = notify_wire(dur_s, msg);
+    PublishReq::transient_msg(format!("smol/{id}/notify"), wire.into_bytes(), format!("Notify id{id}"), false)
+}
+
+/// Fleet-wide toast (`smol/255/notify` → CFG_TARGET_ALL) — a mesh-wide announcement; destructive
+/// (every glass in the house), so it is confirm-gated.
+pub fn notify_fleet(dur_s: Option<u16>, msg: &str) -> PublishReq {
+    let wire = notify_wire(dur_s, msg);
+    PublishReq::transient_msg("smol/255/notify".to_string(), wire.into_bytes(), "FLEET notify → ALL glass".to_string(), true)
+}
+
+/// Greedy word-wrap for the dock PREVIEW — byte-for-byte the fw `toast::wrap` behaviour
+/// (12 cols, 3 rows, hard-split an over-wide word) so what-you-type-is-what-renders. Operates
+/// on the SANITIZED message (what actually goes on the wire).
+pub fn wrap_preview(msg: &str) -> Vec<String> {
+    let s = sanitize(msg);
+    let mut lines: Vec<String> = Vec::new();
+    let mut rest = s.as_str();
+    while !rest.is_empty() && lines.len() < NOTIFY_ROWS {
+        rest = rest.trim_start_matches(' ');
+        if rest.is_empty() {
+            break;
+        }
+        let n = rest.chars().count();
+        if n <= NOTIFY_COLS {
+            lines.push(rest.to_string());
+            break;
+        }
+        // Find the last space within the first COLS chars (word boundary); else hard-split.
+        let window: String = rest.chars().take(NOTIFY_COLS).collect();
+        let cut = window.rfind(' ');
+        let take = match cut {
+            Some(pos) if pos > 0 => pos,          // break at the word boundary
+            _ => NOTIFY_COLS,                      // no space → hard split
+        };
+        let head: String = rest.chars().take(take).collect();
+        lines.push(head.trim_end().to_string());
+        rest = &rest[rest.char_indices().nth(take).map(|(i, _)| i).unwrap_or(rest.len())..];
+    }
+    lines
 }
 
 // --- The publisher (own rumqttc client, distinct id) ----------------------------------
@@ -234,6 +328,26 @@ mod tests {
     fn channel_hint_clear_is_empty() {
         assert!(channel_hint(None).payload.is_empty());
         assert_eq!(channel_hint(Some(11)).payload, b"11");
+    }
+
+    #[test]
+    fn notify_is_transient_and_wire_correct() {
+        // #197: per-node + fleet notify MUST be transient (a retained notify re-toasts every boot).
+        assert!(!notify(7, None, "hi").retain.as_bool());
+        assert!(!notify_fleet(None, "hi").retain.as_bool());
+        assert!(notify(7, None, "hi").retain_is_safe()); // backstop covers /notify too
+        // Topics + the [~<dur>]<msg> wire the fw toast::parse_wire expects.
+        assert_eq!(notify(7, None, "hi").topic, "smol/7/notify");
+        assert_eq!(notify(7, None, "hi").payload, b"hi");
+        assert_eq!(notify(7, Some(5), "hi").payload, b"~5|hi");
+        assert_eq!(notify_fleet(None, "hi").topic, "smol/255/notify");
+        // Fleet is destructive (confirm-gated); per-node is not.
+        assert!(notify_fleet(None, "hi").destructive);
+        assert!(!notify(7, None, "hi").destructive);
+        // Sanitize strips wire delimiters so a message can't corrupt the ~dur|msg framing.
+        assert_eq!(notify(7, None, "a|b;c").payload, b"a b c");
+        // Wrap preview == the 12-col / 3-row fw toast behaviour.
+        assert_eq!(wrap_preview("hello there friend"), ["hello there", "friend"]);
     }
 
     #[test]

--- a/rust/viz/meshscope/src/ui/opdock.rs
+++ b/rust/viz/meshscope/src/ui/opdock.rs
@@ -32,6 +32,8 @@ pub struct OperatorState {
     broker: String,
     ota_host: String,
     channel_hint: String,
+    notify_msg: String,
+    notify_dur: String,
     pending: Option<PublishReq>,
     last: Option<String>,
 }
@@ -204,6 +206,38 @@ pub fn show(ui: &mut egui::Ui, sel: Option<&Node>, publisher: &Publisher, st: &m
                 action = Some(operator::channel_hint(None));
             }
         });
+
+        // ---- #197 herald: send a transient on-glass toast to one node or the whole fleet ----
+        ui.separator();
+        ui.label(RichText::new("message → glass (toast)").small().weak());
+        ui.add(egui::TextEdit::singleline(&mut st.notify_msg).desired_width(170.0).hint_text("hello mesh"));
+        let have_msg = !st.notify_msg.trim().is_empty();
+        let msg = st.notify_msg.clone();
+        ui.horizontal(|ui| {
+            ui.label("secs");
+            ui.add(egui::TextEdit::singleline(&mut st.notify_dur).desired_width(28.0).hint_text("5"));
+            let dur = st.notify_dur.trim().parse::<u16>().ok();
+            if let Some(n) = sel {
+                if ui.add_enabled(have_msg, egui::Button::new(format!("Send → id{}", n.id))).clicked() {
+                    action = Some(operator::notify(n.id, dur, &msg));
+                }
+            }
+            // Fleet-wide (255) is destructive → routed through the confirm modal.
+            if ui.add_enabled(have_msg, egui::Button::new(RichText::new("Send → ALL").color(Color32::from_rgb(230, 200, 70)))).clicked() {
+                action = Some(operator::notify_fleet(dur, &msg));
+            }
+        });
+        // WYSIWYG preview: exactly how the fw toast will wrap it (12 cols / 3 rows), on the
+        // SANITIZED message that goes on the wire — what-you-type-is-what-renders.
+        if have_msg {
+            let lines = operator::wrap_preview(&msg);
+            ui.label(RichText::new("preview (on glass):").small().weak());
+            egui::Frame::none().fill(Color32::from_rgb(18, 20, 26)).inner_margin(3.0).show(ui, |ui| {
+                for l in &lines {
+                    ui.label(RichText::new(l).monospace().color(Color32::from_rgb(215, 220, 230)));
+                }
+            });
+        }
 
         // ---- Last published ----
         if let Some(last) = &st.last {


### PR DESCRIPTION
The **send-UI** half of the herald end-to-end (companion to #28's fw receive side on `feat/197-herald-topic`). Normal review — host tool, no HW gate.

A **"message → glass"** control in the operator dock publishes a transient toast with the exact wire the fw `toast::parse_wire` expects:
- **Per-node** `smol/<id>/notify` (direct) and **fleet** `smol/255/notify` (confirm-gated — every glass in the house).
- Wire `[~<dur>]<msg>` via a value-carrying `transient_msg()` constructor — **retain:false enforced** (a retained notify would re-toast every boot; `retain_is_safe` now backstops `/notify` too).
- `sanitize()` strips wire delimiters so a message can't corrupt the `~dur|msg` framing.
- **WYSIWYG preview** — `wrap_preview()` mirrors the fw toast wrap (12 cols / 3 rows) so what-you-type-is-what-renders, shown live under the field.

**Verification:** 6 operator unit tests (notify transient + `[~<dur>]<msg>` wire + sanitize + wrap-matches-fw + destructive flags); `clippy -D` + build green on familiar. Rebased on main (#205's hardened `transient()`). Creds env-only.

The instant #28's fw send-side lands (held until 89b's feat/204 settles), JP types a message in the dock and watches it toast on glass — demo-complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)