### PR TITLE
fw(#197/#28): herald — transient on-glass toast (receive + send) [HW-GATE-HELD, stacked on #210]

### DIFF
--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -91,6 +91,9 @@ use ssd1306::mode::DisplayConfig;
 // `AppKind`/`App` enum + centralized dispatch, and the `REGISTRY` that
 // auto-builds the menu. The dispatch keystone every screen plugs into.
 mod app;
+// #197 transient on-glass toast overlay — a general primitive (also the mesh-RPG substrate),
+// composited over the active screen from the render loop; never persisted.
+mod toast;
 // ABOUT screen (identity + provenance + OTA stub) and CLOCK screen — both
 // plugins, compiled in EVERY build (identity/time need no radio).
 mod about;
@@ -756,6 +759,8 @@ fn main() -> ! {
     let mut ota_rx_eta = ota_screen::OtaEta::new();
     #[cfg(feature = "espnow")]
     let mut was_ota_rx = false;
+    // #197: tracks a shown toast so its falling edge forces one repaint to clear the box.
+    let mut was_toast = false;
 
     // Hold the boot splash for at least SPLASH_MIN_MS total. The espnow/wifi NTP
     // burst above usually already blew past this (the splash was up throughout);
@@ -1444,6 +1449,15 @@ fn main() -> ! {
                 }
             }
 
+            // #197: a transient on-glass toast (key `M`) — a COMMAND (cache-bypass, one-shot, NEVER
+            // cached → never re-toasts on reboot). Value = `[~<dur>]<msg>`; `toast::parse_wire` splits
+            // the optional `~<sec>` TTL from the message, then we show it over the active screen.
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_NOTIFY) {
+                let (dur_s, msg) = crate::toast::parse_wire(&o.buf[..o.len]);
+                crate::toast::set(msg, now, dur_s as u64 * 1000);
+                log::info!("smol #197: toast shown ({} B, {}s)", msg.len(), dur_s);
+            }
+
             // #52: a remote reboot command (key `R`) — a COMMAND (cache-bypass, one-shot). Applied
             // once (edge — `take` clears it); the value is empty (the key IS the command). Feeds
             // BOTH a leaf (relayed `<id>R`) and the gateway's OWN reset (injected into `self.cfg`),
@@ -1676,6 +1690,17 @@ fn main() -> ! {
         #[cfg(not(feature = "espnow"))]
         app.update(&mut ctx);
 
+        // #197 toast overlay: composite a transient message over the just-painted screen (before
+        // the cast snapshot, so the WLED mirror includes it). The SSD1306 framebuffer persists
+        // between flushes, so re-compositing each tick keeps the box up even after a plugin
+        // repaint. `display` is free here — the `ctx` borrow ended at `update` above. The
+        // falling-edge repaint is deferred to AFTER the redraw-latch reset below (see there).
+        let toast_now = crate::toast::is_active(now);
+        if toast_now {
+            crate::toast::draw(&mut display, now);
+            display.flush().ok();
+        }
+
         // #26 cast: snapshot the just-rendered glass image into the shared cast frame
         // (the `ctx` borrow of `display` has ended at the `update` call above), so the
         // next gateway flush can stream it to the WLED matrix. No-op unless feature=cast.
@@ -1684,6 +1709,13 @@ fn main() -> ! {
 
         // The redraw latch is single-tick: this tick's `update` consumed it.
         redraw = false;
+
+        // #197: a just-EXPIRED toast forces ONE repaint so the plugin redraws over where the box
+        // was. Set AFTER the latch reset above, so it survives to the next tick's top-of-loop seed.
+        if was_toast && !toast_now {
+            redraw = true;
+        }
+        was_toast = toast_now;
 
         delay.delay_millis(SUBTICK_MS);
     }

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -131,6 +131,9 @@ pub use wifi::CFG_KEY_NET;
 pub use wifi::CFG_KEY_BROKER;
 #[cfg(feature = "espnow")]
 pub use wifi::CFG_KEY_OTA;
+// #197 herald NOTIFY key — espnow leaf-apply path (take_cfg_offer(M) → crate::toast::set).
+#[cfg(feature = "espnow")]
+pub use wifi::CFG_KEY_NOTIFY;
 // #72 IO-registry key — the leaf/own apply path (take_cfg_offer(G) → io::apply_wire re-binds
 // the free GPIOs). `io`-gated (⊃ espnow): only the io apply path names it here.
 #[cfg(feature = "io")]

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -194,7 +194,7 @@ const CFG_PREFIX: &[u8] = b"SMOLv1 CFG "; // + "NNN" + KEY + verbatim "<value>"
 /// (a `take_cfg_offer(key)` + apply) and a gateway fill site in `mqtt_session`. Sized `[_; N]`
 /// (not `&[u8]`) so [`CfgTracker`] can allocate exactly one `.bss` buffer slot per key.
 /// An inbound key not listed is dropped at [`CfgTracker::set`] (never buffered/applied).
-const CFG_APPLY_KEYS: [u8; 12] = [
+const CFG_APPLY_KEYS: [u8; 13] = [
     crate::net::wifi::CFG_KEY_SCREEN,
     crate::net::wifi::CFG_KEY_LED,
     crate::net::wifi::CFG_KEY_UNITS,
@@ -218,6 +218,9 @@ const CFG_APPLY_KEYS: [u8; 12] = [
     // #72 IO output states: g — same unconditional-slot rationale as G above (the config
     // PLUMBING is `io`-gated; a non-io build's slot is inert). Leaf takes it via take_cfg_offer(g).
     crate::net::wifi::CFG_KEY_IO_SET,
+    // #197 herald NOTIFY: M — a COMMAND like R/W (buffered/applied via take_cfg_offer(M), NEVER
+    // cached: a cached toast would re-show on every boot). One-shot; the leaf toasts + auto-dismisses.
+    crate::net::wifi::CFG_KEY_NOTIFY,
 ];
 /// #50b leaf-status UPLINK tag: `"SMOLv1 STAT "` (12 B, trailing space) then `"NNN"`
 /// (3-ASCII zero-padded SENDER leaf id) then the verbatim live `<AppKind>:<page>` value

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2233,6 +2233,7 @@ impl RadioManager {
         let mut _gw_own = crate::net::wifi::GwOwnCfg::new(); // #48: recovery burst never captures gateway-own cfg
         let mut _reset_req = crate::net::wifi::ResetReq::new(); // #52: recovery burst issues no reboots
         let mut _scan_req = crate::net::wifi::ScanReq::new(); // #71: recovery burst issues no scans
+        let mut _notify_req = crate::net::wifi::NotifyReq::new(); // #197: recovery burst issues no toasts
         let mut install_requested = false;
         let mut _leaf_install_seen = false; // #40 #1: a leaf's recovery burst is not a gateway relay
         let reached = match self.sta.as_mut() {
@@ -2263,6 +2264,7 @@ impl RadioManager {
                     &[], // #71: recovery burst publishes no own scan
                     None, // #71: recovery burst republishes no cached scan
                     &mut _scan_req, // #71: recovery burst subscribes no cmd/scan (cfg_cache=None)
+                    &mut _notify_req, // #197: recovery burst subscribes no notify (cfg_cache=None)
                     &mut None, // #40: a leaf's recovery burst never relays a leaf OTA
                     &mut None, // #40: recovery burst carries no persistent staged
                     &mut None, // #40: recovery burst publishes no relay diag
@@ -4135,6 +4137,9 @@ impl RadioManager {
         // #71: capture any on-demand WiFi-scan COMMANDS this flush surfaces (transient cmd/scan).
         // Drained below like reset_req: ONE-SHOT `<id>W` relay per leaf target + a self-scan inject.
         let mut scan_req = crate::net::wifi::ScanReq::new();
+        // #197 herald: capture any transient on-glass toast commands (smol/+/notify); one-shot
+        // relayed / self-toasted below like reset/scan.
+        let mut notify_req = crate::net::wifi::NotifyReq::new();
         // #33: capture any OTA install command this flush surfaces.
         let mut install_requested = false;
         // #40 #1: set iff this flush SEES a retained leaf install (pre-arm) → latch pending below.
@@ -4194,6 +4199,7 @@ impl RadioManager {
                     scan_bytes, // #71: gateway publishes its own smol/<id>/scan (empty unless it self-scanned)
                     Some(&self.scan_cache), // #71: republish cached relayed-node scans
                     &mut scan_req, // #71: capture on-demand scan commands (one-shot relay below)
+                    &mut notify_req, // #197: capture on-glass toast commands (one-shot relay below)
                     leaf_ota, // #40: surface a pending leaf-OTA install for main to relay
                     &mut self.staged_raw, // #40: persist the staged across flushes (pair-safe)
                     &mut self.leaf_ota_diag, // #40: publish smol/<leaf>/ota/diag + clear/retry
@@ -4338,6 +4344,18 @@ impl RadioManager {
         }
         if scan_req.own() {
             self.cfg.set(crate::net::wifi::CFG_KEY_SCAN, b"");
+        }
+        // #197 herald toast — twin of the reset/scan drain: a ONE-SHOT `<id>M` frame CARRYING the
+        // message to the target leaf (direct `broadcast_config`, NEVER cached — a cached toast
+        // re-shows on every boot). Own id / fleet-255 → inject `M` into our OWN CfgTracker so
+        // `main`'s take_cfg_offer(M) toasts us on the SAME path as a leaf. Value = the wire message.
+        if notify_req.have() {
+            if let Some(t) = notify_req.relay() {
+                self.broadcast_config(t, crate::net::wifi::CFG_KEY_NOTIFY, notify_req.msg());
+            }
+            if notify_req.own() {
+                self.cfg.set(crate::net::wifi::CFG_KEY_NOTIFY, notify_req.msg());
+            }
         }
         // #33: OR-in an install command (one-shot; `main`'s take clears it).
         if install_requested {

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1007,6 +1007,7 @@ pub fn run_ntp_burst(
     let mut _ntp_gw_own = GwOwnCfg::new(); // #48: boot/NTP burst never captures gateway-own cfg (cfg_cache=None)
     let mut _ntp_reset_req = ResetReq::new(); // #52: boot/NTP burst subscribes no cmd/reset (cfg_cache=None)
     let mut _ntp_scan_req = ScanReq::new(); // #71: boot/NTP burst subscribes no cmd/scan (cfg_cache=None)
+    let mut _ntp_notify_req = NotifyReq::new(); // #197: boot/NTP burst subscribes no notify (cfg_cache=None)
     // #89 Stage 1: hand the machine's LIVE stack to the UNCHANGED blocking session —
     // the boot screen freezes for this ≤ MQTT_SESSION_BUDGET tail exactly as before
     // (making the tail cooperative is #89 Stage 2). `tick` still runs (LED + abort),
@@ -1037,6 +1038,7 @@ pub fn run_ntp_burst(
         &[], // #71: boot burst publishes no own scan
         None, // #71: boot burst republishes no cached scan
         &mut _ntp_scan_req, // #71: boot burst subscribes no cmd/scan (cfg_cache=None)
+        &mut _ntp_notify_req, // #197: boot burst subscribes no notify (cfg_cache=None)
         &mut None, // #40: boot burst never relays a leaf OTA
         &mut None, // #40: boot burst has no persistent staged to carry
         &mut None, // #40: boot burst has no relay diag to publish
@@ -1453,6 +1455,60 @@ impl ScanReq {
     /// The queued leaf scan targets (to relay one-shot; NEVER cached).
     pub fn targets(&self) -> &[u8] {
         &self.targets[..self.n]
+    }
+}
+
+/// #197 herald NOTIFY capture — a transient toast COMMAND seen on `smol/+/notify` this burst.
+/// Like [`ResetReq`]/[`ScanReq`] it is NEVER cached (a cached toast re-shows on every boot), but it
+/// CARRIES the message (unlike the value-less R/W). One notify per burst (last-wins): the operator
+/// sends one message to one target (or `CFG_TARGET_ALL` = 255 for the whole fleet). After the burst
+/// `service()` fires a ONE-SHOT `broadcast_config(target, M, msg)` relay + injects `M` into its OWN
+/// `CfgTracker` if `own`, so `main`'s `take_cfg_offer(M)` toasts a leaf or the gateway on one path.
+#[cfg(feature = "wifi")]
+#[allow(dead_code)]
+pub struct NotifyReq {
+    msg: [u8; CFG_VALUE_MAX],
+    len: usize,
+    relay_to: Option<u8>, // Some(leaf | 255) to relay; None = own-only (target was our id)
+    own: bool,
+    have: bool,
+}
+
+#[cfg(feature = "wifi")]
+#[allow(dead_code)]
+impl NotifyReq {
+    pub const fn new() -> Self {
+        Self { msg: [0; CFG_VALUE_MAX], len: 0, relay_to: None, own: false, have: false }
+    }
+    /// Capture a notify for `target` (the `<id>` from `smol/<id>/notify`, may be `CFG_TARGET_ALL`),
+    /// given our own id. Bounded copy (untrusted relayed value → the #46 clamp discipline).
+    pub fn set(&mut self, target: u8, own_id: u8, payload: &[u8]) {
+        let n = payload.len().min(CFG_VALUE_MAX);
+        self.msg[..n].copy_from_slice(&payload[..n]);
+        self.len = n;
+        self.have = true;
+        if target == CFG_TARGET_ALL {
+            self.own = true; // fleet: toast us too
+            self.relay_to = Some(CFG_TARGET_ALL); // ...and relay to every leaf
+        } else if target == own_id {
+            self.own = true; // just us — no relay
+        } else {
+            self.relay_to = Some(target); // a specific leaf
+        }
+    }
+    pub fn have(&self) -> bool {
+        self.have
+    }
+    pub fn own(&self) -> bool {
+        self.own
+    }
+    /// The leaf/fleet id to one-shot relay the toast to, if any.
+    pub fn relay(&self) -> Option<u8> {
+        self.relay_to
+    }
+    /// The captured `[~<dur>]<msg>` wire.
+    pub fn msg(&self) -> &[u8] {
+        &self.msg[..self.len]
     }
 }
 
@@ -1928,6 +1984,10 @@ fn mqtt_session(
     // #71: filled with the scan COMMANDS seen on the transient `smol/+/cmd/scan` topics this burst
     // (leaf targets to one-shot-relay `<id>W` + own flag). Twin of `reset_req`; NEVER cached.
     scan_req: &mut ScanReq,
+    // #197 herald: filled with the notify COMMAND (target + message) seen on the transient
+    // `smol/+/notify` topics this burst → a one-shot `<id>M` relay + own self-toast after the
+    // burst. Twin of `scan_req` (carries a message value); NEVER cached.
+    notify_req: &mut NotifyReq,
     // #40 leaf-mesh-OTA: on a GATEWAY flush, filled with `(leaf_id, raw staged announce)`
     // when a retained `smol/<leaf>/ota/install = INSTALL` is present for a leaf id ≠ self
     // AND a staged image is available — the caller then relays it over ESP-NOW. The retained
@@ -2183,6 +2243,12 @@ fn mqtt_session(
         // #72 IO output control (pid 23): every node's retained output-states topic (key `g`).
         #[cfg(feature = "io")]
         if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 23, b"smol/+/io/set") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
+        // #197 herald: wildcard-subscribe the TRANSIENT `smol/+/notify` toast command (pid 24, QoS 1
+        // like cmd/reset|scan — a transient command must not be silently dropped). The gateway relays
+        // a captured toast to the target leaf (one-shot `<id>M`) after the burst; 255 = fleet.
+        if let Some(n) = crate::net::mqtt::encode_subscribe_qos1(&mut pkt, 24, b"smol/+/notify") {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
     }
@@ -2857,6 +2923,15 @@ fn mqtt_session(
                             scan_req.push_leaf(leaf_id);
                             log::info!("smol #71: leaf id{} scan command — one-shot relay queued", leaf_id);
                         }
+                    } else if let Some(target) = parse_leaf_config_topic(topic, b"/notify") {
+                        // #197 herald toast — a COMMAND on a TRANSIENT topic (retain:false), twin of
+                        // reset/scan but the PAYLOAD IS the message (`[~<dur>]<msg>`). NEVER cached (a
+                        // cached toast re-shows on every boot). Capture into `notify_req` for a
+                        // one-shot `<id>M` relay after the burst. `target` may be our own id (self-
+                        // toast) or `CFG_TARGET_ALL`=255 (fleet: self + relay to all leaves); the
+                        // own/leaf routing is decided in `NotifyReq::set`.
+                        notify_req.set(target, node_id, payload);
+                        log::info!("smol #197: notify target{} captured ({} B)", target, payload.len());
                     } else if let Some(leaf_id) = parse_leaf_install_topic(topic) {
                         // #40 (§B3): a wildcard-delivered leaf OTA install command. On a
                         // GATEWAY flush (cfg_cache = Some), an `INSTALL` for a leaf id ≠ self
@@ -3650,6 +3725,8 @@ pub fn run_mqtt_burst(
     scan_cache: Option<&RelayCache>,
     // #71: filled with the scan commands seen on `smol/+/cmd/scan` this burst (one-shot relay below).
     scan_req: &mut ScanReq,
+    // #197: filled with the notify command seen on `smol/+/notify` this burst (one-shot relay below).
+    notify_req: &mut NotifyReq,
     // #40: on a gateway flush, filled with `(leaf_id, staged announce)` when a leaf install
     // is pending → the caller relays it over ESP-NOW. `&mut None` on boot/leaf bursts.
     leaf_ota: &mut Option<(u8, crate::ota::Announce)>,
@@ -3852,6 +3929,7 @@ pub fn run_mqtt_burst(
         scan, // #71: forward this node's own scan record (or empty)
         scan_cache, // #71: forward the gateway's cached relayed scans (or None)
         scan_req, // #71: forward the scan-command capture (one-shot relay)
+        notify_req, // #197: forward the notify-command capture (one-shot relay)
         leaf_ota, // #40: forward the leaf-OTA install pairing (or &mut None)
         staged_raw, // #40: forward the persistent staged announce (or &mut None)
         leaf_diag, // #40: forward the diag/clear state (or &mut None)

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1276,6 +1276,18 @@ pub const CFG_KEY_IO: u8 = b'G';
 #[allow(dead_code)]
 pub const CFG_KEY_IO_SET: u8 = b'g';
 
+/// #197 herald NOTIFY (key `M`) = a TRANSIENT on-glass toast message. Verified free against
+/// the full key family (`S L U P R Y W N B O G g`). One-shot like R/W — captured from the
+/// transient `smol/<id>/notify` topic (retain:false), relayed via `broadcast_config` with the
+/// message as the value, and **NEVER cached / re-armed** (a retained or cached notify would
+/// re-toast on every boot — the load-bearing #197 invariant). The leaf applies it by pushing a
+/// `crate::toast` overlay (auto-dismiss), it is NOT in `CFG_APPLY_KEYS`' cached set. Value =
+/// `[~<dur>]<msg>` (optional TTL-seconds prefix, then the message), ≤ `CFG_VALUE_MAX`.
+/// Same wifi-tier / allow(dead_code) rationale as R/W (unused in a wifi-only build).
+#[cfg(feature = "wifi")]
+#[allow(dead_code)]
+pub const CFG_KEY_NOTIFY: u8 = b'M';
+
 /// #48 (GwOwnCfg — approved arch): the GATEWAY's OWN per-node configs read from its own MQTT
 /// topics this burst. A leaf gets these RELAYED (→ its `CfgTracker`); the gateway reads them
 /// DIRECTLY. Bundled into ONE `run_mqtt_burst`/`mqtt_session` out-param (net +1, not +N) — after

--- a/rust/clock/src/toast.rs
+++ b/rust/clock/src/toast.rs
@@ -105,45 +105,52 @@ pub fn is_active(now_ms: u64) -> bool {
 fn wrap(s: &str) -> ([(usize, usize); ROWS], usize) {
     let mut lines = [(0usize, 0usize); ROWS];
     let mut n = 0;
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() && n < ROWS {
-        // Skip leading spaces on a new line.
-        while i < bytes.len() && bytes[i] == b' ' {
-            i += 1;
-        }
-        if i >= bytes.len() {
-            break;
-        }
-        let start = i;
-        let mut last_break = 0usize; // byte index of the last space that fits, 0 = none
-        let mut col = 0usize;
-        while i < bytes.len() && bytes[i] != b'\n' {
-            if col == COLS {
-                break; // line full
-            }
-            if bytes[i] == b' ' {
-                last_break = i;
-            }
-            col += 1;
-            i += 1;
-        }
-        // Decide the line end: prefer the last space (word boundary) unless none fits.
-        let end = if i < bytes.len() && bytes[i] != b'\n' && last_break > start {
-            let e = last_break;
-            i = last_break; // resume after the space (skipped next iteration)
-            e
-        } else {
-            if i < bytes.len() && bytes[i] == b'\n' {
-                let e = i;
-                i += 1; // consume the newline
-                e
-            } else {
-                i // hard split / end of string
-            }
+    // Walk by CHAR, not byte: `COLS` counts glyphs (a multibyte char is ONE column, not N),
+    // and every offset stored is a char boundary — so `&s[start..end]` in `draw` can never
+    // panic on a crafted multibyte message arriving over the unauthenticated CFG-`M` frame.
+    let mut cursor = 0usize; // byte offset, always a char boundary
+    while cursor < s.len() && n < ROWS {
+        // Skip leading ASCII spaces to the next real char (char-boundary offset).
+        let start = match s[cursor..].char_indices().find(|&(_, c)| c != ' ') {
+            Some((i, _)) => cursor + i,
+            None => break,
         };
-        lines[n] = (start, end);
+        let mut line_end = start; // char boundary
+        let mut next = s.len();
+        let mut break_at: Option<usize> = None; // last space's byte offset within the window
+        let mut cols = 0usize;
+        for (i, c) in s[start..].char_indices() {
+            let abs = start + i; // this char's byte offset (a char boundary)
+            if c == '\n' {
+                line_end = abs;
+                next = abs + 1; // consume the newline
+                break;
+            }
+            if cols == COLS {
+                line_end = abs; // line full at a char boundary
+                next = abs;
+                break;
+            }
+            if c == ' ' {
+                break_at = Some(abs);
+            }
+            cols += 1;
+            line_end = abs + c.len_utf8(); // one past this char (a char boundary)
+            next = line_end;
+        }
+        // Full line mid-word → prefer the last space (word wrap); no space → hard split (both
+        // at char boundaries).
+        if cols == COLS {
+            if let Some(b) = break_at {
+                if b > start {
+                    line_end = b;
+                    next = b;
+                }
+            }
+        }
+        lines[n] = (start, line_end);
         n += 1;
+        cursor = next;
     }
     (lines, n)
 }
@@ -183,7 +190,10 @@ where
         .text_color(BinaryColor::Off)
         .build();
     for (row, &(a, b)) in lines[..n].iter().enumerate() {
-        let line = &s[a..b];
+        // `wrap` guarantees `a`/`b` are char boundaries, but this value arrives over an
+        // unauthenticated ESP-NOW CFG-`M` frame — `get(..).unwrap_or("")` is belt-and-braces so
+        // no future wrap edit can ever turn a crafted message into a panic→reset.
+        let line = s.get(a..b).unwrap_or("");
         let ly = y + 2 + row as i32 * LINE_H;
         Text::with_baseline(line, Point::new(x + 3, ly), style, Baseline::Top)
             .draw(display)

--- a/rust/clock/src/toast.rs
+++ b/rust/clock/src/toast.rs
@@ -1,0 +1,189 @@
+//! Transient on-glass **toast** overlay (#197) — a single short message composited over
+//! whatever screen is active, auto-cleared on expiry. Deliberately a GENERAL primitive,
+//! not herald-specific: the parked mesh-RPG LitRPG engine needs exactly this ("stat toasts,
+//! one line, ~2 s"), so this is its substrate. Replace-on-new (no queue).
+//!
+//! **Never persisted** — the toast lives only in RAM with an expiry; a reboot never
+//! re-shows it (the #197 transient invariant, mirrored by the never-cached CFG-`M` relay).
+//!
+//! Set from the CFG-`M` apply arm (`net/mode.rs`); drawn from the main render loop after the
+//! active plugin has painted (the SSD1306 framebuffer persists, so a re-composite each tick
+//! survives a plugin repaint). Word-wrap matches the HA herald composer's greedy behaviour so
+//! the same message renders the same from the operator dock and from HA.
+
+use embedded_graphics::{
+    mono_font::{ascii::FONT_5X8, MonoTextStyleBuilder},
+    pixelcolor::BinaryColor,
+    prelude::*,
+    primitives::{PrimitiveStyle, Rectangle},
+    text::{Baseline, Text},
+};
+
+/// Max stored message bytes (fits the CFG-value cap; `net/wifi.rs` `CFG_VALUE_MAX = 64`).
+const TOAST_MAX: usize = 64;
+/// 72 px panel / (5 px glyph + 1 px advance) = 12 glyphs per line (FONT_5X8).
+const COLS: usize = 12;
+/// 40 px panel: 3 lines × ~11 px + padding fits with margin.
+const ROWS: usize = 3;
+const LINE_H: i32 = 10; // FONT_5X8 is 8 px tall; 10 px baseline pitch leaves a gap
+const PANEL_W: i32 = 72;
+const PANEL_H: i32 = 40;
+
+/// Default on-glass duration when the wire carries no `~<dur>` prefix.
+pub const TOAST_DEFAULT_S: u16 = 5;
+/// Clamp a wire-supplied duration so a bad value can't pin a toast on glass forever.
+const TOAST_MAX_S: u16 = 60;
+
+/// Parse the notify wire value `[~<dur>]<msg>` → `(dur_seconds, msg_bytes)`. A leading
+/// `~<digits>` sets the TTL (clamped to `TOAST_MAX_S`); absent → `TOAST_DEFAULT_S`. Panic-free,
+/// bounded (untrusted relayed value — the #46 clamp discipline). The returned slice borrows
+/// the input.
+pub fn parse_wire(v: &[u8]) -> (u16, &[u8]) {
+    if v.first() == Some(&b'~') {
+        let mut i = 1;
+        let mut dur: u32 = 0;
+        while i < v.len() && v[i].is_ascii_digit() {
+            dur = dur.saturating_mul(10).saturating_add((v[i] - b'0') as u32);
+            i += 1;
+        }
+        // An optional single separator (space or '|') after the duration is consumed.
+        if i < v.len() && (v[i] == b' ' || v[i] == b'|') {
+            i += 1;
+        }
+        let dur = (dur.min(TOAST_MAX_S as u32) as u16).max(1);
+        (dur, &v[i..])
+    } else {
+        (TOAST_DEFAULT_S, v)
+    }
+}
+
+struct Toast {
+    buf: [u8; TOAST_MAX],
+    len: usize,
+    expiry_ms: u64,
+}
+
+static mut ACTIVE: Toast = Toast { buf: [0; TOAST_MAX], len: 0, expiry_ms: 0 };
+
+fn active() -> &'static mut Toast {
+    // Single-threaded, single-core (like `OTA_WINDOW_BUF` et al.) — no aliasing.
+    unsafe { &mut *core::ptr::addr_of_mut!(ACTIVE) }
+}
+
+/// Show `msg` for `dur_ms` from `now_ms` (replace-on-new). `msg` is truncated to
+/// `TOAST_MAX`; non-UTF8 is stored verbatim (draw sanitizes). Empty `msg` clears.
+pub fn set(msg: &[u8], now_ms: u64, dur_ms: u64) {
+    let t = active();
+    if msg.is_empty() {
+        t.expiry_ms = 0;
+        t.len = 0;
+        return;
+    }
+    let n = msg.len().min(TOAST_MAX);
+    t.buf[..n].copy_from_slice(&msg[..n]);
+    t.len = n;
+    t.expiry_ms = now_ms.saturating_add(dur_ms);
+}
+
+/// Is a toast currently showing?
+pub fn is_active(now_ms: u64) -> bool {
+    let t = active();
+    t.len > 0 && now_ms < t.expiry_ms
+}
+
+/// Greedy word-wrap `s` into up to `ROWS` lines of ≤`COLS` glyphs — the HA composer's
+/// behaviour. Returns `(line_byte_ranges, n_lines)`. A single word longer than `COLS` is
+/// hard-split. Pure + host-testable (no display).
+fn wrap(s: &str) -> ([(usize, usize); ROWS], usize) {
+    let mut lines = [(0usize, 0usize); ROWS];
+    let mut n = 0;
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && n < ROWS {
+        // Skip leading spaces on a new line.
+        while i < bytes.len() && bytes[i] == b' ' {
+            i += 1;
+        }
+        if i >= bytes.len() {
+            break;
+        }
+        let start = i;
+        let mut last_break = 0usize; // byte index of the last space that fits, 0 = none
+        let mut col = 0usize;
+        while i < bytes.len() && bytes[i] != b'\n' {
+            if col == COLS {
+                break; // line full
+            }
+            if bytes[i] == b' ' {
+                last_break = i;
+            }
+            col += 1;
+            i += 1;
+        }
+        // Decide the line end: prefer the last space (word boundary) unless none fits.
+        let end = if i < bytes.len() && bytes[i] != b'\n' && last_break > start {
+            let e = last_break;
+            i = last_break; // resume after the space (skipped next iteration)
+            e
+        } else {
+            if i < bytes.len() && bytes[i] == b'\n' {
+                let e = i;
+                i += 1; // consume the newline
+                e
+            } else {
+                i // hard split / end of string
+            }
+        };
+        lines[n] = (start, end);
+        n += 1;
+    }
+    (lines, n)
+}
+
+/// Composite the active toast over the current framebuffer: a filled box (inverted text,
+/// `draw_center_banner` style) centred on the panel. Call AFTER the plugin has drawn, then
+/// flush. No-op if inactive.
+pub fn draw<D>(display: &mut D, now_ms: u64)
+where
+    D: DrawTarget<Color = BinaryColor>,
+{
+    if !is_active(now_ms) {
+        return;
+    }
+    let t = active();
+    let s = core::str::from_utf8(&t.buf[..t.len]).unwrap_or("");
+    let (lines, n) = wrap(s);
+    if n == 0 {
+        return;
+    }
+    // Box sized to the widest line.
+    let mut widest = 0usize;
+    for &(a, b) in &lines[..n] {
+        widest = widest.max(b - a);
+    }
+    let box_w = ((widest as i32) * 6 + 5).clamp(0, PANEL_W);
+    let box_h = (n as i32) * LINE_H + 3;
+    let x = (PANEL_W - box_w) / 2;
+    let y = (PANEL_H - box_h) / 2;
+
+    Rectangle::new(Point::new(x, y), Size::new(box_w as u32, box_h as u32))
+        .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
+        .draw(display)
+        .ok();
+    let style = MonoTextStyleBuilder::new()
+        .font(&FONT_5X8)
+        .text_color(BinaryColor::Off)
+        .build();
+    for (row, &(a, b)) in lines[..n].iter().enumerate() {
+        let line = &s[a..b];
+        let ly = y + 2 + row as i32 * LINE_H;
+        Text::with_baseline(line, Point::new(x + 3, ly), style, Baseline::Top)
+            .draw(display)
+            .ok();
+    }
+}
+
+// NOTE: this crate builds for bare-metal riscv32imc (no host test harness), matching the
+// convention that no `clock/src` module carries `#[cfg(test)]`. `wrap()` is pure and a
+// candidate for an `experiments/` host-test crate (the flood_verify/relay_compat pattern);
+// meanwhile the HW-gate canary validates on-glass rendering directly.

--- a/rust/clock/src/toast.rs
+++ b/rust/clock/src/toast.rs
@@ -29,15 +29,22 @@ const LINE_H: i32 = 10; // FONT_5X8 is 8 px tall; 10 px baseline pitch leaves a 
 const PANEL_W: i32 = 72;
 const PANEL_H: i32 = 40;
 
+// #197: the notify PRODUCER API (`set` + its wire parser + timing consts) is fed only by the
+// espnow CFG-`M` apply (main's take_cfg_offer(M)); a no-radio (default/wifi) build has no feed, so
+// it reads as dead there — `allow(dead_code)`, same rationale as the CFG_KEY_* consts. The overlay
+// CONSUMER (`draw`/`is_active`, called every render tick) stays always-live in every build.
 /// Default on-glass duration when the wire carries no `~<dur>` prefix.
+#[allow(dead_code)]
 pub const TOAST_DEFAULT_S: u16 = 5;
 /// Clamp a wire-supplied duration so a bad value can't pin a toast on glass forever.
+#[allow(dead_code)]
 const TOAST_MAX_S: u16 = 60;
 
 /// Parse the notify wire value `[~<dur>]<msg>` → `(dur_seconds, msg_bytes)`. A leading
 /// `~<digits>` sets the TTL (clamped to `TOAST_MAX_S`); absent → `TOAST_DEFAULT_S`. Panic-free,
 /// bounded (untrusted relayed value — the #46 clamp discipline). The returned slice borrows
 /// the input.
+#[allow(dead_code)] // espnow-fed producer API (see the note above the timing consts)
 pub fn parse_wire(v: &[u8]) -> (u16, &[u8]) {
     if v.first() == Some(&b'~') {
         let mut i = 1;
@@ -72,6 +79,7 @@ fn active() -> &'static mut Toast {
 
 /// Show `msg` for `dur_ms` from `now_ms` (replace-on-new). `msg` is truncated to
 /// `TOAST_MAX`; non-UTF8 is stored verbatim (draw sanitizes). Empty `msg` clears.
+#[allow(dead_code)] // espnow-fed producer API (see the note above the timing consts)
 pub fn set(msg: &[u8], now_ms: u64, dur_ms: u64) {
     let t = active();
     if msg.is_empty() {


### PR DESCRIPTION
Closes #28. The fw side of the herald: a **transient on-glass toast** driven by `smol/<id>/notify`, so the operator dock (#211) and HA notify (#160) ping the glass identically.

**⚠ Stacked on #210 (feat/204).** Base is set to `feat/204-crown-selfheal` so the diff is **herald-only** (2 commits). Per team-lead's sequencing: **held open** until #210 merges, then I retarget/rebase onto `main` and it merges in the **same wave as #211** (the dock send-UI) so the control is born working — not publishing to a dead topic. **HW-GATE-HELD** (radio + display path).

## Receive side (0e385ff)
- General **`toast` module** — bordered overlay box over the active screen (`draw_center_banner` style), greedy word-wrap matching the HA composer (12 cols / 3 rows), auto-dismiss, replace-on-new, **never persisted**. Built as the mesh-RPG LitRPG substrate, not herald-specific.
- Render composite in the main loop (before the cast snapshot; falling-edge repaint clears the box on expiry).
- CFG key **`'M'`** (verified free vs the full family) — a never-cached one-shot command like R/W; leaf applies via `take_cfg_offer(M)` → `toast::set`. Wire `[~<dur>]<msg>`.

## Send transport (025daee)
- `NotifyReq` captured from `smol/+/notify` (**SUBSCRIBE pid 24**, QoS 1, twin of cmd/reset|scan) — carries the message; own/leaf/**fleet-255** routing in `NotifyReq::set`.
- One-shot relay in the flush drain: `broadcast_config(target, 'M', msg)` (never cached); own/fleet self-injects `'M'` into the gateway's own `CfgTracker` so it toasts on the same path as a leaf.
- Threaded `&mut NotifyReq` through `mqtt_session` + `run_mqtt_burst` (+ boot/recovery dummies), mirroring `scan_req`.

## Load-bearing invariant
**Never cached / never retained** end-to-end (topic transient, CFG-`M` not in the cached set, dock uses `transient_msg`) → a leaf never re-toasts on reboot.

## Verification
4-tier green on **katana** (pinned 1.96.1): `clippy -D` (espnow, espnow+cast+io) + `--release` (default, wifi, espnow) — all warning-clean. Collision courtesy: pid 24 cleared with 89/89b; the additive `flush_telemetry` touch (reset/scan-twin lines) pinged to 89b.

HW-gate canary: publish `smol/<leaf>/notify` → leaf toasts for `~dur` then auto-reverts; a reboot does NOT re-toast; `smol/255/notify` toasts all glass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)