### PR TITLE
fix(fw): #155 channel_hint MQTT pid collision — move subscribe 13→25

### DIFF
--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -2165,11 +2165,15 @@ fn mqtt_session(
     if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 3, MESH_CHANNEL_TOPIC) {
         let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
     }
-    // #155 channel-drag operator lever: subscribe the retained channel-hint (packet-id 13 — the
-    // first free id; 9 is `smol/+/ota/install`). Sent right after the election topic so its retained
-    // value rides the SAME broker burst as `MC` and is captured before the resolver runs (the settle
-    // window after the primary downlinks catches it, exactly like the OTA/config retained topics).
-    if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 13, MESH_CHANNEL_HINT_TOPIC) {
+    // #155 channel-drag operator lever: subscribe the retained channel-hint (packet-id 25). NOTE:
+    // this was originally 13, which COLLIDES with the QoS-1 `smol/+/cmd/reset` subscribe (pids
+    // 13/14 are cmd/reset|cmd/scan via `encode_subscribe_qos1`, missed by #155's original
+    // uniqueness check — that grep only matched `encode_subscribe(`). Two in-flight SUBSCRIBEs
+    // sharing a packet id is an MQTT-3.1.1 violation; moved to 25 (13/14 = cmd/reset|scan, 24 =
+    // #197 herald notify, 25 = first free above that). Sent right after the election topic so its
+    // retained value rides the SAME broker burst as `MC` and is captured before the resolver runs
+    // (the settle window after the primary downlinks catches it, like the OTA/config retained topics).
+    if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 25, MESH_CHANNEL_HINT_TOPIC) {
         let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
     }
 


### PR DESCRIPTION
Fixes a latent MQTT packet-id collision I introduced in #155 and found while reviewing #215 (herald).

## The bug
The `channel_hint` subscribe used packet-id **13**, which **collides with the QoS-1 `smol/+/cmd/reset` subscribe** (pids 13/14 = `cmd/reset`/`cmd/scan` via `encode_subscribe_qos1`). Two in-flight SUBSCRIBEs sharing a packet id violates MQTT 3.1.1 §2.3.1.

**Root cause:** #155's uniqueness check grepped only `encode_subscribe(` and missed the `_qos1` variant, so pid 13 looked free. (Same class of bug I caught + hardened in #201 — turned on my own merged work this time.)

## The fix
Move `channel_hint` to pid **25** (13/14 = cmd/reset|scan, 24 = #197 herald notify, 25 = first free above that). One-line change + a corrected comment documenting the pid space and the lesson.

## Impact
Harmless in practice **today** (subscribes are fire-and-forget; both subscriptions take effect; the client doesn't correlate SUBACKs), but a real spec violation and latent — a stricter broker or any future SUBACK/pid correlation would break `cmd/reset` (reboot) and/or `channel_hint`.

## Verify (katana / 1.96.1)
- `cargo build --release` (default) ✅
- `cargo build --release --features espnow` ✅
- `cargo clippy --release --features espnow -- -D warnings` ✅
- All subscribe pids (incl. `_qos1`) now unique ✅

Scope: one line in `net/wifi.rs`. Refs #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)