### PR TITLE
feat(fw): #182 mesh-ledger L1 — hash-chained append-only log (pure core, host-tested)

### DIFF
--- a/experiments/ledger_verify/Cargo.toml
+++ b/experiments/ledger_verify/Cargo.toml
@@ -1,0 +1,17 @@
+# #182 host-test harness for the PURE mesh-ledger L1 core (net/ledger.rs). Runs OFF-target
+# on the host (std) via `cargo run` — the firmware crate is no_std/riscv32imc and can't
+# host-test, so this #[path]-includes the real ledger.rs (no drift) and exercises the
+# hash-chain append/verify/prune. Mirrors experiments/flood_verify + etx_verify.
+# sha2 supplies the injected hasher (the ledger core is hasher-agnostic / dependency-free).
+[package]
+name = "ledger_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "ledger_verify"
+path = "src/main.rs"
+[dependencies]
+sha2 = "0.10"
+[profile.dev]
+opt-level = 0

--- a/experiments/ledger_verify/src/main.rs
+++ b/experiments/ledger_verify/src/main.rs
@@ -1,0 +1,158 @@
+//! Host verification of the PURE #182 mesh-ledger L1 core. Includes the real
+//! `net/ledger.rs` verbatim (#[path], no drift) and exercises the hash-chain:
+//! append→chain-onto-prev, verify→detect-tamper, bounded-ring→prune-with-checkpoint.
+//! Run: `cargo run` — panics on failure.
+//!
+//! The ledger core is **hasher-agnostic** (dependency-free): every append/verify takes an
+//! injected `sha256` closure. Here we inject the real sha2 crate so the tamper tests are
+//! meaningful. Tamper is simulated by mutating the ledger's `pub(crate)` ring directly —
+//! this file is compiled *as part of* the ledger_verify crate via #[path], so no test-only
+//! production method is needed (an attacker flipping a stored byte is exactly this).
+
+#[path = "../../../rust/clock/src/net/ledger.rs"]
+mod ledger;
+
+use ledger::{Ledger, VerifyError, GENESIS, HASH_LEN, MAX_PAYLOAD};
+use sha2::{Digest, Sha256};
+
+/// The injected hasher — a full sha256 (the ledger core never imports sha2 itself).
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    h.finalize().into()
+}
+
+fn main() {
+    // --- new(): empty ledger verifies clean; tip is GENESIS ----------------
+    let mut l: Ledger<16, 32> = Ledger::new();
+    assert_eq!(l.verify(sha256), Ok(()), "empty ledger verifies");
+    assert_eq!(l.tip(), GENESIS, "fresh tip is GENESIS");
+    assert_eq!(l.len(), 0);
+    assert!(l.is_empty(), "fresh ledger is empty");
+    assert_eq!(l.pruned(), 0);
+
+    // --- MAX_PAYLOAD boundary: a record at the hashable cap verifies ------
+    {
+        let mut capl: Ledger<2, MAX_PAYLOAD> = Ledger::new();
+        capl.append(&[0x5a; MAX_PAYLOAD], sha256);
+        assert_eq!(
+            capl.verify(sha256),
+            Ok(()),
+            "a max-payload (cap) record verifies"
+        );
+    }
+
+    // --- append chains onto prev; tip advances; seqs are 1,2,3 -------------
+    let h1 = l.append(b"elect id7 ch6", sha256);
+    let h2 = l.append(b"ota install b45", sha256);
+    let h3 = l.append(b"cfg id7 default=batt", sha256);
+    assert_ne!(h1, GENESIS, "first record's hash != genesis");
+    assert_ne!(h1, h2);
+    assert_ne!(h2, h3);
+    assert_eq!(l.tip(), h3, "tip is the newest record's hash");
+    assert_eq!(l.len(), 3);
+    assert_eq!(
+        l.verify(sha256),
+        Ok(()),
+        "an untampered 3-record chain verifies"
+    );
+
+    // --- determinism: identical (seq, payload) sequence ⇒ identical tip ----
+    let mut m: Ledger<16, 32> = Ledger::new();
+    m.append(b"elect id7 ch6", sha256);
+    m.append(b"ota install b45", sha256);
+    m.append(b"cfg id7 default=batt", sha256);
+    assert_eq!(
+        m.tip(),
+        l.tip(),
+        "same records ⇒ same chain tip (deterministic)"
+    );
+
+    // --- tamper a PAYLOAD byte ⇒ verify fails at that record ---------------
+    {
+        let mut t: Ledger<16, 32> = Ledger::new();
+        t.append(b"aaaa", sha256);
+        t.append(b"bbbb", sha256);
+        t.append(b"cccc", sha256);
+        t.ring[1].payload[0] ^= 0xff; // flip a byte of record index 1 (the "bbbb")
+        assert_eq!(
+            t.verify(sha256),
+            Err(VerifyError::BadHash { index: 1 }),
+            "a flipped payload byte is detected at its record"
+        );
+    }
+
+    // --- tamper a stored HASH ⇒ verify fails -------------------------------
+    {
+        let mut t: Ledger<16, 32> = Ledger::new();
+        t.append(b"one", sha256);
+        t.append(b"two", sha256);
+        t.ring[0].hash[0] ^= 0xff; // corrupt record 0's stored hash
+        assert!(
+            t.verify(sha256).is_err(),
+            "a corrupted stored hash is detected"
+        );
+    }
+
+    // --- tamper SEQ (non-contiguous) ⇒ BadSeq ------------------------------
+    {
+        let mut t: Ledger<16, 32> = Ledger::new();
+        t.append(b"one", sha256);
+        t.append(b"two", sha256);
+        t.ring[1].seq = 99; // break seq contiguity at index 1
+        assert_eq!(
+            t.verify(sha256),
+            Err(VerifyError::BadSeq { index: 1 }),
+            "non-contiguous seq is detected"
+        );
+    }
+
+    // --- genesis: the first record chains onto GENESIS (verify from base) --
+    // (implicitly covered by the Ok() above; assert the base is GENESIS pre-prune)
+    {
+        let mut t: Ledger<16, 32> = Ledger::new();
+        t.append(b"x", sha256);
+        assert_eq!(
+            t.base(),
+            GENESIS,
+            "before any prune, the chain base is GENESIS"
+        );
+        assert_eq!(t.verify(sha256), Ok(()));
+    }
+
+    // --- bounded ring: overflow prunes oldest, keeps a checkpoint ----------
+    {
+        let mut t: Ledger<4, 16> = Ledger::new(); // CAP=4
+        for i in 0..7u32 {
+            let mut p = [0u8; 8];
+            p[..4].copy_from_slice(&i.to_le_bytes());
+            t.append(&p, sha256);
+        }
+        assert_eq!(t.len(), 4, "ring is bounded at CAP");
+        assert_eq!(t.pruned(), 3, "3 oldest records pruned (7 appended, CAP 4)");
+        assert_ne!(
+            t.base(),
+            GENESIS,
+            "base is now the pruned checkpoint, not GENESIS"
+        );
+        assert_eq!(
+            t.verify(sha256),
+            Ok(()),
+            "the retained suffix still verifies against the pruned checkpoint"
+        );
+        // tamper a retained record post-prune ⇒ still detected
+        t.ring[t.head].payload[0] ^= 0xff; // corrupt the oldest RETAINED record
+        assert!(
+            t.verify(sha256).is_err(),
+            "tamper after prune is still detected"
+        );
+    }
+
+    // --- const-constructible (must live in a .bss static, no heap) ---------
+    const _CONST_OK: Ledger<8, 16> = Ledger::new();
+
+    // --- HASH_LEN is the truncated width documented in the study -----------
+    assert_eq!(HASH_LEN, 16, "16-B truncated chain hash");
+
+    println!("ledger_verify: all assertions passed");
+}

--- a/rust/clock/src/net/ledger.rs
+++ b/rust/clock/src/net/ledger.rs
@@ -1,0 +1,210 @@
+//! #182 mesh-ledger L1 — the PURE per-node hash-chained append-only log (unsigned v1).
+//!
+//! ## What this is (design of record: `docs/superpowers/research/mesh-ledger-study.md`, #181)
+//! The study's #1 ADOPT: give smol a **tamper-evident, replayable** history without a
+//! blockchain, BFT, or a full CRDT. Each node keeps its **own** append-only log; every record
+//! links the previous record's hash, so any insertion / deletion / reorder / byte-flip breaks
+//! the chain and is caught by [`Ledger::verify`]. It finishes primitives smol already ships —
+//! `dl_seq` (a per-source monotonic seq) and `boot_count` (a crash-safe monotonic head) — into
+//! one structure. Enables fleet provenance (tamper-evident OTA/election/config history) and the
+//! mesh-RPG world-state substrate.
+//!
+//! ## L1 scope (this module)
+//! - **Unsigned, tamper-EVIDENT** (hash chain, sha256). *Authenticity/non-repudiation* (ed25519
+//!   record signing) is **#184**, which rides ON TOP later — L1 is the substrate.
+//! - **Pure + host-testable** (the `net/flood.rs` / `net/etx.rs` pattern): no `esp-hal`/`esp-wifi`,
+//!   no `std`, no alloc, and — deliberately — **no hash crate dependency**. The sha256 is
+//!   **injected** (`F: Fn(&[u8]) -> [u8; 32]`) so the core is dependency-free; the caller (the
+//!   host verifier now, the firmware at #183) supplies it. Host-tested in `experiments/ledger_verify`.
+//! - **NOT wired into the radio path** — gossip/relay of the chain is L2 (**#183**, HW-gated).
+//!   This module is intentionally *not declared in `net.rs`* until then (it would otherwise be
+//!   dead-code under `-D warnings`, the #164 lesson).
+//!
+//! ## The chain
+//! `record_hash = truncate16( sha256( prev_hash(16) ‖ seq_le(4) ‖ payload ) )`. The first record
+//! chains onto [`GENESIS`]. 16-byte truncation gives 2⁻¹²⁸ collision resistance — ample for a
+//! 4–30 node fleet (study §3), at 16 B/record instead of 32.
+//!
+//! ## Bounded + crash-safe by construction
+//! A fixed circular ring (`Ledger<CAP, PAY>`, no alloc, lives in `.bss`). When it overflows, the
+//! oldest record is pruned and its hash becomes the **checkpoint** ([`Ledger::base`]) the retained
+//! suffix chains onto — so tamper-evidence *survives pruning* (you can't rewrite the retained
+//! chain without breaking from the checkpoint). RAM ≈ `CAP × (21 + PAY)` bytes (e.g. `<16, 32>` ≈
+//! 850 B), well within the C3 budget.
+
+/// Truncated chain-hash width in bytes (study §3: 16 B ⇒ 2⁻¹²⁸ collision).
+pub const HASH_LEN: usize = 16;
+/// A truncated chain hash.
+pub type Hash = [u8; HASH_LEN];
+/// The prev-hash the first record chains onto (an empty ledger's tip + base).
+pub const GENESIS: Hash = [0u8; HASH_LEN];
+/// Largest record payload that is hashed in one pass (bounds the stack scratch buffer). A
+/// `Ledger<_, PAY>` requires `PAY <= MAX_PAYLOAD` (compile-time checked) so every stored byte is
+/// covered by the chain hash — no un-hashed tail an attacker could tamper undetected.
+pub const MAX_PAYLOAD: usize = 96;
+
+/// Why [`Ledger::verify`] rejected a chain — with the record index (0 = oldest retained).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VerifyError {
+    /// Record `index`'s recomputed hash ≠ its stored hash — a payload/hash/prev-link tamper.
+    BadHash { index: usize },
+    /// Record `index`'s seq is not contiguous with its predecessor — a reorder/insert/delete.
+    BadSeq { index: usize },
+}
+
+/// One stored record. `Copy` so the ring lives inline in `.bss` (no heap). Fields are
+/// `pub(crate)` so the `#[path]`-included host verifier can simulate on-wire tamper directly
+/// (an attacker flipping a stored byte is exactly that) without a test-only production method.
+#[derive(Clone, Copy)]
+pub struct Rec<const PAY: usize> {
+    pub(crate) seq: u32,
+    pub(crate) len: u8,
+    pub(crate) payload: [u8; PAY],
+    pub(crate) hash: Hash,
+}
+
+impl<const PAY: usize> Rec<PAY> {
+    const EMPTY: Self = Self {
+        seq: 0,
+        len: 0,
+        payload: [0u8; PAY],
+        hash: GENESIS,
+    };
+}
+
+/// `prev ‖ seq ‖ payload` → truncated chain hash. Pure; `sha256` injected. Payload is already
+/// clamped to `PAY <= MAX_PAYLOAD` by the caller, so the fixed scratch buffer always fits.
+fn chain_hash<F: Fn(&[u8]) -> [u8; 32]>(prev: &Hash, seq: u32, payload: &[u8], sha256: &F) -> Hash {
+    let mut buf = [0u8; HASH_LEN + 4 + MAX_PAYLOAD];
+    buf[..HASH_LEN].copy_from_slice(prev);
+    buf[HASH_LEN..HASH_LEN + 4].copy_from_slice(&seq.to_le_bytes());
+    let n = payload.len().min(MAX_PAYLOAD);
+    buf[HASH_LEN + 4..HASH_LEN + 4 + n].copy_from_slice(&payload[..n]);
+    let full = sha256(&buf[..HASH_LEN + 4 + n]);
+    let mut h = GENESIS;
+    h.copy_from_slice(&full[..HASH_LEN]);
+    h
+}
+
+/// A per-node hash-chained append-only log over a fixed ring of `CAP` records, each ≤ `PAY`
+/// bytes. See the module docs. `CAP >= 1` and `PAY <= MAX_PAYLOAD` are compile-time enforced.
+pub struct Ledger<const CAP: usize, const PAY: usize> {
+    pub(crate) ring: [Rec<PAY>; CAP],
+    /// Index of the oldest retained record (circular).
+    pub(crate) head: usize,
+    count: usize,
+    next_seq: u32,
+    tip: Hash,
+    /// The hash the oldest RETAINED record chains onto: [`GENESIS`] until the first prune, then
+    /// the pruned checkpoint's hash.
+    base: Hash,
+    /// Seq of the last pruned record (0 = nothing pruned ⇒ first retained seq is 1).
+    base_seq: u32,
+    pruned: u32,
+}
+
+impl<const CAP: usize, const PAY: usize> Ledger<CAP, PAY> {
+    /// Compile-time invariants (evaluated when referenced in [`append`](Ledger::append)).
+    const INVARIANTS: () = {
+        assert!(CAP >= 1, "Ledger CAP must be >= 1");
+        assert!(
+            PAY <= MAX_PAYLOAD,
+            "Ledger PAY must be <= MAX_PAYLOAD (else un-hashed tail)"
+        );
+    };
+
+    /// An empty ledger (tip + base = [`GENESIS`], next seq = 1). `const` so a fleet of these
+    /// initializes in `.bss` with no runtime work.
+    pub const fn new() -> Self {
+        Self {
+            ring: [Rec::EMPTY; CAP],
+            head: 0,
+            count: 0,
+            next_seq: 1,
+            tip: GENESIS,
+            base: GENESIS,
+            base_seq: 0,
+            pruned: 0,
+        }
+    }
+
+    /// Append `payload` (clamped to `PAY`) as the next record, chaining it onto the current tip.
+    /// Returns the new record's hash (the new tip). On overflow, prunes the oldest record and
+    /// advances the [`base`](Ledger::base) checkpoint. `sha256` is the injected hasher.
+    pub fn append<F: Fn(&[u8]) -> [u8; 32]>(&mut self, payload: &[u8], sha256: F) -> Hash {
+        let () = Self::INVARIANTS; // force the compile-time CAP/PAY checks
+        let seq = self.next_seq;
+        self.next_seq = self.next_seq.wrapping_add(1);
+        let n = payload.len().min(PAY);
+        let hash = chain_hash(&self.tip, seq, &payload[..n], &sha256);
+
+        let mut rec = Rec::<PAY>::EMPTY;
+        rec.seq = seq;
+        rec.len = n as u8;
+        rec.payload[..n].copy_from_slice(&payload[..n]);
+        rec.hash = hash;
+
+        if self.count == CAP {
+            // Full → prune the oldest (ring[head]); its hash becomes the checkpoint.
+            self.base = self.ring[self.head].hash;
+            self.base_seq = self.ring[self.head].seq;
+            self.pruned = self.pruned.saturating_add(1);
+            self.ring[self.head] = rec;
+            self.head = (self.head + 1) % CAP;
+        } else {
+            let idx = (self.head + self.count) % CAP;
+            self.ring[idx] = rec;
+            self.count += 1;
+        }
+        self.tip = hash;
+        hash
+    }
+
+    /// Replay the retained chain from the [`base`](Ledger::base) checkpoint forward, recomputing
+    /// each record's hash and checking seq contiguity. `Ok(())` if intact (including empty);
+    /// `Err` at the first tampered record. Pure; `sha256` injected.
+    pub fn verify<F: Fn(&[u8]) -> [u8; 32]>(&self, sha256: F) -> Result<(), VerifyError> {
+        let mut prev = self.base;
+        let mut expected_seq = self.base_seq.wrapping_add(1);
+        for i in 0..self.count {
+            let rec = &self.ring[(self.head + i) % CAP];
+            if rec.seq != expected_seq {
+                return Err(VerifyError::BadSeq { index: i });
+            }
+            let n = rec.len as usize;
+            if chain_hash(&prev, rec.seq, &rec.payload[..n], &sha256) != rec.hash {
+                return Err(VerifyError::BadHash { index: i });
+            }
+            prev = rec.hash;
+            expected_seq = expected_seq.wrapping_add(1);
+        }
+        Ok(())
+    }
+
+    /// The newest record's hash (the chain tip), or [`GENESIS`] if empty.
+    pub fn tip(&self) -> Hash {
+        self.tip
+    }
+    /// The hash the oldest retained record chains onto ([`GENESIS`] until the first prune).
+    pub fn base(&self) -> Hash {
+        self.base
+    }
+    /// Retained record count (≤ `CAP`).
+    pub fn len(&self) -> usize {
+        self.count
+    }
+    /// True if no records are retained.
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+    /// Total records pruned by ring overflow (the checkpoint has advanced this many times).
+    pub fn pruned(&self) -> u32 {
+        self.pruned
+    }
+}
+
+impl<const CAP: usize, const PAY: usize> Default for Ledger<CAP, PAY> {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
Closes #182 (L1). The #181 study's **#1 ADOPT** — smol's tamper-evident, replayable per-node history, no blockchain/BFT/CRDT. Each record links the previous record's hash; any insert/delete/reorder/byte-flip breaks the chain and is caught by `verify()`.

## Scope (L1 = the pure substrate)
- **`net/ledger.rs`** — the PURE core (the `flood.rs`/`etx.rs` pattern): no `esp-hal`/`esp-wifi`, no `std`, no alloc, and **no hash-crate dependency** — sha256 is **injected** (`F: Fn(&[u8]) -> [u8;32]`) so the core is dependency-free; the caller (host verifier now, firmware at #183) supplies it.
- **`experiments/ledger_verify`** — host TDD harness (`#[path]`-includes ledger.rs, sha2 for the real hasher). Written **test-first (RED → GREEN)**.
- **Unsigned / tamper-EVIDENT only.** ed25519 record **signing (#184)** rides on top later — composes, doesn't overlap.
- **NOT wired into the radio path** (team-lead: L1 is the substrate; gossip/relay = **L2/#183**, HW-gated). Deliberately **not declared in `net.rs`** until then — so the firmware build never compiles it (inert; avoids the `-D warnings` dead-code trap, the #164 lesson).

## Design (module rustdoc is the design doc; of record: mesh-ledger-study.md §L1)
- `record_hash = truncate16(sha256(prev(16) ‖ seq_le(4) ‖ payload))`; first record chains onto `GENESIS`. 16-B truncation = 2⁻¹²⁸ collision (study §3), 16 B/record.
- Fixed circular ring `Ledger<CAP, PAY>` (`.bss`, ~`CAP×(21+PAY)` B; `<16,32>` ≈ 850 B). Overflow **prunes oldest + advances a checkpoint** (`base`) the retained suffix chains onto — **tamper-evidence survives pruning**.
- Compile-time guards: `CAP >= 1`, `PAY <= MAX_PAYLOAD` (no un-hashed tail).

## Tests (all green)
empty-ok · append-chains + seq 1,2,3 · determinism · **payload-tamper → BadHash{index}** · hash-tamper → Err · **seq-tamper → BadSeq{index}** · genesis-base · **ring-overflow → prune + checkpoint verifies** · **post-prune tamper still detected** · max-payload boundary · const-constructible.

## Verification (katana / 1.96.1)
`ledger_verify`: **all assertions pass** · `clippy -D warnings`: **clean** · `ledger.rs` + harness **rustfmt-clean**. Firmware crate **unaffected** (ledger.rs undeclared → never compiled).

Design of record: `docs/superpowers/research/mesh-ledger-study.md` (#181). Refs #182, #181, #184, #183. → morpheus-155 reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
