### PR TITLE
feat(fw): #183 mesh-ledger L2 — crown-ordered tree-head (CT-style Merkle anchor, host-tested)

### DIFF
--- a/experiments/treehead_verify/Cargo.toml
+++ b/experiments/treehead_verify/Cargo.toml
@@ -1,0 +1,16 @@
+# #183 host-test harness for the PURE mesh-ledger L2 core (net/treehead.rs) — the crown-ordered
+# tree-head / CT-style Merkle anchor over the per-node #182 chain heads. Runs OFF-target (std)
+# via `cargo run`; #[path]-includes the real treehead.rs (no drift). sha256 injected via sha2.
+# Mirrors experiments/flood_verify + etx_verify + ledger_verify.
+[package]
+name = "treehead_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "treehead_verify"
+path = "src/main.rs"
+[dependencies]
+sha2 = "0.10"
+[profile.dev]
+opt-level = 0

--- a/experiments/treehead_verify/src/main.rs
+++ b/experiments/treehead_verify/src/main.rs
@@ -1,0 +1,161 @@
+//! Host verification of the PURE #183 L2 core: the crown-ordered tree-head — a CT-style
+//! (RFC 6962 lineage) Merkle **anchor** over the per-node #182 chain heads. Includes the real
+//! `net/treehead.rs` verbatim (#[path], no drift). Run: `cargo run` — panics on failure.
+//!
+//! The load-bearing invariant is **order-independence**: every node must compute the *identical*
+//! anchor from the same set of heads regardless of the order it learned them — that's the
+//! "ordered" in crown-ordered, and what lets a node compare its anchor to the crown's in O(1).
+//! Inclusion proofs let a node prove its head is under the anchor in O(log n) hashes instead of
+//! shipping every head. sha256 is injected (the core is dependency-free).
+
+#[path = "../../../rust/clock/src/net/treehead.rs"]
+mod treehead;
+
+use sha2::{Digest, Sha256};
+use treehead::{verify_inclusion, HeadSet, EMPTY_ROOT, HASH_LEN};
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    h.finalize().into()
+}
+
+/// A stand-in per-node chain head (a #182 tip) — arbitrary 16 bytes.
+fn head(seed: u8) -> [u8; 16] {
+    let mut x = [0u8; 16];
+    x[0] = seed;
+    x[15] = seed ^ 0xa5;
+    x
+}
+
+fn main() {
+    // --- empty set → EMPTY_ROOT --------------------------------------------
+    let hs: HeadSet<16> = HeadSet::new();
+    assert_eq!(
+        hs.root(sha256),
+        EMPTY_ROOT,
+        "empty head-set anchors to EMPTY_ROOT"
+    );
+    assert!(hs.is_empty());
+    assert_eq!(hs.len(), 0);
+
+    // --- single head → non-empty deterministic root ------------------------
+    let mut a: HeadSet<16> = HeadSet::new();
+    a.upsert(7, head(0x77), 3).unwrap();
+    assert_eq!(a.len(), 1);
+    assert_ne!(a.root(sha256), EMPTY_ROOT);
+
+    // --- ORDER-INDEPENDENCE: same heads, different insert order → same root -
+    let mut x: HeadSet<16> = HeadSet::new();
+    x.upsert(7, head(7), 1).unwrap();
+    x.upsert(8, head(8), 1).unwrap();
+    x.upsert(9, head(9), 1).unwrap();
+    let mut y: HeadSet<16> = HeadSet::new();
+    y.upsert(9, head(9), 1).unwrap();
+    y.upsert(7, head(7), 1).unwrap();
+    y.upsert(8, head(8), 1).unwrap();
+    assert_eq!(
+        x.root(sha256),
+        y.root(sha256),
+        "canonical order ⇒ identical anchor regardless of insert order"
+    );
+
+    // --- divergence: one changed head ⇒ a different anchor ------------------
+    let mut z: HeadSet<16> = HeadSet::new();
+    z.upsert(7, head(7), 1).unwrap();
+    z.upsert(8, head(0x88), 1).unwrap(); // different head for node 8
+    z.upsert(9, head(9), 1).unwrap();
+    assert_ne!(
+        z.root(sha256),
+        x.root(sha256),
+        "a changed head ⇒ a different anchor"
+    );
+
+    // --- upsert = insert-or-update (same node twice updates, not adds) ------
+    let mut u: HeadSet<16> = HeadSet::new();
+    u.upsert(5, head(1), 1).unwrap();
+    u.upsert(5, head(2), 2).unwrap();
+    assert_eq!(u.len(), 1, "re-upserting a node updates it, does not add");
+
+    // --- inclusion proofs round-trip for every node, across odd counts -----
+    for n in [1usize, 2, 3, 5] {
+        let mut s: HeadSet<16> = HeadSet::new();
+        for i in 0..n {
+            s.upsert(i as u8, head(i as u8 + 1), i as u32 + 1).unwrap();
+        }
+        let root = s.root(sha256);
+        for i in 0..n {
+            let p = s
+                .inclusion_proof(i as u8, sha256)
+                .expect("proof for a present node");
+            assert!(
+                verify_inclusion(root, i as u8, head(i as u8 + 1), i as u32 + 1, &p, sha256),
+                "node {i} of {n} proves inclusion under the anchor"
+            );
+        }
+    }
+
+    // --- tampered leaf (wrong head) ⇒ verify fails -------------------------
+    {
+        let mut s: HeadSet<16> = HeadSet::new();
+        for i in 0..5 {
+            s.upsert(i, head(i + 1), 1).unwrap();
+        }
+        let root = s.root(sha256);
+        let p = s.inclusion_proof(2, sha256).unwrap();
+        assert!(
+            verify_inclusion(root, 2, head(3), 1, &p, sha256),
+            "honest proof verifies"
+        );
+        assert!(
+            !verify_inclusion(root, 2, head(0xff), 1, &p, sha256),
+            "a wrong head ⇒ inclusion verify fails"
+        );
+    }
+
+    // --- tampered proof (flipped sibling) ⇒ verify fails -------------------
+    {
+        let mut s: HeadSet<16> = HeadSet::new();
+        for i in 0..5 {
+            s.upsert(i, head(i + 1), 1).unwrap();
+        }
+        let root = s.root(sha256);
+        let mut p = s.inclusion_proof(2, sha256).unwrap();
+        if p.len > 0 {
+            p.siblings[0][0] ^= 0xff;
+            assert!(
+                !verify_inclusion(root, 2, head(3), 1, &p, sha256),
+                "a tampered proof sibling ⇒ verify fails"
+            );
+        }
+    }
+
+    // --- bounded capacity: upsert past N ⇒ Full; update-when-full ok -------
+    {
+        let mut s: HeadSet<2> = HeadSet::new();
+        s.upsert(1, head(1), 1).unwrap();
+        s.upsert(2, head(2), 1).unwrap();
+        assert!(s.upsert(3, head(3), 1).is_err(), "a new node past N ⇒ Full");
+        assert_eq!(s.len(), 2);
+        assert!(
+            s.upsert(1, head(9), 2).is_ok(),
+            "updating an existing node when full is ok"
+        );
+    }
+
+    // --- absent node ⇒ no inclusion proof ----------------------------------
+    {
+        let mut s: HeadSet<16> = HeadSet::new();
+        s.upsert(1, head(1), 1).unwrap();
+        assert!(
+            s.inclusion_proof(42, sha256).is_none(),
+            "absent node has no proof"
+        );
+    }
+
+    // --- const-constructible (a crown holds one in .bss) -------------------
+    const _C: HeadSet<8> = HeadSet::new();
+    assert_eq!(HASH_LEN, 16);
+
+    println!("treehead_verify: all assertions passed");
+}

--- a/rust/clock/src/net/treehead.rs
+++ b/rust/clock/src/net/treehead.rs
@@ -1,0 +1,300 @@
+//! #183 L2 — the PURE crown-ordered **tree-head**: a CT-style (RFC 6962 lineage) Merkle
+//! **anchor** over the per-node #182 chain heads.
+//!
+//! ## What this is (design of record: `docs/superpowers/research/mesh-ledger-study.md` §L2, #181)
+//! #182 gives each node its own tamper-evident chain. L2 gives the *fleet* a single
+//! **consistency anchor**: hash the set of per-node chain heads into one root, so any node can
+//! compare its view to the crown's in O(1) and detect divergence — the study's "crown-ordered
+//! tree-head" (a Certificate-Transparency Signed-Tree-Head, minus the signature in v1). The
+//! anchor also yields **inclusion proofs**: a node proves its head is under the anchor in
+//! O(log n) sibling hashes instead of shipping every head — real airtime economy on a 250-B MTU.
+//!
+//! ## L2 scope (this module — the pure anchor-COMPUTATION core)
+//! - Pure + host-testable (the `flood.rs`/`etx.rs`/`ledger.rs` pattern): no `esp-hal`/`esp-wifi`,
+//!   no `std`, no alloc, **no hash-crate dep** — sha256 is **injected**. Host-tested in
+//!   `experiments/treehead_verify`.
+//! - **The "crown ORDERS it" coordination is OUT of scope** (gossiping the anchor via
+//!   `dl_seq`+retained-MQTT and collecting peer heads over the mesh is the fw/radio layer,
+//!   HW-gated). This module just *computes* the anchor + proofs from a head-set.
+//! - **NOT wired into the radio path** — deliberately *not declared in `net.rs`* (inert; no
+//!   dead-code under `-D warnings`, the #164 lesson), same as #182's `ledger.rs`.
+//!
+//! ## The Merkle construction (CT / RFC 6962)
+//! Heads are kept in **canonical order by `node_id`** so every node computes the *identical*
+//! anchor regardless of the order it learned them (the load-bearing invariant). Domain-separated
+//! hashing prevents leaf/internal confusion: `leaf = H(0x00 ‖ node_id ‖ head ‖ seq)`,
+//! `internal = H(0x01 ‖ left ‖ right)`, split at the largest power of two `< n` (balanced,
+//! O(log n) proofs). 16-byte truncation (matches #182). Empty set → [`EMPTY_ROOT`].
+
+/// Truncated hash width (matches #182's chain hash).
+pub const HASH_LEN: usize = 16;
+/// A truncated hash — a node's chain head, a Merkle node, or the anchor root.
+pub type Hash = [u8; HASH_LEN];
+/// The anchor of an empty head-set.
+pub const EMPTY_ROOT: Hash = [0u8; HASH_LEN];
+/// Max audit-path depth — supports up to `2^MAX_DEPTH` = 256 nodes (smol fleet is ≤ ~30).
+pub const MAX_DEPTH: usize = 8;
+
+const LEAF_PREFIX: u8 = 0x00;
+const NODE_PREFIX: u8 = 0x01;
+
+/// A head-set is full (a *new* node past capacity `N`; updating an existing node still works).
+#[derive(Debug)]
+pub struct Full;
+
+/// One node's chain head: `(node_id, head_hash, seq)`.
+#[derive(Clone, Copy)]
+pub struct Head {
+    pub(crate) node_id: u8,
+    pub(crate) head: Hash,
+    pub(crate) seq: u32,
+}
+impl Head {
+    const EMPTY: Self = Self {
+        node_id: 0,
+        head: EMPTY_ROOT,
+        seq: 0,
+    };
+}
+
+/// An inclusion proof: the audit path (sibling hashes, deepest-first) plus the `index`/`size`
+/// needed to reconstruct the anchor. `siblings[..len]` are meaningful.
+#[derive(Clone, Copy)]
+pub struct Proof {
+    pub(crate) index: usize,
+    pub(crate) size: usize,
+    pub(crate) siblings: [Hash; MAX_DEPTH],
+    pub len: usize,
+}
+
+fn truncate(full: [u8; 32]) -> Hash {
+    let mut h = EMPTY_ROOT;
+    h.copy_from_slice(&full[..HASH_LEN]);
+    h
+}
+
+/// `H(0x00 ‖ node_id ‖ head ‖ seq_le)` — a domain-separated leaf hash.
+fn leaf_hash<F: Fn(&[u8]) -> [u8; 32]>(node_id: u8, head: &Hash, seq: u32, sha256: &F) -> Hash {
+    let mut buf = [0u8; 1 + 1 + HASH_LEN + 4];
+    buf[0] = LEAF_PREFIX;
+    buf[1] = node_id;
+    buf[2..2 + HASH_LEN].copy_from_slice(head);
+    buf[2 + HASH_LEN..].copy_from_slice(&seq.to_le_bytes());
+    truncate(sha256(&buf))
+}
+
+/// `H(0x01 ‖ left ‖ right)` — a domain-separated internal node.
+fn internal<F: Fn(&[u8]) -> [u8; 32]>(left: &Hash, right: &Hash, sha256: &F) -> Hash {
+    let mut buf = [0u8; 1 + 2 * HASH_LEN];
+    buf[0] = NODE_PREFIX;
+    buf[1..1 + HASH_LEN].copy_from_slice(left);
+    buf[1 + HASH_LEN..].copy_from_slice(right);
+    truncate(sha256(&buf))
+}
+
+/// Largest power of two strictly less than `n` (`n >= 2`).
+fn split(n: usize) -> usize {
+    let mut k = 1;
+    while k << 1 < n {
+        k <<= 1;
+    }
+    k
+}
+
+/// Merkle Tree Hash over already-computed leaf hashes (`leaves.len() >= 1`), RFC 6962 recursion.
+fn mth<F: Fn(&[u8]) -> [u8; 32]>(leaves: &[Hash], sha256: &F) -> Hash {
+    if leaves.len() == 1 {
+        return leaves[0];
+    }
+    let k = split(leaves.len());
+    internal(
+        &mth(&leaves[..k], sha256),
+        &mth(&leaves[k..], sha256),
+        sha256,
+    )
+}
+
+/// Audit path for leaf `m` in `leaves`: sibling subtree-roots, appended deepest-first. Returns
+/// the number written. Depth ≤ `MAX_DEPTH` for `leaves.len() ≤ 256` (guarded on `HeadSet`).
+fn audit_path<F: Fn(&[u8]) -> [u8; 32]>(
+    leaves: &[Hash],
+    m: usize,
+    sha256: &F,
+    out: &mut [Hash; MAX_DEPTH],
+) -> usize {
+    if leaves.len() == 1 {
+        return 0;
+    }
+    let k = split(leaves.len());
+    let (l, sib) = if m < k {
+        (
+            audit_path(&leaves[..k], m, sha256, out),
+            mth(&leaves[k..], sha256),
+        )
+    } else {
+        (
+            audit_path(&leaves[k..], m - k, sha256, out),
+            mth(&leaves[..k], sha256),
+        )
+    };
+    if l < MAX_DEPTH {
+        out[l] = sib;
+    }
+    l + 1
+}
+
+/// Reconstruct the root from a leaf hash + its audit path, mirroring [`audit_path`]. Never
+/// panics on a malformed/tampered proof (returns a value that simply won't match the anchor).
+fn root_from<F: Fn(&[u8]) -> [u8; 32]>(
+    leaf: Hash,
+    m: usize,
+    n: usize,
+    sibs: &[Hash],
+    sha256: &F,
+) -> Hash {
+    if n <= 1 {
+        return leaf;
+    }
+    if sibs.is_empty() {
+        return EMPTY_ROOT; // malformed proof — cannot match a real anchor
+    }
+    let k = split(n);
+    let sib = sibs[sibs.len() - 1];
+    let rest = &sibs[..sibs.len() - 1];
+    if m < k {
+        internal(&root_from(leaf, m, k, rest, sha256), &sib, sha256)
+    } else {
+        internal(&sib, &root_from(leaf, m - k, n - k, rest, sha256), sha256)
+    }
+}
+
+/// A bounded, canonically-ordered (by `node_id`) set of per-node chain heads → one Merkle anchor.
+pub struct HeadSet<const N: usize> {
+    pub(crate) heads: [Head; N],
+    count: usize,
+}
+
+impl<const N: usize> HeadSet<N> {
+    /// `N` must fit the audit-path depth (≤ 2^MAX_DEPTH), evaluated when referenced in `upsert`.
+    const DEPTH_OK: () = assert!(
+        N <= (1usize << MAX_DEPTH),
+        "HeadSet N must be <= 2^MAX_DEPTH"
+    );
+
+    /// An empty head-set. `const` so a crown holds one in `.bss`.
+    pub const fn new() -> Self {
+        Self {
+            heads: [Head::EMPTY; N],
+            count: 0,
+        }
+    }
+
+    /// Insert-or-update a node's head, keeping canonical `node_id` order. `Err(Full)` only when a
+    /// *new* node exceeds `N` (updating an existing node always succeeds).
+    pub fn upsert(&mut self, node_id: u8, head: Hash, seq: u32) -> Result<(), Full> {
+        let () = Self::DEPTH_OK;
+        for i in 0..self.count {
+            if self.heads[i].node_id == node_id {
+                self.heads[i].head = head;
+                self.heads[i].seq = seq;
+                return Ok(());
+            }
+        }
+        if self.count == N {
+            return Err(Full);
+        }
+        let mut pos = self.count;
+        while pos > 0 && self.heads[pos - 1].node_id > node_id {
+            self.heads[pos] = self.heads[pos - 1];
+            pos -= 1;
+        }
+        self.heads[pos] = Head { node_id, head, seq };
+        self.count += 1;
+        Ok(())
+    }
+
+    /// Number of nodes in the set.
+    pub fn len(&self) -> usize {
+        self.count
+    }
+    /// True if no nodes are tracked.
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// The Merkle **anchor** (tree-head) over the canonical head-set. Deterministic — identical
+    /// for the same set regardless of upsert order. `EMPTY_ROOT` for an empty set.
+    pub fn root<F: Fn(&[u8]) -> [u8; 32]>(&self, sha256: F) -> Hash {
+        if self.count == 0 {
+            return EMPTY_ROOT;
+        }
+        let mut leaves = [EMPTY_ROOT; N];
+        for (leaf, h) in leaves[..self.count]
+            .iter_mut()
+            .zip(self.heads[..self.count].iter())
+        {
+            *leaf = leaf_hash(h.node_id, &h.head, h.seq, &sha256);
+        }
+        mth(&leaves[..self.count], &sha256)
+    }
+
+    /// An inclusion [`Proof`] that `node_id`'s head is under the anchor, or `None` if absent.
+    pub fn inclusion_proof<F: Fn(&[u8]) -> [u8; 32]>(
+        &self,
+        node_id: u8,
+        sha256: F,
+    ) -> Option<Proof> {
+        let mut index = None;
+        for i in 0..self.count {
+            if self.heads[i].node_id == node_id {
+                index = Some(i);
+                break;
+            }
+        }
+        let index = index?;
+        let mut leaves = [EMPTY_ROOT; N];
+        for (leaf, h) in leaves[..self.count]
+            .iter_mut()
+            .zip(self.heads[..self.count].iter())
+        {
+            *leaf = leaf_hash(h.node_id, &h.head, h.seq, &sha256);
+        }
+        let mut siblings = [EMPTY_ROOT; MAX_DEPTH];
+        let len = audit_path(&leaves[..self.count], index, &sha256, &mut siblings);
+        Some(Proof {
+            index,
+            size: self.count,
+            siblings,
+            len,
+        })
+    }
+}
+
+impl<const N: usize> Default for HeadSet<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Verify that `(node_id, head, seq)` is included under `root` via `proof`. Recomputes the leaf
+/// and replays the audit path; total (no panic) on any malformed/tampered proof.
+pub fn verify_inclusion<F: Fn(&[u8]) -> [u8; 32]>(
+    root: Hash,
+    node_id: u8,
+    head: Hash,
+    seq: u32,
+    proof: &Proof,
+    sha256: F,
+) -> bool {
+    if proof.len > MAX_DEPTH || proof.index >= proof.size.max(1) {
+        return false;
+    }
+    let leaf = leaf_hash(node_id, &head, seq, &sha256);
+    root_from(
+        leaf,
+        proof.index,
+        proof.size,
+        &proof.siblings[..proof.len],
+        &sha256,
+    ) == root
+}


### PR DESCRIPTION
The #181 study's **L2** — the host-testable anchor-computation core. #182 gives each node a tamper-evident chain; L2 gives the *fleet* a single **consistency anchor** so a node compares its view to the crown's in O(1) and detects divergence — a Certificate-Transparency **Signed-Tree-Head**, minus the signature (v1).

## Scope call (team-lead flagged "might be too thin")
Root-only *would* be thin — so this ships the full **CT-style Merkle anchor + inclusion proofs**. The proofs are the substantive, useful part: a node proves its head is under the anchor in **O(log n)** sibling hashes instead of shipping every head — real airtime economy on a 250-B MTU, and directly useful to the RPG. That makes the core clearly worth a PR.

## What's in it
- **`net/treehead.rs`** — the PURE core (the `flood.rs`/`etx.rs`/`ledger.rs` pattern): no `esp-hal`/`esp-wifi`, no `std`, no alloc, **no hash-crate dep** — sha256 **injected**.
  - `HeadSet<N>`: bounded, **canonically ordered by `node_id`** (the load-bearing invariant — every node computes the *identical* anchor regardless of learn order).
  - `root()` = CT Merkle (RFC 6962: `0x00` leaf / `0x01` node domain separation, split-at-largest-power-of-2), 16-B truncated (matches #182).
  - `inclusion_proof()` / `verify_inclusion()` = audit paths; **total (no panic) on malformed/tampered proofs**. Compile-time `N <= 2^MAX_DEPTH` guard.
- **`experiments/treehead_verify`** — host TDD (RED→GREEN): empty→EMPTY_ROOT, **order-independence**, divergence, upsert-update, **inclusion round-trip across odd counts (1/2/3/5)**, wrong-head + tampered-sibling → verify fails, bounded/`Full`, absent→`None`, const-constructible.

## Scope discipline
- The **"crown ORDERS it"** coordination (gossip the anchor via `dl_seq`+MQTT, collect peer heads over the mesh) is the fw/radio layer = **HW-gated, OUT of scope**. This is just the anchor-computation substrate.
- Builds on **#182** (chain heads); composes with **#184** (sign the anchor → a true CT Signed-Tree-Head).
- **NOT wired** — deliberately undeclared in `net.rs` (inert; no dead-code under `-D warnings`, the #164/#182 pattern). Firmware build unaffected.

## Verification (katana / 1.96.1)
`treehead_verify`: **all assertions pass** · `clippy -D warnings`: **clean** · rustfmt-clean.

Design of record: `docs/superpowers/research/mesh-ledger-study.md` §L2 (#181). Refs #183, #181, #182, #184. → morpheus-155 reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
