### PR TITLE
feat(fw): #184 mesh-ledger L3 — ed25519 Signed-Tree-Head core (host-tested, inert)

### DIFF
--- a/experiments/sth_verify/Cargo.toml
+++ b/experiments/sth_verify/Cargo.toml
@@ -1,0 +1,19 @@
+# #184 host-test harness for the PURE mesh-ledger L3 core (net/sth.rs) — the ed25519
+# Signed-Tree-Head over the L2 (#183) CT-Merkle anchor. Runs OFF-target (std) via `cargo run`;
+# #[path]-includes the real sth.rs + treehead.rs (no drift) and tests the genuine
+# sign-anchor → verify-STH + verify-inclusion composition. Mirrors flood_verify/etx_verify/
+# ledger_verify/treehead_verify. ed25519-compact (the OTA verifier, here also signing via a
+# fixed seed) + sha2 (for the treehead anchor) supply the injected crypto — the core is agnostic.
+[package]
+name = "sth_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "sth_verify"
+path = "src/main.rs"
+[dependencies]
+sha2 = "0.10"
+ed25519-compact = "2"
+[profile.dev]
+opt-level = 0

--- a/experiments/sth_verify/src/main.rs
+++ b/experiments/sth_verify/src/main.rs
@@ -1,0 +1,147 @@
+//! Host verification of the PURE #184 mesh-ledger L3 core: the ed25519 **Signed-Tree-Head**
+//! over the L2 (#183) CT-Merkle anchor. Includes the real `net/sth.rs` + `net/treehead.rs`
+//! verbatim (#[path], no drift). Run: `cargo run` — panics on failure.
+//!
+//! The point of L3: L2's anchor is *symmetric-unforgeable-free* (anyone can recompute it) — so a
+//! node can't tell a genuine crown anchor from a forged one. Signing the anchor makes it
+//! **non-repudiable**: only the crown's private key can author a valid STH. This test exercises
+//! the real end-to-end: build an L2 head-set → its anchor → **sign it** → a peer **verifies the
+//! STH signature AND an inclusion proof against the signed root** (the "prove my head is in a
+//! crown-signed anchor" flow). Both the sha256 hasher and the ed25519 sign/verify are INJECTED
+//! (the core is crypto-agnostic); here ed25519-compact (smol's OTA verifier) supplies real ones.
+
+#[path = "../../../rust/clock/src/net/sth.rs"]
+mod sth;
+#[path = "../../../rust/clock/src/net/treehead.rs"]
+mod treehead;
+
+use ed25519_compact::{KeyPair, Seed, Signature};
+use sha2::{Digest, Sha256};
+use sth::{accept, sign_sth, verify_sth};
+use treehead::{verify_inclusion, HeadSet};
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    h.finalize().into()
+}
+
+fn head(seed: u8) -> [u8; 16] {
+    let mut x = [0u8; 16];
+    x[0] = seed;
+    x[15] = seed ^ 0xa5;
+    x
+}
+
+fn main() {
+    // Fixed-seed crown keypair (deterministic — no RNG) + an attacker keypair.
+    let crown = KeyPair::from_seed(Seed::new([7u8; 32]));
+    let attacker = KeyPair::from_seed(Seed::new([9u8; 32]));
+    let sign = |m: &[u8]| -> [u8; 64] {
+        let s = crown.sk.sign(m, None);
+        let mut b = [0u8; 64];
+        b.copy_from_slice(&s[..]);
+        b
+    };
+    let verify = |m: &[u8], sig: &[u8; 64]| -> bool {
+        Signature::from_slice(sig)
+            .map(|s| crown.pk.verify(m, &s).is_ok())
+            .unwrap_or(false)
+    };
+    let verify_attacker = |m: &[u8], sig: &[u8; 64]| -> bool {
+        Signature::from_slice(sig)
+            .map(|s| attacker.pk.verify(m, &s).is_ok())
+            .unwrap_or(false)
+    };
+
+    let root = [0x5au8; 16];
+
+    // --- sign → verify round-trip -----------------------------------------
+    let sth = sign_sth(root, 12, 5, sign);
+    assert_eq!(sth.root(), root);
+    assert_eq!(sth.size(), 12);
+    assert_eq!(sth.epoch(), 5);
+    assert!(verify_sth(&sth, verify), "an honestly-signed STH verifies");
+
+    // --- tamper each authenticated field ⇒ verify fails -------------------
+    {
+        let mut t = sth;
+        t.root[0] ^= 0xff;
+        assert!(!verify_sth(&t, verify), "tampered root ⇒ STH verify fails");
+    }
+    {
+        let mut t = sth;
+        t.size ^= 0xff;
+        assert!(!verify_sth(&t, verify), "tampered size ⇒ STH verify fails");
+    }
+    {
+        let mut t = sth;
+        t.epoch ^= 0xff; // epoch is authenticated ⇒ an old STH can't be replayed as a new one
+        assert!(!verify_sth(&t, verify), "tampered epoch ⇒ STH verify fails");
+    }
+    {
+        let mut t = sth;
+        t.sig[0] ^= 0xff;
+        assert!(
+            !verify_sth(&t, verify),
+            "tampered signature ⇒ STH verify fails"
+        );
+    }
+
+    // --- wrong key (attacker) ⇒ verify fails ------------------------------
+    assert!(
+        !verify_sth(&sth, verify_attacker),
+        "a different key ⇒ STH verify fails"
+    );
+
+    // --- epoch is authenticated: same root, different epoch → different sig -
+    let sth5 = sign_sth(root, 12, 5, sign);
+    let sth6 = sign_sth(root, 12, 6, sign);
+    assert_ne!(
+        sth5.sig(),
+        sth6.sig(),
+        "epoch is part of the signed message"
+    );
+
+    // --- THE REAL COMPOSITION: sign an L2 anchor, then prove a head is in it
+    {
+        let mut hs: HeadSet<16> = HeadSet::new();
+        for i in 0..5u8 {
+            hs.upsert(i, head(i + 1), i as u32 + 1).unwrap();
+        }
+        assert!(!hs.is_empty(), "head-set has entries before anchoring");
+        let anchor = hs.root(sha256);
+        let signed = sign_sth(anchor, hs.len() as u32, 7, sign); // the crown signs its anchor
+
+        // A peer: verify the STH sig AND that node 3's head is included under the signed root.
+        let proof = hs.inclusion_proof(3, sha256).unwrap();
+        let incl_ok = verify_inclusion(signed.root(), 3, head(4), 4, &proof, sha256);
+        assert!(
+            accept(&signed, incl_ok, verify),
+            "a crown-signed anchor + a valid inclusion proof ⇒ accept"
+        );
+
+        // Tamper the claimed head ⇒ inclusion fails ⇒ accept fails (even with a valid STH).
+        let incl_bad = verify_inclusion(signed.root(), 3, head(0xff), 4, &proof, sha256);
+        assert!(
+            !accept(&signed, incl_bad, verify),
+            "wrong head ⇒ not accepted"
+        );
+
+        // Tamper the STH signature ⇒ accept fails (even with a valid inclusion proof).
+        let mut forged = signed;
+        forged.sig[0] ^= 0xff;
+        assert!(
+            !accept(&forged, incl_ok, verify),
+            "forged STH ⇒ not accepted"
+        );
+
+        // A valid STH but from the attacker's key ⇒ not accepted.
+        assert!(
+            !accept(&signed, incl_ok, verify_attacker),
+            "wrong signer ⇒ not accepted"
+        );
+    }
+
+    println!("sth_verify: all assertions passed");
+}

--- a/rust/clock/src/net/sth.rs
+++ b/rust/clock/src/net/sth.rs
@@ -1,0 +1,119 @@
+//! #184 mesh-ledger L3 — the PURE ed25519 **Signed-Tree-Head** over the L2 (#183) anchor.
+//!
+//! ## What this is (design of record: `docs/superpowers/research/mesh-ledger-study.md` §L3, #181)
+//! L2 ([`super::treehead`]) produces a Merkle **anchor** over the per-node #182 chains — but that
+//! anchor is *symmetric-unforgeable-free*: anyone with the head-set recomputes it, so a node
+//! can't distinguish a genuine crown anchor from a forged one. L3 makes it **non-repudiable**:
+//! the crown **signs** the anchor (root + size + epoch) with ed25519, yielding a Certificate-
+//! Transparency **Signed-Tree-Head**. Now a peer accepts "my head is in the fleet's anchor" only
+//! if the STH signature is the crown's *and* an inclusion proof checks against the signed root.
+//!
+//! ## L3 scope (this module — the pure sign/verify core)
+//! - Pure + host-testable (the `flood.rs`/`etx.rs`/`ledger.rs`/`treehead.rs` pattern): no
+//!   `esp-hal`/`esp-wifi`, no `std`, no alloc, **no crypto-crate dep** — the ed25519 sign/verify
+//!   are **injected** (`sign: Fn(&[u8]) -> [u8;64]`, `verify: Fn(&[u8], &[u8;64]) -> bool`). The
+//!   firmware injects the **verify** it already ships (`ota.rs`'s `ed25519-compact` OTA verifier);
+//!   whoever authors the STH injects the **sign**. Host-tested in `experiments/sth_verify`.
+//! - **The key PROVISIONING is OUT of scope** — putting an on-device signing key on the crown is
+//!   the #181-L3 gate (JP's greenlight/defer, HW-gated). This core is *agnostic to where the key
+//!   lives*: it composes whatever sign/verify it's handed.
+//! - **Decoupled from the anchor's internals:** the STH signs the anchor as an opaque 16-byte
+//!   root (consistent with L1/L2 each being self-contained over `[u8;16]`). The composition with
+//!   an inclusion proof is [`accept`] — the caller runs [`super::treehead::verify_inclusion`]
+//!   against [`SignedTreeHead::root`] and passes the result.
+//! - **NOT wired into the radio path** — deliberately *not declared in `net.rs`* (inert; no
+//!   dead-code under `-D warnings`, the #164/#182/#183 pattern). Firmware build unaffected.
+//!
+//! ## The signed message (domain-separated)
+//! `sig = ed25519( 0x02 ‖ root(16) ‖ size_le(4) ‖ epoch_le(4) )`. The `0x02` prefix is distinct
+//! from L2's `0x00`/`0x01` leaf/node prefixes, so an STH signature can never be confused with a
+//! Merkle hash pre-image. **`epoch` is inside the signed message** — a monotonic freshness marker
+//! (the `dl_seq`/`boot_count` lineage) so a stale STH can't be replayed as a current one; the
+//! caller enforces "epoch strictly newer," the signature makes epoch unforgeable.
+
+/// Anchor/root width (matches L1/L2).
+pub const HASH_LEN: usize = 16;
+/// A Merkle anchor root (from L2) — signed here as opaque bytes.
+pub type Hash = [u8; HASH_LEN];
+/// An ed25519 detached signature.
+pub type Sig = [u8; 64];
+/// Domain-separation prefix for the STH signed message (distinct from L2's `0x00`/`0x01`).
+pub const STH_PREFIX: u8 = 0x02;
+/// Length of the canonical STH message that gets signed: `prefix ‖ root ‖ size ‖ epoch`.
+pub const STH_MSG_LEN: usize = 1 + HASH_LEN + 4 + 4;
+
+/// A crown-signed tree-head: the L2 anchor (`root`) at fleet size `size` and freshness `epoch`,
+/// plus the ed25519 signature over their canonical encoding. `Copy` (no heap). Fields are
+/// `pub(crate)` so the `#[path]`-included host verifier can simulate tamper directly.
+#[derive(Clone, Copy)]
+pub struct SignedTreeHead {
+    pub(crate) root: Hash,
+    pub(crate) size: u32,
+    pub(crate) epoch: u32,
+    pub(crate) sig: Sig,
+}
+
+impl SignedTreeHead {
+    /// The signed L2 anchor root (feed this to [`super::treehead::verify_inclusion`]).
+    pub fn root(&self) -> Hash {
+        self.root
+    }
+    /// The fleet size (node count) the anchor covered.
+    pub fn size(&self) -> u32 {
+        self.size
+    }
+    /// The freshness epoch (authenticated — see the module docs).
+    pub fn epoch(&self) -> u32 {
+        self.epoch
+    }
+    /// The ed25519 signature.
+    pub fn sig(&self) -> Sig {
+        self.sig
+    }
+}
+
+/// The canonical bytes that get signed/verified: `0x02 ‖ root ‖ size_le ‖ epoch_le`.
+pub fn sth_message(root: &Hash, size: u32, epoch: u32) -> [u8; STH_MSG_LEN] {
+    let mut m = [0u8; STH_MSG_LEN];
+    m[0] = STH_PREFIX;
+    m[1..1 + HASH_LEN].copy_from_slice(root);
+    m[1 + HASH_LEN..1 + HASH_LEN + 4].copy_from_slice(&size.to_le_bytes());
+    m[1 + HASH_LEN + 4..].copy_from_slice(&epoch.to_le_bytes());
+    m
+}
+
+/// Sign an anchor `(root, size, epoch)` into a [`SignedTreeHead`] using the injected `sign`.
+pub fn sign_sth<S: Fn(&[u8]) -> [u8; 64]>(
+    root: Hash,
+    size: u32,
+    epoch: u32,
+    sign: S,
+) -> SignedTreeHead {
+    let msg = sth_message(&root, size, epoch);
+    SignedTreeHead {
+        root,
+        size,
+        epoch,
+        sig: sign(&msg),
+    }
+}
+
+/// Verify an STH's signature over its own `(root, size, epoch)` using the injected `verify`.
+/// Recomputes the canonical message from the STH's fields, so tampering *any* field fails.
+pub fn verify_sth<V: Fn(&[u8], &[u8; 64]) -> bool>(sth: &SignedTreeHead, verify: V) -> bool {
+    let msg = sth_message(&sth.root, sth.size, sth.epoch);
+    verify(&msg, &sth.sig)
+}
+
+/// The L3 acceptance rule: a claim is accepted iff **the STH is a valid crown signature** AND
+/// **the head is included under the signed root**. `inclusion_ok` is the caller's
+/// [`super::treehead::verify_inclusion`]`(sth.root(), node_id, head, seq, proof, sha256)` result —
+/// kept as a parameter so this module stays decoupled from L2's internals. Signature checked
+/// first (cheap short-circuit before trusting the root the proof is checked against).
+pub fn accept<V: Fn(&[u8], &[u8; 64]) -> bool>(
+    sth: &SignedTreeHead,
+    inclusion_ok: bool,
+    verify: V,
+) -> bool {
+    verify_sth(sth, verify) && inclusion_ok
+}


### PR DESCRIPTION
Completes the ledger substrate trio — **L1 (#182)** per-node chain + **L2 (#183)** CT-Merkle anchor + **L3 (#184)** ed25519 Signed-Tree-Head. L2's anchor is recomputable by anyone (symmetric, un-authored); L3 makes it **non-repudiable** — the crown *signs* the anchor, so a peer accepts "my head is in the fleet anchor" only if the STH signature is the crown's **and** an inclusion proof checks against the signed root.

## What's in it
- **`net/sth.rs`** — the PURE sign/verify core (the `flood`/`etx`/`ledger`/`treehead` pattern): no `esp-hal`/`esp-wifi`, no `std`, no alloc, **no crypto-crate dep** — ed25519 sign+verify are **injected**. The firmware injects the **verify** it already ships (`ota.rs`'s `ed25519-compact` OTA verifier); whoever authors the STH injects **sign**.
  - Signed message is **domain-separated**: `0x02 ‖ root ‖ size_le ‖ epoch_le` — `0x02` distinct from L2's `0x00`/`0x01` leaf/node prefixes (no cross-protocol pre-image confusion).
  - **`epoch` is inside the signed bytes** — authenticated freshness, so a stale STH can't be replayed as current (caller enforces strictly-newer; the sig makes epoch unforgeable).
  - `accept(sth, inclusion_ok, verify)` = the composition rule (**STH-valid AND inclusion-ok**), decoupled from L2 via an injected `inclusion_ok` bool.
- **`experiments/sth_verify`** — host TDD (RED→GREEN): sign/verify round-trip; tamper root/size/epoch/sig → fail; wrong-key → fail; epoch authenticated; and the **real end-to-end composition** — `HeadSet → anchor → sign_sth → verify_sth + treehead::verify_inclusion` against the signed root, with wrong-head / forged-sig / wrong-signer all rejected. Real crypto via `ed25519-compact` (fixed seed) + `sha2`.

## Scope discipline
- **Key provisioning is OUT of scope** — an on-device signing key on the crown is the #181-L3 gate (JP's greenlight/defer, HW-gated). This core is *agnostic to where the key lives*.
- **NOT wired** — undeclared in `net.rs` (inert; no dead-code under `-D warnings`; firmware unaffected), the #164/#182/#183 pattern.

## Verification (katana / 1.96.1)
`sth_verify`: **all assertions pass** · `clippy -D warnings`: **clean** · rustfmt-clean.

The ledger substrate is now three pure, host-tested, merge-ready layers; the crown-ordering/gossip + key-provisioning coordination is the remaining HW-gated wiring lane. Design of record: `docs/superpowers/research/mesh-ledger-study.md` §L3 (#181). Refs #184, #181, #182, #183. → morpheus-155 (mesh-auth author + adversarial security eye) reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
