### PR TITLE
fix(fw): #195 self-fetch consecutive-failure cap [HW-GATE-HELD, post-#210]

### DIFF
--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -844,37 +844,56 @@ fn main() -> ! {
                 && (crate::ota::OTA_AUTO_INSTALL || r.take_install_request());
             if do_install {
                 if let Some(announce) = r.take_ota_offer() {
-                    let mut ota_draw_ms = 0u64;
-                    let mut ota_abort = false;
-                    // #161: OTA self-install is minutes-scale → paint the dedicated full-glass OTA
-                    // screen (source host + big block bar + %/ETA + the incoming build's codename)
-                    // from the live byte counts the fetch writes into `ota_prog`, throttled to
-                    // SYNC_REDRAW_MS. Supersedes #153's 1-px edge for the self-fetch path.
-                    let ota_prog = core::cell::Cell::new(ota::OtaProgress::default());
-                    let ota_host = ota::split_url(announce.url()).map(|(h, _, _)| h).unwrap_or("net");
-                    let ota_build = announce.build;
-                    let mut ota_eta = ota_screen::OtaEta::new();
-                    r.run_ota_update(&announce, &mut || {
-                        let t = millis();
-                        led.apply(led::LedState::WifiSync, t);
-                        if matches!(button.poll(t), Some(input::Press::Long)) {
-                            ota_abort = true;
+                    // #195: bound the mesh-deaf hammer — if THIS build's self-fetch has already
+                    // failed SELF_OTA_MAX_RETRIES times in a row (e.g. a #204 broken-downstream
+                    // crown), STOP re-triggering. The retained arm is deliberately kept (#134: a
+                    // gateway-local fetch failure says nothing about the image — a #204 self-heal,
+                    // a post-shed relay via a healthy successor crown, a new staged build, or a
+                    // reboot all resume it). This is the #195 self-fetch cap (mirrors the relay's
+                    // leaf_ota_retries; the arm-clear path was proven unreachable on a deaf crown).
+                    if r.self_ota_fetch_capped(announce.build) {
+                        log::info!(
+                            "smol #195: self-fetch capped for build {} — suppressing re-trigger (arm kept)",
+                            announce.build
+                        );
+                    } else {
+                        let mut ota_draw_ms = 0u64;
+                        let mut ota_abort = false;
+                        // #161: OTA self-install is minutes-scale → paint the dedicated full-glass OTA
+                        // screen (source host + big block bar + %/ETA + the incoming build's codename)
+                        // from the live byte counts the fetch writes into `ota_prog`, throttled to
+                        // SYNC_REDRAW_MS. Supersedes #153's 1-px edge for the self-fetch path.
+                        let ota_prog = core::cell::Cell::new(ota::OtaProgress::default());
+                        let ota_host = ota::split_url(announce.url()).map(|(h, _, _)| h).unwrap_or("net");
+                        let ota_build = announce.build;
+                        let mut ota_eta = ota_screen::OtaEta::new();
+                        // #195: a SUCCESS reboots inside the fetch (never returns); a `false` return is
+                        // a genuine self-fetch failure → count it toward the cap above.
+                        let ok = r.run_ota_update(&announce, &mut || {
+                            let t = millis();
+                            led.apply(led::LedState::WifiSync, t);
+                            if matches!(button.poll(t), Some(input::Press::Long)) {
+                                ota_abort = true;
+                            }
+                            if t.saturating_sub(ota_draw_ms) >= SYNC_REDRAW_MS {
+                                ota_draw_ms = t;
+                                let p = ota_prog.get();
+                                ota_screen::draw(&mut display, &ota_screen::OtaView {
+                                    kind: ota_screen::OtaKind::SelfFetch { host: ota_host },
+                                    build: ota_build,
+                                    done: p.done,
+                                    total: p.total,
+                                    eta_s: ota_eta.sample(p.done, p.total, t),
+                                    unit: ota_screen::OtaUnit::Bytes,
+                                });
+                            }
+                            ota_abort
+                        }, &ota_prog);
+                        if !ok {
+                            r.note_self_ota_failed(announce.build);
                         }
-                        if t.saturating_sub(ota_draw_ms) >= SYNC_REDRAW_MS {
-                            ota_draw_ms = t;
-                            let p = ota_prog.get();
-                            ota_screen::draw(&mut display, &ota_screen::OtaView {
-                                kind: ota_screen::OtaKind::SelfFetch { host: ota_host },
-                                build: ota_build,
-                                done: p.done,
-                                total: p.total,
-                                eta_s: ota_eta.sample(p.done, p.total, t),
-                                unit: ota_screen::OtaUnit::Bytes,
-                            });
-                        }
-                        ota_abort
-                    }, &ota_prog);
-                    redraw = true;
+                        redraw = true;
+                    }
                 }
             }
             // A gateway's SMOLv1 BATT downlink (buffered in `service`) → store it in

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -293,6 +293,14 @@ const GW_CONFIRM_TIMEOUT_MS: u64 = 120_000;
 /// for one retained install before the gateway gives up + clears it — bounds the auto-retry
 /// so a persistently-failing leaf can't loop the (mesh-deaf) relay every flush forever.
 const LEAF_OTA_MAX_RETRIES: u8 = 3;
+/// #195: max consecutive failed SELF-fetch bursts for one staged build before `main` STOPS
+/// auto-re-triggering the fetch — bounds the mesh-deaf hammer a broken-downstream crown
+/// otherwise sustains (the #204 blackout: id7's canary hit 24 retries before self-terminating).
+/// Mirrors `LEAF_OTA_MAX_RETRIES` (the relay's post-handoff cap). Unlike a doomed-image relay,
+/// a self-fetch failure is a GATEWAY-LOCAL link problem (#134 class), so hitting this cap
+/// SUPPRESSES the re-trigger but does NOT clear the retained arm — a #204 self-heal, a post-shed
+/// relay via a healthy successor crown, a NEW staged build, or a reboot all resume it.
+const SELF_OTA_MAX_RETRIES: u8 = 3;
 /// One-window relay readback buffer (off the stack, in `.bss`). Alias-safe: a gateway
 /// relays to ONE leaf at a time (serial canary), and never runs a leaf receive session.
 static mut GW_OTA_WINDOW: [u8; crate::ota_mesh::WINDOW_BYTES] =
@@ -1930,6 +1938,13 @@ pub struct RadioManager {
     /// it NEVER burns the order (a gateway-local fetch failure says nothing about the leaf/image, so
     /// the install survives for the next attempt / the next crown). Reset on a terminal outcome.
     leaf_ota_fetch_retries: u8,
+    /// #195: consecutive failed SELF-fetch bursts for `self_ota_fail_build`. Build-scoped so a NEW
+    /// staged target starts fresh; `main` skips the re-trigger once it reaches `SELF_OTA_MAX_RETRIES`
+    /// (see `self_ota_fetch_capped`). RAM-only → a reboot clears it. Mirrors `leaf_ota_retries`.
+    self_ota_fail_streak: u8,
+    /// #195: the build number `self_ota_fail_streak` is counted against. A `note_self_ota_failed`
+    /// for a DIFFERENT build resets the streak to 1 (a new target deserves its own N attempts).
+    self_ota_fail_build: u32,
     /// #21 node-manager: the parsed default-screen command surfaced by a burst,
     /// pending `main`'s `take_config_offer` → apply. `None` when nothing is pending.
     config_offer: Option<crate::app::DefaultScreen>,
@@ -2052,6 +2067,8 @@ impl RadioManager {
             ota_self_fail: None,
             leaf_ota_retries: 0,
             leaf_ota_fetch_retries: 0,
+            self_ota_fail_streak: 0,
+            self_ota_fail_build: 0,
             leaf_ota_pending: false,
             leaf_installs_outstanding: false,
             leaf_ota_mac: None,
@@ -3464,6 +3481,32 @@ impl RadioManager {
             }
         }
         ok
+    }
+
+    /// #195: record a FAILED self-fetch of `build` (called by `main` after `run_ota_update`
+    /// returns `false` — a success reboots inside the fetch and never returns here). Build-scoped,
+    /// saturating streak, mirroring the relay's `leaf_ota_retries` counting: a DIFFERENT build
+    /// starts a fresh count (a new target deserves its own N attempts). RAM-only (reboot clears).
+    pub fn note_self_ota_failed(&mut self, build: u32) {
+        if build != self.self_ota_fail_build {
+            self.self_ota_fail_build = build;
+            self.self_ota_fail_streak = 1;
+        } else {
+            self.self_ota_fail_streak = self.self_ota_fail_streak.saturating_add(1);
+        }
+        log::info!(
+            "smol #195: self-fetch fail streak {}/{} for build {}",
+            self.self_ota_fail_streak, SELF_OTA_MAX_RETRIES, build
+        );
+    }
+
+    /// #195: has the self-fetch of `build` hit its consecutive-failure cap? `main` skips the
+    /// re-trigger while true, bounding the mesh-deaf hammer a broken-downstream crown otherwise
+    /// sustains (#204). Build-scoped, so a NEW staged build (or a reboot) resumes it automatically.
+    /// Deliberately does NOT clear the retained arm (#134: a gateway-local fetch failure says
+    /// nothing about the image — a self-heal / post-shed relay / successor crown can still finish it).
+    pub fn self_ota_fetch_capped(&self, build: u32) -> bool {
+        build == self.self_ota_fail_build && self.self_ota_fail_streak >= SELF_OTA_MAX_RETRIES
     }
 
     /// #40: record a leaf-OTA attempt's outcome (called by `main` after `run_leaf_ota_relay`,


### PR DESCRIPTION
**DRAFT / HELD** — do not merge until feat/204 (#204 self-heal) lands via #210; retarget to `main` then. HW-gate-held (bench canary with the v342 wave).

## What
Adds the missing **cross-burst consecutive-failure cap** on the SELF-fetch install path: after `SELF_OTA_MAX_RETRIES=3` consecutive failed self-fetch bursts for a staged build, `main` stops auto-re-triggering the fetch — bounding the mesh-deaf hammer a broken-downstream crown otherwise sustains (#204; a canary hit 24 retries after a verified arm-clear).

## Why this (not the two originally-filed #195 fixes)
Verify-before-code found both already present:
- body-byte STALL reset (`wifi.rs` ~4398) — a zero-body blackout already trips `OTA_MAX_STALL=6`.
- arm re-read each burst (`wifi.rs` ~2544) + one-shot `take_install_request` (`mode.rs` ~3426) — a *received* arm-clear already stops the cross-burst re-trigger.
The v341-canary hammer was a **#204 consequence** (the deaf crown never *received* the arm-clear). The one real gap: the self-fetch path had no consecutive-failure cap (the relay path has `leaf_ota_retries`).

## Design
- `net/mode.rs`: `SELF_OTA_MAX_RETRIES` const + `self_ota_fail_streak`/`self_ota_fail_build` fields + `note_self_ota_failed(build)` + `self_ota_fetch_capped(build)`. Mirrors `leaf_ota_retries`.
- `main.rs`: gate the self-fetch on `!self_ota_fetch_capped(build)`; call `note_self_ota_failed` on failure (`run_ota_update`'s `false` return was previously ignored).
- **Honors #134**: does NOT clear the retained arm — a gateway-local fetch failure says nothing about the image; a #204 self-heal / post-shed relay / new build / reboot all resume it. Build-scoped, RAM-only streak.

## Verify
Stacked on frozen feat/204 (`25f756a`). katana 1.96.1: `clippy -D warnings` green on espnow,cast,io + bare-wifi + default; release build green.

Refs #195 (re-scoped), #204, #134, #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)