### PR TITLE
feat(fw): #228 enrich HA discovery device block (model/manufacturer/sw_version)

### DIFF
--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -2226,8 +2226,11 @@ fn mqtt_session(
             json.clear();
             let _ = write!(
                 json,
-                "{{\"unique_id\":\"smol{}_{}\",\"object_id\":\"smol_{}_{}\",\"has_entity_name\":true,\"name\":\"{}\",\"state_topic\":\"smol/{}/telemetry\",\"value_template\":\"{}\"{},\"expire_after\":300,\"device\":{{\"identifiers\":[\"smol{}\"],\"name\":\"smol {} {}\"}}}}",
-                id, field, id, field, name, id, tmpl, extra, id, id, noun
+                // #228: device block enriched with model/manufacturer/sw_version so HA groups
+                // every entity under one device card with the running sigil version shown.
+                // sw_version = "v<build#> <forge-noun>" (e.g. "v342 Jig"); none of these are secret.
+                "{{\"unique_id\":\"smol{}_{}\",\"object_id\":\"smol_{}_{}\",\"has_entity_name\":true,\"name\":\"{}\",\"state_topic\":\"smol/{}/telemetry\",\"value_template\":\"{}\"{},\"expire_after\":300,\"device\":{{\"identifiers\":[\"smol{}\"],\"name\":\"smol {} {}\",\"model\":\"smol ESP32-C3\",\"manufacturer\":\"jphein\",\"sw_version\":\"v{} {}\"}}}}",
+                id, field, id, field, name, id, tmpl, extra, id, id, noun, env!("BUILD_NUMBER"), crate::net::names::version_name().1
             );
             if let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, dtopic.as_bytes(), json.as_bytes(), true) {
                 let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
@@ -2264,8 +2267,8 @@ fn mqtt_session(
             // entity_category) so HA derives the clean entity_id `sensor.smol_<id>_uplink`
             // from object_id instead of the device-name-concatenated form. unique_id bumped
             // (_uplk) to force HA to re-derive the entity_id for the corrected config.
-            "{{\"unique_id\":\"smol{}_uplk\",\"object_id\":\"smol_{}_uplink\",\"has_entity_name\":true,\"name\":\"Uplink\",\"state_topic\":\"smol/{}/uplink\",\"unit_of_measurement\":\"dBm\",\"device_class\":\"signal_strength\",\"expire_after\":120,\"device\":{{\"identifiers\":[\"smol{}\"],\"name\":\"smol {} {}\"}}}}",
-            node_id, node_id, node_id, node_id, node_id, unoun
+            "{{\"unique_id\":\"smol{}_uplk\",\"object_id\":\"smol_{}_uplink\",\"has_entity_name\":true,\"name\":\"Uplink\",\"state_topic\":\"smol/{}/uplink\",\"unit_of_measurement\":\"dBm\",\"device_class\":\"signal_strength\",\"expire_after\":120,\"device\":{{\"identifiers\":[\"smol{}\"],\"name\":\"smol {} {}\",\"model\":\"smol ESP32-C3\",\"manufacturer\":\"jphein\",\"sw_version\":\"v{} {}\"}}}}",
+            node_id, node_id, node_id, node_id, node_id, unoun, env!("BUILD_NUMBER"), crate::net::names::version_name().1
         );
         if let Some(n) =
             crate::net::mqtt::encode_publish(&mut pkt, dtopic.as_bytes(), json.as_bytes(), true)


### PR DESCRIPTION
Closes part of #228. Findings: `scratch/228-discovery-dns/luna-notify.md`.

## Part 1 — HA discovery device-block enrichment ✅ (this PR)
Both discovery `device` blocks in `net/wifi.rs` (the 3-typed-config telemetry loop + the uplink config)
now carry `model` + `manufacturer` + `sw_version`:
```
"device":{"identifiers":["smol<id>"],"name":"smol <id> <noun>",
          "model":"smol ESP32-C3","manufacturer":"jphein","sw_version":"v<build#> <forge-noun>"}
```
- `sw_version` = `env!("BUILD_NUMBER")` + `version_name().1` (the running sigil version, e.g. **"v342 Jig"**) — every entity now shows the live firmware version, and HA groups them under one device card with model/manufacturer.
- All three fields are **non-secret** → inline literals + existing build env (no gitignored placement needed).
- Budget: enriched config ≈446 B < `JsonScratch` 512 (66 B margin); arg counts verified (13 telemetry / 8 uplink).
- **Gate: 4-tier `clippy -D warnings` green** — default / wifi / espnow / espnow+cast+io+wifi (riscv32imc, 1.96.1).
- Build-and-hold: **not flashed** (HW-gated; team-lead runs the coordinated flash+canary).

## Part 2 — DNS-with-fallback-IP ⚠️ intentionally NOT in this PR (design conflict)
main smol **deliberately has no DNS resolver**: `net/wifi.rs:54` — *"We hardcode an anycast IP so we need
no DNS resolver in the smoltcp build."* Every fetch target is a baked IP (NTP anycast; `secrets.rs`
`broker_ip`/`ota_hosts`/`WLED_CAST_HOST`, all gitignored). smol is **IP-only by design** — there is no DNS
to "fall back" from, and the baked IPs already live in gitignored `secrets.rs` (Part 2's security
requirement is already satisfied). "resolve-by-hostname → fallback IP" is a **watch** pattern (esp32c6-watch
uses embassy-net + a DNS socket). Adding a resolver to smol's smoltcp build contradicts the design and is
untestable under build-and-hold.
**Recommendation:** fold DNS-with-fallback into **#227 (weather)** — `api.open-meteo.com` is the only real
internet hostname smol will resolve; that's where the DNS + gitignored fallback-IP const belong, with a consumer.

_No LAN IPs/MACs/SSIDs in the diff; `grep beginagain`=0; only `wifi.rs` touched (secrets.rs/board.rs gitignored)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)