### PR TITLE
feat(viz): #188 meshscope OTA progress arc + loud death-point

### DIFF
--- a/rust/viz/mesh-model/src/model.rs
+++ b/rust/viz/mesh-model/src/model.rs
@@ -13,7 +13,7 @@
 use std::collections::{BTreeMap, VecDeque};
 
 use crate::names;
-use crate::parse::{self, Diag, OtaState, PeerLink};
+use crate::parse::{self, Diag, OtaProgress, OtaState, PeerLink};
 
 // --- Semantic thresholds — the SINGLE SOURCE OF DERIVATION TRUTH (HA parity) ---
 // Every derived signal is defined ONCE here; the HA dashboard mirrors these (and
@@ -21,6 +21,10 @@ use crate::parse::{self, Diag, OtaState, PeerLink};
 // → update HA to match.
 /// A node fades to "stale" after this long without any message (~1.5 flush cycles).
 pub const STALE_S: f64 = 45.0;
+/// #188: an ota/progress record with no update for this long, while `done < total`, is a DEAD
+/// transfer — it stopped AT `done` bytes (the death-point). ~30 s ≫ the fw's ~5 s publish cadence,
+/// so a live transfer never trips it, but a stalled/blackholed one goes loud within one window.
+pub const OTA_PROGRESS_STALE_S: f64 = 30.0;
 /// A link at or weaker than this dBm is a "weak link" (dashed in the graph).
 pub const WEAK_LINK_DBM: i32 = -80;
 /// Free heap at or below this many bytes is "low heap" (flagged).
@@ -108,6 +112,11 @@ pub struct Node {
     pub ota: Option<OtaState>,
     pub ota_armed: bool,
     pub ota_phase: Option<String>, // latest smol/<id>/ota/diag phase (e.g. "fetch-failed retry=3")
+    /// #188 live transfer progress (smol/<id>/ota/progress) + the frame-time it last updated. A
+    /// stale record with done<total is the DEATH-POINT — the transfer stopped AT `done` bytes. See
+    /// [`Node::ota_progress_view`].
+    pub ota_progress: Option<OtaProgress>,
+    pub ota_progress_at: f64,
     pub links: Vec<PeerLink>, // peers this node hears (edges out)
     pub heap_hist: VecDeque<[f64; 2]>,
     pub rssi_hist: VecDeque<[f64; 2]>,
@@ -129,6 +138,8 @@ impl Node {
             ota: None,
             ota_armed: false,
             ota_phase: None,
+            ota_progress: None,
+            ota_progress_at: 0.0,
             links: Vec::new(),
             heap_hist: VecDeque::new(),
             rssi_hist: VecDeque::new(),
@@ -149,6 +160,21 @@ impl Node {
 
     pub fn is_stale(&self, now_s: f64) -> bool {
         now_s - self.last_seen_s > STALE_S
+    }
+
+    /// #188: OTA transfer view for meshscope — `(fraction 0..=1, dead, &OtaProgress)`, or `None`
+    /// if the node published no ota/progress. `dead` = the retained progress went STALE
+    /// (`now_s - ota_progress_at > OTA_PROGRESS_STALE_S`) while `done < total` — i.e. the transfer
+    /// stopped AT `done` bytes (the death-point). `now_s` is the render frame time.
+    pub fn ota_progress_view(&self, now_s: f64) -> Option<(f32, bool, &OtaProgress)> {
+        let p = self.ota_progress.as_ref()?;
+        let frac = if p.total > 0 {
+            (p.done as f32 / p.total as f32).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        let dead = p.done < p.total && (now_s - self.ota_progress_at) > OTA_PROGRESS_STALE_S;
+        Some((frac, dead, p))
     }
 
     /// The node's LIVE screen — the "familiar"/app it is showing. The AppKind from the
@@ -389,6 +415,15 @@ impl Model {
                         self.event(now_s, EventKind::Ota, format!("⏳ id{id} installing v{}", o.latest));
                     }
                     self.node_mut(id, now_s).ota = Some(o);
+                }
+            }
+            // #188 live transfer progress (bytes). Stamp the frame-time so the render can detect a
+            // STALE record (the death-point). Render-only — no per-update ticker event (too chatty).
+            "ota/progress" => {
+                if let Some(p) = parse::parse_ota_progress(text) {
+                    let n = self.node_mut(id, now_s);
+                    n.ota_progress = Some(p);
+                    n.ota_progress_at = now_s;
                 }
             }
             "ota/install" => {

--- a/rust/viz/mesh-model/src/parse.rs
+++ b/rust/viz/mesh-model/src/parse.rs
@@ -42,6 +42,18 @@ pub struct OtaState {
     pub title: String,
 }
 
+/// #188 live transfer progress from `smol/<id>/ota/progress` = `<done>|<total>|<phase>` (bytes;
+/// phase `self` | `relayfetch` | `relaychunks`). Retained by the firmware, so the LAST value pins
+/// exactly WHERE a transfer got to — the meshscope death-point render keys off it going stale while
+/// `done < total` (the transfer stopped AT `done` bytes). This is the live % the old ota/state
+/// consumer explicitly could NOT show ("no live transfer % is published").
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct OtaProgress {
+    pub done: u32,
+    pub total: u32,
+    pub phase: String,
+}
+
 /// Split `smol/<id>/<suffix...>` into `(id, suffix)`. Non-numeric second segment
 /// (e.g. `smol/mesh/channel`, `smol/display/batt`) returns `None` — those are
 /// handled by exact-topic match, not as per-node topics.
@@ -127,6 +139,16 @@ pub fn parse_ota_state(payload: &str) -> Option<OtaState> {
         in_progress: v.get("in_progress").and_then(|x| x.as_bool()).unwrap_or(false),
         title: s("title"),
     })
+}
+
+/// #188: parse `smol/<id>/ota/progress` = `done|total|phase` (pipe-delimited, not JSON). Panic-free;
+/// `None` on a malformed line. `phase` defaults to "" if the third field is absent.
+pub fn parse_ota_progress(payload: &str) -> Option<OtaProgress> {
+    let mut f = payload.splitn(3, '|');
+    let done: u32 = f.next()?.trim().parse().ok()?;
+    let total: u32 = f.next()?.trim().parse().ok()?;
+    let phase = f.next().unwrap_or("").trim().to_string();
+    Some(OtaProgress { done, total, phase })
 }
 
 /// Extract the device noun from an HA discovery config JSON, e.g. device.name
@@ -250,6 +272,18 @@ mod tests {
         assert_eq!(o.latest, "48");
         assert!(o.in_progress);
         assert_eq!(o.title, "v48 Molten Crucible");
+    }
+
+    #[test]
+    fn ota_progress() {
+        let p = parse_ota_progress("393216|1006688|relayfetch").unwrap();
+        assert_eq!(p.done, 393216);
+        assert_eq!(p.total, 1006688);
+        assert_eq!(p.phase, "relayfetch");
+        // phase optional; garbage rejected.
+        assert_eq!(parse_ota_progress("0|1006688").unwrap().phase, "");
+        assert!(parse_ota_progress("").is_none());
+        assert!(parse_ota_progress("abc|1|self").is_none());
     }
 
     #[test]

--- a/rust/viz/meshscope/src/ui/graph.rs
+++ b/rust/viz/meshscope/src/ui/graph.rs
@@ -250,10 +250,49 @@ impl GraphLayout {
             painter.circle_filled(ndot, 4.0, sync_color(node.sync_freshness()));
             painter.circle_stroke(ndot, 4.0, Stroke::new(1.0_f32, Color32::from_black_alpha(130)));
 
-            // #159 — OTA in progress: a pulsing ring + "OTA→vLATEST". (No live transfer %
-            // is published to MQTT — ota/state carries only in_progress + installed/latest —
-            // so this is an honest indeterminate indicator, not a fake bar.)
-            if let Some(o) = &node.ota {
+            // #188 — LIVE OTA transfer. A real progress ARC (%+phase) now that the firmware publishes
+            // smol/<id>/ota/progress, OR a LOUD death-point when that record goes stale mid-flight
+            // (the transfer stopped AT `done` bytes — exactly the diagnostic we lacked). Falls back to
+            // the old indeterminate pulse only when a node reports in_progress with no live progress
+            // record yet (pre-first-publish / older firmware).
+            if let Some((frac, dead, prog)) = node.ota_progress_view(now_s) {
+                let ring_r = r + 5.0;
+                if dead {
+                    // Death-point: a loud red pulsing full ring + the exact byte count it died at.
+                    let pulse = (0.55 + 0.45 * (now_s * 6.0).sin() as f32).clamp(0.15, 1.0);
+                    painter.circle_stroke(sp, ring_r, Stroke::new(3.5_f32, Color32::from_rgb(240, 60, 60).gamma_multiply(pulse)));
+                    painter.text(
+                        sp + Vec2::new(0.0, -r - 12.0),
+                        Align2::CENTER_CENTER,
+                        format!("✖ DIED {}k/{}k", prog.done / 1024, prog.total / 1024),
+                        FontId::proportional(11.0),
+                        Color32::from_rgb(255, 120, 120),
+                    );
+                } else if !stale {
+                    // Live: a cyan-green arc sweeping `frac` of the ring, clockwise from the top.
+                    let segs = 40usize;
+                    let sweep = frac.max(0.02) * std::f32::consts::TAU;
+                    let col = Color32::from_rgb(70, 210, 170);
+                    let mut prev: Option<Pos2> = None;
+                    for i in 0..=segs {
+                        let a = -std::f32::consts::FRAC_PI_2 + sweep * (i as f32 / segs as f32);
+                        let pt = sp + Vec2::new(a.cos() * ring_r, a.sin() * ring_r);
+                        if let Some(pv) = prev {
+                            painter.line_segment([pv, pt], Stroke::new(3.0_f32, col));
+                        }
+                        prev = Some(pt);
+                    }
+                    if Some(id) != crown {
+                        painter.text(
+                            sp + Vec2::new(0.0, -r - 12.0),
+                            Align2::CENTER_CENTER,
+                            format!("OTA {}% {}", (frac * 100.0) as u32, prog.phase),
+                            FontId::proportional(10.5),
+                            Color32::from_rgb(120, 230, 200),
+                        );
+                    }
+                }
+            } else if let Some(o) = &node.ota {
                 if o.in_progress && !stale {
                     let pulse = (0.5 + 0.4 * ((now_s * 4.0).sin() as f32 * 0.5 + 0.5)).clamp(0.2, 1.0);
                     painter.circle_stroke(sp, r + 5.0, Stroke::new(2.5_f32, Color32::from_rgb(210, 120, 235).gamma_multiply(pulse)));

--- a/rust/viz/meshscope/src/ui/panel.rs
+++ b/rust/viz/meshscope/src/ui/panel.rs
@@ -82,6 +82,31 @@ pub fn show(ui: &mut egui::Ui, model: &Model, selected: Option<u8>, now_s: f64) 
                     .color(Color32::from_rgb(220, 140, 240)),
             );
         }
+        // #188 live transfer progress + death-point (smol/<id>/ota/progress). The bytes/% is the
+        // live "watch it happen" signal the old inspector couldn't show; a DIED line pins exactly
+        // where a stalled transfer stopped.
+        if let Some((frac, dead, prog)) = node.ota_progress_view(now_s) {
+            let line = format!(
+                "{} / {} KB  ({}%, {})",
+                prog.done / 1024,
+                prog.total / 1024,
+                (frac * 100.0) as u32,
+                prog.phase
+            );
+            if dead {
+                ui.label(
+                    RichText::new(format!("✖ transfer DIED @ {line}"))
+                        .strong()
+                        .color(Color32::from_rgb(255, 110, 110)),
+                );
+            } else {
+                ui.label(
+                    RichText::new(format!("↓ {line}"))
+                        .monospace()
+                        .color(Color32::from_rgb(120, 230, 200)),
+                );
+            }
+        }
         if node.ota_armed {
             ui.label(RichText::new("🎯 install armed").color(Color32::from_rgb(210, 120, 235)));
         }


### PR DESCRIPTION
## What
Consumes the retained `smol/<id>/ota/progress = <done>|<total>|<phase>` the firmware now publishes (#188 send-side, merged in #239) and renders it in meshscope — **including the death-point** (exactly where a transfer stopped).

Companion PR to the fw send-side (#239). Closes the "+ viz" half of #188.

## Changes
- **mesh-model** `parse.rs`: `OtaProgress { done, total, phase }` + `parse_ota_progress` (pipe-delimited, panic-free) + a unit test.
- **mesh-model** `model.rs`: `Node.ota_progress` + `ota_progress_at` (frame-time) + an `ota/progress` dispatch arm + `Node::ota_progress_view(now_s) -> (frac, dead, &OtaProgress)`. **`dead` = the retained record went stale (>30 s) while `done < total`** → the transfer stopped AT `done` bytes.
- **meshscope** `graph.rs`: replaces the old *indeterminate pulse* (which existed only because "no live % is published") with a **real cyan-green progress arc** (frac of the ring) + `OTA <pct>% <phase>`; and a **LOUD red pulsing ring + "✖ DIED Nk/Mk"** when dead. Falls back to the pulse only for `in_progress` with no live record yet (older fw).
- **meshscope** `panel.rs`: inspector adds `↓ done/total KB (pct%, phase)` / a bold `✖ transfer DIED @ …` line.

## Why it matters now
The v343→id9 roll is currently stalled **deaf-at-response-byte-0** (#204). When v344 (carrying #239) flashes, this render becomes the **first-class death-point witness** — no more hand-correlating server GET logs.

## Verify
katana: mesh-model tests (incl. `ota_progress`, 23 pass) + workspace `clippy -D warnings` + release build — all green. Secret-scan 0.

Refs #188, #239, #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)