### PR TITLE
feat: #233 upgrade wave — esp-hal 1.1 / esp-radio 0.18 matched set + edition 2024 [HW-CANARY-HELD]

### DIFF
--- a/rust/clock/.cargo/config.toml
+++ b/rust/clock/.cargo/config.toml
@@ -40,20 +40,15 @@ build-std = ["core", "alloc"]
 [registries.crates-io]
 protocol = "sparse"
 
-# #140 esp-wifi RX-buffer tuning (heap-gated — see scratch/smol-ha-batt/140-heap-audit.md).
-# We ran esp-wifi 0.15's stock-low defaults (rx_queue 5 / static_rx 10 / dynamic_rx 32 / rx_ba_win 6),
+# #140 RX-buffer tuning (heap-gated — see scratch/smol-ha-batt/140-heap-audit.md).
+# We ran the stock-low defaults (rx_queue 5 / static_rx 10 / dynamic_rx 32 / rx_ba_win 6),
 # which starve sustained RX and were a co-cause of the mid-body OTA-fetch stalls (nebula finding 3 /
 # esp-hosted #184). The bump is UNLOCKED by growing the heap 72→128 KiB (net::init_heap) — the audit
 # showed ~120 KB of DRAM free and only ~5.9 KB heap headroom at the old size, so tuning buffers on the
-# 72 KiB heap would OOM. Keys/ranges verified against esp-wifi 0.15's generated config table; each
-# static RX buffer ≈ 1.6 KB, allocated at esp_wifi::init from the (now-grown) esp-alloc heap.
+# 72 KiB heap would OOM. Each static RX buffer ≈ 1.6 KB, allocated at radio init from the esp-alloc heap.
 # HW-GATE-HELD: throughput/stability win only provable on the deaf-list/fetch rig (pairs with #143).
-[env]
-# 10→16: more 802.11 RX headroom (IDF throughput profile uses 16–25). +~9.6 KB permanent at init.
-ESP_WIFI_CONFIG_STATIC_RX_BUF_NUM = "16"
-# 32→40: on-demand ceiling; must be ≥ static_rx_buf_num. Freed as the TCP stack drains each frame.
-ESP_WIFI_CONFIG_DYNAMIC_RX_BUF_NUM = "40"
-# 5→8: deeper RX frame queue to ride short bursts without drop.
-ESP_WIFI_CONFIG_RX_QUEUE_SIZE = "8"
-# 6→12: bigger Block-Ack RX window for AMPDU throughput. MUST stay ≤ static_rx_buf_num (16). iperf 9–12.
-ESP_WIFI_CONFIG_RX_BA_WIN = "12"
+#
+# #233: esp-radio 0.18 moved ALL of these RX knobs out of build-env into the runtime
+# `ControllerConfig` — static_rx 16 / dynamic_rx 40 / rx_queue 8 / rx_ba_win 12 are now applied
+# in net::radio_controller_config() (threaded into wifi::new). esp-config HARD-ERRORS on unknown
+# ESP_RADIO_CONFIG_* env keys, and RX_QUEUE_SIZE is no longer one, so there is no [env] block.

--- a/rust/clock/Cargo.lock
+++ b/rust/clock/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c583acf993cf4245c4acb0a2cc2ab1f9cc097de73411bb6d3647ff6af2b1013d"
 
 [[package]]
-name = "anyhow"
-version = "1.0.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,13 +21,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
-name = "basic-toml"
-version = "0.1.10"
+name = "base64"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
-dependencies = [
- "serde",
-]
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitfield"
@@ -105,6 +96,7 @@ name = "clock"
 version = "0.1.0"
 dependencies = [
  "ed25519-compact",
+ "embassy-futures",
  "embedded-graphics",
  "embedded-storage",
  "esp-alloc",
@@ -112,15 +104,22 @@ dependencies = [
  "esp-bootloader-esp-idf",
  "esp-hal",
  "esp-println",
+ "esp-radio",
+ "esp-rtos",
  "esp-storage",
- "esp-wifi",
- "esp-wifi-sys",
+ "esp-wifi-sys-esp32c3",
  "log",
  "nb 1.1.0",
  "sha2",
  "smoltcp",
  "ssd1306",
 ]
+
+[[package]]
+name = "const-default"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "cpufeatures"
@@ -297,12 +296,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "docsplay"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8547ea80db62c5bb9d7796fcce5e6e07d1136bdc1a02269095061e806758fab4"
+dependencies = [
+ "docsplay-macros",
+]
+
+[[package]]
+name = "docsplay-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11772ed3eb3db124d826f3abeadf5a791a557f62c19b123e3f07288158a71fdd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
- "litrs 1.0.0",
+ "litrs",
 ]
 
 [[package]]
@@ -313,31 +332,13 @@ checksum = "5c24599140dc39d7a81e4476e7573d41bbc18e07c803900298e522a5fbcfbfb6"
 
 [[package]]
 name = "embassy-embedded-hal"
-version = "0.3.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c62a3bf127e03832fb97d8b01a058775e617653bc89e2a12c256485a7fb54c1"
-dependencies = [
- "embassy-embedded-hal 0.4.0",
- "embassy-futures",
- "embassy-sync 0.6.2",
- "embassy-time",
- "embedded-hal 0.2.7",
- "embedded-hal 1.0.0",
- "embedded-hal-async",
- "embedded-storage",
- "embedded-storage-async",
- "nb 1.1.0",
-]
-
-[[package]]
-name = "embassy-embedded-hal"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1611b7a7ab5d1fbed84c338df26d56fd9bded58006ebb029075112ed2c5e039"
+checksum = "b0641612053b2f34fc250bb63f6630ae75de46e02ade7f457268447081d709ce"
 dependencies = [
  "embassy-futures",
  "embassy-hal-internal",
- "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -354,9 +355,9 @@ checksum = "dc2d050bdc5c21e0862a89256ed8029ae6c290a93aecefc73084b3002cdebb01"
 
 [[package]]
 name = "embassy-hal-internal"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95285007a91b619dc9f26ea8f55452aa6c60f7115a4edc05085cd2bd3127cd7a"
+checksum = "7f10ce10a4dfdf6402d8e9bd63128986b96a736b1a0a6680547ed2ac55d55dba"
 dependencies = [
  "num-traits",
 ]
@@ -375,10 +376,10 @@ checksum = "8d2c8cdff05a7a51ba0087489ea44b0b1d97a296ca6b1d6d1a33ea7423d34049"
 dependencies = [
  "cfg-if",
  "critical-section",
- "embedded-io-async",
+ "embedded-io-async 0.6.1",
  "futures-sink",
  "futures-util",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -389,35 +390,24 @@ checksum = "73974a3edbd0bd286759b3d483540f0ebef705919a5f56f4fc7709066f71689b"
 dependencies = [
  "cfg-if",
  "critical-section",
- "embedded-io-async",
+ "embedded-io-async 0.6.1",
  "futures-core",
  "futures-sink",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
-name = "embassy-time"
-version = "0.4.0"
+name = "embassy-sync"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f820157f198ada183ad62e0a66f554c610cdcd1a9f27d4b316358103ced7a1f8"
+checksum = "7bbd85cf5a5ae56bdf26f618364af642d1d0a4e245cdd75cd9aabda382f65a81"
 dependencies = [
  "cfg-if",
  "critical-section",
- "document-features",
- "embassy-time-driver",
- "embedded-hal 0.2.7",
- "embedded-hal 1.0.0",
- "embedded-hal-async",
- "futures-util",
-]
-
-[[package]]
-name = "embassy-time-driver"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
-dependencies = [
- "document-features",
+ "embedded-io-async 0.7.0",
+ "futures-core",
+ "futures-sink",
+ "heapless 0.9.3",
 ]
 
 [[package]]
@@ -484,12 +474,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
 name = "embedded-io-async"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
- "embedded-io",
+ "embedded-io 0.6.1",
+]
+
+[[package]]
+name = "embedded-io-async"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
+dependencies = [
+ "embedded-io 0.7.1",
 ]
 
 [[package]]
@@ -536,40 +541,48 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "esp-alloc"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e95f1de57ce5a6600368f3d3c931b0dfe00501661e96f5ab83bc5cdee031784"
+checksum = "46ced060d4085858283df950b80a4da2348e1707d7d07b1e966308582dae79f5"
 dependencies = [
  "allocator-api2",
  "cfg-if",
- "critical-section",
  "document-features",
  "enumset",
+ "esp-config",
+ "esp-sync",
  "linked_list_allocator",
+ "rlsf",
 ]
 
 [[package]]
 name = "esp-backtrace"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f270a29a3c4e492399b13e157b10151a7616cba69c4d554076ea93ed1bd2916"
+checksum = "37950e24b2dfd98f1581102d1798281d4d9547af881e6bffc2c2b534c026ec8f"
 dependencies = [
  "cfg-if",
+ "document-features",
  "esp-config",
+ "esp-metadata-generated",
  "esp-println",
- "heapless",
+ "heapless 0.9.3",
+ "riscv",
+ "xtensa-lx",
 ]
 
 [[package]]
 name = "esp-bootloader-esp-idf"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a093dbdc64b0288baacc214c2e8c2f3f13ecbf979c36ee2f63797ecf22538f1"
+checksum = "35ffc117c3a9859835d89d0e90f5ee9886ce2264a71a849a7a22ab5308f6653c"
 dependencies = [
  "cfg-if",
  "document-features",
  "embedded-storage",
  "esp-config",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
  "esp-rom-sys",
  "jiff",
  "strum",
@@ -577,22 +590,22 @@ dependencies = [
 
 [[package]]
 name = "esp-config"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd4a8db4b72794637a25944bc8d361c3cc271d4f03987ce8741312b6b61529c"
+checksum = "4d9b92fd9cfb0b4f8f1b6219b9763269a335571e307b014903b8201619374b80"
 dependencies = [
  "document-features",
- "esp-metadata-generated 0.1.0",
- "evalexpr",
+ "esp-metadata-generated",
  "serde",
  "serde_yaml",
+ "somni-expr",
 ]
 
 [[package]]
 name = "esp-hal"
-version = "1.0.0-rc.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3887eda2917deef3d99e7a5c324f9190714e99055361ad36890dffd0a995b49"
+checksum = "2bfcf2a0842903717f4663f6a08512c32b0f6b2d7fb7db3c8a6895d2e6d49f72"
 dependencies = [
  "bitfield",
  "bitflags 2.13.1",
@@ -602,36 +615,40 @@ dependencies = [
  "delegate",
  "digest",
  "document-features",
- "embassy-embedded-hal 0.3.2",
+ "embassy-embedded-hal",
  "embassy-futures",
- "embassy-sync 0.6.2",
+ "embassy-sync 0.8.0",
  "embedded-can",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "embedded-io",
- "embedded-io-async",
+ "embedded-io 0.6.1",
+ "embedded-io 0.7.1",
+ "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
  "enumset",
  "esp-config",
  "esp-hal-procmacros",
- "esp-metadata-generated 0.1.0",
+ "esp-metadata-generated",
  "esp-riscv-rt",
  "esp-rom-sys",
+ "esp-sync",
  "esp32",
  "esp32c2",
- "esp32c3 0.30.0",
+ "esp32c3",
  "esp32c6",
  "esp32h2",
  "esp32s2",
  "esp32s3",
  "fugit",
  "instability",
+ "log",
  "nb 1.1.0",
  "paste",
  "portable-atomic",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "rand_core 0.9.5",
  "riscv",
- "serde",
  "strum",
  "ufmt-write",
  "xtensa-lx",
@@ -640,41 +657,16 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-procmacros"
-version = "0.19.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbece384edaf0d1eabfa45afa96d910634d4158638ef983b2d419a8dec832246"
+checksum = "6aebfabb2c21bec45e575e4f6cb6bb7aa8e1b33e7ac45b5dffa0f9d33ff59105"
 dependencies = [
  "document-features",
- "litrs 0.4.2",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
  "termcolor",
-]
-
-[[package]]
-name = "esp-metadata"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fbc1d166be84c0750f121e95c8989ddebd7e7bdd86af3594a6cfb34f039650"
-dependencies = [
- "anyhow",
- "basic-toml",
- "indexmap",
- "proc-macro2",
- "quote",
- "serde",
- "strum",
-]
-
-[[package]]
-name = "esp-metadata-generated"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d36b8c8a752bdebec67fd02a15ebb1432feea345553749bca7ce2393cc795"
-dependencies = [
- "esp-metadata",
 ]
 
 [[package]]
@@ -684,27 +676,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42c2ee95b945a4780796e4359e72c033aed3b45073880e8029458f538532db8a"
 
 [[package]]
-name = "esp-println"
-version = "0.15.0"
+name = "esp-phy"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7e3ab41e96093d7fd307e93bfc88bd646a8ff23036ebf809e116b18869f719"
+checksum = "e7c0a29815cd105ae1a02f3d0c6e7aafda9504a41effae17fac4c3f827719228"
 dependencies = [
- "critical-section",
+ "cfg-if",
  "document-features",
- "esp-metadata-generated 0.1.0",
+ "embassy-sync 0.8.0",
+ "esp-config",
+ "esp-hal",
+ "esp-metadata-generated",
+ "esp-sync",
+ "esp-wifi-sys-esp32c3",
+ "esp32c3",
+ "log",
+]
+
+[[package]]
+name = "esp-println"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42dee1e9ac7c3539bf6464db1707b0edd7557168f98278cf3c84fe70e63c6ce6"
+dependencies = [
+ "document-features",
+ "esp-metadata-generated",
+ "esp-sync",
  "log",
  "portable-atomic",
 ]
 
 [[package]]
-name = "esp-riscv-rt"
-version = "0.12.0"
+name = "esp-radio"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a00370dfcb0ccc01c6b2540076379c6efd6890a27f584de217c38e3239e19d5"
+checksum = "23fbff98b06a96b6ce3791ecec5c668524052a068e23aacd23afe17ddba844ce"
+dependencies = [
+ "allocator-api2",
+ "cfg-if",
+ "docsplay",
+ "document-features",
+ "embassy-net-driver",
+ "embassy-sync 0.8.0",
+ "embedded-io 0.6.1",
+ "embedded-io 0.7.1",
+ "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
+ "enumset",
+ "esp-alloc",
+ "esp-config",
+ "esp-hal",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
+ "esp-phy",
+ "esp-radio-rtos-driver",
+ "esp-sync",
+ "esp-wifi-sys-esp32",
+ "esp-wifi-sys-esp32c2",
+ "esp-wifi-sys-esp32c3",
+ "esp-wifi-sys-esp32c6",
+ "esp-wifi-sys-esp32h2",
+ "esp-wifi-sys-esp32s2",
+ "esp-wifi-sys-esp32s3",
+ "esp32c3",
+ "heapless 0.9.3",
+ "instability",
+ "log",
+ "num-derive",
+ "num-traits",
+ "portable-atomic",
+ "portable_atomic_enum",
+]
+
+[[package]]
+name = "esp-radio-rtos-driver"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd75cd9073a90ffaa53db0bf17df7dc14164f2407a6ff36c725d2d1f78ff494"
+dependencies = [
+ "cfg-if",
+ "esp-sync",
+ "portable-atomic",
+]
+
+[[package]]
+name = "esp-riscv-rt"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a814ae91452de56a5e74f69aebfee40579511756837d3774a56fd24cf0ab79"
 dependencies = [
  "document-features",
  "riscv",
- "riscv-rt-macros",
+ "riscv-rt",
 ]
 
 [[package]]
@@ -715,85 +778,143 @@ checksum = "eae852ccb08971155023d1371c96d5490cbc26860f06aee2d629ef73f1a890c3"
 dependencies = [
  "cfg-if",
  "document-features",
- "esp-metadata-generated 0.4.0",
- "esp32c3 0.32.2",
+ "esp-metadata-generated",
+ "esp32c3",
+]
+
+[[package]]
+name = "esp-rtos"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551f90766e1527edaa0c91e8d559e9e2a60397b545e93357ac61fb31845e5712"
+dependencies = [
+ "allocator-api2",
+ "cfg-if",
+ "document-features",
+ "embassy-sync 0.8.0",
+ "esp-alloc",
+ "esp-config",
+ "esp-hal",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
+ "esp-radio-rtos-driver",
+ "esp-rom-sys",
+ "esp-sync",
+ "log",
+ "portable-atomic",
+ "riscv",
+ "xtensa-lx",
 ]
 
 [[package]]
 name = "esp-storage"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f276ad8a3bdc6b47cd92a3e91013f2e42dce9b3fc5023392063387a1ce2ed69a"
+checksum = "4cf2b3f00c9f94b27c62a4f5296b19470c3a083c687c8146e554a459f9bee596"
 dependencies = [
- "critical-section",
  "document-features",
  "embedded-storage",
- "esp-rom-sys",
-]
-
-[[package]]
-name = "esp-wifi"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84908f2e95cb99a200cf448abafc416576338be590778a15d9224eee237f3210"
-dependencies = [
- "allocator-api2",
- "cfg-if",
- "critical-section",
- "document-features",
- "embassy-net-driver",
- "embedded-io",
- "embedded-io-async",
- "enumset",
- "esp-alloc",
- "esp-config",
  "esp-hal",
- "esp-metadata-generated 0.1.0",
- "esp-wifi-sys",
- "num-derive",
- "num-traits",
- "portable-atomic",
- "portable_atomic_enum",
- "rand_core 0.9.5",
- "smoltcp",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
+ "esp-rom-sys",
+ "esp-sync",
 ]
 
 [[package]]
-name = "esp-wifi-sys"
-version = "0.7.1"
+name = "esp-sync"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b5438361891c431970194a733415006fb3d00b6eb70b3dcb66fd58f04d9b39"
+checksum = "b4736bfbbb9e3f6353344e14fc61b6d18d3b877c3286914cf8c0a037be0ed224"
 dependencies = [
- "anyhow",
+ "cfg-if",
+ "document-features",
+ "embassy-sync 0.6.2",
+ "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
+ "esp-metadata-generated",
+ "riscv",
+ "xtensa-lx",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2556f38f5292d9735d4e156e276815fc001c9a0a2be0544a575c5fb867129d24"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32c2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4b3eb3435dae84de611d4384639e61eed862818223e93fa70c525cb6a70127f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32c3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b290846b53db9a3965866964260220b67f2c41cc2dbc0b377e7136239fe168a7"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32c6"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57649401fc2f906a16e2268de88693724a125adcd0eba89b594a157affcee2d5"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32h2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf1be2e311f4b4e75b5507c6b007ffc3fcb8c6cb57f83cc6a9569ecdcf58484"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32s2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a9a7f1bc51e7026c3012cda4f11d8799e5e0c0bb3be85797462219def6c26e"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32s3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8321f44b57d8112cbd8607cc83b85783b9195289acb45532728e3e229e7786"
+dependencies = [
+ "log",
 ]
 
 [[package]]
 name = "esp32"
-version = "0.38.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7680f79e3a4770e59c2dc25b17dcd852921ee57ffae9a4c4806c9ca5001d54d"
+checksum = "5726e07689249d1a2cb7c492077bc424837fb68a64f7eb5d46569325352e9428"
 dependencies = [
- "critical-section",
  "vcell",
 ]
 
 [[package]]
 name = "esp32c2"
-version = "0.27.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da1bcf86fca83543e0e95561cba27bbcc6b6e7adc5428f49187f5868bc0c3ed2"
+checksum = "5ef0b623533bbaa37e348c18b6b41cfd5b47c3cb64a4b9e44f0295941d62aa2e"
 dependencies = [
- "critical-section",
- "vcell",
-]
-
-[[package]]
-name = "esp32c3"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2c5a33d4377f974cbe8cadf8307f04f2c39755704cb09e81852c63ee4ac7b8"
-dependencies = [
- "critical-section",
  "vcell",
 ]
 
@@ -808,49 +929,39 @@ dependencies = [
 
 [[package]]
 name = "esp32c6"
-version = "0.21.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca8fc81b7164df58b5e04aaac9e987459312e51903cca807317990293973a6e"
+checksum = "c58f34ff2633968c12125efc7f4f8f101078d5d34c7cb60eab82268db20986f9"
 dependencies = [
- "critical-section",
  "vcell",
 ]
 
 [[package]]
 name = "esp32h2"
-version = "0.17.0"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80171d08c17d8c63b53334c60ca654786a7593481531d19b639c4e5c76d276de"
+checksum = "c5bab026020ed4606ce113b6fde598dbc48f7eefcc46e9469ece77cc2b1aa4be"
 dependencies = [
- "critical-section",
  "vcell",
 ]
 
 [[package]]
 name = "esp32s2"
-version = "0.29.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c90d347480fca91f4be3e94b576af9c6c7987795c58dc3c5a7c108b6b3966dc"
+checksum = "d0ad6f21cdf6ec7b06b7f7e0fbe51f0d975fd6a5fa67c3f8a5a910d3981af531"
 dependencies = [
- "critical-section",
  "vcell",
 ]
 
 [[package]]
 name = "esp32s3"
-version = "0.33.0"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3769c56222c4548833f236c7009f1f8b3f2387af26366f6bd1cea456666a49d"
+checksum = "8b4b8c4e4d9f187553ecdb7173edec7b2deb2beea106eedefecdb1654b8ee25a"
 dependencies = [
- "critical-section",
  "vcell",
 ]
-
-[[package]]
-name = "evalexpr"
-version = "12.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae893d2d5e908b78f151ed89de3bfc272cdf6d368c7ed866942f98e24dea208a"
 
 [[package]]
 name = "float-cmp"
@@ -947,6 +1058,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,8 +1087,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1045,15 +1164,6 @@ name = "linked_list_allocator"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b23ac50abb8261cb38c6e2a7192d3302e0836dac1628f6a93b82b4fad185897"
-
-[[package]]
-name = "litrs"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
-dependencies = [
- "proc-macro2",
-]
 
 [[package]]
 name = "litrs"
@@ -1244,12 +1354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r0"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7a31eed1591dcbc95d92ad7161908e72f4677f8fabf2a32ca49b4237cbf211"
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,10 +1366,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
-name = "riscv"
-version = "0.12.1"
+name = "rand_core"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea8ff73d3720bdd0a97925f0bf79ad2744b6da8ff36be3840c48ac81191d7a7"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "riscv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05cfa3f7b30c84536a9025150d44d26b8e1cc20ddf436448d74cd9591eefb25"
 dependencies = [
  "critical-section",
  "embedded-hal 1.0.0",
@@ -1276,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "riscv-macros"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f265be5d634272320a7de94cea15c22a3bfdd4eb42eb43edc528415f066a1f25"
+checksum = "7d323d13972c1b104aa036bc692cd08b822c8bbf23d79a27c526095856499799"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1292,14 +1402,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
 
 [[package]]
-name = "riscv-rt-macros"
-version = "0.4.0"
+name = "riscv-rt"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc71814687c45ba4cd1e47a54e03a2dbc62ca3667098fbae9cc6b423956758fa"
+checksum = "3d07b9f3a0eff773fc4df11f44ada4fa302e529bff4b7fe7e6a4b98a65ce9174"
+dependencies = [
+ "riscv",
+ "riscv-pac",
+ "riscv-rt-macros",
+ "riscv-target-parser",
+]
+
+[[package]]
+name = "riscv-rt-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def519ddeeb5e43c2b4fc3952c27b3a86782fc05192f322b2309125cd85b1fc3"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "riscv-target-parser"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1376b15f3ff160e9b1e8ea564ce427f2f6fcf77528cc0a8bf405cb476f9cea7"
+
+[[package]]
+name = "rlsf"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1646a59a9734b8b7a0ac51689388a60fe1625d4b956348e9de07591a1478457a"
+dependencies = [
+ "cfg-if",
+ "const-default",
+ "libc",
+ "rustversion",
+ "svgbobdoc",
 ]
 
 [[package]]
@@ -1370,16 +1511,31 @@ dependencies = [
 
 [[package]]
 name = "smoltcp"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
+checksum = "5f73d40463bba65efc9adc6370b56df76d563cc46e2482bba58351b4afb7535e"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
- "heapless",
+ "heapless 0.9.3",
  "managed",
 ]
+
+[[package]]
+name = "somni-expr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed9b7648d5e8b2df6c5e49940c54bcdd2b4dd71eafc6e8f1c714eb4581b0f53"
+dependencies = [
+ "somni-parser",
+]
+
+[[package]]
+name = "somni-parser"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0f368519fc6c85fc1afdb769fb5a51123f6158013e143656e25a3485a0d401c"
 
 [[package]]
 name = "ssd1306"
@@ -1426,6 +1582,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "svgbobdoc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c04b93fc15d79b39c63218f15e3fdffaa4c227830686e3b7c5f41244eb3e50"
+dependencies = [
+ "base64",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1545,6 +1714,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,30 +1778,29 @@ dependencies = [
 
 [[package]]
 name = "xtensa-lx"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a564fffeb3cd773a524e8d8a5c66ca5e9739ea7450e36a3e6a54dd31f1e652f"
+checksum = "e012d667b0aa6d2592ace8ef145a98bff3e76cca7a644f4181ecd7a916ed289b"
 dependencies = [
  "critical-section",
 ]
 
 [[package]]
 name = "xtensa-lx-rt"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520a8fb0121eb6868f4f5ff383e262dc863f9042496724e01673a98a9b7e6c2b"
+checksum = "409a9b4629d429e995cde4dfbd9fe562ccae66f7624514e200733fc5d0ea8905"
 dependencies = [
  "document-features",
- "r0",
  "xtensa-lx",
  "xtensa-lx-rt-proc-macros",
 ]
 
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a56a616147f5947ceb673790dd618d77b30e26e677f4a896df049d73059438"
+checksum = "96fb42cd29c42f8744c74276e9f5bee7b06685bbe5b88df891516d72cb320450"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -1,31 +1,44 @@
 [package]
 name = "clock"
 version = "0.1.0"
-edition = "2021"
-rust-version = "1.96"
+edition = "2024"
+rust-version = "1.88"
 description = "smol: ESP32-C3 SuperMini + 0.42\" SSD1306 OLED clock with WiFi/NTP + ESP-NOW"
 license = "MIT OR Apache-2.0"
 
 # -----------------------------------------------------------------------------
-# Pinned, mutually-compatible crate versions.
+# THE MATCHED SET (issue #233 upgrade wave — esp-hal 1.1 / esp-radio 0.18).
 #
-# The esp-hal / esp-wifi / esp-hal-embassy / esp-alloc quartet is extremely
-# version-sensitive because esp-wifi links against esp-hal INTERNAL APIs, and
-# its Cargo `^1.0.0-rc.0` requirement is looser than what actually compiles.
+# esp-radio (the renamed esp-wifi) compiles against esp-hal INTERNAL APIs, so
+# the HAL / radio / scheduler / storage crates are a MATCHED SET: a mixed set
+# fails to compile even when Cargo's semver check passes. The canonical trap
+# from the old set was `Rng::new(RNG)` → `Rng::new()` (the peripheral argument
+# was dropped in esp-hal 1.x); that is now RESOLVED — every call site here uses
+# the arg-less `esp_hal::rng::Rng::new()` against esp-hal 1.1.
 #
-# THE KEY GOTCHA: esp-wifi 0.15.x calls `esp_hal::rng::Rng::new(peripherals.RNG)`
-# internally. In esp-hal 1.0.0-rc.1 and the 1.0.0 release, `Rng::new()` was
-# changed to take NO argument, which makes esp-wifi 0.15.x fail to compile
-# ("this function takes 0 arguments but 1 was supplied") even though Cargo's
-# semver check passes. We therefore pin esp-hal to the EXACT release esp-wifi
-# 0.15.x was built against: the 2025-07-16 cluster.
+# The proven, mutually-compatible cluster (mirrors the esp32c6-watch reference,
+# adapted C6→C3 / riscv32imac→riscv32imc):
 #
-#   esp-hal          1.0.0-rc.0  (2025-07-16; Rng::new(RNG) still takes the peripheral)
-#   esp-wifi         0.15.0      (2025-07-16; requires esp-alloc ^0.8.0)
-#   esp-hal-embassy  0.9.0       (2025-07-16)
-#   esp-alloc        0.8.0
-#   esp-backtrace    0.17.0      (2025-07-16)
-#   esp-println      0.15.0      (2025-07-16)
+#   esp-hal                 1.1.x
+#   esp-radio               0.18.0   (was esp-wifi 0.15 — RENAMED crate)
+#   esp-rtos                0.3.0    (NEW — the preemption scheduler that backs
+#                                     esp-radio's os-adapter; replaces esp-wifi's
+#                                     in-crate `builtin-scheduler` feature)
+#   esp-wifi-sys-esp32c3    0.2.0    (per-chip raw bindings; aliased to esp_wifi_sys)
+#   esp-alloc               0.10.0
+#   esp-storage             0.9.0
+#   esp-bootloader-esp-idf  0.5.0    (otadata/flash APIs changed — see src/ota.rs)
+#   esp-backtrace           0.19.0
+#   esp-println             0.17.0
+#   smoltcp                 0.13.x   (esp-radio 0.18 has NO smoltcp feature — its
+#                                     device impls embassy-net-driver only, so smol
+#                                     provides its own smoltcp `phy::Device` shim in
+#                                     src/net/radio_dev.rs over the raw rx/tx tokens)
+#
+# ARCHITECTURE NOTE: smol stays a SYNCHRONOUS superloop. esp-rtos is enabled with
+# its `esp-radio` + `esp-alloc` features but NOT `embassy`: `esp_rtos::start()`
+# converts the current context into the scheduler's main task and returns, so the
+# existing blocking main() runs unchanged while the radio task is preempted in.
 #
 # ssd1306 0.10.0 + embedded-graphics 0.8 target embedded-hal 1.0, which esp-hal
 # 1.x implements, so the display stack composes cleanly with the HAL.
@@ -34,21 +47,21 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # --- Core HAL (Phase 1, always on) ---------------------------------------
 # `unstable` is required for I2C/SPI/RNG and is also a hard requirement of
-# esp-wifi. `esp32c3` selects the chip. `rt` + `exception-handler` come from
+# esp-radio. `esp32c3` selects the chip. `rt` + `exception-handler` come from
 # the default features (runtime + fault handler).
-esp-hal = { version = "=1.0.0-rc.0", features = ["esp32c3", "unstable"], optional = true }
+esp-hal = { version = "1.1", features = ["esp32c3", "unstable"], optional = true }
 # NOTE: esp-hal's default features already install the exception handler, so
 # esp-backtrace only provides the panic handler + backtrace printing here.
 # Enabling esp-backtrace's `exception-handler` too causes a duplicate
 # `ExceptionHandler` symbol and an LTO bitcode-load failure at link time.
-esp-backtrace = { version = "=0.17.0", features = ["esp32c3", "panic-handler", "println"], optional = true }
+esp-backtrace = { version = "0.19", features = ["esp32c3", "panic-handler", "println"], optional = true }
 # Force the USB Serial/JTAG backend explicitly. This board's console is the
 # native USB Serial/JTAG link (/dev/ttyACM0); esp-println's default `auto`
 # backend only routes to USB-JTAG when it detects host SOF packets at the
 # instant it writes, which proved unreliable during the busy WiFi burst and
 # left app logs going to the (unwired) UART0. `jtag-serial` pins the output to
 # USB-JTAG so boot/WiFi/NTP/ESP-NOW logs always appear on /dev/ttyACM0.
-esp-println = { version = "=0.15.0", default-features = false, optional = true, features = [
+esp-println = { version = "0.17", default-features = false, optional = true, features = [
     "esp32c3",
     "log-04",
     "jtag-serial",
@@ -68,22 +81,34 @@ nb = "1"
 ssd1306 = { version = "=0.10.0", optional = true }
 embedded-graphics = "=0.8.1"
 
-# --- WiFi / NTP (Phase 2, feature = "wifi") ------------------------------
-# esp-alloc pinned to 0.8.x to satisfy esp-wifi 0.15.1's `^0.8.0` requirement.
-esp-alloc = { version = "=0.8.0", optional = true }
-esp-wifi-sys = { version = "=0.7.1", optional = true, default-features = false }
-esp-wifi = { version = "=0.15.0", optional = true, default-features = false, features = [
+# --- WiFi / NTP + radio (Phase 2, feature = "wifi") ----------------------
+esp-alloc = { version = "0.10", optional = true }
+# The preemption scheduler that backs esp-radio's `esp_radio_preempt_*` os-adapter
+# hooks. In the old stack this was esp-wifi's in-crate `builtin-scheduler`; in the
+# 0.18 stack it moved OUT to esp-rtos. We enable ONLY its `esp-radio` + `esp-alloc`
+# drivers (NOT `embassy`) — smol is a blocking superloop, and `esp_rtos::start()`
+# turns main() into the scheduler's pinned main task, so blocking code runs as-is.
+esp-rtos = { version = "0.3", optional = true, features = [
+    "esp32c3",
+    "esp-radio",
+    "esp-alloc",
+    "log-04",
+] }
+# esp-wifi RENAMED → esp-radio in 0.18. `unstable` unlocks the raw rx/tx tokens
+# (our smoltcp shim) + the `esp_now` interface. `default-features = false` drops
+# esp-radio's default `esp-alloc` so we re-add it explicitly.
+esp-radio = { version = "0.18", optional = true, default-features = false, features = [
     "esp32c3",
     "wifi",
     "esp-alloc",
-    "smoltcp",
-    # esp-wifi needs a preemption scheduler backing its `esp_wifi_preempt_*`
-    # os-adapter hooks. `builtin-scheduler` is normally in esp-wifi's default
-    # feature set, but we set `default-features = false`, so we must re-add it
-    # explicitly (otherwise: `undefined symbol: esp_wifi_preempt_*` at link).
-    "builtin-scheduler",
+    "unstable",
+    "log-04",
 ] }
-smoltcp = { version = "=0.12.0", optional = true, default-features = false, features = [
+# #141 TX-power clamp + AP-info readback use raw esp-idf bindings. esp-radio's
+# `sys` module is pub(crate), so we depend on the per-chip bindings crate directly
+# and alias it to `esp_wifi_sys` — net.rs keeps `esp_wifi_sys::include::…` verbatim.
+esp-wifi-sys = { package = "esp-wifi-sys-esp32c3", version = "0.2", optional = true, default-features = false }
+smoltcp = { version = "0.13", optional = true, default-features = false, features = [
     "medium-ethernet",
     "proto-ipv4",
     "proto-dhcpv4",
@@ -91,36 +116,34 @@ smoltcp = { version = "=0.12.0", optional = true, default-features = false, feat
     "socket-dhcpv4",
     "socket-tcp",
 ] }
+# #233: esp-radio 0.18 made connect/disconnect/scan ASYNC-only (no blocking variants).
+# smol is a synchronous superloop, so we drive those futures to completion with
+# embassy-futures' busy-loop `block_on` (no executor needed; the esp-rtos scheduler
+# preempts the busy loop to run the radio task that posts the completion events).
+embassy-futures = { version = "0.1", optional = true }
 
 # --- OTA (Phase B, issue #6) — HAL-decoupled, folded into `wifi` ----------
-# Spike-proven co-compile with the pinned quartet (WAVE 10). Both are optional
-# and pulled ONLY by `wifi`, so the `default` (no-radio) build compiles NO OTA
-# code. `esp32c3` on esp-bootloader-esp-idf is REQUIRED — without it the crate's
-# rom.rs references an unresolved `esp_rom_sys` (md5/crc pulled by the chip
-# feature). esp-storage gives XIP-safe flash writes (FlashStorage auto-detects
-# 4 MB); esp-bootloader-esp-idf gives the otadata slot/state API + esp_app_desc!.
-esp-storage = { version = "=0.7.0", optional = true, features = ["esp32c3"] }
-esp-bootloader-esp-idf = { version = "=0.2.0", optional = true, features = ["esp32c3"] }
+# Both optional + pulled ONLY by `wifi`, so the `default` (no-radio) build compiles
+# NO OTA code. `esp32c3` on esp-bootloader-esp-idf is REQUIRED (its rom.rs pulls the
+# chip's md5/crc). esp-storage gives XIP-safe flash writes; esp-bootloader-esp-idf
+# gives the otadata slot/state API + esp_app_desc!.
+esp-storage = { version = "0.9", optional = true, features = ["esp32c3"] }
+esp-bootloader-esp-idf = { version = "0.5", optional = true, features = ["esp32c3"] }
 # Software SHA-256 for the OTA image integrity gate. Chosen over the HW `esp_hal::sha`
-# peripheral deliberately: the HW path needs the SHA peripheral threaded through boot
-# into the OTA burst + a self-referential `ShaDigest` (borrows the `Sha` beside it),
-# whereas `sha2` is peripheral-free + move-friendly. Cost is ~4 KB flash — negligible
-# at ~30% slot usage (3.3x headroom). Hashing is bound by the ~600 KB HTTP download,
-# not the digest, so there's no throughput reason to prefer HW here. (spec §Stage C-4.)
+# peripheral deliberately: peripheral-free + move-friendly. Cost is ~4 KB flash.
+# Hashing is bound by the ~600 KB HTTP download, not the digest. (spec §Stage C-4.)
 sha2 = { version = "0.10", default-features = false, optional = true }
 # The `NorFlash` trait (erase/write) whose impl on esp-storage's FlashStorage the OTA
-# ImageWriter drives. Trait-only crate; pin to the 0.3.x esp-storage already links.
+# ImageWriter drives.
 embedded-storage = { version = "0.3", optional = true }
 # #32 OTA authenticity: Ed25519 VERIFY-ONLY over the signed manifest ("build|size|sha256").
-# no_std, pure-Rust, no getrandom/curve25519 (self-contained) — spike-proven co-compile vs the
-# pinned quartet on riscv32imc (issue-32-spike-result.md). Gated in `espnow` (only run_ota_fetch
-# verifies) → default/wifi-only builds pull NO crypto. ⚠️ REQUIRES the opt-z per-pkg override in
-# [profile.release.package.ed25519-compact] below — without it the scalar-mult unrolls to ~1.19 MB.
+# no_std, pure-Rust, self-contained. Gated in `espnow`. ⚠️ REQUIRES the opt-z per-pkg
+# override in [profile.release.package.ed25519-compact] below — without it the
+# scalar-mult unrolls to ~1.19 MB and overflows the OTA slot.
 ed25519-compact = { version = "2", default-features = false, optional = true }
 
 # --- ESP-NOW (Phase 3, feature = "espnow") -------------------------------
-# ESP-NOW support lives inside esp-wifi behind its `esp-now` feature.
-# (No extra top-level crate; the feature is toggled on esp-wifi below.)
+# ESP-NOW lives inside esp-radio behind its `esp-now` feature (toggled below).
 
 [features]
 # Phase 1 only: clock on the OLED. `default` = `hw` so `cargo build --release` with no
@@ -162,9 +185,11 @@ io = ["espnow"]
 wifi = [
     "hw", # #152: every firmware tier carries the bare-metal crates (byte-identical to before)
     "dep:esp-alloc",
-    "dep:esp-wifi",
+    "dep:esp-rtos",
+    "dep:esp-radio",
     "dep:esp-wifi-sys",
     "dep:smoltcp",
+    "dep:embassy-futures",
     "dep:esp-storage",
     "dep:esp-bootloader-esp-idf",
     "dep:sha2",
@@ -173,8 +198,14 @@ wifi = [
 ]
 
 # Phase 3: ESP-NOW peer messaging + WiFi<->ESP-NOW switching.
-# Builds on `wifi` (shares the radio init path) and turns on esp-wifi/esp-now.
-espnow = ["wifi", "esp-wifi/esp-now", "dep:ed25519-compact"]
+# Builds on `wifi` (shares the radio init path); turns on esp-radio's `esp-now`.
+# NOTE (#233): we deliberately do NOT enable esp-radio's `coex` feature. `coex` is the
+# cross-radio (WiFi+BLE) coexistence arbiter and esp-radio's build script HARD-ERRORS if
+# `coex` is set without `ble`. smol's WiFi<->ESP-NOW coexistence (#40/#23) is SAME-RADIO
+# channel management (both live in the WiFi domain), not cross-radio arbitration — the old
+# esp-wifi 0.15 build never enabled coex either. Pulling BLE in would also wedge the C3 in
+# ROM (btdm init busy-wait — see the "native BLE refuted on C3" finding). So: esp-now only.
+espnow = ["wifi", "esp-radio/esp-now", "dep:ed25519-compact"]
 
 # #25 WLED WiZmote-emit: smol impersonates a WLED "linked remote" (13-B WiZmote
 # ESP-NOW broadcast). Needs the ESP-NOW broadcast path + RadioManager, so it builds
@@ -211,7 +242,7 @@ coexist-soak = ["espnow"]
 mesh-test = ["espnow"]
 
 [profile.release]
-# esp-wifi strongly recommends opt-level "s"/2/3 and LTO; the radio blobs are
+# esp-radio strongly recommends opt-level "s"/2/3 and LTO; the radio blobs are
 # timing-sensitive and misbehave when built at opt-level 0.
 opt-level = "s"
 lto = "fat"

--- a/rust/clock/src/about.rs
+++ b/rust/clock/src/about.rs
@@ -44,7 +44,12 @@ impl About {
     /// boot), so the entry stamp is reserved, not needed.
     pub fn new(_now_ms: u64) -> Self {
         Self {
-            mac: esp_hal::efuse::Efuse::read_base_mac_address(),
+            // #233: esp-hal 1.1 replaced `Efuse::read_base_mac_address() -> [u8;6]` with the
+            // free fn `efuse::base_mac_address() -> MacAddress` (newtype; `.as_bytes()` → &[u8;6]).
+            mac: esp_hal::efuse::base_mac_address()
+                .as_bytes()
+                .try_into()
+                .unwrap_or([0u8; 6]),
             last_s: None,
         }
     }

--- a/rust/clock/src/familiar/mod.rs
+++ b/rust/clock/src/familiar/mod.rs
@@ -753,11 +753,10 @@ impl FamState {
             return None;
         }
         // Honour a bias (call / greet) when that peer is still present.
-        if let Some(b) = self.bias_to {
-            if cand[..n].contains(&b) {
+        if let Some(b) = self.bias_to
+            && cand[..n].contains(&b) {
                 return Some(b);
             }
-        }
         // Otherwise pick among the nearer half, rotated by seq so it varies (it
         // "wanders" rather than pinning to the single strongest peer).
         let strong = n.div_ceil(2);

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -62,7 +62,7 @@ esp_bootloader_esp_idf::esp_app_desc!();
 // bootloader auto-reverts too, if it was built with rollback enabled). rc.0 puts
 // `software_reset` in `esp_hal::system`, NOT `esp_hal::reset` (spike-verified).
 #[cfg(feature = "wifi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "Rust" fn custom_halt() -> ! {
     // #70 observability: record that THIS reset was a PANIC before we reboot. A panic halts
     // here → software_reset, which the SoC logs as a plain `CoreSw` (same as an intentional
@@ -532,7 +532,7 @@ fn main() -> ! {
         net::try_time_sync(
             net::WifiPeripherals {
                 timg0: peripherals.TIMG0,
-                rng: peripherals.RNG,
+                sw_int: peripherals.SW_INTERRUPT,
                 wifi: peripherals.WIFI,
             },
             &mut batt_cache,
@@ -586,7 +586,7 @@ fn main() -> ! {
         net::mode::start(
             net::WifiPeripherals {
                 timg0: peripherals.TIMG0,
-                rng: peripherals.RNG,
+                sw_int: peripherals.SW_INTERRUPT,
                 wifi: peripherals.WIFI,
             },
             // This unit's short id (see NODE_ID) — embedded in HELLO/ACK/BEACON/TIME
@@ -857,8 +857,8 @@ fn main() -> ! {
             let do_install = !r.leaf_ota_pending()
                 && !r.leaf_installs_outstanding()
                 && (crate::ota::OTA_AUTO_INSTALL || r.take_install_request());
-            if do_install {
-                if let Some(announce) = r.take_ota_offer() {
+            if do_install
+                && let Some(announce) = r.take_ota_offer() {
                     // #195: bound the mesh-deaf hammer — if THIS build's self-fetch has already
                     // failed SELF_OTA_MAX_RETRIES times in a row (e.g. a #204 broken-downstream
                     // crown), STOP re-triggering. The retained arm is deliberately kept (#134: a
@@ -910,7 +910,6 @@ fn main() -> ! {
                         redraw = true;
                     }
                 }
-            }
             // A gateway's SMOLv1 BATT downlink (buffered in `service`) → store it in
             // our cache so LEAVES render HA battery voltages too. `store` validates
             // the `BATT|` marker; a repaint shows fresh data at once. (A gateway
@@ -934,8 +933,8 @@ fn main() -> ! {
             // past the origin NTP node's, so the mesh converges and stops
             // swapping (loop-free — see net::mode's TimeTracker + should_adopt).
             // Checked every subtick so a never-synced board picks up time fast.
-            if let Some((punix, psynced, pid)) = r.take_time_offer() {
-                if should_adopt(my_synced_at, psynced) {
+            if let Some((punix, psynced, pid)) = r.take_time_offer()
+                && should_adopt(my_synced_at, psynced) {
                     let old = my_synced_at;
                     base_unix = punix;
                     anchor_ms = now;
@@ -950,7 +949,6 @@ fn main() -> ! {
                     bottom_line = alloc::string::String::from("mesh");
                     log::info!("smol: adopted mesh time (synced_at {} -> {})", old, psynced);
                 }
-            }
             // ~every 2 s advertise ourselves (HELLO drives the LED handshake).
             // 2000 ms / SUBTICK_MS aligned via the monotonic clock.
             if (now / 2000) != ((now.saturating_sub(SUBTICK_MS as u64)) / 2000) {
@@ -1368,8 +1366,8 @@ fn main() -> ! {
             // #48: pull the relayed LED-mode config (leaf) and update the held mode. Edge-safe:
             // a garbage/unknown value parses to None → keep the current mode (never a bad LED).
             // On the gateway, its OWN led config is applied via the gateway-own path (deferred).
-            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_LED) {
-                if let Some(m) = led::LedMode::from_wire(core::str::from_utf8(&o.buf[..o.len]).unwrap_or("")) {
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_LED)
+                && let Some(m) = led::LedMode::from_wire(core::str::from_utf8(&o.buf[..o.len]).unwrap_or("")) {
                     if m != led_mode {
                         log::info!("smol #48: LED mode -> {:?}", m);
                         // #114 U2: an APPLIED config change rides the DIAG record's cfg= field —
@@ -1379,35 +1377,32 @@ fn main() -> ! {
                     }
                     led_mode = m;
                 }
-            }
 
             // #43: pull the relayed/gateway-own display-units config (key `U`, fleet-global via
             // broadcast target 255) and update the held `Units`. Edge-safe: a garbage/partial
             // value parses to None → keep the current units (never a half-applied unit). Same
             // unified path as LED: a leaf gets it relayed, the gateway injects its own (GwOwnCfg).
-            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_UNITS) {
-                if let Some(u) = units::Units::from_wire(core::str::from_utf8(&o.buf[..o.len]).unwrap_or("")) {
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_UNITS)
+                && let Some(u) = units::Units::from_wire(core::str::from_utf8(&o.buf[..o.len]).unwrap_or("")) {
                     if u != units {
                         log::info!("smol #43: display units -> {:?}", u);
                         diag_dirty = true; // #114 U2: expedite DIAG (units ride cfg=) — see LED above
                     }
                     units = u;
                 }
-            }
 
             // #55: pull the relayed/gateway-own plugin-visibility mask (key `P`) and update it.
             // Edge-safe: garbage/partial hex parses to None → keep the current mask (never blanks
             // the menu). The mask filters Home-menu rows; a masked-off LIVE screen is caught after
             // `ctx` is built (below) and falls back to the board default.
-            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_PLUGINS) {
-                if let Some(m) = menu::parse_plugin_mask(core::str::from_utf8(&o.buf[..o.len]).unwrap_or("")) {
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_PLUGINS)
+                && let Some(m) = menu::parse_plugin_mask(core::str::from_utf8(&o.buf[..o.len]).unwrap_or("")) {
                     if m != plugin_mask {
                         log::info!("smol #55: plugin mask -> {:#06x}", m);
                         diag_dirty = true; // #114 U2: expedite DIAG (mask rides cfg=) — see LED above
                     }
                     plugin_mask = m;
                 }
-            }
 
             // #45: pull the relayed / gateway-own Custom-screen layout (key `Y`) and store the raw
             // RESOLVED wire (entities already substituted HA-side) for the Custom plugin to render.
@@ -1498,8 +1493,8 @@ fn main() -> ! {
             // reset outputs). On change: re-bind the free GPIOs via io::apply_wire (validates +
             // rejects reserved/unknown pins). No NVS — survives reboot via the gateway's re-relay.
             #[cfg(feature = "io")]
-            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_IO) {
-                if o.len != io_wire_len || io_wire[..o.len] != o.buf[..o.len] {
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_IO)
+                && (o.len != io_wire_len || io_wire[..o.len] != o.buf[..o.len]) {
                     io_wire[..o.len].copy_from_slice(&o.buf[..o.len]);
                     io_wire_len = o.len;
                     let n = io::apply_wire(&mut io_pins, &o.buf[..o.len]);
@@ -1510,19 +1505,17 @@ fn main() -> ! {
                     }
                     log::info!("smol #72 io: pin-map applied ({} B, {} pins bound)", o.len, n);
                 }
-            }
             // #72: the relayed / gateway-own output states (key `g`). EDGE-triggered on a CHANGE;
             // drives each bound OUTPUT to its commanded level (io::apply_set no-ops on unbound /
             // input slots). Held in io_set_wire so a later `G` re-bind re-asserts it.
             #[cfg(feature = "io")]
-            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_IO_SET) {
-                if o.len != io_set_len || io_set_wire[..o.len] != o.buf[..o.len] {
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_IO_SET)
+                && (o.len != io_set_len || io_set_wire[..o.len] != o.buf[..o.len]) {
                     io_set_wire[..o.len].copy_from_slice(&o.buf[..o.len]);
                     io_set_len = o.len;
                     let n = io::apply_set(&mut io_pins, &o.buf[..o.len]);
                     log::info!("smol #72 io: output states set ({} B, {} driven)", o.len, n);
                 }
-            }
 
             // #197: a transient on-glass toast (key `M`) — a COMMAND (cache-bypass, one-shot, NEVER
             // cached → never re-toasts on reboot). Value = `[~<dur>]<msg>`; `toast::parse_wire` splits

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -9,6 +9,13 @@
 #[cfg(feature = "wifi")]
 mod wifi;
 
+// #233: smoltcp `phy::Device` shim over esp-radio 0.18's raw rx/tx tokens (esp-radio
+// dropped esp-wifi's `smoltcp` feature). Transitional — deleted when #198 lands embassy-net.
+#[cfg(feature = "wifi")]
+mod radio_dev;
+#[cfg(feature = "wifi")]
+pub use radio_dev::SmolWifiDevice;
+
 /// #141: clamp the radio's max TX power. Cheap C3-supermini boards distort their own TX at
 /// full power (worse on marginal USB supplies) — the AP receives corrupted auth/ACK frames
 /// (the "auth expired at strong signal" / silent-hostapd / mid-transfer-stall class). Units
@@ -185,6 +192,21 @@ pub(crate) use wifi::NTP_RESYNC_AGE_S;
 #[cfg(feature = "wifi")]
 pub fn init_heap() {
     esp_alloc::heap_allocator!(size: 128 * 1024);
+}
+
+/// #233/#140: the esp-radio 0.18 controller config. In the old esp-wifi 0.15 stack the
+/// RX-buffer counts were compile-time `ESP_WIFI_CONFIG_*` env knobs (.cargo/config.toml);
+/// in 0.18 they are runtime `ControllerConfig` fields threaded into `wifi::new`. The
+/// #140 tuning (static_rx 16 / dynamic_rx 40 / rx_ba_win 12, unlocked by the 128 KiB heap
+/// above) is re-applied here; `ESP_RADIO_CONFIG_RX_QUEUE_SIZE` stays the env knob. Shared
+/// by both radio-init paths (`wifi::try_time_sync` and `mode::RadioManager::new`).
+#[cfg(feature = "wifi")]
+pub(crate) fn radio_controller_config() -> esp_radio::wifi::ControllerConfig {
+    esp_radio::wifi::ControllerConfig::default()
+        .with_static_rx_buf_num(16)
+        .with_dynamic_rx_buf_num(40)
+        .with_rx_queue_size(8)
+        .with_rx_ba_win(12)
 }
 
 /// Phase-1 (default) placeholder used when no radio features are enabled: the

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2824,7 +2824,11 @@ impl RadioManager {
         // scan_n = scan_with_config_sync_max(Default, N): a synchronous full-band scan capped at N
         // results. We cap generously then keep the strongest few, so a busy band still yields the
         // most-relevant APs.
-        let record = match block_on(self.controller.scan_async(&ScanConfig::default())) {
+        // #233 REGRESSION FIX: esp-radio 0.18 scan_async(ScanConfig::default()) has max=None and
+        // returns EVERY AP in range as a heap Vec — the old esp-wifi scan_n(16) capped at 16. In a
+        // dense RF environment the unbounded Vec is an OOM-panic risk (alloc failure = rst=panic);
+        // .with_max(16) restores the proven bound.
+        let record = match block_on(self.controller.scan_async(&ScanConfig::default().with_max(16))) {
             Ok(mut aps) => {
                 // Strongest RSSI first (descending → Reverse of the ascending key).
                 aps.sort_by_key(|a| core::cmp::Reverse(a.signal_strength));
@@ -2861,7 +2865,9 @@ impl RadioManager {
         }
         let net = &crate::secrets::WIFI_NETWORK;
         // Strongest ch6 BSSID if any; else strongest overall; else None (plain reconnect on creds).
-        let (bssid, pin_ch6): (Option<[u8; 6]>, bool) = match block_on(self.controller.scan_async(&ScanConfig::default())) {
+        // #233 REGRESSION FIX: bound the scan (see run_scan) — the old scan_n(16) capped results;
+        // scan_async(default) is unbounded (max=None) → OOM-panic risk on the crown-deaf path.
+        let (bssid, pin_ch6): (Option<[u8; 6]>, bool) = match block_on(self.controller.scan_async(&ScanConfig::default().with_max(16))) {
             Ok(aps) => {
                 if let Some(a) = aps
                     .iter()

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -43,18 +43,19 @@
 extern crate alloc;
 
 use esp_hal::{
+    interrupt::software::SoftwareInterruptControl,
     rng::Rng,
     time::Instant,
     timer::timg::TimerGroup,
 };
-use esp_wifi::{
+use embassy_futures::block_on;
+use esp_radio::{
     esp_now::{EspNow, EspNowWifiInterface, PeerInfo, BROADCAST_ADDRESS},
-    wifi::{WifiController, WifiMode},
-    EspWifiController,
+    wifi::{scan::ScanConfig, sta::StationConfig, Config, WifiController},
 };
 
 use crate::led::LedState;
-use crate::net::WifiPeripherals;
+use crate::net::{SmolWifiDevice, WifiPeripherals};
 // #13: the relay-family wire codec + ASCII field helpers live in the PURE, host-testable
 // `net::wire` module (extracted from here, byte-identical). Glob-imported so every call site
 // below (encode_relay, parse_relay[2], *relayack*, encode_dl, write_u5/u10, parse_id/u5/u10,
@@ -261,12 +262,12 @@ const SCAN_SSID_MAX: usize = 12;
 /// stripped (they're free-form → keep the record parseable); BSSIDs are truncated to 3 octets
 /// (PUBLIC-repo topic — a full BSSID is a privacy leak). `|none` when the scan found nothing.
 /// Panic-free (heap `String`); the caller bounds it to `RELAY_VALUE_MAX` at broadcast/publish.
-fn format_scan_record(aps: &[esp_wifi::wifi::AccessPointInfo]) -> alloc::string::String {
+fn format_scan_record(aps: &[esp_radio::wifi::ap::AccessPointInfo]) -> alloc::string::String {
     use core::fmt::Write;
     let mut s = alloc::string::String::from("SCAN");
     for ap in aps.iter().take(SCAN_MAX_APS) {
         let mut ssid = alloc::string::String::new();
-        for c in ap.ssid.chars().take(SCAN_SSID_MAX) {
+        for c in ap.ssid.as_str().chars().take(SCAN_SSID_MAX) {
             ssid.push(if c == '|' || c == ',' { '_' } else { c });
         }
         let b = ap.bssid;
@@ -1808,7 +1809,7 @@ pub enum Mode {
 ///
 /// The `EspWifiController` and `WifiController` are kept alive for `'static`
 /// (leaked once at construction) so the radio stays initialised for the life
-/// of the program — we never re-run `esp_wifi::init`, which is both expensive
+/// of the program — we never re-run `esp_radio::init`, which is both expensive
 /// and, per esp-wifi's docs, must happen exactly once.
 pub struct RadioManager {
     controller: WifiController<'static>,
@@ -1822,7 +1823,7 @@ pub struct RadioManager {
     /// and is available again for periodic relay flushes (`flush_telemetry`). The
     /// smoltcp stack is built/dropped inside each burst, so between bursts this is
     /// just an idle handle that doesn't contend with ESP-NOW on ch6.
-    sta: Option<esp_wifi::wifi::WifiDevice<'static>>,
+    sta: Option<SmolWifiDevice>,
     /// Kept for the SNTP ephemeral-port seed during the burst.
     rng: Rng,
     mode: Mode,
@@ -2051,17 +2052,24 @@ impl RadioManager {
         super::init_heap();
 
         let timg0 = TimerGroup::new(p.timg0);
-        let rng = Rng::new(p.rng);
-        // esp-wifi's `init` takes the RNG by value; `Rng` is a `Copy` handle
-        // (not the entropy itself), so we keep our own copy for the SNTP
-        // ephemeral-port seed while also handing one to `init`.
-        let ctrl: EspWifiController<'static> = esp_wifi::init(timg0.timer0, rng).ok()?;
-        let ctrl: &'static EspWifiController<'static> =
-            alloc::boxed::Box::leak(alloc::boxed::Box::new(ctrl));
-
-        let (mut controller, interfaces) = esp_wifi::wifi::new(ctrl, p.wifi).ok()?;
-        controller.set_mode(WifiMode::Sta).ok()?;
-        controller.start().ok()?;
+        let sw = SoftwareInterruptControl::new(p.sw_int);
+        // #233: start the esp-rtos scheduler that backs esp-radio's os-adapter BEFORE
+        // wifi::new (NON-embassy: start() pins THIS context as the main task and returns).
+        esp_rtos::start(timg0.timer0, sw.software_interrupt0);
+        // `Rng` is a `Copy` handle (not entropy itself); kept for the SNTP ephemeral-port seed.
+        let rng = Rng::new();
+        // 0.18: WIFI is 'static → wifi::new returns an owned 'static controller + interfaces
+        // (no EspWifiController Box::leak). STA mode derives from the Config::Station set in
+        // associate(); the old explicit set_mode(WifiMode::Sta) is gone in 0.18.
+        let (mut controller, interfaces) =
+            esp_radio::wifi::new(p.wifi, super::radio_controller_config()).ok()?;
+        // #233: esp-radio 0.18 has no controller.start(); `set_config` is what STARTS the
+        // WiFi driver. ESP-NOW rides the STA interface and needs the driver started even on a
+        // leaf that never associates, so start it here in STA mode with an empty config.
+        // associate() later re-configs with real creds + connect_async().
+        controller
+            .set_config(&Config::Station(StationConfig::default()))
+            .ok()?;
         // #139: assert PowerSaveMode::None at RADIO INIT — the esp-wifi/IDF default is
         // WIFI_PS_MIN_MODEM (the STA sleeps between DTIMs; the AP then buffers UNICAST at DTIM and
         // drops it on marginal links → the re-ARP-after-reply / forwarded-NTP-never-arrives /
@@ -2069,21 +2077,22 @@ impl RadioManager {
         // (which resets ps to the default), and the post-is_connected() sites stay belt-and-
         // suspenders. Shared by every espnow association (NTP/MQTT/OTA/re-election). See nebula
         // finding 2 (scratch/smol-ha-batt/nebula-c3-wifi-research.md).
-        let _ = controller.set_power_saving(esp_wifi::config::PowerSaveMode::None);
+        let _ = controller.set_power_saving(esp_radio::wifi::PowerSaveMode::None);
         crate::net::assert_max_tx_power(); // #141: 8.5 dBm clamp, right after driver start
 
         // #68/#76 SELF-MAC: capture our STA MAC (ESP-NOW rides the STA interface) so service()
         // can DROP frames from our own address. The esp-wifi RX queue can deliver our own
         // broadcasts back to us; with no self-filter the gateway rosters ITSELF (constant-RSSI,
         // age-0, flags-3 self-entry — roster anomaly #1) and wastes an eviction-immune slot.
-        let self_mac = interfaces.sta.mac_address();
+        let self_mac = interfaces.station.mac_address();
 
         Some(Self {
             controller,
             self_mac,
             esp_now: interfaces.esp_now,
             // Keep the STA device alive for the NTP burst; dropped afterward.
-            sta: Some(interfaces.sta),
+            // #233: wrapped in the smoltcp phy::Device shim (net::radio_dev).
+            sta: Some(SmolWifiDevice::new(interfaces.station)),
             rng,
             mode: Mode::WifiSta,
             id,
@@ -2514,7 +2523,7 @@ impl RadioManager {
             Mode::EspNow => {
                 // TIME-SHARE: relinquish the AP association so nothing else
                 // steers the channel, then pin the fixed ESP-NOW channel.
-                let _ = self.controller.disconnect();
+                let _ = block_on(self.controller.disconnect_async());
                 // Keep the MAC/PHY powered (do NOT stop the controller) so the
                 // esp_now handle stays valid; just retune the channel.
                 self.esp_now
@@ -2529,14 +2538,14 @@ impl RadioManager {
                 // COEXIST: come back to the AP. Re-associating retunes the PHY
                 // to the AP's channel automatically; ESP-NOW then coexists on
                 // that channel. (Caller must have valid credentials set.)
-                let _ = self.controller.connect();
+                let _ = block_on(self.controller.connect_async());
                 // #139: connect() resets power-save to the WIFI_PS_MIN_MODEM default, so the
                 // association/auth handshake that follows would otherwise run under modem-sleep
                 // (unicast-deaf window). Re-assert None NOW — before the handshake completes — not
                 // only after the downstream is_connected() gates (MQTT flush / OTA fetch).
                 let _ = self
                     .controller
-                    .set_power_saving(esp_wifi::config::PowerSaveMode::None);
+                    .set_power_saving(esp_radio::wifi::PowerSaveMode::None);
                 crate::net::assert_max_tx_power(); // #141
                 log::info!("smol: radio -> WiFi STA (coexist)");
             }
@@ -2815,7 +2824,7 @@ impl RadioManager {
         // scan_n = scan_with_config_sync_max(Default, N): a synchronous full-band scan capped at N
         // results. We cap generously then keep the strongest few, so a busy band still yields the
         // most-relevant APs.
-        let record = match self.controller.scan_n(16) {
+        let record = match block_on(self.controller.scan_async(&ScanConfig::default())) {
             Ok(mut aps) => {
                 // Strongest RSSI first (descending → Reverse of the ascending key).
                 aps.sort_by_key(|a| core::cmp::Reverse(a.signal_strength));
@@ -2852,7 +2861,7 @@ impl RadioManager {
         }
         let net = &crate::secrets::WIFI_NETWORK;
         // Strongest ch6 BSSID if any; else strongest overall; else None (plain reconnect on creds).
-        let (bssid, pin_ch6): (Option<[u8; 6]>, bool) = match self.controller.scan_n(16) {
+        let (bssid, pin_ch6): (Option<[u8; 6]>, bool) = match block_on(self.controller.scan_async(&ScanConfig::default())) {
             Ok(aps) => {
                 if let Some(a) = aps
                     .iter()
@@ -2866,19 +2875,22 @@ impl RadioManager {
             }
             Err(_) => (None, false),
         };
-        let _ = self.controller.disconnect();
-        let _ = self
-            .controller
-            .set_configuration(&esp_wifi::wifi::Configuration::Client(
-                esp_wifi::wifi::ClientConfiguration {
-                    ssid: net.ssid.into(),
-                    password: net.pass.into(),
-                    bssid,
-                    channel: if pin_ch6 { Some(6) } else { None },
-                    ..Default::default()
-                },
-            ));
-        let _ = self.controller.connect();
+        let _ = block_on(self.controller.disconnect_async());
+        // #233: StationConfig has private fields — build via BuilderLite setters.
+        // #233: 0.18 with_bssid/with_channel take the INNER value (wrapping in Some), so only
+        // call them when we actually have a bssid / a pinned channel; otherwise leave the
+        // StationConfig defaults (None).
+        let mut sta_cfg = StationConfig::default()
+            .with_ssid(net.ssid)
+            .with_password(net.pass.into());
+        if let Some(b) = bssid {
+            sta_cfg = sta_cfg.with_bssid(b);
+        }
+        if pin_ch6 {
+            sta_cfg = sta_cfg.with_channel(6);
+        }
+        let _ = self.controller.set_config(&Config::Station(sta_cfg));
+        let _ = block_on(self.controller.connect_async());
         log::warn!(
             "smol #204: crown deaf → ch6-prefer reassoc (ch6_found={}, bssid_set={})",
             pin_ch6,
@@ -3047,21 +3059,19 @@ impl RadioManager {
         // `main` populated it (espnow build). ASCII by construction (as_wire/to_wire/hex/F24). HA
         // reconstructs the same string from its command topics + plain-string-compares (luna's
         // `sensor.smol_<id>_config_applied` + drift binary_sensor) — no hash primitive needed.
-        if e.cfg_len > 0 {
-            if let Ok(cfg) = core::str::from_utf8(&e.cfg[..e.cfg_len as usize]) {
+        if e.cfg_len > 0
+            && let Ok(cfg) = core::str::from_utf8(&e.cfg[..e.cfg_len as usize]) {
                 rec.push_str("|cfg=");
                 rec.push_str(cfg);
             }
-        }
         // #72: append the io registry's bound-input press counters (io=<pin>:<count>,…) AFTER cfg=.
         // `io`-gated + only when populated → the DIAG string is byte-identical on a non-io build.
         #[cfg(feature = "io")]
-        if self.diag_io_len > 0 {
-            if let Ok(io) = core::str::from_utf8(&self.diag_io[..self.diag_io_len]) {
+        if self.diag_io_len > 0
+            && let Ok(io) = core::str::from_utf8(&self.diag_io[..self.diag_io_len]) {
                 rec.push_str("|io=");
                 rec.push_str(io);
             }
-        }
         // #13 MESH-TEST rig: surface the deaf-list state so a leftover entry is visible in HA at a
         // glance (the anti-"won't-rejoin-ghost" guard) — `deaf` = active entries, `ddrops` = frames
         // dropped by it. `mesh-test`-gated → the DIAG string is byte-identical on a production build.
@@ -3569,11 +3579,10 @@ impl RadioManager {
         // Release images are serial-silent, so this retained record is the ONLY fleet-visible signal
         // of WHY a self-fetch died (the blindness that turned tonight's mid-body deaths into a
         // three-hour diagnosis). `id` avoids borrowing self across the field set.
-        if !ok {
-            if let Some(rec) = fail {
+        if !ok
+            && let Some(rec) = fail {
                 self.ota_self_fail = Some(rec);
             }
-        }
         ok
     }
 
@@ -3695,7 +3704,7 @@ impl RadioManager {
         use crate::ota_mesh::{
             self as om, LeafOtaOutcome, CHUNK_PAYLOAD, WINDOW_BYTES, WINDOW_CHUNKS,
         };
-        use esp_bootloader_esp_idf::ota::Slot;
+        use esp_bootloader_esp_idf::partitions::AppPartitionSubType;
         if !self.relay.is_gateway {
             return LeafOtaOutcome::RelayFailed;
         }
@@ -3723,10 +3732,10 @@ impl RadioManager {
             let _ = self.switch(Mode::EspNow); // ch6 (the flush left us in WifiSta)
             let mut s = 0u16;
             while s < 40 {
-                if !matches!(self.controller.is_connected(), Ok(true)) {
+                if !self.controller.is_connected() {
                     break;
                 }
-                let _ = self.controller.disconnect();
+                let _ = block_on(self.controller.disconnect_async());
                 s = s.saturating_add(1);
                 if tick() {
                     return LeafOtaOutcome::Aborted;
@@ -3735,7 +3744,7 @@ impl RadioManager {
             let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
             if !self.esp_now.peer_exists(&BROADCAST_ADDRESS) {
                 let _ = self.esp_now.add_peer(PeerInfo {
-                    interface: EspNowWifiInterface::Sta,
+                    interface: EspNowWifiInterface::Station,
                     peer_address: BROADCAST_ADDRESS,
                     lmk: None,
                     channel: None,
@@ -3760,8 +3769,8 @@ impl RadioManager {
                         let _ = self.esp_now.send(&BROADCAST_ADDRESS, &otam_pre[..pre_len]);
                         last = t;
                     }
-                    if let Some(recv) = self.esp_now.receive() {
-                        if recv.info.src_address == leaf_mac {
+                    if let Some(recv) = self.esp_now.receive()
+                        && recv.info.src_address == leaf_mac {
                             let armed = matches!(
                                 om::parse_ldbg(recv.data(), leaf_id),
                                 Some((_, 1, _, _))
@@ -3773,7 +3782,6 @@ impl RadioManager {
                                 break; // leaf armed pre-fetch → its is_active hold now carries ch6
                             }
                         }
-                    }
                 }
                 log::info!("smol #3b: pre-fetch arm burst done (leaf id{})", leaf_id);
             }
@@ -3791,7 +3799,7 @@ impl RadioManager {
         let _ = self.switch(Mode::EspNow);
         let _ = self.switch(Mode::WifiSta);
         let rng = self.rng;
-        let mut staged: Option<Slot> = None;
+        let mut staged: Option<AppPartitionSubType> = None;
         let fetched = match self.sta.as_mut() {
             Some(sta) => crate::net::wifi::run_ota_fetch(
                 &mut self.controller, sta, rng, announce, tick, true, &mut staged, &mut None,
@@ -3826,7 +3834,7 @@ impl RadioManager {
         // below proves whether the send now succeeds.
         if !self.esp_now.peer_exists(&BROADCAST_ADDRESS) {
             let _ = self.esp_now.add_peer(PeerInfo {
-                interface: EspNowWifiInterface::Sta,
+                interface: EspNowWifiInterface::Station,
                 peer_address: BROADCAST_ADDRESS,
                 lmk: None,
                 channel: None,
@@ -3842,10 +3850,10 @@ impl RadioManager {
         // the STA held on — settle>0 confirms this WAS the off-channel egress.
         let mut settle: u16 = 0;
         while settle < 40 {
-            if !matches!(self.controller.is_connected(), Ok(true)) {
+            if !self.controller.is_connected() {
                 break;
             }
-            let _ = self.controller.disconnect();
+            let _ = block_on(self.controller.disconnect_async());
             settle = settle.saturating_add(1);
             if tick() {
                 return LeafOtaOutcome::Aborted;
@@ -3901,15 +3909,14 @@ impl RadioManager {
             if t.saturating_sub(last_wake_ms) >= WAKE_GAP_MS {
                 let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
                 otam_tx = otam_tx.saturating_add(1);
-                if let Ok(waiter) = self.esp_now.send(&BROADCAST_ADDRESS, &otam[..otam_len]) {
-                    if waiter.wait().is_ok() {
+                if let Ok(waiter) = self.esp_now.send(&BROADCAST_ADDRESS, &otam[..otam_len])
+                    && waiter.wait().is_ok() {
                         otam_ok = otam_ok.saturating_add(1);
                     }
-                }
                 last_wake_ms = t;
             }
-            if let Some(recv) = self.esp_now.receive() {
-                if recv.info.src_address == leaf_mac {
+            if let Some(recv) = self.esp_now.receive()
+                && recv.info.src_address == leaf_mac {
                     rx_any = rx_any.saturating_add(1);
                     if let Some((h, v, n, c)) = om::parse_ldbg(recv.data(), leaf_id) {
                         ldbg_heard = h;
@@ -3924,7 +3931,6 @@ impl RadioManager {
                         break; // leaf armed + NAKing → proceed to the windowed transfer
                     }
                 }
-            }
         }
 
         let mut wb: u32 = 0;
@@ -3981,11 +3987,10 @@ impl RadioManager {
                     // (send_to swallows it) to prove egress.
                     let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
                     otam_tx = otam_tx.saturating_add(1);
-                    if let Ok(waiter) = self.esp_now.send(&BROADCAST_ADDRESS, &otam[..otam_len]) {
-                        if waiter.wait().is_ok() {
+                    if let Ok(waiter) = self.esp_now.send(&BROADCAST_ADDRESS, &otam[..otam_len])
+                        && waiter.wait().is_ok() {
                             otam_ok = otam_ok.saturating_add(1);
                         }
-                    }
                 }
                 for i in 0..wlen_chunks as usize {
                     if (missing >> i) & 1 == 1 {
@@ -4003,8 +4008,8 @@ impl RadioManager {
                 let mut advanced = false;
                 let mut got_nak = false;
                 while now_ms() < deadline {
-                    if let Some(recv) = self.esp_now.receive() {
-                        if recv.info.src_address == leaf_mac {
+                    if let Some(recv) = self.esp_now.receive()
+                        && recv.info.src_address == leaf_mac {
                             rx_any = rx_any.saturating_add(1); // #3: heard SOMETHING from the leaf
                             // #3: capture the leaf's LDBG self-report (latest wins) — names WHY
                             // otan=0 without needing the leaf back online post-relay.
@@ -4016,8 +4021,7 @@ impl RadioManager {
                             }
                             if let Some(om::OtaFrame::Nak { origin, session: s, window_base, bitmap }) =
                                 om::parse_ota_frame(recv.data())
-                            {
-                                if origin == leaf_id && s == session && window_base as u32 == wb {
+                                && origin == leaf_id && s == session && window_base as u32 == wb {
                                     otan_valid = otan_valid.saturating_add(1); // #3: valid OTAN
                                     let miss = om::bitmap_to_u64(bitmap) & full;
                                     if miss == 0 {
@@ -4028,9 +4032,7 @@ impl RadioManager {
                                     }
                                     break;
                                 }
-                            }
                         }
-                    }
                 }
                 if advanced {
                     // #157: an all-zero OTAN at the LAST window base is the leaf's finalize-ack —
@@ -4820,14 +4822,13 @@ impl RadioManager {
                     // seq is more than +1 beyond the last, the in-between seqs
                     // were lost. (Only counts forward jumps; reordering/wrap is
                     // treated as no loss to avoid huge spurious counts.)
-                    if let Some(prev) = self.bench.peer_last_seq {
-                        if seq > prev {
+                    if let Some(prev) = self.bench.peer_last_seq
+                        && seq > prev {
                             self.bench.lost_count = self
                                 .bench
                                 .lost_count
                                 .wrapping_add(seq - prev - 1);
                         }
-                    }
                     // Track the highest peer seq (what our own beacons echo).
                     if self.bench.peer_last_seq.is_none_or(|p| seq > p) {
                         self.bench.peer_last_seq = Some(seq);
@@ -5301,11 +5302,10 @@ impl RadioManager {
             self.leaf_ota_mac = Some((id, mac)); // freshest wins; refresh the session cache
             return Some(mac);
         }
-        if let Some((cid, mac)) = self.leaf_ota_mac {
-            if cid == id {
+        if let Some((cid, mac)) = self.leaf_ota_mac
+            && cid == id {
                 return Some(mac); // roster evicted it mid-session → use the session cache
             }
-        }
         // #68 roster-admission robustness: the roster (a 16-slot LRU with no staleness reaping)
         // can EVICT a leaf that HELLOs sparsely while a chatty peer stays resident — so a leaf the
         // gateway currently RELAYS/STATs (id8, live) can be absent from `mac_for_id`, silently
@@ -5343,7 +5343,7 @@ impl RadioManager {
             }
         }
         let _ = self.esp_now.add_peer(PeerInfo {
-            interface: EspNowWifiInterface::Sta,
+            interface: EspNowWifiInterface::Station,
             peer_address: mac,
             lmk: None,
             channel: None,
@@ -5676,11 +5676,10 @@ pub fn start(
     radio.elected_owner = elect.owner_id;
     // #51 B: if we associated, seed the initial RSSI-to-AP so the first recovery
     // election already has a real signal-strength reading to compare on.
-    if reached_dhcp {
-        if let Ok(r) = radio.controller.rssi() {
+    if reached_dhcp
+        && let Ok(r) = radio.controller.rssi() {
             radio.my_rssi_to_ap = r.clamp(-127, 0) as i8;
         }
-    }
     // #23 fix: persist the boot election's staleness observation → a leaf's later
     // recovery re-election measures the owner's seq freshness FROM this first sample.
     radio.mc_seen_owner = elect.seen_owner;

--- a/rust/clock/src/net/radio_dev.rs
+++ b/rust/clock/src/net/radio_dev.rs
@@ -1,0 +1,85 @@
+//! smoltcp `phy::Device` shim over esp-radio 0.18's raw WiFi rx/tx tokens.
+//!
+//! #233 TRANSITIONAL. esp-radio 0.18 dropped the `smoltcp` feature that esp-wifi
+//! 0.15 shipped: its STA `Interface` now implements only `embassy_net_driver::Driver`.
+//! smol drives a *raw* smoltcp `Interface`/`SocketSet` from its synchronous superloop
+//! (see `net::wifi` / `net::mode`), so we re-expose the device's raw `receive()` /
+//! `transmit()` tokens through smoltcp's `phy::Device` trait. This is exactly the
+//! adapter esp-wifi used to provide internally; when smol moves to embassy-net
+//! (#198) this whole module is deleted.
+
+use esp_radio::wifi::{Interface, WifiRxToken, WifiTxToken};
+use smoltcp::phy::{self, DeviceCapabilities, Medium};
+use smoltcp::time::Instant;
+
+/// Standard Ethernet frame MTU. esp-radio's internal `MTU` const is `pub(crate)`,
+/// so we mirror the 1514 the old esp-wifi `WifiDevice` reported for the same silicon.
+const WIFI_MTU: usize = 1514;
+
+/// Newtype wrapping esp-radio's (Copy) STA `Interface` handle so we can implement
+/// smoltcp's `phy::Device` on it. The real rx/tx state lives in esp-radio's global
+/// packet queues; this handle is just a lightweight token source.
+pub struct SmolWifiDevice(Interface<'static>);
+
+impl SmolWifiDevice {
+    /// Wrap the STA interface returned by `esp_radio::wifi::new(..).1.station`.
+    pub fn new(iface: Interface<'static>) -> Self {
+        Self(iface)
+    }
+
+    /// STA MAC — used to seed the smoltcp `Interface`'s hardware address.
+    pub fn mac_address(&self) -> [u8; 6] {
+        self.0.mac_address()
+    }
+}
+
+/// smoltcp RX token wrapping esp-radio's raw `WifiRxToken`.
+pub struct RxToken(WifiRxToken);
+/// smoltcp TX token wrapping esp-radio's raw `WifiTxToken`.
+pub struct TxToken(WifiTxToken);
+
+impl phy::RxToken for RxToken {
+    fn consume<R, F>(self, f: F) -> R
+    where
+        F: FnOnce(&[u8]) -> R,
+    {
+        // esp-radio hands the callback a `&mut [u8]`; smoltcp's RxToken wants `&[u8]`
+        // (a `&mut` coerces to `&` at the call site).
+        self.0.consume_token(|buf| f(buf))
+    }
+}
+
+impl phy::TxToken for TxToken {
+    fn consume<R, F>(self, len: usize, f: F) -> R
+    where
+        F: FnOnce(&mut [u8]) -> R,
+    {
+        self.0.consume_token(len, f)
+    }
+}
+
+impl phy::Device for SmolWifiDevice {
+    type RxToken<'a>
+        = RxToken
+    where
+        Self: 'a;
+    type TxToken<'a>
+        = TxToken
+    where
+        Self: 'a;
+
+    fn receive(&mut self, _now: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+        self.0.receive().map(|(rx, tx)| (RxToken(rx), TxToken(tx)))
+    }
+
+    fn transmit(&mut self, _now: Instant) -> Option<Self::TxToken<'_>> {
+        self.0.transmit().map(TxToken)
+    }
+
+    fn capabilities(&self) -> DeviceCapabilities {
+        let mut caps = DeviceCapabilities::default();
+        caps.max_transmission_unit = WIFI_MTU;
+        caps.medium = Medium::Ethernet;
+        caps
+    }
+}

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -29,15 +29,18 @@ extern crate alloc;
 use core::net::Ipv4Addr;
 
 use esp_hal::{
-    peripherals::{RNG, TIMG0, WIFI},
+    interrupt::software::SoftwareInterruptControl,
+    peripherals::{SW_INTERRUPT, TIMG0, WIFI},
     rng::Rng,
     time::{Duration, Instant},
     timer::timg::TimerGroup,
 };
-use esp_wifi::{
-    wifi::{ClientConfiguration, Configuration},
-    EspWifiController,
-};
+use esp_radio::wifi::{sta::StationConfig, Config};
+
+use crate::net::SmolWifiDevice;
+// #233: esp-radio 0.18's connect/disconnect are async-only; drive them to completion
+// synchronously (the esp-rtos scheduler preempts the busy loop to run the radio task).
+use embassy_futures::block_on;
 use smoltcp::{
     iface::{Interface, SocketSet, SocketStorage},
     socket::{dhcpv4, tcp, udp},
@@ -402,7 +405,10 @@ pub(crate) const RELAY_FLUSH_BUDGET: Duration = Duration::from_secs(15); // #136
 
 pub struct WifiPeripherals {
     pub timg0: TIMG0<'static>,
-    pub rng: RNG<'static>,
+    // #233: esp-radio 0.18's scheduler (esp-rtos) needs SW_INTERRUPT.software_interrupt0
+    // for context switches. The RNG peripheral is no longer threaded in — esp-hal 1.1's
+    // `Rng::new()` is arg-less and esp-radio pulls entropy internally.
+    pub sw_int: SW_INTERRUPT<'static>,
     pub wifi: WIFI<'static>,
 }
 
@@ -415,7 +421,7 @@ fn smoltcp_now() -> smoltcp::time::Instant {
 
 /// Build a smoltcp `Interface` bound to the WiFi STA device (verbatim from the
 /// esp-wifi `wifi_dhcp` example's `create_interface`).
-fn create_interface(device: &mut esp_wifi::wifi::WifiDevice) -> Interface {
+fn create_interface(device: &mut SmolWifiDevice) -> Interface {
     Interface::new(
         smoltcp::iface::Config::new(HardwareAddress::Ethernet(EthernetAddress::from_bytes(
             &device.mac_address(),
@@ -438,19 +444,20 @@ pub fn try_time_sync(
 ) -> Option<u32> {
     super::init_heap();
 
-    // --- Radio init ------------------------------------------------------
+    // --- Radio init (#233: esp-radio 0.18 + esp-rtos scheduler) ----------
     let timg0 = TimerGroup::new(p.timg0);
-    // `Rng` is a `Copy` handle; keep our own copy for the SNTP port seed.
-    let rng = Rng::new(p.rng);
-    let esp_wifi_ctrl: EspWifiController<'static> =
-        esp_wifi::init(timg0.timer0, rng).ok()?;
-    // Leak the controller so its borrow lives 'static for the rest of the
-    // burst; the device is dropped when we return, which stops WiFi cleanly.
-    let esp_wifi_ctrl: &'static EspWifiController<'static> =
-        alloc::boxed::Box::leak(alloc::boxed::Box::new(esp_wifi_ctrl));
-
-    let (mut controller, interfaces) = esp_wifi::wifi::new(esp_wifi_ctrl, p.wifi).ok()?;
-    let mut device = interfaces.sta;
+    let sw = SoftwareInterruptControl::new(p.sw_int);
+    // esp-radio's os-adapter needs the esp-rtos scheduler running BEFORE wifi::new.
+    // NON-embassy: start() converts THIS context into the pinned main task and returns,
+    // so the blocking superloop below runs unchanged while the radio task preempts in.
+    esp_rtos::start(timg0.timer0, sw.software_interrupt0);
+    // `Rng` is a `Copy` handle; keep our own copy for the SNTP source-port seed.
+    let rng = Rng::new();
+    // In 0.18 the WIFI peripheral is 'static, so wifi::new returns an owned 'static
+    // controller + interfaces — no more EspWifiController Box::leak.
+    let (mut controller, interfaces) =
+        esp_radio::wifi::new(p.wifi, super::radio_controller_config()).ok()?;
+    let mut device = SmolWifiDevice::new(interfaces.station);
 
     // Phase-2 (wifi-only) build has no status LED, so the tick is a no-op.
     // wifi-only build has no relay/gateway role, so the reached-DHCP flag is unused.
@@ -608,7 +615,7 @@ impl NtpMachine {
     /// Build the hoisted smoltcp stack (DHCP + UDP/SNTP + TCP/MQTT sockets over the
     /// module `static mut` buffers) and start in `Assoc`. `sntp_src_port` is the
     /// caller's RNG-seeded ephemeral port for the SNTP request.
-    fn new(device: &mut esp_wifi::wifi::WifiDevice, sntp_src_port: u16) -> Self {
+    fn new(device: &mut SmolWifiDevice, sntp_src_port: u16) -> Self {
         let iface = create_interface(device);
 
         // SAFETY: F2 precedent — boot-only, single-caller, main-thread, never re-entered
@@ -671,8 +678,8 @@ impl NtpMachine {
     /// `BURST_POLL_BUDGET` of continuous progress.
     fn poll(
         &mut self,
-        controller: &mut esp_wifi::wifi::WifiController<'static>,
-        device: &mut esp_wifi::wifi::WifiDevice<'static>,
+        controller: &mut esp_radio::wifi::WifiController<'static>,
+        device: &mut SmolWifiDevice,
     ) -> NtpPoll {
         let poll_start = Instant::now();
         loop {
@@ -697,14 +704,14 @@ impl NtpMachine {
     /// reconfigure, not pumpable — design §2) runs once per attempt; then we poll
     /// `is_connected()`. Returns whether the phase advanced this step (`false` = still
     /// waiting → yield).
-    fn step_assoc(&mut self, controller: &mut esp_wifi::wifi::WifiController<'static>) -> bool {
+    fn step_assoc(&mut self, controller: &mut esp_radio::wifi::WifiController<'static>) -> bool {
         let net = &crate::secrets::WIFI_NETWORK;
         // #192: an ALREADY-associated caller (the periodic NTP re-sync burst on a coexist
         // gateway) skips the disconnect/reconfigure/connect FFI — issuing it would TEAR a live
         // coexist association (mesh-deaf + re-election churn) for no reason. Go straight to DHCP.
         // Boot is NOT yet connected here, so the boot burst still runs the full setup below →
         // boot behaviour is byte-identical.
-        if !self.assoc_configured && matches!(controller.is_connected(), Ok(true)) {
+        if !self.assoc_configured && controller.is_connected() {
             self.assoc_configured = true;
             self.deadline = Instant::now() + SYNC_BUDGET; // shared DHCP+SNTP budget
             self.phase = NtpPhase::Dhcp;
@@ -712,19 +719,23 @@ impl NtpMachine {
         }
         if !self.assoc_configured {
             // Drop any prior association before reconfiguring (harmless if not connected).
-            let _ = controller.disconnect();
+            let _ = block_on(controller.disconnect_async());
+            // #233: esp-radio 0.18's StationConfig has private fields — build via BuilderLite.
+            #[allow(unused_mut)]
+            let mut sta_cfg = StationConfig::default()
+                .with_ssid(net.ssid)
+                .with_password(net.pass.into());
+            // COEXIST SOAK (#23 PART 1): pin association to ch1. (0.18 with_channel takes u8,
+            // wrapping it in Some internally.)
+            #[cfg(feature = "coexist-soak")]
+            {
+                sta_cfg = sta_cfg.with_channel(1);
+            }
             let ok = controller
-                .set_configuration(&Configuration::Client(ClientConfiguration {
-                    ssid: net.ssid.into(),
-                    password: net.pass.into(),
-                    // COEXIST SOAK (#23 PART 1): pin association to ch1.
-                    #[cfg(feature = "coexist-soak")]
-                    channel: Some(1),
-                    ..Default::default()
-                }))
+                // #233: set_config STARTS the controller in 0.18 (no separate start()).
+                .set_config(&Config::Station(sta_cfg))
                 .is_ok()
-                && (matches!(controller.is_started(), Ok(true)) || controller.start().is_ok())
-                && controller.connect().is_ok();
+                && block_on(controller.connect_async()).is_ok();
             if !ok {
                 return self.assoc_attempt_failed();
             }
@@ -732,7 +743,7 @@ impl NtpMachine {
             self.deadline = Instant::now() + SYNC_BUDGET; // per-attempt assoc budget
             return true;
         }
-        if matches!(controller.is_connected(), Ok(true)) {
+        if controller.is_connected() {
             log::info!("smol #142: associated to '{}'", net.ssid);
             // Shared DHCP+SNTP budget starts now (mirrors the pre-#89 `deadline` set at
             // the top of the DHCP loop).
@@ -764,7 +775,7 @@ impl NtpMachine {
 
     /// DHCP step: one `iface.poll()`, apply a lease if it arrived. On a lease, set the
     /// gateway qualifier (N3c: `run_ntp_burst` returns `ReachedDhcp`) and advance to SNTP.
-    fn step_dhcp(&mut self, device: &mut esp_wifi::wifi::WifiDevice<'static>) -> bool {
+    fn step_dhcp(&mut self, device: &mut SmolWifiDevice) -> bool {
         let changed = matches!(
             self.iface.poll(smoltcp_now(), device, &mut self.sockets),
             smoltcp::iface::PollResult::SocketStateChanged
@@ -793,7 +804,7 @@ impl NtpMachine {
     /// SNTP step: bind once, send the NTPv4 request once the socket can send, parse a
     /// reply into Unix seconds. Deadline → `Done(None)` (DHCP already succeeded → MQTT
     /// tail still runs, just no time this burst).
-    fn step_sntp(&mut self, device: &mut esp_wifi::wifi::WifiDevice<'static>) -> bool {
+    fn step_sntp(&mut self, device: &mut SmolWifiDevice) -> bool {
         let changed = matches!(
             self.iface.poll(smoltcp_now(), device, &mut self.sockets),
             smoltcp::iface::PollResult::SocketStateChanged
@@ -822,8 +833,8 @@ impl NtpMachine {
 
         if socket.can_recv() {
             let mut buf = [0u8; 48];
-            if let Ok((len, _from)) = socket.recv_slice(&mut buf) {
-                if len >= 48 {
+            if let Ok((len, _from)) = socket.recv_slice(&mut buf)
+                && len >= 48 {
                     // Transmit Timestamp seconds field = bytes 40..44, big-endian, from
                     // the NTP epoch (1900).
                     let ntp_secs = u32::from_be_bytes([buf[40], buf[41], buf[42], buf[43]]);
@@ -832,7 +843,6 @@ impl NtpMachine {
                         return true;
                     }
                 }
-            }
         }
 
         if Instant::now() > self.deadline {
@@ -942,9 +952,9 @@ pub(crate) const NTP_RESYNC_AGE_S: u32 = 3600;
 /// flush/burst is ever in flight in the single-threaded main loop), so the borrows never overlap.
 #[cfg(feature = "espnow")]
 pub fn run_ntp_resync(
-    controller: &mut esp_wifi::wifi::WifiController<'static>,
-    device: &mut esp_wifi::wifi::WifiDevice<'static>,
-    mut rng: Rng,
+    controller: &mut esp_radio::wifi::WifiController<'static>,
+    device: &mut SmolWifiDevice,
+    rng: Rng,
     tick: &mut dyn FnMut() -> bool,
 ) -> Option<u32> {
     let sntp_src_port = 49152 + (rng.random() % 16384) as u16;
@@ -978,9 +988,9 @@ pub fn run_ntp_resync(
 /// of the firmware's style and keeping the dependency set on crates.io.
 #[allow(clippy::too_many_arguments)] // +grid (issue #16) tips this to 8 params
 pub fn run_ntp_burst(
-    controller: &mut esp_wifi::wifi::WifiController<'static>,
-    device: &mut esp_wifi::wifi::WifiDevice<'static>,
-    mut rng: Rng,
+    controller: &mut esp_radio::wifi::WifiController<'static>,
+    device: &mut SmolWifiDevice,
+    rng: Rng,
     tick: &mut dyn FnMut() -> bool,
     // #89 Stage 1: painted on each prologue yield (assoc/DHCP/SNTP stall) so the boot
     // screen shows a LIVE clock through the sync window. UI-agnostic here — the display
@@ -1850,7 +1860,7 @@ impl RelayCache {
 #[cfg(feature = "wifi")]
 fn tcp_send(
     iface: &mut Interface,
-    device: &mut esp_wifi::wifi::WifiDevice,
+    device: &mut SmolWifiDevice,
     sockets: &mut SocketSet,
     handle: smoltcp::iface::SocketHandle,
     data: &[u8],
@@ -1890,11 +1900,10 @@ fn recv_into(
     acc_len: &mut usize,
 ) {
     let socket = sockets.get_mut::<tcp::Socket>(handle);
-    if socket.can_recv() && *acc_len < acc.len() {
-        if let Ok(n) = socket.recv_slice(&mut acc[*acc_len..]) {
+    if socket.can_recv() && *acc_len < acc.len()
+        && let Ok(n) = socket.recv_slice(&mut acc[*acc_len..]) {
             *acc_len += n;
         }
-    }
 }
 
 /// #147 self-fetch failure POINT — the exact stage a failed `run_ota_fetch` died at, carried as
@@ -1977,7 +1986,7 @@ pub(crate) fn ota_fail_is_bulk_deaf(w: u32) -> bool {
 #[allow(clippy::too_many_arguments)]
 fn mqtt_session(
     iface: &mut Interface,
-    device: &mut esp_wifi::wifi::WifiDevice,
+    device: &mut SmolWifiDevice,
     sockets: &mut SocketSet,
     tcp_handle: smoltcp::iface::SocketHandle,
     node_id: u8,
@@ -2730,8 +2739,8 @@ fn mqtt_session(
                         // broadcast_cached_configs). `leaf_id == node_id` is the gateway's
                         // OWN config — already handled by the `cfg_topic` arm above; guard
                         // anyway. Only present when cfg_cache = Some (gateway flush).
-                        if leaf_id != node_id {
-                            if let Some(cache) = cfg_cache.as_deref_mut() {
+                        if leaf_id != node_id
+                            && let Some(cache) = cfg_cache.as_deref_mut() {
                                 // #56: `default_screen` is the SCREEN channel → cache under key
                                 // `S` (#48 led / #43 units / #55 plugins add their own topic + fill
                                 // site; the relay machinery is already key-generic).
@@ -2745,7 +2754,6 @@ fn mqtt_session(
                                     payload.len()
                                 );
                             }
-                        }
                     } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/config/led") {
                         // #48 blue-LED mode: twin of the default_screen arm. OTHER leaf → cache
                         // under key `L` for the ESP-NOW relay; OUR OWN id → capture into gw_own so
@@ -3040,11 +3048,10 @@ fn mqtt_session(
             // NOT abort()/RST that would discard a still-buffered PUBACK). Even an operator
             // long-press abort BREAKS to that same clean DISCONNECT. So the ack always egresses
             // before the post-flush reboot → the redelivery loop physically cannot occur.
-            if let Some(pid) = puback_id {
-                if let Some(n) = crate::net::mqtt::encode_puback(&mut pkt, pid) {
+            if let Some(pid) = puback_id
+                && let Some(n) = crate::net::mqtt::encode_puback(&mut pkt, pid) {
                     let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
                 }
-            }
         }
         // #40 QUIET-PERIOD break: exit once the 3 downlink flags are in AND no new packet has
         // arrived for DOWNLINK_SETTLE. The retained backlog (staged/install/cfg) arrives as a
@@ -3523,11 +3530,10 @@ fn mqtt_session(
                 loop {
                     match crate::net::mqtt::parse_packet(&acc[..acc_len]) {
                         Some((crate::net::mqtt::Incoming::Publish { topic, payload, .. }, consumed)) => {
-                            if topic == MESH_CHANNEL_TOPIC {
-                                if let Some(mc2) = parse_mesh_channel(payload) {
+                            if topic == MESH_CHANNEL_TOPIC
+                                && let Some(mc2) = parse_mesh_channel(payload) {
                                     competitor = Some(mc2);
                                 }
-                            }
                             acc.copy_within(consumed..acc_len, 0);
                             acc_len -= consumed;
                         }
@@ -3552,12 +3558,10 @@ fn mqtt_session(
                     let _ = write!(mcp2, "MC|{}|{}|{}", node_id, elect.my_channel, reseq);
                     if let Some(n) =
                         crate::net::mqtt::encode_publish(&mut pkt, MESH_CHANNEL_TOPIC, mcp2.as_bytes(), true)
-                    {
-                        if tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick) {
+                        && tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick) {
                             elect.seen_seq = reseq;
                             log::info!("smol: #114 H2 — re-asserted claim over higher-id {} (seq {})", owner2, reseq);
                         }
-                    }
                 } else if owner2 < node_id {
                     // A LOWER id also claimed and holds the slot → YIELD (no duplicate gateway).
                     elect.i_am_owner = false;
@@ -3661,11 +3665,10 @@ fn mqtt_session(
         // must PRESERVE the order — the same never-clear semantics #135/#134 give pre-relay failures
         // (`reached_leaf()==false`) — so the next good staging (or the next crown) still installs.
         // `ota_offer.is_some()` ⟹ `staged_raw.is_some()`, so the boot-race guard above is unchanged.
-        if *install_requested && ota_offer.is_some() {
-            if let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, cmd_topic.as_bytes(), &[], true) {
+        if *install_requested && ota_offer.is_some()
+            && let Some(n) = crate::net::mqtt::encode_publish(&mut pkt, cmd_topic.as_bytes(), &[], true) {
                 let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
             }
-        }
     }
 
     // --- #40 §B2: publish each RELAYED LEAF's Update discovery + ota/state ON ITS BEHALF ---
@@ -3755,9 +3758,9 @@ fn mqtt_session(
 #[cfg(feature = "espnow")]
 #[allow(clippy::too_many_arguments)] // +grid (issue #16) tips this to 8 params
 pub fn run_mqtt_burst(
-    controller: &mut esp_wifi::wifi::WifiController<'static>,
-    device: &mut esp_wifi::wifi::WifiDevice<'static>,
-    mut rng: Rng,
+    controller: &mut esp_radio::wifi::WifiController<'static>,
+    device: &mut SmolWifiDevice,
+    rng: Rng,
     node_id: u8,
     messages: &[(u8, &[u8])],
     batt: &mut crate::batt::BattCache,
@@ -3892,12 +3895,12 @@ pub fn run_mqtt_burst(
     // one full RECONNECT_EVERY window before the first retry.
     const RECONNECT_EVERY: Duration = Duration::from_millis(2000);
     let mut next_reconnect = Instant::now() + RECONNECT_EVERY;
-    while !matches!(controller.is_connected(), Ok(true)) {
+    while !controller.is_connected() {
         if tick() {
             return false; // #20 abort during flush re-association
         }
         if Instant::now() > next_reconnect {
-            let _ = controller.connect();
+            let _ = block_on(controller.connect_async());
             next_reconnect = Instant::now() + RECONNECT_EVERY;
         }
         if Instant::now() > deadline {
@@ -3911,7 +3914,7 @@ pub fn run_mqtt_burst(
     // resets the IDF ps state, and here the unicast that matters is the whole TCP /
     // MQTT stream (the old UDP path only needed the ARP reply). Same reasoning,
     // same placement (must be AFTER the reconnect). Tradeoff: higher idle draw.
-    let _ = controller.set_power_saving(esp_wifi::config::PowerSaveMode::None);
+    let _ = controller.set_power_saving(esp_radio::wifi::PowerSaveMode::None);
     crate::net::assert_max_tx_power(); // #141
 
     // #64: capture the WiFi-uplink RSSI HERE — the STA is confirmed connected (the loop
@@ -4057,7 +4060,7 @@ const CAST_FRAME_INTERVAL: Duration = Duration::from_millis(100);
 #[cfg(feature = "cast")]
 fn cast_stream(
     iface: &mut Interface,
-    device: &mut esp_wifi::wifi::WifiDevice<'static>,
+    device: &mut SmolWifiDevice,
     sockets: &mut SocketSet,
     cast_handle: smoltcp::iface::SocketHandle,
     src_port: u16,
@@ -4182,7 +4185,7 @@ fn parse_ipv4(host: &str) -> Option<smoltcp::wire::Ipv4Address> {
 #[allow(clippy::too_many_arguments)]
 fn publish_ota_progress(
     iface: &mut Interface,
-    device: &mut esp_wifi::wifi::WifiDevice,
+    device: &mut SmolWifiDevice,
     sockets: &mut SocketSet,
     tcp_handle: smoltcp::iface::SocketHandle,
     src_port: u16,
@@ -4301,9 +4304,9 @@ fn publish_ota_progress(
 #[cfg(feature = "espnow")]
 #[allow(clippy::too_many_arguments)] // +fail diag (#139-followup) tips this to 8 params
 pub fn run_ota_fetch(
-    controller: &mut esp_wifi::wifi::WifiController<'static>,
-    device: &mut esp_wifi::wifi::WifiDevice<'static>,
-    mut rng: Rng,
+    controller: &mut esp_radio::wifi::WifiController<'static>,
+    device: &mut SmolWifiDevice,
+    rng: Rng,
     announce: &crate::ota::Announce,
     tick: &mut dyn FnMut() -> bool,
     // #40 relay-mode: when true, stage+verify the image to the inactive slot but do NOT
@@ -4311,7 +4314,7 @@ pub fn run_ota_fetch(
     // it to a leaf (no gateway reboot). Self-OTA passes `false` + `&mut None` → the fetch
     // body is byte-identical, only the terminal action differs (activate-reboot vs return).
     relay_mode: bool,
-    staged_slot: &mut Option<esp_bootloader_esp_idf::ota::Slot>,
+    staged_slot: &mut Option<esp_bootloader_esp_idf::partitions::AppPartitionSubType>,
     // #139-followup observability: on a genuine self-fetch FAILURE (not a user abort), set to
     // `(chunk_k, chunk_n, retries, stalls)` — how far the download got + the transfer-trouble
     // counters. The self-OTA caller (`run_ota_update`) formats + publishes it retained to
@@ -4376,7 +4379,7 @@ pub fn run_ota_fetch(
     let deadline = Instant::now() + OTA_FETCH_BUDGET;
 
     // The caller's switch(WifiSta) already issued connect(); wait for association.
-    while !matches!(controller.is_connected(), Ok(true)) {
+    while !controller.is_connected() {
         if tick() {
             return false;
         }
@@ -4386,7 +4389,7 @@ pub fn run_ota_fetch(
             return false;
         }
     }
-    let _ = controller.set_power_saving(esp_wifi::config::PowerSaveMode::None);
+    let _ = controller.set_power_saving(esp_radio::wifi::PowerSaveMode::None);
     crate::net::assert_max_tx_power(); // #141
 
     // Fresh DHCP lease (interface just rebuilt).
@@ -4486,8 +4489,8 @@ pub fn run_ota_fetch(
         // #188: throttled live progress → retained MQTT (viz + the death-point diagnostic). Best-effort;
         // reuses the tcp socket in this between-chunks idle window (the per-chunk recycle below re-cleans
         // + reconnects to the HTTP host). None ⇒ skipped entirely (byte-identical to the pre-#188 path).
-        if let Some(pid) = progress_id {
-            if Instant::now() >= next_progress_pub {
+        if let Some(pid) = progress_id
+            && Instant::now() >= next_progress_pub {
                 next_progress_pub = Instant::now() + Duration::from_secs(5);
                 let src_port = 49152 + (rng.random() % 16384) as u16;
                 let phase = if relay_mode { "relayfetch" } else { "self" };
@@ -4496,7 +4499,6 @@ pub fn run_ota_fetch(
                     writer.written(), announce.size, phase, tick,
                 );
             }
-        }
         if tick() {
             log::warn!("smol OTA: aborted by long-press (slot untouched)");
             return false;
@@ -4671,12 +4673,10 @@ pub fn run_ota_fetch(
                                         range_ok = false;
                                         if let Some(cl) =
                                             crate::ota::content_length(&header_buf[..header_len])
-                                        {
-                                            if cl != announce.size {
+                                            && cl != announce.size {
                                                 bad = true;
                                                 return (take, false); // length mismatch → abort
                                             }
-                                        }
                                     }
                                     _ => {
                                         bad = true; // non-206 range reply (or 200 mid-stream)

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -55,6 +55,7 @@ use esp_storage::FlashStorage;
 /// - ALL flash access stays on the main loop: OTA is strictly serial (one
 ///   `ImageWriter`/`LeafImageWriter` at a time; the otadata/identity helpers run before
 ///   begin / after finalize, never concurrently), and no ISR touches flash.
+///
 /// This holds STRUCTURALLY in the non-embassy superloop. #198 (embassy-net migration):
 /// re-evaluate this deliberately — once flash users can interleave at await points, move
 /// to a single owned instance (StaticCell/once-init here in `ota::`) instead of per-op

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -26,14 +26,40 @@
 //! is defence-in-depth, not authentication. Do NOT let any code imply sha256 == trust.
 
 use esp_bootloader_esp_idf::ota::{Ota, OtaImageState};
-use esp_bootloader_esp_idf::partitions::{read_partition_table, DataPartitionSubType, PartitionType};
+// #233: esp-bootloader 0.5 made the `Slot` enum PRIVATE. The public currency is now
+// `AppPartitionSubType` (the APP partition you name), so smol's OTA engine uses that
+// throughout: Slot0↔Ota0, Slot1↔Ota1, blank-otadata↔Factory (what current_app_partition()
+// returns on a blank/uninitialised record — smol has no factory partition, so the ROM boots
+// ota_0 and the true inactive target is Ota1).
+use esp_bootloader_esp_idf::partitions::{
+    read_partition_table, AppPartitionSubType, DataPartitionSubType, PartitionType,
+};
 use esp_storage::FlashStorage;
-// Named only by the download/activation path (the wifi-only build reads announces but
-// never fetches, so these would be unused imports there).
-#[cfg(feature = "espnow")]
-use esp_bootloader_esp_idf::ota::Slot;
-#[cfg(feature = "espnow")]
-use esp_bootloader_esp_idf::partitions::AppPartitionSubType;
+
+/// #233: esp-storage 0.9's `FlashStorage` is a once-only singleton that CONSUMES the FLASH
+/// peripheral (`FlashStorage::new(FLASH)`; panics if constructed twice). smol's OTA is strictly
+/// SERIAL — one `ImageWriter`/`LeafImageWriter` at a time, and the otadata/identity helpers run
+/// before begin / after finalize, never concurrently with the writer or each other — and only
+/// ever reads a CONSTANT flash capacity, so a freshly-stolen per-op handle reproduces the exact
+/// (safe) semantics of the old 0.7 throwaway `flash()`. This avoids threading the
+/// FLASH peripheral through the whole radio stack (main → mode → RadioManager → run_ota_fetch)
+/// and dodges introducing a `&mut FlashStorage` borrow held across the streaming write.
+/// SAFETY: no two `FlashStorage` handles are live-and-in-use at the same instant on this chip.
+#[cfg(feature = "wifi")]
+fn flash() -> FlashStorage<'static> {
+    FlashStorage::new(unsafe { esp_hal::peripherals::FLASH::steal() })
+}
+
+/// The OTHER app partition — the inactive slot to write / roll back to. Replaces the old
+/// `Slot::next()` (now private in 0.5). Blank otadata reports `Factory`; smol has no factory
+/// partition (ROM boots ota_0), so `Factory`/`Ota0` ⇒ the inactive target is `Ota1`.
+#[cfg(feature = "wifi")]
+fn other_app(cur: AppPartitionSubType) -> AppPartitionSubType {
+    match cur {
+        AppPartitionSubType::Ota1 => AppPartitionSubType::Ota0,
+        _ => AppPartitionSubType::Ota1, // Ota0 | Factory(blank) | anything else
+    }
+}
 
 /// This firmware's monotonic build number (git `rev-list --count`), embedded by
 /// `build.rs` as `BUILD_NUMBER` and parsed at compile time. The MONOTONICITY gate
@@ -368,11 +394,10 @@ pub fn status_code(headers: &[u8]) -> Option<u16> {
 pub fn content_length(headers: &[u8]) -> Option<u32> {
     let s = core::str::from_utf8(headers).ok()?;
     for line in s.lines() {
-        if let Some((name, val)) = line.split_once(':') {
-            if name.eq_ignore_ascii_case("content-length") {
+        if let Some((name, val)) = line.split_once(':')
+            && name.eq_ignore_ascii_case("content-length") {
                 return val.trim().parse().ok();
             }
-        }
     }
     None
 }
@@ -397,7 +422,9 @@ static mut OTA_STAGE: [u8; CHUNK] = [0xFF; CHUNK];
 
 #[cfg(feature = "espnow")]
 pub struct ImageWriter {
-    flash: FlashStorage,
+    // #233: esp-storage 0.9 FlashStorage is lifetime'd; the writer owns a 'static handle
+    // (from the stolen FLASH peripheral via `flash()`), held for the whole streaming write.
+    flash: FlashStorage<'static>,
     /// Absolute flash offset of the target slot.
     base: u32,
     /// Target slot capacity (write bound).
@@ -416,7 +443,7 @@ pub struct ImageWriter {
     stage: &'static mut [u8; CHUNK],
     stage_len: usize,
     hasher: sha2::Sha256,
-    target: Slot,
+    target: AppPartitionSubType,
 }
 
 #[cfg(feature = "espnow")]
@@ -426,14 +453,12 @@ impl ImageWriter {
     pub fn begin() -> Option<ImageWriter> {
         use sha2::Digest;
         let target = inactive_slot()?;
-        let sub = if target == Slot::Slot1 {
-            AppPartitionSubType::Ota1
-        } else {
-            AppPartitionSubType::Ota0
-        };
+        // #233: `target` is already the AppPartitionSubType to write (inactive_slot → other_app,
+        // always Ota0/Ota1), so the write-target partition IS the target.
+        let sub = target;
         // Fresh flash + scratch: only `find_partition` is used here (it borrows the
         // parsed table, NOT the flash), so `flash` stays free to move into the writer.
-        let mut flash = FlashStorage::new();
+        let mut flash = flash();
         let mut buf = [0u8; PT_SCRATCH];
         let (base, size) = {
             let pt = read_partition_table(&mut flash, &mut buf).ok()?;
@@ -459,7 +484,7 @@ impl ImageWriter {
     }
 
     /// The slot this writer targets (needed by [`activate`] after a good finalize).
-    pub fn target(&self) -> Slot {
+    pub fn target(&self) -> AppPartitionSubType {
         self.target
     }
 
@@ -502,7 +527,7 @@ impl ImageWriter {
             return true;
         }
         let erase_to = self.base + self.flushed + len as u32;
-        let sector = <FlashStorage as NorFlash>::ERASE_SIZE as u32;
+        let sector = <FlashStorage<'_> as NorFlash>::ERASE_SIZE as u32;
         while self.erased_upto < erase_to {
             let s = self.erased_upto;
             if self.flash.erase(s, s + sector).is_err() {
@@ -510,7 +535,7 @@ impl ImageWriter {
             }
             self.erased_upto = self.erased_upto.saturating_add(sector);
         }
-        let ws = <FlashStorage as NorFlash>::WRITE_SIZE;
+        let ws = <FlashStorage<'_> as NorFlash>::WRITE_SIZE;
         let padded = len.div_ceil(ws) * ws;
         for b in self.stage[len..padded].iter_mut() {
             *b = 0xFF;
@@ -602,7 +627,7 @@ fn encode_identity(id: u8) -> [u8; IDENT_REC_LEN] {
 #[cfg(feature = "wifi")]
 fn read_identity_nvs() -> Option<u8> {
     use embedded_storage::nor_flash::ReadNorFlash;
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let pt = read_partition_table(&mut flash, &mut buf).ok()?;
     let nvs = pt
@@ -620,7 +645,7 @@ fn read_identity_nvs() -> Option<u8> {
 #[cfg(feature = "wifi")]
 fn seed_identity_nvs(id: u8) {
     use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
         return;
@@ -632,7 +657,7 @@ fn seed_identity_nvs(id: u8) {
     // Refuse to write unless the WHOLE first sector is erased (all 0xFF) — guards any
     // (unexpected) real NVS content from being erased. An erase-flashed board's nvs is
     // uniformly 0xFF, so a genuinely-fresh board always seeds.
-    let sector = <FlashStorage as NorFlash>::ERASE_SIZE as u32;
+    let sector = <FlashStorage<'_> as NorFlash>::ERASE_SIZE as u32;
     let mut chunk = [0u8; 64];
     let mut off = 0u32;
     while off < sector {
@@ -670,42 +695,31 @@ pub fn resolve_node_id() -> u8 {
 /// Read `otadata` → the INACTIVE slot (the write target). Self-contained flash borrow
 /// (its own `FlashStorage`, dropped on return), so it never pins flash for callers.
 #[cfg(feature = "espnow")]
-fn inactive_slot() -> Option<Slot> {
-    let mut flash = FlashStorage::new();
+fn inactive_slot() -> Option<AppPartitionSubType> {
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let pt = read_partition_table(&mut flash, &mut buf).ok()?;
     let od = pt
         .find_partition(PartitionType::Data(DataPartitionSubType::Ota))
         .ok()??;
-    let mut region = od.as_embedded_storage(&mut flash);
-    let mut ota = Ota::new(&mut region).ok()?;
-    // #226 SELF-OVERWRITE FIX: on a BLANK/uninitialized otadata, `current_slot()` returns
-    // `Slot::None`, and `Slot::None.next()` folds to `Slot::Slot0` (esp-bootloader 0.2.0
-    // ota.rs:64) — i.e. the RUNNING slot, so an OTA would overwrite the LIVE image (a boot-
-    // critical self-overwrite / brick class). A blank otadata always ROM-falls-back to ota_0
-    // (there is no factory partition in partitions-ota.csv), so the running slot is provably
-    // ota_0 and the true inactive write-target is ota_1. Explicit match instead of the blind
-    // `.next()`. Validated against JP's ESP32-C6 watch (esp-bootloader 0.5), which avoids this
-    // exact bug the same way — the `.next()` footgun SURVIVES into 0.5 (current_slot() still
-    // returns None on blank), so the crate bump does NOT auto-fix it; the explicit mapping does
-    // (watch study: scratch/watch-backport/226-comment.md, task #49).
-    //
-    // No first-boot otadata write is needed (supersedes the original init sketch): a boot-time
-    // flash write to boot-critical partition state would be an unnecessary risk, and `activate()`
-    // already makes otadata valid (set_current_slot + New) on the first real OTA. So the blank
-    // state self-heals on the first successful update, with zero boot-path flash mutation.
-    let target = match ota.current_slot().ok()? {
-        Slot::None => Slot::Slot1,
-        other => other.next(),
-    };
-    Some(target)
+    let region = od.as_embedded_storage(&mut flash);
+    let mut ota = Ota::new(region, 2).ok()?;
+    // #226/#233 SELF-OVERWRITE FIX: on a BLANK/uninitialised otadata, current_app_partition()
+    // returns `Factory` (esp-bootloader 0.5). smol has NO factory partition (partitions-ota.csv),
+    // so the ROM boots ota_0 — the running slot is provably ota_0 and the true inactive
+    // write-target is ota_1. `other_app` encodes exactly that (Factory|Ota0 => Ota1, Ota1 => Ota0),
+    // replacing the old blind `Slot::next()` — now PRIVATE in 0.5 — which folded a blank record to
+    // ota_0 (the LIVE image → a self-overwrite/brick class). The 0.5 rename made the footgun
+    // structurally unwritable from app code; `other_app` keeps the explicit, audited mapping.
+    // Validated against JP's ESP32-C6 watch (same Factory=>Ota1 mapping).
+    Some(other_app(ota.current_app_partition().ok()?))
 }
 
 /// Point `otadata` at the freshly-written `target` slot + arm the state machine
 /// (`New`), then REBOOT into it. Call ONLY after [`ImageWriter::finalize`] returned
 /// true. If the otadata write fails, we do NOT reboot — the good slot stays active.
 #[cfg(feature = "espnow")]
-pub fn activate(target: Slot, new_build: u32, is_leaf_ota: bool) {
+pub fn activate(target: AppPartitionSubType, new_build: u32, is_leaf_ota: bool) {
     if set_slot_new(target).is_some() {
         // #40: tag the marker with the NEW image's build# + OTA type. `boot_confirm` self-tests
         // IFF the running build matches (bug #5 — a USB flash of a different build won't match a
@@ -724,22 +738,22 @@ pub fn activate(target: Slot, new_build: u32, is_leaf_ota: bool) {
 }
 
 #[cfg(feature = "espnow")]
-fn set_slot_new(target: Slot) -> Option<()> {
-    let mut flash = FlashStorage::new();
+fn set_slot_new(target: AppPartitionSubType) -> Option<()> {
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let pt = read_partition_table(&mut flash, &mut buf).ok()?;
     let od = pt
         .find_partition(PartitionType::Data(DataPartitionSubType::Ota))
         .ok()??;
-    let mut region = od.as_embedded_storage(&mut flash);
-    let mut ota = Ota::new(&mut region).ok()?;
-    ota.set_current_slot(target).ok()?;
+    let region = od.as_embedded_storage(&mut flash);
+    let mut ota = Ota::new(region, 2).ok()?;
+    ota.set_current_app_partition(target).ok()?;
     ota.set_current_ota_state(OtaImageState::New).ok()?;
     Some(())
 }
 
 /// #226 FIRST-BOOT OTADATA INIT: a freshly USB-flashed board has BLANK `otadata` (both
-/// select-entries erased → `current_slot()` == `Slot::None`). The ESP-IDF ROM then boots
+/// select-entries erased → `current_slot()` == `AppPartitionSubType::Factory`). The ESP-IDF ROM then boots
 /// `ota_0` (there is no factory partition in `partitions-ota.csv`), but the ota-select record
 /// stays absent, so `boot_slot()` reports 255 ("unprovisioned") and luna's rollback automation
 /// would see a spurious 255→N jump on the first real OTA. This writes a VALID select record for
@@ -754,13 +768,13 @@ fn set_slot_new(target: Slot) -> Option<()> {
 /// - ONE-TIME: only fires while `current_slot()` is blank; the write makes it non-blank, so every
 ///   later boot is a no-op (no repeated flash wear).
 /// - VERIFY-AFTER-WRITE + FAIL-SAFE: any partition/flash error → no-op, and the `inactive_slot()`
-///   `Slot::None => Slot1` net still targets a subsequent OTA correctly even if this never ran.
+///   `AppPartitionSubType::Factory => Slot1` net still targets a subsequent OTA correctly even if this never ran.
 ///
 /// Call ONCE at earliest boot, BEFORE `capture_boot_diag` (so `boot_slot` reads 0, not 255) and
 /// BEFORE the #40 unconfirmed-boot block. Boot-critical partition write → HW-canary gated.
 #[cfg(feature = "espnow")]
 pub fn init_otadata_if_blank() {
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
         return;
@@ -768,16 +782,16 @@ pub fn init_otadata_if_blank() {
     let Ok(Some(od)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Ota)) else {
         return; // no otadata partition (non-OTA board) → nothing to init
     };
-    let mut region = od.as_embedded_storage(&mut flash);
-    let Ok(mut ota) = Ota::new(&mut region) else {
+    let region = od.as_embedded_storage(&mut flash);
+    let Ok(mut ota) = Ota::new(region, 2) else {
         return;
     };
     // Only touch a genuinely BLANK otadata — never perturb a provisioned record.
-    if !matches!(ota.current_slot(), Ok(Slot::None)) {
+    if !matches!(ota.current_app_partition(), Ok(AppPartitionSubType::Factory)) {
         return;
     }
     // Blank ⟹ ROM booted ota_0 ⟹ formalize Slot0 as the valid boot selection.
-    if ota.set_current_slot(Slot::Slot0).is_err()
+    if ota.set_current_app_partition(AppPartitionSubType::Ota0).is_err()
         || ota.set_current_ota_state(OtaImageState::Valid).is_err()
     {
         log::error!(
@@ -786,8 +800,8 @@ pub fn init_otadata_if_blank() {
         return;
     }
     // Verify-after-write (boot-critical): confirm the record now resolves to Slot0.
-    match ota.current_slot() {
-        Ok(Slot::Slot0) => log::info!("smol #226: otadata first-boot init — blank → Slot0/Valid"),
+    match ota.current_app_partition() {
+        Ok(AppPartitionSubType::Ota0) => log::info!("smol #226: otadata first-boot init — blank → Slot0/Valid"),
         other => log::error!(
             "smol #226: otadata init verify FAILED (got {other:?}) — inactive_slot net still protects OTA"
         ),
@@ -802,16 +816,14 @@ pub fn init_otadata_if_blank() {
 /// (don't roll back into the unknown). `wifi`-scoped so `boot_confirm` (also `wifi`) can call
 /// it; the types resolve from the `esp-bootloader-esp-idf` dep present in every radio build.
 #[cfg(feature = "wifi")]
-fn slot_has_valid_image(slot: esp_bootloader_esp_idf::ota::Slot) -> bool {
+fn slot_has_valid_image(slot: AppPartitionSubType) -> bool {
     use embedded_storage::nor_flash::ReadNorFlash;
-    use esp_bootloader_esp_idf::ota::Slot;
-    use esp_bootloader_esp_idf::partitions::AppPartitionSubType;
+    // #233: brick-safe guard — only ota_0/ota_1 are valid rollback targets on smol's table.
     let sub = match slot {
-        Slot::Slot0 => AppPartitionSubType::Ota0,
-        Slot::Slot1 => AppPartitionSubType::Ota1,
-        _ => return false, // >2-slot table we don't use — refuse (brick-safe)
+        AppPartitionSubType::Ota0 | AppPartitionSubType::Ota1 => slot,
+        _ => return false, // factory/test/>2-slot — refuse (brick-safe)
     };
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
         return false;
@@ -842,7 +854,7 @@ fn slot_has_valid_image(slot: esp_bootloader_esp_idf::ota::Slot) -> bool {
 /// `Valid` (so we don't loop), and reset — the app-side net that works even with the
 /// bootloader's auto-revert OFF.
 pub fn boot_confirm(self_test_passed: bool) {
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let pt = match read_partition_table(&mut flash, &mut buf) {
         Ok(pt) => pt,
@@ -852,8 +864,8 @@ pub fn boot_confirm(self_test_passed: bool) {
         Ok(Some(p)) => p,
         _ => return, // no otadata (non-OTA board) → nothing to confirm
     };
-    let mut region = od.as_embedded_storage(&mut flash);
-    let mut ota = match Ota::new(&mut region) {
+    let region = od.as_embedded_storage(&mut flash);
+    let mut ota = match Ota::new(region, 2) {
         Ok(o) => o,
         Err(_) => return,
     };
@@ -893,12 +905,12 @@ pub fn boot_confirm(self_test_passed: bool) {
         // current image (mark Valid, keep running). A USB-flashed image is operator-intended
         // and a mesh-OTA image was ed25519+sha verified before activate, so accepting it is
         // safe; bricking is not.
-        let target = ota.current_slot().ok().map(|c| c.next());
+        let target = ota.current_app_partition().ok().map(other_app);
         let can_rollback = target.map(slot_has_valid_image).unwrap_or(false);
         clear_ota_activated(); // fate decided either way
         if can_rollback {
             if let Some(t) = target {
-                let _ = ota.set_current_slot(t);
+                let _ = ota.set_current_app_partition(t);
             }
             let _ = ota.set_current_ota_state(OtaImageState::Valid);
             mark_ota_outcome(true); // #70: DIAG ota=rolled-back — set BEFORE reset; the good-slot
@@ -979,7 +991,7 @@ pub struct LeafImageWriter {
     /// Partition-relative address erased through (sector granularity, monotonic).
     erased_upto: u32,
     /// The slot [`activate`] targets after a good finalize.
-    target: Slot,
+    target: AppPartitionSubType,
 }
 
 #[cfg(feature = "espnow")]
@@ -987,12 +999,10 @@ impl LeafImageWriter {
     /// Open a writer for the inactive slot. `None` on any partition/flash error.
     pub fn begin() -> Option<LeafImageWriter> {
         let target = inactive_slot()?;
-        let sub = if target == Slot::Slot1 {
-            AppPartitionSubType::Ota1
-        } else {
-            AppPartitionSubType::Ota0
-        };
-        let mut flash = FlashStorage::new();
+        // #233: `target` is already the AppPartitionSubType to write (inactive_slot → other_app,
+        // always Ota0/Ota1), so the write-target partition IS the target.
+        let sub = target;
+        let mut flash = flash();
         let mut buf = [0u8; PT_SCRATCH];
         let part_len = {
             let pt = read_partition_table(&mut flash, &mut buf).ok()?;
@@ -1003,7 +1013,7 @@ impl LeafImageWriter {
     }
 
     /// The slot this writer targets (passed to [`activate`] after a good finalize).
-    pub fn target(&self) -> Slot {
+    pub fn target(&self) -> AppPartitionSubType {
         self.target
     }
 
@@ -1025,7 +1035,7 @@ impl LeafImageWriter {
         }
         // Re-derive the partition-scoped region from locals (table + flash borrowed
         // together for the region's lifetime; dropped at end of this call).
-        let mut flash = FlashStorage::new();
+        let mut flash = flash();
         let mut ptbuf = [0u8; PT_SCRATCH];
         let pt = match read_partition_table(&mut flash, &mut ptbuf) {
             Ok(pt) => pt,
@@ -1037,8 +1047,8 @@ impl LeafImageWriter {
         };
         let mut region = app.as_embedded_storage(&mut flash);
 
-        let word = <FlashStorage as NorFlash>::WRITE_SIZE as u32; // 4
-        let sector = <FlashStorage as NorFlash>::ERASE_SIZE as u32; // 4096
+        let word = <FlashStorage<'_> as NorFlash>::WRITE_SIZE as u32; // 4
+        let sector = <FlashStorage<'_> as NorFlash>::ERASE_SIZE as u32; // 4096
         let padded = real.div_ceil(word) * word;
         let write_end = self.written + padded;
         // Erase-ahead (sector granularity). Monotonic — never re-erases written bytes.
@@ -1078,7 +1088,7 @@ impl LeafImageWriter {
         if self.written != expected_size {
             return false;
         }
-        let mut flash = FlashStorage::new();
+        let mut flash = flash();
         let mut ptbuf = [0u8; PT_SCRATCH];
         let pt = match read_partition_table(&mut flash, &mut ptbuf) {
             Ok(pt) => pt,
@@ -1124,13 +1134,10 @@ pub struct SlotReader {
 #[cfg(feature = "espnow")]
 impl SlotReader {
     /// Open a reader for `slot` (the gateway's just-staged inactive slot). `None` on error.
-    pub fn open(slot: Slot) -> Option<SlotReader> {
-        let sub = if slot == Slot::Slot1 {
-            AppPartitionSubType::Ota1
-        } else {
-            AppPartitionSubType::Ota0
-        };
-        let mut flash = FlashStorage::new();
+    pub fn open(slot: AppPartitionSubType) -> Option<SlotReader> {
+        // #233: `slot` is already the AppPartitionSubType to read.
+        let sub = slot;
+        let mut flash = flash();
         let mut buf = [0u8; PT_SCRATCH];
         let part_len = {
             let pt = read_partition_table(&mut flash, &mut buf).ok()?;
@@ -1148,7 +1155,7 @@ impl SlotReader {
         if off.saturating_add(out.len() as u32) > self.part_len {
             return false;
         }
-        let mut flash = FlashStorage::new();
+        let mut flash = flash();
         let mut ptbuf = [0u8; PT_SCRATCH];
         let pt = match read_partition_table(&mut flash, &mut ptbuf) {
             Ok(pt) => pt,
@@ -1226,7 +1233,7 @@ fn crc32(data: &[u8]) -> u32 {
 #[cfg(feature = "espnow")]
 fn floor_cell_read(rel: u32) -> Option<u32> {
     use embedded_storage::nor_flash::ReadNorFlash;
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut ptbuf = [0u8; PT_SCRATCH];
     let pt = read_partition_table(&mut flash, &mut ptbuf).ok()?;
     let nvs = pt
@@ -1278,7 +1285,7 @@ pub fn fresh_floor_bump(build: u32) {
     let crc = crc32(&rec[0..8]);
     rec[8..12].copy_from_slice(&crc.to_le_bytes());
 
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut ptbuf = [0u8; PT_SCRATCH];
     let pt = match read_partition_table(&mut flash, &mut ptbuf) {
         Ok(pt) => pt,
@@ -1311,7 +1318,7 @@ pub fn fresh_floor_bump(build: u32) {
 /// `[magic, count]` in persistent RTC-fast RAM. `#[ram(rtc_fast, persistent)]` keeps it
 /// across a `software_reset`; it is uninitialized at power-on (magic detects that).
 #[cfg(feature = "espnow")]
-#[esp_hal::ram(rtc_fast, persistent)]
+#[esp_hal::ram(unstable(rtc_fast, persistent))]
 static mut OTA_BOOT_GUARD: [u32; 2] = [0u32; 2];
 
 #[cfg(feature = "espnow")]
@@ -1344,7 +1351,7 @@ const BOOT_GUARD_MAGIC: u32 = 0x736D_6C4B; // "smlK"
 /// rolled back by the leaf hear-a-frame path (the 113↔114 oscillation), and its role is
 /// ambiguous at that boot anyway.
 #[cfg(feature = "wifi")]
-#[esp_hal::ram(rtc_fast, persistent)]
+#[esp_hal::ram(unstable(rtc_fast, persistent))]
 static mut OTA_ACTIVATE_GUARD: [u32; 3] = [0u32; 3];
 
 #[cfg(feature = "wifi")]
@@ -1433,7 +1440,7 @@ pub fn unconfirmed_boot_reset() {
 /// we can't read otadata on simply skips the OTA bookkeeping).
 #[cfg(feature = "espnow")]
 pub fn otadata_unconfirmed() -> bool {
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
         return false;
@@ -1441,8 +1448,8 @@ pub fn otadata_unconfirmed() -> bool {
     let Ok(Some(od)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Ota)) else {
         return false;
     };
-    let mut region = od.as_embedded_storage(&mut flash);
-    let Ok(mut ota) = Ota::new(&mut region) else {
+    let region = od.as_embedded_storage(&mut flash);
+    let Ok(mut ota) = Ota::new(region, 2) else {
         return false;
     };
     matches!(
@@ -1486,7 +1493,7 @@ const BOOTCOUNT_RECORD_LEN: usize = 12;
 #[cfg(feature = "espnow")]
 fn bootcount_cell_read(rel: u32) -> Option<u32> {
     use embedded_storage::nor_flash::ReadNorFlash;
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut ptbuf = [0u8; PT_SCRATCH];
     let pt = read_partition_table(&mut flash, &mut ptbuf).ok()?;
     let nvs = pt
@@ -1530,7 +1537,7 @@ pub fn boot_count_bump() -> u32 {
     rec[4..8].copy_from_slice(&next.to_le_bytes());
     let crc = crc32(&rec[0..8]);
     rec[8..12].copy_from_slice(&crc.to_le_bytes());
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut ptbuf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut ptbuf) else {
         return next;
@@ -1552,7 +1559,7 @@ pub fn boot_count_bump() -> u32 {
 /// next boot can tell a panic-reset (`rr=panic`) from a clean `rr=sw`. Survives the reset AND
 /// a USB reflash; a true power cycle clears it (a power-cycled board reports `por`, correct).
 #[cfg(feature = "wifi")]
-#[esp_hal::ram(rtc_fast, persistent)]
+#[esp_hal::ram(unstable(rtc_fast, persistent))]
 static mut PANIC_MARK: [u32; 1] = [0u32; 1];
 
 #[cfg(feature = "wifi")]
@@ -1773,7 +1780,7 @@ fn encode_net_cfg(c: NetCfg) -> [u8; NET_REC_LEN] {
 #[cfg(feature = "wifi")]
 pub fn read_net_cfg() -> Option<NetCfg> {
     use embedded_storage::nor_flash::ReadNorFlash;
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let pt = read_partition_table(&mut flash, &mut buf).ok()?;
     let nvs = pt
@@ -1796,7 +1803,7 @@ pub fn read_net_cfg() -> Option<NetCfg> {
 #[cfg(feature = "espnow")]
 pub fn write_net_cfg(c: NetCfg) {
     use embedded_storage::nor_flash::NorFlash;
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
         return;
@@ -1811,7 +1818,7 @@ pub fn write_net_cfg(c: NetCfg) {
     // never persisted. Erase+write RAW at absolute addresses instead — same 4 KB, same
     // segregation (identity/floor/boot-count live in sectors 0-4, untouched).
     let base = nvs.offset(); // absolute flash address of the nvs partition
-    let sector = <FlashStorage as NorFlash>::ERASE_SIZE as u32; // 4096
+    let sector = <FlashStorage<'_> as NorFlash>::ERASE_SIZE as u32; // 4096
     if flash.erase(base + NET_REC_OFF, base + NET_REC_OFF + sector).is_err() {
         return;
     }
@@ -1879,7 +1886,7 @@ pub fn parse_ota_host_override(s: &str) -> Option<[u8; 4]> {
 /// error. A silent rollback flips this vs the pushed slot — the headline #70 signal.
 #[cfg(feature = "espnow")]
 pub fn boot_slot() -> u8 {
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
         return 255;
@@ -1887,13 +1894,13 @@ pub fn boot_slot() -> u8 {
     let Ok(Some(od)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Ota)) else {
         return 255;
     };
-    let mut region = od.as_embedded_storage(&mut flash);
-    let Ok(mut ota) = Ota::new(&mut region) else {
+    let region = od.as_embedded_storage(&mut flash);
+    let Ok(mut ota) = Ota::new(region, 2) else {
         return 255;
     };
-    match ota.current_slot() {
-        Ok(Slot::Slot0) => 0,
-        Ok(Slot::Slot1) => 1,
+    match ota.current_app_partition() {
+        Ok(AppPartitionSubType::Ota0) => 0,
+        Ok(AppPartitionSubType::Ota1) => 1,
         _ => 255,
     }
 }
@@ -1906,7 +1913,7 @@ pub fn boot_slot() -> u8 {
 /// good-slot boot reports `rolled-back`; a power cycle clears it → `none`, correct). Magic-gated
 /// so uninitialised RTC RAM reads as `none`, never a false outcome.
 #[cfg(feature = "wifi")]
-#[esp_hal::ram(rtc_fast, persistent)]
+#[esp_hal::ram(unstable(rtc_fast, persistent))]
 static mut OTA_OUTCOME: [u32; 2] = [0u32; 2]; // [magic, 1=confirmed / 2=rolled-back]
 
 #[cfg(feature = "wifi")]

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -36,15 +36,29 @@ use esp_bootloader_esp_idf::partitions::{
 };
 use esp_storage::FlashStorage;
 
-/// #233: esp-storage 0.9's `FlashStorage` is a once-only singleton that CONSUMES the FLASH
-/// peripheral (`FlashStorage::new(FLASH)`; panics if constructed twice). smol's OTA is strictly
-/// SERIAL — one `ImageWriter`/`LeafImageWriter` at a time, and the otadata/identity helpers run
-/// before begin / after finalize, never concurrently with the writer or each other — and only
-/// ever reads a CONSTANT flash capacity, so a freshly-stolen per-op handle reproduces the exact
-/// (safe) semantics of the old 0.7 throwaway `flash()`. This avoids threading the
-/// FLASH peripheral through the whole radio stack (main → mode → RadioManager → run_ota_fetch)
-/// and dodges introducing a `&mut FlashStorage` borrow held across the streaming write.
-/// SAFETY: no two `FlashStorage` handles are live-and-in-use at the same instant on this chip.
+/// #233: esp-storage 0.9's `FlashStorage::new` CONSUMES the FLASH peripheral. Its
+/// "Panics if called more than once" doc is the *compile-time move contract* on the
+/// esp-hal peripheral singleton, NOT a runtime check — two independent source-reads
+/// (scratch/233-upgrade/flashstorage-steal-verdict.md) confirmed there is NO once-guard
+/// anywhere in esp-storage 0.9 (the lone `.unwrap()` is capacity-detect), and esp-hal
+/// 1.1.1's `FLASH::steal()` fabricates the zero-state token unconditionally. So a
+/// freshly-stolen per-op handle reproduces the exact semantics of the old 0.7 throwaway
+/// `FlashStorage::new()` — each call just re-reads the constant flash-size header. This
+/// avoids threading the FLASH peripheral through the whole radio stack
+/// (main → mode → RadioManager → run_ota_fetch) and dodges a `&mut FlashStorage` borrow
+/// held across the streaming write.
+///
+/// ⚠️ HUMAN-AUDITED INVARIANT (steal() moves the exclusivity guarantee from the compiler
+/// to us — the risk class is a torn write from a concurrent flash user overlapping an
+/// in-flight OTA op):
+/// - Callers must NEVER hold two `FlashStorage` instances live-and-in-use at once.
+/// - ALL flash access stays on the main loop: OTA is strictly serial (one
+///   `ImageWriter`/`LeafImageWriter` at a time; the otadata/identity helpers run before
+///   begin / after finalize, never concurrently), and no ISR touches flash.
+/// This holds STRUCTURALLY in the non-embassy superloop. #198 (embassy-net migration):
+/// re-evaluate this deliberately — once flash users can interleave at await points, move
+/// to a single owned instance (StaticCell/once-init here in `ota::`) instead of per-op
+/// steal. Do not carry this helper into an async world unexamined.
 #[cfg(feature = "wifi")]
 fn flash() -> FlashStorage<'static> {
     FlashStorage::new(unsafe { esp_hal::peripherals::FLASH::steal() })

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -326,7 +326,7 @@ pub fn stat_build(value: &[u8]) -> Option<u32> {
 // with otadata untouched (the good slot boots; a hard brick ⇒ USB recovery, §4).
 // ===========================================================================
 
-use esp_bootloader_esp_idf::ota::Slot;
+use esp_bootloader_esp_idf::partitions::AppPartitionSubType;
 
 /// Emit a gap-NAK if a window stays incomplete this long since the last NAK (ms).
 const LEAF_IDLE_NAK_MS: u64 = 500;
@@ -436,7 +436,7 @@ pub enum LeafAction {
     /// The image is fully received AND verified (sig + size + readback sha). Activate
     /// this slot with the manifest build# — [`crate::ota::activate`] reboots into it
     /// (never returns on success); the build# tags the self-test exemption marker.
-    Complete(Slot, u32),
+    Complete(AppPartitionSubType, u32),
     /// The session aborted (bad frame class handled internally) — discard; nothing to send.
     Abort,
 }
@@ -489,7 +489,7 @@ pub struct OtaLeafSession {
     /// The last window's base seq — the OTAN window_base the finalize-ack carries.
     finalize_wb: u32,
     /// The verified target slot to activate (captured before `finalize()` consumed the writer).
-    finalize_slot: Option<Slot>,
+    finalize_slot: Option<AppPartitionSubType>,
     /// Finalize-acks emitted so far this session (bounded by `LEAF_FINALIZE_ACK_MAX`).
     finalize_acks_sent: u8,
 }

--- a/rust/clock/src/toast.rs
+++ b/rust/clock/src/toast.rs
@@ -140,14 +140,12 @@ fn wrap(s: &str) -> ([(usize, usize); ROWS], usize) {
         }
         // Full line mid-word → prefer the last space (word wrap); no space → hard split (both
         // at char boundaries).
-        if cols == COLS {
-            if let Some(b) = break_at {
-                if b > start {
+        if cols == COLS
+            && let Some(b) = break_at
+                && b > start {
                     line_end = b;
                     next = b;
                 }
-            }
-        }
         lines[n] = (start, line_end);
         n += 1;
         cursor = next;


### PR DESCRIPTION
## What

The coordinated **matched-set** upgrade from #233 — esp-hal / esp-wifi(→esp-radio) / scheduler /
storage / bootloader move together (a mixed set won't compile) + **edition 2021 → 2024**. Rides
the #198 spike groundwork and mirrors the esp32c6-watch reference (adapted C6→C3).

Matched set: **esp-hal 1.1.1 · esp-wifi 0.15 → esp-radio 0.18 (RENAMED) · esp-rtos 0.3 (NEW
scheduler) · esp-storage 0.9 · esp-bootloader-esp-idf 0.5 · esp-alloc 0.10 · esp-backtrace 0.19 ·
esp-println 0.17 · smoltcp 0.13 · edition 2024** (+ new: embassy-futures 0.1 for `block_on`).

## Architecture decisions

- **smol stays a SYNCHRONOUS superloop.** esp-radio 0.18 needs a preemption scheduler (esp-rtos,
  replacing esp-wifi's in-crate `builtin-scheduler`), enabled **NON-embassy**: `esp_rtos::start()`
  converts the current context into the scheduler's pinned main task and returns, so the existing
  blocking `main()` runs unchanged while the radio task preempts in. A concurrency-model change
  belongs to #198, not this dep migration.
- **smoltcp shim** (`net/radio_dev.rs`, transitional): esp-radio 0.18 dropped esp-wifi's `smoltcp`
  feature — its STA `Interface` implements only `embassy_net_driver::Driver`. smol drives *raw*
  smoltcp, so this shim re-exposes the raw `WifiRxToken`/`WifiTxToken` through smoltcp's
  `phy::Device`. It's exactly what #198's embassy-net move later deletes.
- **`coex` NOT enabled.** 0.18's `coex` is the WiFi+**BLE** arbiter and its build script hard-errors
  without `ble`. smol's WiFi↔ESP-NOW coexistence (#40/#23) is *same-radio* channel management (the
  old esp-wifi build had no coex either), and pulling BLE in would wedge the C3 in ROM (btdm init
  busy-wait — the "native BLE refuted on C3" finding). So: esp-now only.
- **async→sync bridge.** connect/disconnect/scan are async-only in 0.18; `embassy_futures::block_on`
  drives them from the superloop. `set_config` STARTS the driver (no `start()`/`is_started()`);
  `is_connected()` returns `bool`.

## OTA port (esp-bootloader 0.5 / esp-storage 0.9) — boot-critical

- `Slot` enum is now **private**. The engine uses `AppPartitionSubType` as its currency across
  `ota`/`ota_mesh`/`mode`. The **#226 self-overwrite footgun** is preserved via an explicit
  `other_app()` (`Factory|Ota0 => Ota1`, `Ota1 => Ota0`) — NOT the now-private `.next()` (which
  folded blank→ota_0 = the live image). `current_slot`/`set_current_slot` →
  `current_app_partition`/`set_current_app_partition`; `Ota::new` gains a partition-count arg.
- **Exact safety semantics preserved**: partition-scoped writer that cannot reach the active slot
  or otadata; ed25519-verify-before-any-flash-write; sha256 before otadata touch; word-aligned
  writes + verify-after-write.
- **FlashStorage — per-op `FLASH::steal()` (`ota::flash()`), VERDICT: SAFE (two independent
  source-reads agree; `scratch/233-upgrade/flashstorage-steal-verdict.md`).** esp-storage 0.9 has
  **no runtime once-guard** — the "Panics if called more than once" doc is the *compile-time move
  contract* on the esp-hal peripheral singleton (the lone `.unwrap()` is capacity-detect), and
  esp-hal 1.1.1's `FLASH::steal()` fabricates the zero-state token unconditionally. Per-op steal
  therefore reproduces the exact old 0.7 throwaway semantics, without threading FLASH through the
  whole radio stack or holding a `&mut FlashStorage` borrow across the streaming write.
  **Residual (now human-audited) invariant**, stated in `ota::flash()`'s doc: the risk class is a
  torn write from a concurrent flash user overlapping an in-flight OTA op — callers must never
  hold two instances, and all flash access stays on the main loop (OTA strictly serial, no ISR
  writes flash). This holds *structurally* in the non-embassy superloop; **#198 must re-evaluate
  it deliberately** (at await-point interleaving, switch to a single owned instance in `ota::`).

## Gate results (KATANA, `riscv32imc`, `-j2`)

| Check | Result |
|---|---|
| `cargo check` default / wifi / espnow / espnow,cast,io | ✅ all clean |
| `cargo clippy --features espnow,cast,io -- -D warnings` | ✅ clean (collapsible_if → edition-2024 let-chains) |
| `cargo build --release` default / wifi / espnow,cast,io | ✅ all exit 0 |
| OTA image (espnow,cast,io) vs slot 0x1F0000 | ✅ **1,058,096 B = 52%** (ed25519 opt-z gate intact; up from ~37% — the 0.18 stack is larger, still ~48% headroom) |
| Honest dev version stamp | ✅ `…+dev.9e399f5` |
| Host experiments (relay_compat/etx/sth/ledger/flood/treehead) | ✅ compile clean (pure cores untouched — no drift) |

## Bonus — kills a latent cold-build fragility (duplicate esp-metadata-generated)

Beyond go-latest, this migration removes the root of main's current RED cold-build (the
`portable-atomic`/`unsafe-assume-single-core` host feature-unification leak): on the rc.0 set
**four** crates (esp-hal 1.0.0-rc.0, esp-wifi 0.15.0, esp-println 0.15.0, esp-config 0.5.0) pin
**esp-metadata-generated 0.1.0**, which uniquely pulls the heavy host build crate `esp-metadata`
0.8 (anyhow/basic-toml/indexmap → heapless → portable-atomic) alongside the modern **0.4.0** (no
deps) → the duplicate that leaks the single-core feature host-ward. The #233 set puts **every**
crate on esp-metadata-generated **0.4.0** — verified: this branch's Cargo.lock has ZERO 0.1.0 and
ZERO `esp-metadata`. So the fragility is a symptom of the stale pins, and the matched-set bump is
its structural cure. (main's focused fix is owned separately by v346; rebase onto it when it lands.)

## ⛔ CANARY FINDING — HARD BLOCKER (do not merge)

First bench-C3 (id13) canary run: the migration image **panic-loops ~every 80 s** on hardware
(MQTT DIAG: `rst=panic`, boot 11→12, up≈79 s→reboot; it also crowned a ch1 AP and pulled the mesh
off ch6 while unstable). A panic-looping build can't ship regardless of the coexist-disease question,
so **#247 is blocked** on root-causing + fixing this.

- **Why serial-silent (0 bytes on panic):** `custom_halt()` `software_reset()`s with no flush, so the
  esp-backtrace dump is truncated out of the USB-JTAG FIFO before the host reads it. Fixed for capture
  via a forensics image (temp 6 s drain-delay in `custom_halt` + `ESP_LOG=info`; edit reverted, branch
  clean). Artifact for the next canary flash: `scratch/233-upgrade/forensic-id13.{bin,elf}`.
- **`rst=panic` = a genuine Rust panic** (overflow-checks off). Live backtrace capture is **HW-gated**
  — there is no spare C3 on katana (the "bench board" was JP's ESPHome laundry BLE proxy, since
  restored), so the panic was root-caused by **static analysis**:
  - **Subscriber-exhaustion (`EVENT_CHANNEL_SUBSCRIBERS=2`): REFUTED.** esp-radio holds zero persistent
    subscribers (all `.subscriber()` sites transient; driver is publisher-side), smol holds none, and
    `block_on` is serial (≤1 subscriber alive < 2) — the `.expect("Unable to subscribe")` cannot fire.
  - **Regression found + FIXED (0ab3d0a) — leading candidate:** esp-radio 0.18
    `scan_async(ScanConfig::default())` is **unbounded** (`max=None`, heap `Vec` of every AP), where the
    old `scan_n(16)` capped at 16 → OOM-panic risk on the crown-deaf reassoc path (which first fires
    ~79 s in, matching the cadence). Restored the bound with `.with_max(16)` at both scan sites.
    Confidence it's THE panic: moderate — **must be confirmed by a clean canary on a real spare C3.**

## Canary plan — once green, DOUBLES as the coexist-disease experiment

Per the coexist study (`docs/superpowers/research/coexist-disease-esp-radio-018-study.md`
§"How to DEFINITIVELY settle it"): same C3 silicon, new stack, crown scenario — serve ESP-NOW while
pulling a ~1 MB body, **off-ch6 AND co-channel ch6**. The study's open sliver (does the newer WiFi
driver smooth the co-channel duty-cycle case?) gets answered for free. **Do NOT fleet-roll without a
canary** — the esp-radio scheduler/os-adapter change and the OTA otadata path are exactly the class
that fails only on hardware. **[HW-CANARY-HELD]**

Refs #233, #198 (spike), #226 (OTA slot footgun), #52 (audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
