### PR TITLE
[HW-HELD, v346, stacked on #190] #181 wire the L1/L2/L3 mesh-ledger cores into fw

### DIFF
--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -176,6 +176,12 @@ wifi = [
 # Builds on `wifi` (shares the radio init path) and turns on esp-wifi/esp-now.
 espnow = ["wifi", "esp-wifi/esp-now", "dep:ed25519-compact"]
 
+# #181/#184 mesh-ledger key PROVISIONING (a JP-supervised USB-touch build, NOT for the fleet OTA
+# image). Enables the one-shot NVS seeding of the ed25519 signing key from a build-time
+# `SMOL_LEDGER_SEED` (hex, supplied out-of-band, NEVER committed). The default / OTA image omits this
+# feature → it only ever READS an already-provisioned key. NO key generation in the firmware or CI.
+ledger-provision = ["espnow"]
+
 # #25 WLED WiZmote-emit: smol impersonates a WLED "linked remote" (13-B WiZmote
 # ESP-NOW broadcast). Needs the ESP-NOW broadcast path + RadioManager, so it builds
 # on `espnow`. Nothing new links — pure encode + the existing `esp_now.send`. The

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -76,6 +76,26 @@ pub mod flood;
 #[cfg(feature = "espnow")]
 pub mod wire;
 
+// #181 mesh-ledger cores — the PURE, host-tested L1/L2/L3 primitives (sha256 + ed25519 injected),
+// wired into the firmware by `ledger_link` (#182 hash-chain, #183 CT-Merkle anchor, #184 signed
+// tree-head; landed inert via PRs #220/#223/#224). Each is a frozen library-of-primitives with a
+// full host-test suite (`experiments/{ledger,treehead,sth}_verify`); `ledger_link` wires a
+// meaningful SUBSET now (own-chain append + crown anchor/sign + verify-what-you-sign self-check),
+// with peer-STH gossip/acceptance the HW-gated L2-coordination follow-up. `#[allow(dead_code)]` on
+// the CORE modules (this is a binary crate, so a not-yet-wired pub primitive would trip `-D
+// warnings`) — the integration `ledger_link` below carries NO allow, so its own quality is enforced.
+#[cfg(feature = "espnow")]
+#[allow(dead_code)]
+pub mod ledger;
+#[cfg(feature = "espnow")]
+#[allow(dead_code)]
+pub mod treehead;
+#[cfg(feature = "espnow")]
+#[allow(dead_code)]
+pub mod sth;
+#[cfg(feature = "espnow")]
+pub mod ledger_link;
+
 // #25 WLED WiZmote-emit (smol as a WLED "linked remote"). `wled = ["espnow"]`, so
 // this is present only in a wled build; the default/wifi/espnow builds are byte-free
 // of it (the module is `#![cfg(feature = "wled")]`). Referenced by `app` (the

--- a/rust/clock/src/net/ledger_link.rs
+++ b/rust/clock/src/net/ledger_link.rs
@@ -1,0 +1,155 @@
+//! #181 mesh-ledger FIRMWARE WIRING — binds the pure, host-tested L1/L2/L3 cores
+//! ([`super::ledger`] #182 hash-chain · [`super::treehead`] #183 CT-Merkle anchor · [`super::sth`]
+//! #184 ed25519 Signed-Tree-Head) into the running firmware. The cores are pure (sha256 + ed25519
+//! *injected*, no HAL); this module supplies the concrete injections — `sha2` (the same crate the
+//! OTA path uses) and `ed25519-compact` — and owns the per-node state.
+//!
+//! ## What a node does with the ledger
+//! - **L1:** each node keeps its OWN tamper-evident append-only chain in `.bss` (resets at boot —
+//!   it is a within-session provenance log, gossip/persistence is the HW-gated follow-up).
+//! - **L2/L3 (crown):** the crown folds the head-set into a Merkle anchor and, IF it has an
+//!   on-device ed25519 key ([provisioned at a JP-supervised USB touch](crate::ota) — never in CI,
+//!   the repo, MQTT, or logs), signs it into a Signed-Tree-Head.
+//! - **verify-what-you-sign:** before surfacing an STH the crown re-verifies its OWN signature AND
+//!   an inclusion proof of its own head under the signed root — a self-consistency gate that also
+//!   exercises the full verify half of the cores (so nothing is dead-code in this binary crate).
+//!
+//! ## Key provisioning (the #181-L3 gate — NO key generation here)
+//! The signing key is a 32-byte ed25519 SEED read from NVS ([`crate::ota::resolve_ledger_key`]),
+//! seeded ONLY by a deliberate USB-touch provisioning step. A node with no key runs verify-only /
+//! publishes an UNSIGNED anchor — never fabricates a key. The seed never leaves the device.
+
+use super::{ledger, sth, treehead};
+
+/// L1 chain depth (records retained before the oldest is pruned into the checkpoint). 16 × ~53 B
+/// ≈ 850 B `.bss` (study §L1). The chain is tamper-evident across pruning via the checkpoint.
+pub const LEDGER_CAP: usize = 16;
+/// Max L1 record payload (≤ [`ledger::MAX_PAYLOAD`]). A compact provenance digest fits well under.
+pub const LEDGER_PAY: usize = 32;
+/// Max nodes in the crown's head-set for the L2 anchor (fleet ≤ ~30; must be ≤ 2^treehead::MAX_DEPTH).
+pub const LEDGER_NODES: usize = 32;
+
+/// The injected SHA-256 (the L1/L2 hasher). Same primitive the OTA path already links, so the
+/// ledger adds no new hash dependency.
+pub fn sha256(data: &[u8]) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(data);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&h.finalize());
+    out
+}
+
+/// Detached ed25519 sign of `msg` under the 32-byte `seed` (the injected L3 signer). Deterministic
+/// (no RNG — `Noise` omitted), so it is CI/attestation-free. Derives the keypair from the seed each
+/// call — a few ms, dwarfed by the anchor cadence.
+fn ed25519_sign(seed: &[u8; 32], msg: &[u8]) -> [u8; 64] {
+    use ed25519_compact::{KeyPair, Seed};
+    let kp = KeyPair::from_seed(Seed::new(*seed));
+    let sig = kp.sk.sign(msg, None);
+    let mut out = [0u8; 64];
+    out.copy_from_slice(sig.as_ref());
+    out
+}
+
+/// Verify `sig` over `msg` against the public key DERIVED FROM `seed` (the injected L3 verifier for
+/// the self-check — a node verifies its own STH with its own key). Peer-STH acceptance (verifying a
+/// DIFFERENT crown's key) is the HW-gated L2-coordination follow-up; this local verify keeps the
+/// cores' verify half exercised.
+fn ed25519_verify(seed: &[u8; 32], msg: &[u8], sig: &[u8; 64]) -> bool {
+    use ed25519_compact::{KeyPair, Seed, Signature};
+    let kp = KeyPair::from_seed(Seed::new(*seed));
+    let Ok(s) = Signature::from_slice(sig) else {
+        return false;
+    };
+    kp.pk.verify(msg, &s).is_ok()
+}
+
+/// Per-node ledger state: the L1 chain, the crown's L2 head-set view, a monotonic STH freshness
+/// epoch, and the optional on-device signing seed.
+pub struct LedgerLink {
+    chain: ledger::Ledger<LEDGER_CAP, LEDGER_PAY>,
+    heads: treehead::HeadSet<LEDGER_NODES>,
+    epoch: u32,
+    signing_key: Option<[u8; 32]>,
+}
+
+impl LedgerLink {
+    /// An empty link (no key until [`set_signing_key`](Self::set_signing_key)). `const` → lives in
+    /// `.bss` with no runtime init.
+    pub const fn new() -> Self {
+        Self {
+            chain: ledger::Ledger::new(),
+            heads: treehead::HeadSet::new(),
+            epoch: 0,
+            signing_key: None,
+        }
+    }
+
+    /// Install (or clear) the on-device ed25519 signing seed read from NVS at boot. A `Some` key
+    /// makes this node a signing crown; `None` publishes an unsigned anchor.
+    pub fn set_signing_key(&mut self, key: Option<[u8; 32]>) {
+        self.signing_key = key;
+    }
+
+    /// True once a signing key is installed (surfaced so the fleet can see which nodes can sign,
+    /// without ever exposing the key).
+    pub fn can_sign(&self) -> bool {
+        self.signing_key.is_some()
+    }
+
+    /// L1: append a provenance record to this node's chain, returning the new tip. Payload is
+    /// clamped to [`LEDGER_PAY`] by the core.
+    pub fn append(&mut self, payload: &[u8]) -> ledger::Hash {
+        self.chain.append(payload, sha256)
+    }
+
+    /// A compact chain summary for the DIAG record: `(tip, retained_len, verify_ok)`. Re-verifies
+    /// the retained chain (cheap for `CAP=16`) so `verify_ok=false` in telemetry is an immediate
+    /// tamper flag.
+    pub fn chain_summary(&self) -> (ledger::Hash, usize, bool) {
+        (self.chain.tip(), self.chain.len(), self.chain.verify(sha256).is_ok())
+    }
+
+    /// L2: fold this node's current head into the head-set and return the Merkle anchor over it.
+    /// Used both directly (unsigned-anchor path) and inside [`sign_and_selfcheck`](Self::sign_and_selfcheck).
+    pub fn anchor(&mut self, own_id: u8) -> treehead::Hash {
+        // seq = retained record count (0 for an empty chain) — the freshness the leaf hash binds.
+        let _ = self.heads.upsert(own_id, self.chain.tip(), self.chain.len() as u32);
+        self.heads.root(sha256)
+    }
+
+    /// L3 (crown): fold in this node's head, sign the anchor into a Signed-Tree-Head, and
+    /// VERIFY-WHAT-YOU-SIGN — re-check the STH signature AND an inclusion proof of this node's head
+    /// under the signed root before returning it. `None` when there is no signing key, or if the
+    /// self-check fails (never surface an STH that doesn't verify). Bumps the freshness epoch.
+    pub fn sign_and_selfcheck(&mut self, own_id: u8) -> Option<sth::SignedTreeHead> {
+        let key = self.signing_key?;
+        let own_head = self.chain.tip();
+        let own_seq = self.chain.len() as u32;
+        let root = self.anchor(own_id);
+        let size = self.heads.len() as u32;
+        let epoch = self.epoch;
+        self.epoch = self.epoch.wrapping_add(1);
+
+        let head = sth::sign_sth(root, size, epoch, |m| ed25519_sign(&key, m));
+
+        // Self-consistency gate: the signature must verify under our own key AND our head must be
+        // provably included under the signed root (exercises verify_sth + verify_inclusion + accept).
+        let proof = self.heads.inclusion_proof(own_id, sha256)?;
+        let inclusion_ok =
+            treehead::verify_inclusion(head.root(), own_id, own_head, own_seq, &proof, sha256);
+        if sth::accept(&head, inclusion_ok, |m, s| ed25519_verify(&key, m, s)) {
+            Some(head)
+        } else {
+            log::warn!("smol #181: STH self-check FAILED — not surfacing");
+            None
+        }
+    }
+}
+
+impl Default for LedgerLink {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1910,6 +1910,10 @@ pub struct RadioManager {
     diag: DiagCounters,
     /// #74 obs wave-2: node state mirrored from `main` (LED mode + time-sync) for the DIAG record.
     diag_extra: DiagExtra,
+    /// #181 mesh-ledger: this node's L1 hash-chain (own provenance) + the crown's L2 head-set for the
+    /// signed tree-head (L3). The on-device ed25519 signing key (if any) is loaded from NVS at
+    /// construction — see [`crate::ota::resolve_ledger_key`]. Surfaced in the DIAG record each cadence.
+    ledger: crate::net::ledger_link::LedgerLink,
     /// #72 io registry: this node's compact `io=<pin>:<count>,…` DIAG field (bound-input press
     /// counters), pushed from `main` via `set_diag_io` each diag-sample tick. Fixed buffer, no heap.
     #[cfg(feature = "io")]
@@ -2130,6 +2134,14 @@ impl RadioManager {
             own_scan: None,
             diag: DiagCounters::new(),
             diag_extra: DiagExtra::new(),
+            // #181: load the on-device ed25519 signing key from NVS (None ⇒ verify-only / unsigned
+            // anchor). resolve_ledger_key NEVER generates a key — provisioning is a deliberate
+            // USB-touch act (feature `ledger-provision`); the OTA image only ever reads.
+            ledger: {
+                let mut l = crate::net::ledger_link::LedgerLink::new();
+                l.set_signing_key(crate::ota::resolve_ledger_key());
+                l
+            },
             #[cfg(feature = "io")]
             diag_io: [0u8; IO_DIAG_MAX],
             #[cfg(feature = "io")]
@@ -3075,6 +3087,33 @@ impl RadioManager {
         // (like cfg=/io=) so the deployed dashboard's positional parse of the fixed set is intact;
         // HA picks these by key. `mo`/`mf` = frames whose group HMAC verified / failed (design §7.1).
         rec.push_str(&alloc::format!("|mo={}|mf={}", self.diag.mac_ok, self.diag.mac_fail));
+        // #181 mesh-ledger: L1 — append a compact provenance record for THIS cadence, then surface
+        // the chain tip (a tamper canary), retained len, self-verify result, and whether a signing
+        // key is held. On the CROWN, also fold in the L2 anchor + (if provisioned) the L3 signed
+        // tree-head epoch — the "publish path" rides the already-retained DIAG topic (peer-STH gossip
+        // is the HW-gated follow-up). Appended LAST → positional parse of the fixed fields intact.
+        let prov = alloc::format!("u{}b{}s{}o{}", up_s, d.boot_count, d.boot_slot, ota);
+        self.ledger.append(prov.as_bytes());
+        let (tip, clen, lok) = self.ledger.chain_summary();
+        rec.push_str(&alloc::format!(
+            "|lgt={:02x}{:02x}{:02x}{:02x}|lgn={}|lgok={}|lgk={}",
+            tip[0], tip[1], tip[2], tip[3], clen, lok as u8, self.ledger.can_sign() as u8
+        ));
+        if self.relay.is_gateway {
+            if let Some(sth) = self.ledger.sign_and_selfcheck(self.id) {
+                let r = sth.root();
+                rec.push_str(&alloc::format!(
+                    "|lgan={:02x}{:02x}{:02x}{:02x}|lgep={}|lgsz={}|lgsg=1",
+                    r[0], r[1], r[2], r[3], sth.epoch(), sth.size()
+                ));
+            } else {
+                let a = self.ledger.anchor(self.id);
+                rec.push_str(&alloc::format!(
+                    "|lgan={:02x}{:02x}{:02x}{:02x}|lgsg=0",
+                    a[0], a[1], a[2], a[3]
+                ));
+            }
+        }
         // #74 item 3 (stage-2): fold in the APPLIED-config string for HA config-drift, ONLY when
         // `main` populated it (espnow build). ASCII by construction (as_wire/to_wire/hex/F24). HA
         // reconstructs the same string from its command topics + plain-string-compares (luna's

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -664,6 +664,152 @@ pub fn resolve_node_id() -> u8 {
 }
 
 // ---------------------------------------------------------------------------
+// #181/#184 mesh-ledger signing key — a per-node ed25519 SEED persisted in `nvs`
+// ---------------------------------------------------------------------------
+// The L3 Signed-Tree-Head (net/sth.rs) needs an on-device ed25519 key on the crown. Same NVS
+// discipline as identity, with three HARD rules the #184 gate demands:
+//   1. NO KEY GENERATION anywhere in the firmware or CI. The seed is supplied out-of-band by JP at
+//      a SUPERVISED USB touch; `resolve_ledger_key` only ever READS it, and `provision_*` only
+//      writes a seed it was HANDED. A node with no key runs verify-only / publishes an UNSIGNED
+//      anchor — it NEVER fabricates one (contrast `resolve_node_id`, which auto-seeds from a baked
+//      const; a signing key must be a deliberate act).
+//   2. The seed NEVER leaves the device — never committed, never in a log line, never over MQTT.
+//   3. It lives in `nvs` SECTOR 3 (offset 0x3000) — distinct from identity (sector 0) and the
+//      freshness-floor cells (sectors 1-2), so no operation on those touches it, and (like identity)
+//      it survives every OTA (the image write never touches `nvs`).
+// Provisioning is gated behind the `ledger-provision` feature + a JP-supplied `SMOL_LEDGER_SEED`
+// (hex): the default / OTA image carries neither, so it is read-only and seed-free.
+
+/// Ledger signing-key record magic ("smol ledger key, v1").
+#[cfg(feature = "espnow")]
+const LEDGER_KEY_MAGIC: [u8; 4] = *b"SMlk";
+#[cfg(feature = "espnow")]
+const LEDGER_KEY_VERSION: u8 = 1;
+/// `nvs` byte offset of the ledger-key record — SECTOR 3 (0x3000), clear of identity + floor cells.
+#[cfg(feature = "espnow")]
+const LEDGER_KEY_OFFSET: u32 = 0x3000;
+/// Record length: magic(4) + version(1) + seed(32) + checksum(1) = 38, padded to a WRITE_SIZE(4)
+/// multiple (40) so the raw `write` never NotAligned-fails (the [[smol-flash-write-word-align]] trap).
+#[cfg(feature = "espnow")]
+const LEDGER_KEY_REC_LEN: usize = 40;
+
+/// Decode a stored ledger-key record. `Some(seed)` iff magic + version + the seed checksum all
+/// check out. Erased flash (all 0xFF) and any corruption fail — never misread as a key.
+#[cfg(feature = "espnow")]
+fn parse_ledger_key(rec: &[u8]) -> Option<[u8; 32]> {
+    if rec.len() < 38 || rec[0..4] != LEDGER_KEY_MAGIC || rec[4] != LEDGER_KEY_VERSION {
+        return None;
+    }
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&rec[5..37]);
+    let sum = seed.iter().fold(0u8, |a, &b| a ^ b).wrapping_add(0x5A);
+    if rec[37] != sum {
+        return None; // checksum guard
+    }
+    Some(seed)
+}
+
+/// Encode the 40-byte ledger-key record for `seed`.
+#[cfg(feature = "ledger-provision")]
+fn encode_ledger_key(seed: &[u8; 32]) -> [u8; LEDGER_KEY_REC_LEN] {
+    let mut r = [0u8; LEDGER_KEY_REC_LEN];
+    r[0..4].copy_from_slice(&LEDGER_KEY_MAGIC);
+    r[4] = LEDGER_KEY_VERSION;
+    r[5..37].copy_from_slice(seed);
+    r[37] = seed.iter().fold(0u8, |a, &b| a ^ b).wrapping_add(0x5A);
+    r
+}
+
+/// Read the ledger signing seed from `nvs` sector 3. `None` on any flash error or when no valid
+/// record is present (unprovisioned) — the caller then runs verify-only / publishes unsigned.
+#[cfg(feature = "espnow")]
+fn read_ledger_key_nvs() -> Option<[u8; 32]> {
+    use embedded_storage::nor_flash::ReadNorFlash;
+    let mut flash = FlashStorage::new();
+    let mut buf = [0u8; PT_SCRATCH];
+    let pt = read_partition_table(&mut flash, &mut buf).ok()?;
+    let nvs = pt
+        .find_partition(PartitionType::Data(DataPartitionSubType::Nvs))
+        .ok()??;
+    let mut region = nvs.as_embedded_storage(&mut flash);
+    let mut rec = [0u8; LEDGER_KEY_REC_LEN];
+    region.read(LEDGER_KEY_OFFSET, &mut rec).ok()?;
+    parse_ledger_key(&rec)
+}
+
+/// Persist `seed` as the ledger signing key — the JP-supervised USB-touch primitive. Writes ONLY
+/// when sector 3 is fully erased (all 0xFF), so it never clobbers an existing key or foreign data;
+/// re-provisioning requires an explicit `espflash erase-region` of the sector first (deliberate).
+/// Best-effort: returns whether the write landed. Never logs the seed.
+#[cfg(feature = "ledger-provision")]
+fn provision_ledger_key_nvs(seed: &[u8; 32]) -> bool {
+    use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
+    let mut flash = FlashStorage::new();
+    let mut buf = [0u8; PT_SCRATCH];
+    let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
+        return false;
+    };
+    let Ok(Some(nvs)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Nvs)) else {
+        return false;
+    };
+    let mut region = nvs.as_embedded_storage(&mut flash);
+    let sector = <FlashStorage as NorFlash>::ERASE_SIZE as u32;
+    // Refuse unless the WHOLE target sector is erased — never overwrite an existing key.
+    let mut chunk = [0u8; 64];
+    let mut off = LEDGER_KEY_OFFSET;
+    let end = LEDGER_KEY_OFFSET + sector;
+    while off < end {
+        if region.read(off, &mut chunk).is_err() {
+            return false;
+        }
+        if chunk.iter().any(|&b| b != 0xFF) {
+            return false; // not erased → don't touch
+        }
+        off += chunk.len() as u32;
+    }
+    if region.erase(LEDGER_KEY_OFFSET, end).is_err() {
+        return false;
+    }
+    region.write(LEDGER_KEY_OFFSET, &encode_ledger_key(seed)).is_ok()
+}
+
+/// Parse the JP-supplied `SMOL_LEDGER_SEED` (64 lowercase/upper hex chars) into a 32-byte seed.
+/// Compile-time env, read at runtime; absent/malformed → `None` (no provisioning). Never logged.
+#[cfg(feature = "ledger-provision")]
+fn ledger_seed_from_env() -> Option<[u8; 32]> {
+    let s = option_env!("SMOL_LEDGER_SEED")?;
+    if s.len() != 64 {
+        return None;
+    }
+    let b = s.as_bytes();
+    let mut seed = [0u8; 32];
+    for (i, out) in seed.iter_mut().enumerate() {
+        let hi = (b[i * 2] as char).to_digit(16)?;
+        let lo = (b[i * 2 + 1] as char).to_digit(16)?;
+        *out = ((hi << 4) | lo) as u8;
+    }
+    Some(seed)
+}
+
+/// The node's ledger signing key: the NVS record if provisioned, else `None`. Called once at boot.
+/// Provisioning is a DELIBERATE act, never automatic — only a `ledger-provision` build with a
+/// JP-supplied `SMOL_LEDGER_SEED` seeds NVS (once, if the sector is erased). The default / OTA image
+/// has neither → it only ever reads an already-provisioned key. NO key generation, NO key in the
+/// repo / MQTT / logs (the #184 on-device-key gate). BRICK-SAFE — never panics.
+#[cfg(feature = "espnow")]
+pub fn resolve_ledger_key() -> Option<[u8; 32]> {
+    #[cfg(feature = "ledger-provision")]
+    if read_ledger_key_nvs().is_none() {
+        if let Some(seed) = ledger_seed_from_env() {
+            if provision_ledger_key_nvs(&seed) {
+                log::info!("smol #181: ledger signing key provisioned into NVS (seed not logged)");
+            }
+        }
+    }
+    read_ledger_key_nvs()
+}
+
+// ---------------------------------------------------------------------------
 // otadata operations: inactive-slot lookup, activation, first-boot confirm
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
> **Stacked on #190** (`feat/190-hmac-auth`) — both edit `net.rs`, so one owner did both sequentially. **This PR's base is `feat/190-hmac-auth`; review/merge #190 first.** The diff below is the ledger wiring only.

## What

Wires the **inert, host-tested L1/L2/L3 mesh-ledger cores** (landed via #220/#223/#224) into the running firmware: **L1** [`net/ledger.rs`](../blob/main/rust/clock/src/net/ledger.rs) per-node hash-chain (#182) · **L2** [`net/treehead.rs`](../blob/main/rust/clock/src/net/treehead.rs) CT-Merkle anchor (#183) · **L3** [`net/sth.rs`](../blob/main/rust/clock/src/net/sth.rs) ed25519 Signed-Tree-Head (#184). The cores are pure with **sha256 + ed25519 injected**; this PR supplies the injections (`sha2`, `ed25519-compact`) and the per-node state. Study: `docs/superpowers/research/mesh-ledger-study.md`. **HW-held into v346.**

## How it's wired

- **`net.rs`** — declare `ledger`/`treehead`/`sth` (`#[allow(dead_code)]`: this is a **binary** crate, so a not-yet-wired pub primitive would trip `-D warnings`; they're frozen library-of-primitives with full host-test suites, wired incrementally) + the new `ledger_link` integration (**no** allow — its own quality is enforced).
- **`net/ledger_link.rs`** (new) — `LedgerLink`: this node's L1 chain, the crown's L2 head-set, a monotonic STH epoch, and an optional NVS signing key.
  - `append` (L1), `anchor` (L2 root), `sign_and_selfcheck` (L3: sign the anchor, then **verify-what-you-sign** — re-check the STH signature *and* an inclusion proof of our own head under the signed root before surfacing it). The self-check is what exercises the cores' whole **verify** half (verify_sth/accept/verify_inclusion) with **no new gossip path**.
- **`ota.rs`** — `resolve_ledger_key` reads a 32-byte ed25519 **seed** from `nvs` **sector 3** (distinct from identity sector 0 / floor sectors 1-2; survives every OTA — the image write never touches `nvs`). Modeled on `resolve_node_id`.
- **`mode.rs`** — `RadioManager` holds a `LedgerLink` (key loaded from NVS at construction); `diag_record` appends a per-cadence provenance record and surfaces the chain tip / len / self-verify / has-key, plus (on the crown) the L2 anchor + L3 STH epoch. **The publish path rides the already-retained `smol/<id>/diag` topic** — no new frame/topic surface.
- **`Cargo.toml`** — `ledger-provision` feature.

## Key provisioning — the #184 on-device-key gate (NO key generation)

The signing key is **never generated** in the firmware or CI. `resolve_ledger_key` only **reads**; a node with no key runs verify-only / publishes an **unsigned** anchor — it never fabricates one (contrast `resolve_node_id`, which auto-seeds from a baked const). Provisioning is a **deliberate JP-supervised USB touch**: a `--features ledger-provision` build reads a JP-supplied `SMOL_LEDGER_SEED` (hex, **never committed, logged, or sent over MQTT**) and seeds NVS sector 3 **once, only if erased**. The default / OTA fleet image carries neither the feature nor a seed. The seed never leaves the device.

## Size — the on-device ed25519 SIGN fits the OTA slot

The fat-LTO ed25519 unroll (the trap noted in `Cargo.toml`) is contained by the existing `[profile.release.package.ed25519-compact]` override: **espnow OTA image = 1,032,864 B (1.01 MB) vs the 1.94 MB (0x1F0000) slot — 49% headroom.**

## Gate (4-tier, all green)

- **clippy `-D warnings`:** default · wifi · espnow · cast · io · **ledger-provision** ✓
- **release builds:** espnow (1.01 MB, fits slot) · ledger-provision ✓
- **host tests:** `ledger_verify` · `treehead_verify` · `sth_verify` (the cores) · `relay_compat` · `mac_verify` ✓

## Scope boundary (HW-gated follow-up)

**Peer-STH gossip + acceptance** (verifying a *different* crown's key over the mesh) and **chain persistence to flash** are the L2-coordination follow-up the cores' own docs scope as HW-gated. This PR delivers: cores declared + used, each node's L1 chain live, the crown's anchor/STH produced + self-verified + published via DIAG, and the NVS key provisioning. Diff scanned: no key/seed material, `beginagain` = 0.

Refs #181 #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
