### PR TITLE
[HW-HELD, train TBD] #227 weather-on-glass: gateway Open-Meteo fetch → WX2 flood → fleet screen (+#228 DNS-with-fallback)

### DIFF
--- a/experiments/dns_verify/Cargo.toml
+++ b/experiments/dns_verify/Cargo.toml
@@ -1,0 +1,17 @@
+# #227/#228 host-test harness for the PURE minimal DNS A-query codec (net/dns.rs). Runs OFF-target
+# on the host (std) via `cargo run` — the firmware crate is no_std/riscv32imc and can't host-test,
+# so this #[path]-includes the REAL dns.rs (no drift) and asserts golden query bytes, a synthetic
+# CNAME-chain + compression-pointer response, and malformed/tampered rejection (every parse failure
+# must degrade to the baked fallback IP, never panic). Mirrors experiments/relay_compat.
+[package]
+name = "dns_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "dns_verify"
+path = "src/main.rs"
+
+[profile.dev]
+opt-level = 0

--- a/experiments/dns_verify/src/main.rs
+++ b/experiments/dns_verify/src/main.rs
@@ -1,0 +1,72 @@
+//! #227/#228 host verification of the PURE minimal DNS A-query codec. `#[path]`-includes the
+//! REAL `net/dns.rs` (no drift). Run: `cargo run` — panics on any failure.
+//!
+//! Coverage: golden query bytes for `api.open-meteo.com` · response parse through a CNAME chain
+//! with compression pointers (the realistic resolver answer shape) · rejection of wrong-txid /
+//! non-response / NXDOMAIN / zero-answer / truncated / pointer-loop packets (every failure is a
+//! clean `None` → the caller falls back to the baked IP; a panic on a hostile packet would be a
+//! remote crash).
+
+#[path = "../../../rust/clock/src/net/dns.rs"]
+mod dns;
+
+use dns::{encode_a_query, parse_a_response, DNS_QUERY_MAX};
+
+fn main() {
+    // --- golden query bytes -------------------------------------------------
+    let mut q = [0u8; DNS_QUERY_MAX];
+    let n = encode_a_query(0xBEEF, "api.open-meteo.com", &mut q).expect("encode");
+    // header: txid BEEF, RD, QD=1
+    let mut golden = vec![0xBE, 0xEF, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+    golden.extend_from_slice(b"\x03api\x0aopen-meteo\x03com\x00"); // qname
+    golden.extend_from_slice(&[0x00, 0x01, 0x00, 0x01]); // QTYPE=A, QCLASS=IN
+    assert_eq!(&q[..n], &golden[..], "golden A-query wire bytes");
+    assert_eq!(n, 36, "api.open-meteo.com query is 36 bytes");
+
+    // encode rejects an over-long label + an empty host.
+    let long = "a".repeat(64);
+    assert!(encode_a_query(1, &long, &mut q).is_none(), "64-char label rejected");
+    assert!(encode_a_query(1, "", &mut q).is_none(), "empty host rejected");
+
+    // --- realistic response: question echo + CNAME (pointer name) + A -------
+    // Build: header(QR=1, RCODE=0, QD=1, AN=2) | question | CNAME answer | A answer.
+    let mut r = vec![0xBE, 0xEF, 0x81, 0x80, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00];
+    r.extend_from_slice(b"\x03api\x0aopen-meteo\x03com\x00\x00\x01\x00\x01"); // question
+    // answer 1: name = pointer to offset 12 (the question name), TYPE=CNAME(5), rdata = pointer name (2B)
+    r.extend_from_slice(&[0xC0, 0x0C, 0x00, 0x05, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3C, 0x00, 0x02, 0xC0, 0x10]);
+    // answer 2: name = pointer, TYPE=A(1), CLASS=IN, TTL, RDLENGTH=4, rdata = 188.40.99.226
+    r.extend_from_slice(&[0xC0, 0x0C, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3C, 0x00, 0x04, 188, 40, 99, 226]);
+    assert_eq!(
+        parse_a_response(0xBEEF, &r),
+        Some([188, 40, 99, 226]),
+        "CNAME-chain response yields the A record"
+    );
+
+    // --- rejection cases (all must be a clean None) --------------------------
+    assert_eq!(parse_a_response(0xDEAD, &r), None, "wrong txid rejected");
+    let mut bad = r.clone();
+    bad[2] = 0x01; // QR=0 → not a response
+    assert_eq!(parse_a_response(0xBEEF, &bad), None, "non-response rejected");
+    let mut nx = r.clone();
+    nx[3] = 0x83; // RCODE=3 NXDOMAIN
+    assert_eq!(parse_a_response(0xBEEF, &nx), None, "NXDOMAIN rejected");
+    let mut zero = r.clone();
+    zero[6] = 0;
+    zero[7] = 0; // ANCOUNT=0
+    assert_eq!(parse_a_response(0xBEEF, &zero), None, "zero answers rejected");
+    for cut in [0usize, 5, 11, 13, 30, r.len() - 3] {
+        assert_eq!(parse_a_response(0xBEEF, &r[..cut]), None, "truncated at {cut} rejected");
+    }
+    // hostile: a label that claims to run past the end.
+    let mut runaway = vec![0xBE, 0xEF, 0x81, 0x80, 0x00, 0x01, 0x00, 0x01, 0, 0, 0, 0];
+    runaway.extend_from_slice(&[0x3F, b'x']); // label len 63 but only 1 byte present
+    assert_eq!(parse_a_response(0xBEEF, &runaway), None, "runaway label rejected");
+
+    // A-record-only response (no CNAME) also parses — the simple resolver shape.
+    let mut simple = vec![0xBE, 0xEF, 0x81, 0x80, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00];
+    simple.extend_from_slice(b"\x03api\x0aopen-meteo\x03com\x00\x00\x01\x00\x01");
+    simple.extend_from_slice(&[0xC0, 0x0C, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x01, 0x2C, 0x00, 0x04, 1, 2, 3, 4]);
+    assert_eq!(parse_a_response(0xBEEF, &simple), Some([1, 2, 3, 4]), "plain A response");
+
+    println!("dns_verify: ALL CHECKS PASSED (golden query + CNAME-chain/pointer parse + hostile-packet rejection)");
+}

--- a/experiments/wx_verify/Cargo.toml
+++ b/experiments/wx_verify/Cargo.toml
@@ -1,0 +1,16 @@
+# #227 host-test harness for the PURE weather codec (net/wx.rs): the no-serde Open-Meteo JSON
+# scrape (with the current_units string-value skip), the WX|<tempF>|<code> mesh-payload codec
+# round-trip, and the WMO label table bounds. #[path]-includes the REAL wx.rs (no drift).
+# Mirrors experiments/relay_compat + dns_verify. Run: `cargo run` — panics on failure.
+[package]
+name = "wx_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "wx_verify"
+path = "src/main.rs"
+
+[profile.dev]
+opt-level = 0

--- a/experiments/wx_verify/src/main.rs
+++ b/experiments/wx_verify/src/main.rs
@@ -1,0 +1,73 @@
+//! #227 host verification of the PURE weather codec. `#[path]`-includes the REAL `net/wx.rs`
+//! (no drift). Run: `cargo run` — panics on any failure.
+
+#[path = "../../../rust/clock/src/net/wx.rs"]
+mod wx;
+
+use wx::{encode_wx, parse_open_meteo, parse_wx, wmo_label, WX_PAYLOAD_MAX};
+
+fn main() {
+    // --- Open-Meteo scrape: real response shape, incl. the current_units STRING repeat ------
+    // The `current_units` object repeats both keys with string values — the scrape must skip
+    // them and land on the numeric values in `current`. This is the exact trap the watch's
+    // parser was built around.
+    let body: &[u8] = r#"HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"latitude":47.6,"longitude":-122.3,"generationtime_ms":0.05,"utc_offset_seconds":0,
+"current_units":{"time":"iso8601","interval":"seconds","temperature_2m":"°F","weather_code":"wmo code"},
+"current":{"time":"2026-07-20T05:00","interval":900,"temperature_2m":72.6,"weather_code":3}}"#
+        .as_bytes();
+    let (t, c) = parse_open_meteo(body).expect("scrape");
+    assert_eq!(t, 73, "72.6F rounds to 73");
+    assert_eq!(c, 3, "WMO code 3");
+
+    // negative temp + rounding down + fractional code position
+    let cold: &[u8] = r#"{"current_units":{"temperature_2m":"°F","weather_code":"wmo"},
+"current":{"temperature_2m":-8.4,"weather_code":71}}"#
+        .as_bytes();
+    assert_eq!(parse_open_meteo(cold), Some((-8, 71)), "-8.4F rounds to -8, snow code");
+
+    // missing keys / non-numeric only → None (fetch fails soft)
+    assert_eq!(parse_open_meteo(br#"{"current_units":{"temperature_2m":"F"}}"#), None);
+    assert_eq!(parse_open_meteo(b"HTTP/1.0 500 nope"), None);
+    assert_eq!(parse_open_meteo(b""), None);
+
+    // --- WX| payload codec round-trip --------------------------------------------------------
+    let mut buf = [0u8; WX_PAYLOAD_MAX];
+    let n = encode_wx(73, 3, &mut buf);
+    assert_eq!(&buf[..n], b"WX|73|3", "golden payload bytes");
+    assert_eq!(parse_wx(&buf[..n]), Some((73, 3)), "round-trip");
+
+    let n = encode_wx(-8, 71, &mut buf);
+    assert_eq!(&buf[..n], b"WX|-8|71", "negative temp payload");
+    assert_eq!(parse_wx(&buf[..n]), Some((-8, 71)), "negative round-trip");
+
+    // extremes + width bound
+    let n = encode_wx(-999, 255, &mut buf);
+    assert_eq!(&buf[..n], b"WX|-999|255");
+    assert!(n <= WX_PAYLOAD_MAX, "worst case fits WX_PAYLOAD_MAX");
+    assert_eq!(parse_wx(&buf[..n]), Some((-999, 255)));
+
+    // forward-compat: extra future fields are ignored (the #100 additive rule)
+    assert_eq!(parse_wx(b"WX|73|3|55|hi"), Some((73, 3)), "extra fields ignored");
+
+    // rejection: wrong tag, garbage, out-of-range, empty
+    assert_eq!(parse_wx(b"BATT|48V"), None);
+    assert_eq!(parse_wx(b"WX|"), None);
+    assert_eq!(parse_wx(b"WX|abc|3"), None);
+    assert_eq!(parse_wx(b"WX|1000|3"), None, "temp out of range");
+    assert_eq!(parse_wx(b"WX|70|300"), None, "code out of range");
+    assert_eq!(parse_wx(b""), None);
+
+    // --- WMO label table: total + short enough for the 72px glass (14 chars of FONT_5X8) ----
+    for code in 0..=255u16 {
+        let l = wmo_label(code as u8);
+        assert!(!l.is_empty() && l.len() <= 13, "label for {code} fits the glass: {l}");
+    }
+    assert_eq!(wmo_label(0), "Clear");
+    assert_eq!(wmo_label(95), "Thunderstorm");
+    assert_eq!(wmo_label(42), "Weather", "unknown codes get the safe default");
+
+    println!("wx_verify: ALL CHECKS PASSED (scrape + units-skip + payload round-trip + WMO table)");
+}

--- a/rust/clock/src/app.rs
+++ b/rust/clock/src/app.rs
@@ -121,6 +121,12 @@ pub struct Ctx<'a> {
     /// while this screen is inactive, so the plugin only reads it. cfg(wifi).
     #[cfg(feature = "wifi")]
     pub grid: &'a crate::grid::GridCache,
+    /// #227 weather cache (the Weather screen), borrowed read-only. Owned by `main`,
+    /// filled by the gateway's Open-Meteo fetch (`net/wifi.rs::fetch_weather`) or an
+    /// inbound WX2 frame — either can happen while this screen is inactive, so the
+    /// plugin only reads it. cfg(wifi), the Batt/Grid twin.
+    #[cfg(feature = "wifi")]
+    pub wx: &'a crate::weather::WxCache,
     // --- espnow-only ---
     /// The Clock bottom-line label under espnow: the radio service's most-recent
     /// peer/mesh message (`bottom_line`, owned by `main`). Non-espnow builds derive
@@ -189,6 +195,11 @@ pub enum AppKind {
     // is wifi-only (espnow ⊃ wifi).
     #[cfg(feature = "wifi")]
     Grid,
+    // #227 Weather — Open-Meteo current conditions, gateway-fetched + WX2-relayed. LIVE
+    // whenever compiled (REGISTRY row + `enter` construct it), like Batt/Grid. cfg(wifi):
+    // the screen tier matches Batt (the fetch/relay half is espnow, ⊃ wifi).
+    #[cfg(feature = "wifi")]
+    Weather,
     #[cfg(feature = "espnow")]
     Bench,
     #[cfg(feature = "espnow")]
@@ -254,6 +265,8 @@ impl AppKind {
             "About" => AppKind::About,
             "Batt" => AppKind::Batt,
             "Grid" => AppKind::Grid,
+            // #227: a node's default screen can be set to Weather via #21 too.
+            "Weather" => AppKind::Weather,
             #[cfg(feature = "espnow")]
             "Bench" => AppKind::Bench,
             #[cfg(feature = "espnow")]
@@ -295,6 +308,8 @@ impl AppKind {
             AppKind::Batt => "Batt",
             #[cfg(feature = "wifi")]
             AppKind::Grid => "Grid",
+            #[cfg(feature = "wifi")]
+            AppKind::Weather => "Weather",
             #[cfg(feature = "espnow")]
             AppKind::Bench => "Bench",
             #[cfg(feature = "espnow")]
@@ -366,6 +381,8 @@ pub enum App {
     Batt(crate::batt::BattState),
     #[cfg(feature = "wifi")]
     Grid(crate::grid::GridState),
+    #[cfg(feature = "wifi")]
+    Weather(crate::weather::WxState),
     #[cfg(feature = "espnow")]
     Bench(crate::bench::BenchState),
     #[cfg(feature = "espnow")]
@@ -398,6 +415,8 @@ impl App {
             AppKind::Batt => App::Batt(crate::batt::BattState::new()),
             #[cfg(feature = "wifi")]
             AppKind::Grid => App::Grid(crate::grid::GridState::new()),
+            #[cfg(feature = "wifi")]
+            AppKind::Weather => App::Weather(crate::weather::WxState::new()),
             #[cfg(feature = "espnow")]
             AppKind::Bench => App::Bench(crate::bench::BenchState::new()),
             #[cfg(feature = "espnow")]
@@ -439,6 +458,8 @@ impl App {
             App::Batt(s) => Plugin::on_button(s, press, ctx),
             #[cfg(feature = "wifi")]
             App::Grid(s) => Plugin::on_button(s, press, ctx),
+            #[cfg(feature = "wifi")]
+            App::Weather(s) => Plugin::on_button(s, press, ctx),
             #[cfg(feature = "espnow")]
             App::Bench(s) => Plugin::on_button(s, press, ctx),
             #[cfg(feature = "espnow")]
@@ -469,6 +490,8 @@ impl App {
             App::Batt(s) => Plugin::update(s, ctx),
             #[cfg(feature = "wifi")]
             App::Grid(s) => Plugin::update(s, ctx),
+            #[cfg(feature = "wifi")]
+            App::Weather(s) => Plugin::update(s, ctx),
             #[cfg(feature = "espnow")]
             App::Bench(s) => Plugin::update(s, ctx),
             #[cfg(feature = "espnow")]
@@ -519,6 +542,8 @@ impl App {
             App::Batt(s) => (AppKind::Batt, s.page()),
             #[cfg(feature = "wifi")]
             App::Grid(s) => (AppKind::Grid, s.page()),
+            #[cfg(feature = "wifi")]
+            App::Weather(_) => (AppKind::Weather, 0),
             #[cfg(feature = "espnow")]
             App::Bench(_) => (AppKind::Bench, 0),
             #[cfg(feature = "espnow")]
@@ -580,6 +605,9 @@ pub const REGISTRY: &[AppDesc] = &[
     AppDesc { title: "Batt", kind: AppKind::Batt },
     #[cfg(feature = "wifi")]
     AppDesc { title: "Grid", kind: AppKind::Grid },
+    // #227 Weather — gateway Open-Meteo fetch relayed fleet-wide. wifi tier, like Batt/Grid.
+    #[cfg(feature = "wifi")]
+    AppDesc { title: "Weather", kind: AppKind::Weather },
     // #25 WLED remote — only in a wled build (menu grows by one row; the scrolling
     // window math in menu.rs is length-relative, so it just works).
     #[cfg(feature = "wled")]
@@ -624,6 +652,11 @@ pub const fn plugin_bit(kind: AppKind) -> Option<u8> {
         AppKind::Batt => Some(3),
         #[cfg(feature = "wifi")]
         AppKind::Grid => Some(4),
+        // #227 Weather is NON-maskable (like Custom/Watch/Hunt/Finder): luna's live #55 mask
+        // is the original 7 bits (all-on 007F) — giving Weather a new bit would let a legacy
+        // mask permanently hide it. `None` ⇒ always shown; revisit with a paired HA mask change.
+        #[cfg(feature = "wifi")]
+        AppKind::Weather => None,
         #[cfg(feature = "wled")]
         AppKind::WledRemote => Some(5),
         AppKind::About => Some(6),

--- a/rust/clock/src/board.rs.example
+++ b/rust/clock/src/board.rs.example
@@ -52,7 +52,7 @@ const fn parse_node_id(s: &str) -> u8 {
 /// The screen this board enters at BOOT instead of the Home menu (issue #18).
 /// Valid values, by the feature tier the firmware is built with:
 ///   * always:              `AppKind::Menu` · `AppKind::Clock` · `AppKind::Snake` · `AppKind::About`
-///   * `--features wifi`:   + `AppKind::Batt` · `AppKind::Grid`
+///   * `--features wifi`:   + `AppKind::Batt` · `AppKind::Grid` · `AppKind::Weather`
 ///   * `--features espnow`: + `AppKind::Bench` · `AppKind::MeshSnake`
 ///
 /// `AppKind::Menu` (the default) boots straight to the Home menu — the historical
@@ -91,3 +91,25 @@ pub const DEFAULT_PAGE: u8 = 0;
 /// ```
 #[cfg(feature = "mesh-test")]
 pub const DEAF_MACS: [Option<[u8; 6]>; 4] = [None; 4];
+
+// --- #227 weather-on-glass (espnow builds only) --------------------------------
+// The GATEWAY fetches current weather from Open-Meteo during its WiFi flush window
+// and relays `WX|<tempF>|<code>` to the fleet. These are ENVIRONMENT-SPECIFIC
+// (your location + a resolved frontend IP), so — per the public-repo rule — the
+// real values live only in the git-ignored `board.rs`; this template ships neutral
+// placeholders (Seattle, the watch reference's example coordinates).
+
+/// Forecast location, as the decimal-string lat/lon Open-Meteo takes in the URL
+/// (strings so no_std float formatting is never needed). ~1 decimal place is
+/// plenty (11 km) and avoids over-precise home coordinates ON the wire.
+#[cfg(feature = "espnow")]
+pub const WEATHER_LAT: &str = "47.6";
+#[cfg(feature = "espnow")]
+pub const WEATHER_LON: &str = "-122.3";
+
+/// #228 part-2: the DNS-fallback IP for `api.open-meteo.com` — used ONLY when the
+/// one-shot DNS A-query fails (no DHCP resolver / timeout / hostile reply). The
+/// proper `Host:` header is always sent (Open-Meteo is name-routed behind a shared
+/// frontend). Refresh at build-review time: `getent hosts api.open-meteo.com`.
+#[cfg(feature = "espnow")]
+pub const WEATHER_FALLBACK_IP: [u8; 4] = [188, 40, 99, 226];

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -164,6 +164,13 @@ mod batt;
 #[cfg(feature = "wifi")]
 mod grid;
 
+// #227 weather screen (Weather): the display-only Plugin + its `WxCache` — the Batt/Grid
+// display-case shape with the SOURCE being the gateway's Open-Meteo HTTP fetch during the
+// flush window (net/wifi.rs::fetch_weather) instead of an HA retained topic; leaves fill
+// the cache from the WX2 freshness flood.
+#[cfg(feature = "wifi")]
+mod weather;
+
 // OTA self-update engine (issue #6): announce parse/gate, streaming image writer
 // (HTTP body → flash + HW-SHA), otadata slot activate, and the first-boot
 // self-test/rollback (MF-1). Needs radio + flash-from-running-fw → wifi-only.
@@ -506,6 +513,17 @@ fn main() -> ! {
     // from the gateway's SMOLv1 GRID frame (`take_grid_offer`). cfg(wifi).
     #[cfg(feature = "wifi")]
     let mut grid_cache = grid::GridCache::new();
+
+    // --- #227 weather cache (Weather screen) ---------------------------------
+    // The Batt/Grid twin with an HTTP source: owned by `main`, borrowed read-only via
+    // `Ctx::wx`, filled on the GATEWAY by the Open-Meteo fetch riding the flush window
+    // (threaded &mut into `flush_telemetry` → `run_mqtt_burst` → `fetch_weather`) and,
+    // on a leaf, from the gateway's SMOLv1 WX2 flood (`take_wx_offer`). cfg(wifi).
+    // (cfg_attr: both fill paths — the gateway fetch and the WX2 offer — are espnow-only, so
+    // on plain wifi the cache is never mutated; the Weather screen renders its empty state.)
+    #[cfg(feature = "wifi")]
+    #[cfg_attr(not(feature = "espnow"), allow(unused_mut))]
+    let mut wx_cache = weather::WxCache::new();
 
     // --- Radio bring-up (feature-dependent) ----------------------------------
     // Each branch yields `synced` (Option<u32> Unix time at boot). Phase 3 also
@@ -927,6 +945,13 @@ fn main() -> ! {
                 grid_cache.store(&o.buf[..o.len], now);
                 redraw = true;
             }
+            // #227: the gateway's SMOLv1 WX2 weather flood, buffered in `service`,
+            // stored so leaves render the weather too. `store` validates the `WX|`
+            // marker + a full parse (mirror of BATT/GRID, plus the parse gate).
+            if let Some(o) = r.take_wx_offer() {
+                wx_cache.store(&o.buf[..o.len], now);
+                redraw = true;
+            }
             // Mesh time adoption: if a peer's clock descends from a STRICTLY
             // newer authoritative sync than ours, re-anchor onto its estimate
             // NOW and INHERIT its `synced_at` (not `now`). Because freshness
@@ -1027,6 +1052,16 @@ fn main() -> ! {
             {
                 let unix_now = base_unix + (now.saturating_sub(anchor_ms) / 1000) as u32;
                 r.broadcast_grid(grid_cache.bytes(), unix_now);
+            }
+            // #227 WX2 re-broadcast: same ~10 s gateway-only cadence as BATT/GRID
+            // (weather moves even slower; the DlOrigin seq bumps only on a CHANGED
+            // reading, so relays re-flood a new fetch once and stay quiet otherwise).
+            if r.is_gateway()
+                && !wx_cache.is_empty()
+                && (now / 10_000) != ((now.saturating_sub(SUBTICK_MS as u64)) / 10_000)
+            {
+                let unix_now = base_unix + (now.saturating_sub(anchor_ms) / 1000) as u32;
+                r.broadcast_wx(wx_cache.bytes(), unix_now);
             }
             // #21 leaf-relay: a GATEWAY re-broadcasts each cached leaf's dashboard-set
             // default screen as a SMOLv1 CFG frame on the SAME ~10 s cadence as
@@ -1221,7 +1256,7 @@ fn main() -> ! {
                     // #40: a flush that hears a leaf's retained OTA install surfaces
                     // `(leaf_id, staged announce)` here → relayed below.
                     let mut leaf_ota: Option<(u8, ota::Announce)> = None;
-                    r.flush_telemetry(own.as_bytes(), stat.as_bytes(), &mut batt_cache, &mut grid_cache, &mut leaf_ota, &mut || {
+                    r.flush_telemetry(own.as_bytes(), stat.as_bytes(), &mut batt_cache, &mut grid_cache, &mut wx_cache, &mut leaf_ota, &mut || {
                         let t = millis();
                         led.apply(led::LedState::WifiSync, t);
                         if matches!(button.poll(t), Some(input::Press::Long)) {
@@ -1619,6 +1654,9 @@ fn main() -> ! {
             batt: &batt_cache,
             #[cfg(feature = "wifi")]
             grid: &grid_cache,
+            // #227 weather cache — read by the Weather plugin (the Batt/Grid twin).
+            #[cfg(feature = "wifi")]
+            wx: &wx_cache,
             #[cfg(feature = "espnow")]
             label: bottom_line.as_str(),
             #[cfg(feature = "espnow")]

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -93,6 +93,23 @@ pub mod cast;
 #[cfg(feature = "cast")]
 pub mod cast_oled;
 
+// #227 weather-on-glass: the PURE weather codec (no-serde Open-Meteo JSON scrape, the
+// `WX|<tempF>|<code>` mesh-payload codec, the WMO→label table). Host-tested in
+// experiments/wx_verify, no HAL deps — the `wire`/`flood` pattern. wifi-gated: the Weather
+// screen (wifi, like Batt) parses the payload; the fetch/scrape half (parse_open_meteo /
+// encode_wx) is espnow-only, so the wifi-without-espnow profile allows dead-code on the module
+// (the same shape as net.rs's assert_max_tx_power cfg_attr).
+#[cfg(feature = "wifi")]
+#[cfg_attr(not(feature = "espnow"), allow(dead_code))]
+pub mod wx;
+
+// #227/#228: the PURE minimal DNS A-query codec (one-shot resolve of api.open-meteo.com over
+// the already-enabled smoltcp `socket-udp`; fallback = the git-ignored board.rs IP). Host-tested
+// in experiments/dns_verify. espnow-gated: its only driver is the weather fetch inside
+// `run_mqtt_burst` (espnow), exactly like `etx`/`flood`.
+#[cfg(feature = "espnow")]
+pub mod dns;
+
 // Deterministic magical node names (realm-sigil port). Needs no radio — a node
 // derives its OWN name and any peer's name from the logical id alone — so it is
 // compiled in ALL builds (peer names are only *displayed* under espnow, but our

--- a/rust/clock/src/net/dns.rs
+++ b/rust/clock/src/net/dns.rs
@@ -1,0 +1,135 @@
+//! #227/#228 — the PURE minimal DNS A-query codec (encode one question, parse one answer).
+//!
+//! ## Why this exists (the #228 part-2 decision)
+//! smol is IP-only by design (`net/wifi.rs`: "we hardcode an anycast IP so we need no DNS
+//! resolver in the smoltcp build") — every LAN target is a baked IP. The ONE path that must
+//! resolve a real internet hostname is the #227 weather fetch (`api.open-meteo.com`), whose
+//! frontend IPs rotate. Rather than enable smoltcp's `socket-dns` resolver (a new feature +
+//! background machinery), this is a **hand-rolled one-shot A query** over the already-enabled
+//! `socket-udp` — the same pattern as smol's hand-rolled MQTT 3.1.1 codec and the SNTP
+//! one-datagram exchange (`step_sntp`). On ANY failure the caller falls back to the baked
+//! `WEATHER_FALLBACK_IP` (git-ignored `board.rs`), so the failure mode degrades to exactly the
+//! IP-only behavior smol has everywhere else.
+//!
+//! ## Pure + host-testable
+//! No `esp-hal`/`esp-wifi`/smoltcp deps — `&[u8]` in/out, total (never panics on hostile
+//! input). Host-tested in `experiments/dns_verify` (golden query bytes + a synthetic
+//! CNAME-chain response + compression pointers + malformed/tampered rejection). The driver
+//! (bind ephemeral port → send to resolver:53 → await one reply) lives in `net/wifi.rs`.
+
+/// Max encoded query we ever build: 12-byte header + QNAME (≤255) + QTYPE/QCLASS.
+pub const DNS_QUERY_MAX: usize = 12 + 255 + 4;
+/// A practical response buffer size: one question + a short CNAME chain + a few A records.
+/// Open-Meteo's answer is ~100-200 B; 512 gives ample margin (a truncated response fails
+/// closed → fallback IP).
+pub const DNS_RESPONSE_MAX: usize = 512;
+/// The standard DNS port.
+pub const DNS_PORT: u16 = 53;
+
+/// Encode a recursion-desired A-record query for `host` into `out`; returns the total length,
+/// or `None` if the host has an over-long label (>63) / total (>253) or `out` is too small.
+/// Layout: `txid(2) | flags 0x0100 | QD=1 | AN/NS/AR=0 | qname | QTYPE=A(1) | QCLASS=IN(1)`.
+pub fn encode_a_query(txid: u16, host: &str, out: &mut [u8]) -> Option<usize> {
+    // 12-byte header.
+    if out.len() < 12 || host.is_empty() || host.len() > 253 {
+        return None;
+    }
+    out[0] = (txid >> 8) as u8;
+    out[1] = txid as u8;
+    out[2] = 0x01; // RD (recursion desired)
+    out[3] = 0x00;
+    out[4] = 0x00;
+    out[5] = 0x01; // QDCOUNT = 1
+    out[6..12].fill(0);
+    let mut n = 12;
+    for label in host.split('.') {
+        let l = label.len();
+        if l == 0 || l > 63 || n + 1 + l + 5 > out.len() {
+            return None; // empty/over-long label, or no room for label + terminator + QTYPE/QCLASS
+        }
+        out[n] = l as u8;
+        out[n + 1..n + 1 + l].copy_from_slice(label.as_bytes());
+        n += 1 + l;
+    }
+    out[n] = 0; // root terminator
+    n += 1;
+    out[n..n + 4].copy_from_slice(&[0x00, 0x01, 0x00, 0x01]); // QTYPE=A, QCLASS=IN
+    Some(n + 4)
+}
+
+/// Skip an (possibly compression-pointed) encoded name starting at `pos`; returns the index just
+/// past it, or `None` on truncation/malformation. A pointer (`0b11......`) ends the name in 2
+/// bytes; plain labels run to the 0 terminator. Bounded (≤ 128 labels) so a hostile packet can't
+/// loop us.
+fn skip_name(data: &[u8], mut pos: usize) -> Option<usize> {
+    for _ in 0..128 {
+        let b = *data.get(pos)?;
+        if b == 0 {
+            return Some(pos + 1);
+        }
+        if b & 0xC0 == 0xC0 {
+            // Compression pointer: 2 bytes, name ends here (the target is elsewhere; we never
+            // need to expand names — only to skip past them).
+            return (pos + 2 <= data.len()).then_some(pos + 2);
+        }
+        if b & 0xC0 != 0 {
+            return None; // reserved label type
+        }
+        pos = pos + 1 + b as usize;
+        if pos > data.len() {
+            return None;
+        }
+    }
+    None
+}
+
+/// Parse a response to [`encode_a_query`]: match `txid`, require QR=1 + RCODE=0, skip the echoed
+/// question(s), then return the FIRST `A`/`IN` answer's 4-byte address. CNAME records in the
+/// answer chain are skipped (the resolver follows them; the A record is in the same message).
+/// Total — any truncation/tamper/NXDOMAIN returns `None` (the caller falls back to the baked IP).
+pub fn parse_a_response(txid: u16, data: &[u8]) -> Option<[u8; 4]> {
+    if data.len() < 12 {
+        return None;
+    }
+    if data[0] != (txid >> 8) as u8 || data[1] != txid as u8 {
+        return None; // not our transaction
+    }
+    if data[2] & 0x80 == 0 {
+        return None; // not a response
+    }
+    if data[3] & 0x0F != 0 {
+        return None; // RCODE != NOERROR (NXDOMAIN/SERVFAIL/…)
+    }
+    let qdcount = u16::from_be_bytes([data[4], data[5]]) as usize;
+    let ancount = u16::from_be_bytes([data[6], data[7]]) as usize;
+    if ancount == 0 {
+        return None;
+    }
+    // Skip the echoed question section: name + QTYPE(2) + QCLASS(2), qdcount times.
+    let mut pos = 12;
+    for _ in 0..qdcount.min(4) {
+        pos = skip_name(data, pos)? + 4;
+        if pos > data.len() {
+            return None;
+        }
+    }
+    // Walk the answers: name + TYPE(2) CLASS(2) TTL(4) RDLENGTH(2) + RDATA.
+    for _ in 0..ancount.min(16) {
+        pos = skip_name(data, pos)?;
+        if pos + 10 > data.len() {
+            return None;
+        }
+        let rtype = u16::from_be_bytes([data[pos], data[pos + 1]]);
+        let rclass = u16::from_be_bytes([data[pos + 2], data[pos + 3]]);
+        let rdlen = u16::from_be_bytes([data[pos + 8], data[pos + 9]]) as usize;
+        pos += 10;
+        if pos + rdlen > data.len() {
+            return None;
+        }
+        if rtype == 1 && rclass == 1 && rdlen == 4 {
+            return Some([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
+        }
+        pos += rdlen; // CNAME / other record — skip its RDATA, keep walking
+    }
+    None
+}

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -471,6 +471,10 @@ enum Frame<'a> {
     Batt2 { seq: u32, payload: &'a [u8] },
     /// #13 Stage B: the grid twin of [`Frame::Batt2`].
     Grid2 { seq: u32, payload: &'a [u8] },
+    /// #227: the weather downlink — the third freshness-flooded channel (payload is the
+    /// verbatim `WX|<tempF>|<code>` bytes from the gateway's Open-Meteo fetch, borrows the
+    /// RX buffer). Same strict-newer adopt + re-flood mechanics as [`Frame::Batt2`].
+    Wx2 { seq: u32, payload: &'a [u8] },
     /// #21/#56 leaf-relay: a gateway's keyed CONFIG downlink — `target` leaf id, the config
     /// channel `key` (`S`=screen/…), + the verbatim `value` bytes (`value` borrows the RX
     /// buffer; the leaf buffers it per-key in `CfgTracker` in `service` IFF `target ==
@@ -768,6 +772,49 @@ impl GridTracker {
 #[derive(Clone, Copy)]
 pub struct GridOffer {
     pub buf: [u8; GRID_PAYLOAD_MAX],
+    pub len: usize,
+}
+
+/// #227: buffers the most-recent inbound WX2 weather payload — the third
+/// [`BattTracker`]/[`GridTracker`] twin. `service()` only BUFFERS; `main` takes it via
+/// [`RadioManager::take_wx_offer`] and writes its `WxCache`. Fixed `.bss`, no heap.
+struct WxTracker {
+    buf: [u8; crate::net::wx::WX_PAYLOAD_MAX],
+    len: usize,
+    have: bool,
+    /// Freshness `seq` of the last-adopted WX2 (twin of `BattTracker::dl_seq`).
+    dl_seq: u32,
+}
+
+impl WxTracker {
+    const fn new() -> Self {
+        Self { buf: [0; crate::net::wx::WX_PAYLOAD_MAX], len: 0, have: false, dl_seq: 0 }
+    }
+
+    /// Buffer a freshly-received payload (truncated to capacity; ≤ 32 B by spec).
+    fn set(&mut self, payload: &[u8]) {
+        let n = payload.len().min(crate::net::wx::WX_PAYLOAD_MAX);
+        self.buf[..n].copy_from_slice(&payload[..n]);
+        self.len = n;
+        self.have = true;
+    }
+
+    /// Strict-newer adopt + re-flood decision (twin of `BattTracker::set_fresh`).
+    fn set_fresh(&mut self, payload: &[u8], seq: u32) -> bool {
+        if self.have && seq <= self.dl_seq {
+            return false;
+        }
+        self.set(payload);
+        self.dl_seq = seq;
+        true
+    }
+}
+
+/// A `Copy` snapshot of a buffered WX2 payload handed to `main` by
+/// [`RadioManager::take_wx_offer`]. `buf[..len]` is the verbatim `WX|…` bytes.
+#[derive(Clone, Copy)]
+pub struct WxOffer {
+    pub buf: [u8; crate::net::wx::WX_PAYLOAD_MAX],
     pub len: usize,
 }
 
@@ -1855,11 +1902,16 @@ pub struct RadioManager {
     /// Twin of `batt` (issue #16): most-recent inbound SMOLv1 GRID payload, buffered
     /// for `main` to store into its `GridCache`.
     grid: GridTracker,
+    /// #227: third tracker twin — most-recent inbound SMOLv1 WX2 weather payload, buffered
+    /// for `main` to store into its `WxCache`.
+    wx: WxTracker,
     /// #13 Stage B: GATEWAY-origin freshness state for the BATT2/GRID2 downlink — assigns the
     /// monotonic `dl_seq` (bumped only on a value change) so relays re-flood strictly-newer data.
     /// Inert on a leaf (a leaf never originates downlink; it adopts via the trackers above).
     dl_batt: DlOrigin,
     dl_grid: DlOrigin,
+    /// #227: the WX2 origin twin (seq bumps only when the fetched reading changes).
+    dl_wx: DlOrigin,
     /// #21/#56 leaf-relay (LEAF side): most-recent inbound `SMOLv1 CFG` value PER config
     /// key that targeted THIS leaf, buffered for `main` to apply via `take_cfg_offer(key)`.
     cfg: CfgTracker,
@@ -2102,8 +2154,10 @@ impl RadioManager {
             roster: Roster::new(),
             batt: BattTracker::new(),
             grid: GridTracker::new(),
+            wx: WxTracker::new(),
             dl_batt: DlOrigin::new(),
             dl_grid: DlOrigin::new(),
+            dl_wx: DlOrigin::new(),
             cfg: CfgTracker::new(),
             cfg_cache: crate::net::wifi::CfgCache::new(),
             stat_cache: crate::net::wifi::CfgCache::new(),
@@ -2334,6 +2388,7 @@ impl RadioManager {
                     &empty,
                     batt,
                     grid,
+                    None, // #227: a leaf recovery burst never fetches weather (gateway-only)
                     &mut elect,
                     &mut ota_offer,
                     &mut config_offer,
@@ -2688,6 +2743,32 @@ impl RadioManager {
         if self.grid.have {
             self.grid.have = false;
             Some(GridOffer { buf: self.grid.buf, len: self.grid.len })
+        } else {
+            None
+        }
+    }
+
+    /// #227: broadcast the weather downlink as a `SMOLv1 WX2` frame — the third
+    /// [`broadcast_batt`] twin: tag + 10-digit `dl_seq` + the verbatim `WX|…` payload, seq
+    /// bumped only when the READING changes (a 30-min re-fetch returning the same temp/code
+    /// doesn't re-flood the mesh). GATEWAY-ONLY, same ~10 s `main` cadence as BATT/GRID.
+    ///
+    /// [`broadcast_batt`]: RadioManager::broadcast_batt
+    pub fn broadcast_wx(&mut self, payload: &[u8], now_unix: u32) {
+        let seq = self.dl_wx.seq_for(payload, now_unix);
+        let mut msg = [0u8; DL_FRAME_MAX];
+        let len = encode_dl(WX2_PREFIX, seq, payload, &mut msg);
+        self.send_to(&BROADCAST_ADDRESS, &msg[..len]);
+    }
+
+    /// Take the buffered inbound WX2 payload (if any), clearing it. Third twin of
+    /// [`take_batt_offer`]; `main` stores the bytes into its `WxCache`.
+    ///
+    /// [`take_batt_offer`]: RadioManager::take_batt_offer
+    pub fn take_wx_offer(&mut self) -> Option<WxOffer> {
+        if self.wx.have {
+            self.wx.have = false;
+            Some(WxOffer { buf: self.wx.buf, len: self.wx.len })
         } else {
             None
         }
@@ -4239,6 +4320,7 @@ impl RadioManager {
         }
     }
 
+    #[allow(clippy::too_many_arguments)] // #227's wx cache tips this to 8 params (like run_mqtt_burst)
     pub fn flush_telemetry(
         &mut self,
         own_telemetry: &[u8],
@@ -4247,6 +4329,9 @@ impl RadioManager {
         status: &[u8],
         batt: &mut crate::batt::BattCache,
         grid: &mut crate::grid::GridCache,
+        // #227: the weather cache — the burst's post-session slot re-fetches Open-Meteo into it
+        // when stale (gateway flush only; the leaf recovery burst passes None downstream).
+        wx: &mut crate::weather::WxCache,
         // #40: filled with `(leaf_id, staged announce)` if this flush surfaced a leaf OTA
         // install → `main` then calls `run_leaf_ota_relay` for that leaf. `None` otherwise.
         leaf_ota: &mut Option<(u8, crate::ota::Announce)>,
@@ -4350,6 +4435,7 @@ impl RadioManager {
                     &items[..n],
                     batt,
                     grid,
+                    Some(wx), // #227: gateway flush — refresh the weather in the post-session slot
                     &mut elect,
                     &mut ota_offer,
                     &mut config_offer,
@@ -5136,6 +5222,24 @@ impl RadioManager {
                     }
                     label = Some(alloc::format!("grid2 {}", seq));
                 }
+                Some(Frame::Wx2 { seq, payload }) => {
+                    // #227: the weather twin of the Batt2/Grid2 arms — leaf adopts + re-floods
+                    // strictly newer; gateway ignores (it's the source — its cache comes from the
+                    // Open-Meteo fetch). Only a well-formed `WX|` payload is kept.
+                    self.peers.last_hello_ms = now;
+                    self.roster.heard(src, None, rssi, now);
+                    if !self.relay.is_gateway
+                        && payload.starts_with(b"WX|")
+                        && self.wx.set_fresh(payload, seq)
+                    {
+                        let mut fb = [0u8; DL_FRAME_MAX];
+                        let len = encode_dl(WX2_PREFIX, seq, payload, &mut fb);
+                        self.send_to(&BROADCAST_ADDRESS, &fb[..len]);
+                        self.diag.dfwd = self.diag.dfwd.saturating_add(1); // downlink re-flood (see BATT2)
+                        log::info!("smol: WX2 seq {} adopted + reflooded (dfwd)", seq);
+                    }
+                    label = Some(alloc::format!("wx2 {}", seq));
+                }
                 Some(Frame::Cfg { target, key, value }) => {
                     // #21/#56 leaf-relay: a gateway's keyed CONFIG downlink. Target-filter
                     // FIRST — buffer if addressed to US (`self.id`) OR to the #43 broadcast
@@ -5584,6 +5688,11 @@ fn parse_frame(data: &[u8]) -> Option<Frame<'_>> {
     }
     if let Some((seq, payload)) = parse_dl(GRID2_PREFIX, data) {
         return Some(Frame::Grid2 { seq, payload });
+    }
+    // #227: the weather freshness channel — same `parse_dl` machinery, distinct tag (byte 7
+    // `'W'` — no other SMOLv1 tag starts with W, so order here is moot).
+    if let Some((seq, payload)) = parse_dl(WX2_PREFIX, data) {
+        return Some(Frame::Wx2 { seq, payload });
     }
     if let Some(rest) = data.strip_prefix(CFG_PREFIX) {
         // #21/#56 leaf-relay: "NNN<KEY><value>" — 3-ASCII target id, a 1-byte config KEY,

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -3736,6 +3736,182 @@ fn mqtt_session(
     connected
 }
 
+// ---------------------------------------------------------------------------
+// #227 weather-on-glass — one-shot Open-Meteo fetch riding the flush window
+// ---------------------------------------------------------------------------
+
+/// #227: re-fetch cadence — the gateway refreshes its weather at most once per 30 minutes
+/// (weather moves slowly; Open-Meteo asks for ≤ 1 req/min courtesy — this is 2/hour).
+#[cfg(feature = "espnow")]
+const WX_REFRESH_MS: u64 = 30 * 60 * 1000;
+/// #227: whole-fetch budget (DNS + TCP + HTTP + parse) — the watch reference's 8 s bound.
+#[cfg(feature = "espnow")]
+const WX_FETCH_BUDGET: Duration = Duration::from_secs(8);
+/// The ONE real hostname smol resolves (#228 part-2 — everything else is IP-only by design).
+/// The URL path is built from the git-ignored `board.rs` lat/lon consts; the `Host:` header
+/// is always this name (Open-Meteo is name-routed behind a shared frontend, so the header
+/// matters even when connecting to the fallback IP).
+#[cfg(feature = "espnow")]
+const WEATHER_HOST: &str = "api.open-meteo.com";
+
+/// #227: fetch current weather `(temp_f, wmo_code)` from Open-Meteo over the STILL-LIVE
+/// flush association. One-shot, bounded by [`WX_FETCH_BUDGET`], `tick`-abortable, and
+/// fail-soft (`None` — the caller keeps the previous reading; boot/flush never block on it).
+///
+/// Resolve order (the #228 part-2 decision, documented in `net/dns.rs`): a single DNS
+/// A-query via the DHCP-provided resolver (`dns_ip`, captured this burst) → on ANY failure
+/// (no resolver / timeout / hostile reply) the baked `board::WEATHER_FALLBACK_IP`. The HTTP
+/// exchange reuses the burst's TCP socket via the `publish_ota_progress` recycle idiom
+/// (abort → wait-Closed → connect → wait-Established), HTTP/1.0 + `Connection: close` ⇒
+/// read-until-EOF framing — the exact shape of the esp32c6-watch reference `weather.rs`.
+#[cfg(feature = "espnow")]
+#[allow(clippy::too_many_arguments)]
+fn fetch_weather(
+    iface: &mut Interface,
+    device: &mut esp_wifi::wifi::WifiDevice,
+    sockets: &mut SocketSet,
+    tcp_handle: smoltcp::iface::SocketHandle,
+    dns_handle: smoltcp::iface::SocketHandle,
+    rng: &mut Rng,
+    dns_ip: Option<core::net::Ipv4Addr>,
+    tick: &mut dyn FnMut() -> bool,
+) -> Option<(i16, u8)> {
+    let deadline = Instant::now() + WX_FETCH_BUDGET;
+
+    // --- resolve: one-shot A-query (≤ 2 s sub-bound) → fallback IP ---------------------
+    let mut host_ip: Option<[u8; 4]> = None;
+    if let Some(dns) = dns_ip {
+        let txid = (rng.random() & 0xFFFF) as u16;
+        let mut q = [0u8; crate::net::dns::DNS_QUERY_MAX];
+        if let Some(qn) = crate::net::dns::encode_a_query(txid, WEATHER_HOST, &mut q) {
+            {
+                let s = sockets.get_mut::<udp::Socket>(dns_handle);
+                let _ = s.bind(49152 + (rng.random() % 16384) as u16);
+                let _ = s.send_slice(&q[..qn], (IpAddress::Ipv4(dns), crate::net::dns::DNS_PORT));
+            }
+            let dns_cap = Instant::now() + Duration::from_secs(2);
+            while Instant::now() < dns_cap && Instant::now() < deadline {
+                if tick() {
+                    return None;
+                }
+                iface.poll(smoltcp_now(), device, sockets);
+                let s = sockets.get_mut::<udp::Socket>(dns_handle);
+                if s.can_recv() {
+                    let mut rb = [0u8; crate::net::dns::DNS_RESPONSE_MAX];
+                    if let Ok((n, _meta)) = s.recv_slice(&mut rb) {
+                        host_ip = crate::net::dns::parse_a_response(txid, &rb[..n]);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    // The fallback keeps the failure mode identical to smol's IP-only norm. (Deliberately
+    // not logging the IP or the board.rs lat/lon — environment-private values.)
+    let ip = match host_ip {
+        Some(a) => {
+            log::info!("smol #227: {} resolved via DNS", WEATHER_HOST);
+            a
+        }
+        None => {
+            log::info!("smol #227: DNS unavailable/failed — using the baked fallback IP");
+            crate::board::WEATHER_FALLBACK_IP
+        }
+    };
+
+    // --- HTTP/1.0 GET over the burst's TCP socket (the publish_ota_progress recycle) ----
+    sockets.get_mut::<tcp::Socket>(tcp_handle).abort();
+    loop {
+        iface.poll(smoltcp_now(), device, sockets);
+        if sockets.get_mut::<tcp::Socket>(tcp_handle).state() == tcp::State::Closed {
+            break;
+        }
+        if Instant::now() > deadline {
+            return None;
+        }
+    }
+    let src_port = 49152 + (rng.random() % 16384) as u16;
+    let remote = (
+        IpAddress::Ipv4(smoltcp::wire::Ipv4Address::new(ip[0], ip[1], ip[2], ip[3])),
+        80u16,
+    );
+    if sockets
+        .get_mut::<tcp::Socket>(tcp_handle)
+        .connect(iface.context(), remote, src_port)
+        .is_err()
+    {
+        return None;
+    }
+    loop {
+        if tick() {
+            return None;
+        }
+        iface.poll(smoltcp_now(), device, sockets);
+        match sockets.get_mut::<tcp::Socket>(tcp_handle).state() {
+            tcp::State::Established => break,
+            tcp::State::Closed => return None,
+            _ => {}
+        }
+        if Instant::now() > deadline {
+            return None;
+        }
+    }
+    // Build + send the request. Piecewise into a stack buffer (≤ ~190 B with sane lat/lon);
+    // an over-long board const refuses rather than sending a truncated URL.
+    let mut req = [0u8; 256];
+    let mut rl = 0usize;
+    for part in [
+        &b"GET /v1/forecast?latitude="[..],
+        crate::board::WEATHER_LAT.as_bytes(),
+        b"&longitude=",
+        crate::board::WEATHER_LON.as_bytes(),
+        b"&current=temperature_2m,weather_code&temperature_unit=fahrenheit HTTP/1.0\r\nHost: ",
+        WEATHER_HOST.as_bytes(),
+        b"\r\nConnection: close\r\n\r\n",
+    ] {
+        if rl + part.len() > req.len() {
+            return None;
+        }
+        req[rl..rl + part.len()].copy_from_slice(part);
+        rl += part.len();
+    }
+    if !tcp_send(iface, device, sockets, tcp_handle, &req[..rl], deadline, tick) {
+        return None;
+    }
+    // Read until EOF (peer FIN + drained — the `Connection: close` framing) or buffer/budget
+    // exhaustion. Headers + JSON fit well under 1.5 KB and both keys appear early, so a
+    // truncated tail still parses (the watch's "parse what we have" behavior).
+    let mut resp = [0u8; 1536];
+    let mut filled = 0usize;
+    loop {
+        if tick() {
+            return None;
+        }
+        iface.poll(smoltcp_now(), device, sockets);
+        {
+            let s = sockets.get_mut::<tcp::Socket>(tcp_handle);
+            if s.can_recv() {
+                if let Ok(n) = s.recv_slice(&mut resp[filled..]) {
+                    filled += n;
+                }
+            }
+            if filled == resp.len() || !s.may_recv() {
+                break;
+            }
+        }
+        if Instant::now() > deadline {
+            break;
+        }
+    }
+    sockets.get_mut::<tcp::Socket>(tcp_handle).abort(); // leave the shared socket clean
+
+    let resp = &resp[..filled];
+    if !(resp.starts_with(b"HTTP/1.0 200") || resp.starts_with(b"HTTP/1.1 200")) {
+        return None;
+    }
+    crate::net::wx::parse_open_meteo(resp)
+}
+
 /// Gateway flush → **MQTT burst** (`espnow` gateway only; v2 — this REPLACES the
 /// retired UDP-to-collector egress). The caller has ALREADY triggered re-association
 /// via `RadioManager::switch(Mode::WifiSta)`; here we build a fresh smoltcp stack on
@@ -3762,6 +3938,10 @@ pub fn run_mqtt_burst(
     messages: &[(u8, &[u8])],
     batt: &mut crate::batt::BattCache,
     grid: &mut crate::grid::GridCache,
+    // #227: `Some` on a gateway flush → the post-session slot re-fetches Open-Meteo into the
+    // cache when it's stale (≥ WX_REFRESH_MS). `None` on leaf/recovery bursts (gateway-only,
+    // like `cfg_cache`).
+    wx: Option<&mut crate::weather::WxCache>,
     // #23 fix: caller-OWNED election state (seeded from the live RadioManager role +
     // its persistent staleness observation), filled by `mqtt_session` and read BACK
     // by the caller so the role re-decides at runtime — not just at boot.
@@ -3820,11 +4000,12 @@ pub fn run_mqtt_burst(
     tick: &mut dyn FnMut() -> bool,
 ) -> bool {
     let mut iface = create_interface(device);
-    // #26 cast adds one UDP socket (the WLED pixel-stream) to the set.
+    // #26 cast adds one UDP socket (the WLED pixel-stream) to the set; #227 adds one more
+    // (the one-shot DNS A-query for the weather fetch) — hence 4/5.
     #[cfg(not(feature = "cast"))]
-    let mut sockets_storage: [SocketStorage; 3] = Default::default();
-    #[cfg(feature = "cast")]
     let mut sockets_storage: [SocketStorage; 4] = Default::default();
+    #[cfg(feature = "cast")]
+    let mut sockets_storage: [SocketStorage; 5] = Default::default();
     let mut sockets = SocketSet::new(&mut sockets_storage[..]);
 
     let mut dhcp_socket = dhcpv4::Socket::new();
@@ -3856,6 +4037,22 @@ pub fn run_mqtt_burst(
         udp::PacketBuffer::new(&mut warm_tx_meta[..], &mut warm_tx[..]),
     );
     let warm_handle = sockets.add(warm_socket);
+
+    // #227: a small UDP socket for the weather fetch's one-shot DNS A-query (the #228 part-2
+    // resolve-with-fallback). TX sized for the ~36 B query; RX for a realistic answer (CNAME
+    // chain + a few A records ≤ 512 B — an over-long reply is truncated → parse fails → the
+    // baked fallback IP takes over). Touched ONLY by `fetch_weather` in the post-session slot.
+    let mut dns_rx_meta = [udp::PacketMetadata::EMPTY; 1];
+    let mut dns_tx_meta = [udp::PacketMetadata::EMPTY; 1];
+    let mut dns_rx = [0u8; crate::net::dns::DNS_RESPONSE_MAX];
+    let mut dns_tx = [0u8; 64];
+    let dns_handle = {
+        let s = udp::Socket::new(
+            udp::PacketBuffer::new(&mut dns_rx_meta[..], &mut dns_rx[..]),
+            udp::PacketBuffer::new(&mut dns_tx_meta[..], &mut dns_tx[..]),
+        );
+        sockets.add(s)
+    };
 
     // #26 cast: a real UDP socket for the WLED DNRGB pixel-stream (present only in a
     // cast build). TX sized for one full DNRGB chunk (4 + 3*128 = 388 B ⇒ 512 with
@@ -3925,6 +4122,10 @@ pub fn run_mqtt_burst(
     }
 
     // Fresh DHCP lease each burst (the interface was just rebuilt).
+    // #227: also capture the DHCP-provided DNS resolver (previously discarded — smol is
+    // IP-only everywhere else). Used ONLY by the weather fetch's one-shot A-query; absent
+    // (or failing) → the fetch goes straight to the baked fallback IP.
+    let mut dns_ip: Option<core::net::Ipv4Addr> = None;
     loop {
         if tick() {
             return false; // #20 abort during flush DHCP wait
@@ -3933,7 +4134,10 @@ pub fn run_mqtt_burst(
         let configured = {
             let socket = sockets.get_mut::<dhcpv4::Socket>(dhcp_handle);
             match socket.poll() {
-                Some(dhcpv4::Event::Configured(cfg)) => Some((cfg.address, cfg.router)),
+                Some(dhcpv4::Event::Configured(cfg)) => {
+                    dns_ip = cfg.dns_servers.first().copied();
+                    Some((cfg.address, cfg.router))
+                }
                 _ => None,
             }
         };
@@ -4034,6 +4238,42 @@ pub fn run_mqtt_burst(
             deadline,
             tick,
         );
+    }
+
+    // #227 weather-on-glass: refresh the weather over the STILL-LIVE association (the cast
+    // slot precedent above — the MQTT DISCONNECT only closed the TCP socket, not the STA
+    // link). Gateway flushes only (`wx` = Some), at most once per WX_REFRESH_MS. It runs on
+    // its OWN small budget (WX_FETCH_BUDGET, watch-parity 8 s) rather than the flush
+    // `deadline`: the fetch fires ≤ 2×/hour, so an extra bounded WiFi-committed window twice
+    // an hour is negligible next to cast's per-flush hold — and a session that consumed the
+    // 15 s flush budget must not starve a 30-minute-cadence fetch indefinitely. `tick()`
+    // still aborts it. Fire-and-forget: any failure logs and leaves the cache untouched (the
+    // fleet keeps rendering the previous reading + its age).
+    if let Some(wx) = wx {
+        let now = Instant::now().duration_since_epoch().as_millis();
+        let stale = match wx.fetched_at() {
+            None => true,
+            Some(t) => now.saturating_sub(t) >= WX_REFRESH_MS,
+        };
+        if stale && session_ok {
+            if let Some((temp_f, code)) = fetch_weather(
+                &mut iface,
+                device,
+                &mut sockets,
+                tcp_handle,
+                dns_handle,
+                &mut rng,
+                dns_ip,
+                tick,
+            ) {
+                let mut pl = [0u8; crate::net::wx::WX_PAYLOAD_MAX];
+                let n = crate::net::wx::encode_wx(temp_f, code, &mut pl);
+                wx.store(&pl[..n], Instant::now().duration_since_epoch().as_millis());
+                log::info!("smol #227: weather {} F, WMO {} — cached", temp_f, code);
+            } else {
+                log::info!("smol #227: weather fetch failed — keeping previous reading");
+            }
+        }
     }
 
     session_ok

--- a/rust/clock/src/net/wire.rs
+++ b/rust/clock/src/net/wire.rs
@@ -23,6 +23,11 @@ pub const RELAYACK2_PREFIX: &[u8] = b"SMOLv1 RELAYACK2 "; // + "TTT MMMMM BBB H"
 /// #13 Stage B downlink freshness tags (10-digit `dl_seq` + verbatim `BATT|`/`GRID|` payload).
 pub const BATT2_PREFIX: &[u8] = b"SMOLv1 BATT2 ";
 pub const GRID2_PREFIX: &[u8] = b"SMOLv1 GRID2 ";
+/// #227 weather downlink tag — the third `encode_dl`/`parse_dl` freshness channel (payload
+/// `WX|<tempF>|<code>`, gateway-sourced from the Open-Meteo fetch). Diverges from every other
+/// tag at byte 7 (`'W'` — no other SMOLv1 tag starts with W), so `strip_prefix` never confuses
+/// it; an old firmware `classify()`s it to `None` (harmless — the #100 additive rule).
+pub const WX2_PREFIX: &[u8] = b"SMOLv1 WX2 ";
 /// #124 generic uplink envelope tag (see the UP2 section below). Diverges from `RELAY` at byte 7
 /// (`'U'` vs `'R'`), so `strip_prefix` never confuses it.
 pub const UP2_PREFIX: &[u8] = b"SMOLv1 UP2 "; // + "OOO MMMMM H " + <inner frame>

--- a/rust/clock/src/net/wx.rs
+++ b/rust/clock/src/net/wx.rs
@@ -1,0 +1,178 @@
+//! #227 weather-on-glass — the PURE weather codec: the no-serde Open-Meteo JSON scrape, the
+//! `WX|<tempF>|<code>` mesh-payload codec, and the WMO-code → condition-label table.
+//!
+//! Ported from the esp32c6-watch reference (`weather.rs`, JP's project — the read-only
+//! implementation #227 adopts): find the `"temperature_2m":` / `"weather_code":` keys whose
+//! value is NUMERIC (the `current_units` object repeats the same keys with string values —
+//! those occurrences are skipped), parse the digits, round on the first fractional digit.
+//! No serde, no alloc, total on hostile input.
+//!
+//! Pure + host-testable (the `flood`/`etx`/`wire` pattern): no HAL deps, `&[u8]` in/out.
+//! Host-tested in `experiments/wx_verify` (a real-shape Open-Meteo body + unit-string skip +
+//! payload round-trip + malformed rejection). The HTTP driver lives in `net/wifi.rs`
+//! (`fetch_weather`); the mesh relay + screen consume [`encode_wx`]/[`parse_wx`].
+
+/// Max `WX|…` mesh payload (bytes) — `WX|-999|99` is 10; 32 leaves room for future fields
+/// (parsers read the leading fields and ignore extras — the additive/#100 discipline).
+pub const WX_PAYLOAD_MAX: usize = 32;
+
+/// Scrape an Open-Meteo `current=temperature_2m,weather_code` response (headers + JSON body —
+/// the keys never appear in headers, so scanning the whole buffer is safe) into
+/// `(temp_f, wmo_code)`. `None` if either key has no numeric value.
+pub fn parse_open_meteo(resp: &[u8]) -> Option<(i16, u8)> {
+    let temp = find_number(resp, b"\"temperature_2m\":")?;
+    let code = find_number(resp, b"\"weather_code\":")?;
+    Some((temp.clamp(-999, 999) as i16, code.clamp(0, 255) as u8))
+}
+
+/// Find `key` followed by a NUMERIC value and parse it (rounded). Occurrences where the value
+/// is not numeric (the `current_units` strings, e.g. `"temperature_2m":"°F"`) are skipped.
+fn find_number(hay: &[u8], key: &[u8]) -> Option<i32> {
+    let mut start = 0;
+    while let Some(pos) = find(&hay[start..], key) {
+        let val = &hay[start + pos + key.len()..];
+        if let Some(n) = parse_rounded(val) {
+            return Some(n);
+        }
+        start += pos + key.len();
+    }
+    None
+}
+
+/// Parse `-?digits(.digits)?`, rounding on the first fractional digit. `None` if the slice
+/// doesn't start with a number (e.g. the `"` of a unit string).
+fn parse_rounded(s: &[u8]) -> Option<i32> {
+    let mut i = 0;
+    let neg = *s.first()? == b'-';
+    if neg {
+        i = 1;
+    }
+    let mut int: i32 = 0;
+    let mut digits = 0;
+    while let Some(&c) = s.get(i) {
+        if !c.is_ascii_digit() {
+            break;
+        }
+        int = int.saturating_mul(10).saturating_add((c - b'0') as i32);
+        digits += 1;
+        i += 1;
+    }
+    if digits == 0 {
+        return None;
+    }
+    let mut round_up = false;
+    if s.get(i) == Some(&b'.') {
+        if let Some(&frac) = s.get(i + 1) {
+            round_up = frac.is_ascii_digit() && frac >= b'5';
+        }
+    }
+    if round_up {
+        int += 1;
+    }
+    Some(if neg { -int } else { int })
+}
+
+/// Naive substring search (the haystack is ≤ ~1.5 KB, run once per fetch).
+fn find(hay: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || hay.len() < needle.len() {
+        return None;
+    }
+    hay.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Encode the mesh payload `WX|<tempF>|<code>` into `out`; returns the length (≤ 10 today).
+/// ASCII, sign-prefixed temp, no padding — the same human-greppable style as `BATT|`/`GRID|`.
+pub fn encode_wx(temp_f: i16, code: u8, out: &mut [u8]) -> usize {
+    let mut n = 0;
+    out[..3].copy_from_slice(b"WX|");
+    n += 3;
+    let mut t = temp_f;
+    if t < 0 {
+        out[n] = b'-';
+        n += 1;
+        t = -t;
+    }
+    n += write_dec(t as u32, &mut out[n..]);
+    out[n] = b'|';
+    n += 1;
+    n += write_dec(code as u32, &mut out[n..]);
+    n
+}
+
+/// Parse a `WX|<tempF>|<code>` payload (leading fields; extra future fields ignored).
+pub fn parse_wx(payload: &[u8]) -> Option<(i16, u8)> {
+    let rest = payload.strip_prefix(b"WX|")?;
+    let sep = rest.iter().position(|&b| b == b'|')?;
+    let temp = parse_int(&rest[..sep])?;
+    let code_field = &rest[sep + 1..];
+    let code_end = code_field
+        .iter()
+        .position(|&b| b == b'|')
+        .unwrap_or(code_field.len());
+    let code = parse_int(&code_field[..code_end])?;
+    if !(-999..=999).contains(&temp) || !(0..=255).contains(&code) {
+        return None;
+    }
+    Some((temp as i16, code as u8))
+}
+
+/// Minimal unpadded decimal writer; returns digits written. `v ≤ 999` here so ≤ 3 digits.
+fn write_dec(mut v: u32, out: &mut [u8]) -> usize {
+    let mut tmp = [0u8; 10];
+    let mut i = 0;
+    loop {
+        tmp[i] = b'0' + (v % 10) as u8;
+        v /= 10;
+        i += 1;
+        if v == 0 {
+            break;
+        }
+    }
+    for k in 0..i {
+        out[k] = tmp[i - 1 - k];
+    }
+    i
+}
+
+/// Parse a small signed ASCII integer (no leading/trailing junk). Total.
+fn parse_int(s: &[u8]) -> Option<i32> {
+    if s.is_empty() || s.len() > 5 {
+        return None;
+    }
+    let (neg, digits) = match s[0] {
+        b'-' => (true, &s[1..]),
+        _ => (false, s),
+    };
+    if digits.is_empty() {
+        return None;
+    }
+    let mut v: i32 = 0;
+    for &b in digits {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        v = v.checked_mul(10)?.checked_add((b - b'0') as i32)?;
+    }
+    Some(if neg { -v } else { v })
+}
+
+/// WMO weather-interpretation code → a short condition label (≤ 12 chars — FONT_5X8 fits 14
+/// on the 72-px glass). The standard Open-Meteo WMO buckets.
+pub fn wmo_label(code: u8) -> &'static str {
+    match code {
+        0 => "Clear",
+        1 => "Mostly clear",
+        2 => "Partly cloudy",
+        3 => "Overcast",
+        45 | 48 => "Fog",
+        51..=57 => "Drizzle",
+        61..=65 => "Rain",
+        66 | 67 => "Icy rain",
+        71..=77 => "Snow",
+        80..=82 => "Showers",
+        85 | 86 => "Snow showers",
+        95 => "Thunderstorm",
+        96 | 99 => "Storm + hail",
+        _ => "Weather",
+    }
+}

--- a/rust/clock/src/weather.rs
+++ b/rust/clock/src/weather.rs
@@ -1,0 +1,253 @@
+//! #227 WEATHER screen — Open-Meteo current conditions on the 72×40 OLED (`cfg(wifi)`).
+//!
+//! The GATEWAY fetches current weather over plain HTTP during its WiFi flush window
+//! (`net/wifi.rs::fetch_weather` — the cast-stream slot, riding the still-live association)
+//! and re-broadcasts it as a **SMOLv1 WX2** freshness-flooded frame so every leaf fills its
+//! cache too — the exact BATT display-case shape (#16/#13 Stage B), with the source being an
+//! HTTP fetch instead of an HA retained topic. This module is transport-agnostic: it renders
+//! whatever `WX|<tempF>|<code>` bytes the cache holds + how long ago they arrived.
+//!
+//! ## Payload format
+//! ASCII, ≤ [`crate::net::wx::WX_PAYLOAD_MAX`] bytes: `WX|<tempF>|<code>` — the marker, the
+//! signed integer Fahrenheit temperature, and the WMO weather-interpretation code. Stored
+//! **verbatim, marker included** (the WX2 frame is a memcpy of the cache, like BATT); parsed
+//! only at render time via [`crate::net::wx::parse_wx`]. Extra future fields are ignored by
+//! the parser — the additive/#100 discipline.
+//!
+//! ## Split of responsibility (the BATT pattern, verbatim)
+//!   * [`WxCache`] — the payload bytes + a fetch timestamp. Owned by `main`; filled by the
+//!     gateway's fetch or an inbound WX2 frame while this screen may be inactive; the plugin
+//!     only READS it, borrowed through [`crate::app::Ctx::wx`].
+//!   * [`WxState`] — the [`Plugin`]: big temperature (honoring the #43 fleet units — the
+//!     payload is always °F on the wire; °C is a render-time conversion) + the WMO condition
+//!     label + the fetch age. Single page: Long → Menu, Short → no-op.
+
+use embedded_graphics::{
+    mono_font::{ascii::FONT_10X20, ascii::FONT_5X8, ascii::FONT_6X10, MonoTextStyleBuilder},
+    pixelcolor::BinaryColor,
+    prelude::*,
+    text::{Baseline, Text},
+};
+
+use crate::app::{AppKind, Ctx, Plugin, Transition};
+use crate::input::Press;
+
+/// The payload marker (validated on [`store`](WxCache::store), like BATT's `BATT|`).
+// Both fill paths (gateway fetch, WX2 offer) are espnow-only — unlike BATT, whose boot-burst
+// downlink also fills it on plain wifi — so a wifi-without-espnow build never stores (the
+// screen renders its empty state) and `store`/MARKER read as dead there. cfg_attr, not cfg:
+// the code is correct in that tier, it just has no caller.
+#[cfg_attr(not(feature = "espnow"), allow(dead_code))]
+const MARKER: &[u8] = b"WX|";
+
+/// Max bytes the cache retains — mirrors [`crate::net::wx::WX_PAYLOAD_MAX`].
+const CACHE_CAP: usize = crate::net::wx::WX_PAYLOAD_MAX;
+
+/// The weather cache: the verbatim `WX|…` payload + when it last arrived. Owned by `main`,
+/// filled by the gateway fetch (espnow) or an inbound WX2 frame, read by [`WxState`].
+pub struct WxCache {
+    payload: [u8; CACHE_CAP],
+    len: usize,
+    /// Monotonic-ms stamp of the last successful store (`None` = never — title age `--`).
+    fetched_at_ms: Option<u64>,
+}
+
+impl WxCache {
+    /// An empty cache (never fetched). `const` so `main` seeds it cheaply.
+    pub const fn new() -> Self {
+        Self {
+            payload: [0; CACHE_CAP],
+            len: 0,
+            fetched_at_ms: None,
+        }
+    }
+
+    /// Store a `WX|…` payload VERBATIM and stamp the time. Rejects anything not starting
+    /// with the marker OR that doesn't parse — a corrupt/foreign frame never wipes a good
+    /// reading (the BATT `store` discipline, plus the parse gate since WX is machine-read).
+    // espnow-only callers (fetch + WX2 offer) — see the MARKER note.
+    #[cfg_attr(not(feature = "espnow"), allow(dead_code))]
+    pub fn store(&mut self, payload: &[u8], now_ms: u64) {
+        if !payload.starts_with(MARKER) || crate::net::wx::parse_wx(payload).is_none() {
+            return;
+        }
+        let n = payload.len().min(CACHE_CAP);
+        self.payload[..n].copy_from_slice(&payload[..n]);
+        self.len = n;
+        self.fetched_at_ms = Some(now_ms);
+    }
+
+    /// The verbatim payload bytes, for the gateway's WX2 broadcast (frame = tag + seq +
+    /// `bytes()`). espnow-only: only the espnow build broadcasts.
+    #[cfg(feature = "espnow")]
+    pub fn bytes(&self) -> &[u8] {
+        &self.payload[..self.len]
+    }
+
+    /// True until a payload has been cached — gates the gateway's periodic re-broadcast.
+    #[cfg(feature = "espnow")]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Milliseconds-stamp of the last store (read by the fetch-cadence gate: the gateway
+    /// re-fetches when this is `None` or older than the refresh interval).
+    #[cfg(feature = "espnow")]
+    pub fn fetched_at(&self) -> Option<u64> {
+        self.fetched_at_ms
+    }
+
+    /// The parsed reading `(temp_f, wmo_code)`, or `None` if never fetched.
+    fn reading(&self) -> Option<(i16, u8)> {
+        crate::net::wx::parse_wx(&self.payload[..self.len])
+    }
+}
+
+/// WEATHER screen state — render-dedup bookkeeping only (data lives in the cache).
+/// Repaints once/second (live age), on a forced redraw, and on a fresh reading.
+pub struct WxState {
+    last_s: Option<u32>,
+    last_fetch: Option<u64>,
+}
+
+impl WxState {
+    /// Fresh state. Single-page screen — no boot-page seed needed.
+    pub fn new() -> Self {
+        Self {
+            last_s: None,
+            last_fetch: None,
+        }
+    }
+}
+
+impl Plugin for WxState {
+    fn on_button(&mut self, press: Press, _ctx: &mut Ctx) -> Transition {
+        match press {
+            // Uniform grammar: long press leaves to the menu.
+            Press::Long => Transition::Switch(AppKind::Menu),
+            // Single page — a tap is a deliberate no-op (never opens a burst, #46 style).
+            Press::Short => Transition::Stay,
+        }
+    }
+
+    fn update(&mut self, ctx: &mut Ctx) {
+        let sec = (ctx.now_ms / 1000) as u32;
+        let fetched = ctx.wx.fetched_at_ms;
+        if !(ctx.redraw || self.last_s != Some(sec) || self.last_fetch != fetched) {
+            return;
+        }
+        self.last_s = Some(sec);
+        self.last_fetch = fetched;
+        let age_s = fetched.map(|f| ctx.now_ms.saturating_sub(f) / 1000);
+        render(ctx, age_s);
+    }
+}
+
+/// Paint the screen: `Weather` + age title row, the BIG temperature centered (°F on the
+/// wire; converted to °C at render when the #43 fleet units say so), and the WMO condition
+/// label centered on the bottom row.
+fn render(ctx: &mut Ctx, age_s: Option<u64>) {
+    let big = MonoTextStyleBuilder::new()
+        .font(&FONT_10X20)
+        .text_color(BinaryColor::On)
+        .build();
+    let title_style = MonoTextStyleBuilder::new()
+        .font(&FONT_6X10)
+        .text_color(BinaryColor::On)
+        .build();
+    let small = MonoTextStyleBuilder::new()
+        .font(&FONT_5X8)
+        .text_color(BinaryColor::On)
+        .build();
+
+    ctx.display.clear(BinaryColor::Off).ok();
+
+    Text::with_baseline("Weathr", Point::new(2, 0), title_style, Baseline::Top)
+        .draw(ctx.display)
+        .ok();
+    let mut age = AgeBuf::new();
+    match age_s {
+        Some(s) => write_age(&mut age, s),
+        None => {
+            let _ = age.write_str("--");
+        }
+    }
+    Text::with_baseline(age.as_str(), Point::new(48, 1), small, Baseline::Top)
+        .draw(ctx.display)
+        .ok();
+
+    match ctx.wx.reading() {
+        Some((temp_f, code)) => {
+            // BIG temperature, unit-converted at render (wire is always °F). `NNNF` ≤ 5
+            // glyphs (`-99F`); 10 px advance → always fits + centers on 72 px.
+            let (t, unit) = if ctx.units.temp_f {
+                (temp_f as i32, 'F')
+            } else {
+                // Round-half-away-from-zero (f−32)·5⁄9 in integers — no float on the C3.
+                let x = (temp_f as i32 - 32) * 5;
+                ((x * 2 + if x >= 0 { 9 } else { -9 }) / 18, 'C')
+            };
+            let mut tb = AgeBuf::new();
+            let _ = write!(tb, "{}{}", t.clamp(-999, 999), unit);
+            let w = tb.as_str().chars().count() as i32 * 10;
+            let x = ((72 - w) / 2).max(1);
+            Text::with_baseline(tb.as_str(), Point::new(x, 12), big, Baseline::Top)
+                .draw(ctx.display)
+                .ok();
+            // WMO condition label, centered on the bottom row (≤ 13 chars @ 5 px + 1).
+            let label = crate::net::wx::wmo_label(code);
+            let lw = label.chars().count() as i32 * 6;
+            let lx = ((72 - lw) / 2).max(0);
+            Text::with_baseline(label, Point::new(lx, 32), small, Baseline::Top)
+                .draw(ctx.display)
+                .ok();
+        }
+        None => {
+            Text::with_baseline("no data yet", Point::new(9, 18), small, Baseline::Top)
+                .draw(ctx.display)
+                .ok();
+        }
+    }
+
+    ctx.display.flush().ok();
+}
+
+/// Compact age (`45s` / `12m` / `3h`) — the batt.rs helper, verbatim.
+fn write_age(out: &mut AgeBuf, secs: u64) {
+    if secs < 60 {
+        let _ = write!(out, "{}s", secs);
+    } else if secs < 3600 {
+        let _ = write!(out, "{}m", secs / 60);
+    } else {
+        let _ = write!(out, "{}h", secs / 3600);
+    }
+}
+
+use core::fmt::Write;
+
+/// Tiny heap-free text buffer (the batt.rs `AgeBuf`, also reused for the temp string).
+struct AgeBuf {
+    buf: [u8; 8],
+    len: usize,
+}
+
+impl AgeBuf {
+    fn new() -> Self {
+        Self { buf: [0; 8], len: 0 }
+    }
+    fn as_str(&self) -> &str {
+        core::str::from_utf8(&self.buf[..self.len]).unwrap_or("")
+    }
+}
+
+impl Write for AgeBuf {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        for &b in s.as_bytes() {
+            if self.len < self.buf.len() {
+                self.buf[self.len] = b;
+                self.len += 1;
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What

The esp32c6-watch weather backport (#227), mapped 1:1 onto smol's own patterns: the **gateway fetches current weather from Open-Meteo during its WiFi flush window** (plain HTTP/1.0, `Connection: close`, no-serde numeric scrape — the watch's `weather.rs` shape exactly), then **floods a tiny `WX|<tempF>|<code>` record** as a `SMOLv1 WX2` frame (the third BATT2/GRID2 freshness channel), and **every OLED gets a Weather screen** — big temperature honoring the #43 fleet °F/°C units, a WMO condition label, and the fetch age. Zero new dependencies.

**Also closes the #228 part-2 fold**: DNS-with-fallback lands here, with the decision documented below.

## The #228 part-2 decision — minimal hand-rolled resolver (chosen) vs refreshed-IP

**Chosen: a minimal hand-rolled DNS A-query codec** (`net/dns.rs`, pure + host-tested), driven one-shot over the **already-enabled** smoltcp `socket-udp` (the SNTP one-datagram shape, `step_sntp`), against the **DHCP-provided resolver** — which the flush's DHCP handler previously discarded and now captures. On ANY failure (no resolver / timeout / hostile or truncated reply / NXDOMAIN) it falls back to the git-ignored **`board.rs::WEATHER_FALLBACK_IP`**, still sending the proper `Host:` header (Open-Meteo is name-routed behind a shared frontend).

Why not "refreshed-IP" (baked IP + an operator-driven refresh channel):
- **Self-healing**: when Open-Meteo rotates frontend IPs, DNS recovers with no operator in the loop; a refreshed-IP scheme needs new CFG/NVS override machinery *and* someone to notice the breakage.
- **Smaller surface**: ~130 lines of pure, total, host-tested codec (golden query bytes, CNAME-chain + compression-pointer parse, hostile-packet rejection — every failure is a clean `None`, never a panic on a remote packet). `socket-dns`/`proto-dns` stay OFF; no new crate.
- **Precedent**: smol already hand-rolls its protocol codecs (MQTT 3.1.1, SMOLv1, SNTP exchange).
- **The failure mode degrades to smol's IP-only norm** (the #228 resolution's design position): DNS down ⇒ exactly the baked-IP behavior every other fetch path has.

Weather remains the ONLY smol path that resolves a hostname; everything else stays IP-only by design.

## Shape (all existing patterns, no new machinery)

- **Fetch slot**: the `cast_stream` post-session precedent — after `mqtt_session` returns, the association is still live; the fetch reuses the burst's TCP socket via the `publish_ota_progress` recycle idiom (abort → wait-Closed → connect → wait-Established). **Own 8 s budget** (watch parity), at most **once per 30 min** (≤2 fetches/hour — an extra bounded WiFi-committed window twice an hour, vs cast's per-flush hold), `tick()`-abortable, **fail-soft** (failure logs + keeps the previous reading; flush result unaffected — the fetch only runs after `session_ok`).
- **Relay**: `WX2` = the third `encode_dl`/`parse_dl` channel. `DlOrigin` bumps the seq **only when the reading changes**, so a re-fetch returning the same temp/code never re-floods; leaves adopt strict-newer + re-flood once (`dfwd`).
- **Screen**: `weather.rs` = the `batt.rs` model verbatim (cache owned by `main`, plugin read-only via `Ctx::wx`, once-a-second age repaint). `plugin_bit → None` (legacy `007F` masks can't hide it — the Custom/Watch rationale).

## Wire + budget

`SMOLv1 WX2 <10-digit seq> WX|<tempF>|<code>` ≈ **31 B ≤ 250 MTU** — and ≤ 241, so it stays in-budget under #190's future 9-B group-MAC trailer. Old firmware classifies WX2 to `None` (additive, no flag day, the #100 rule). The fetch is HTTP, unrelated to the ~490 B gateway-MQTT packet cap.

## Privacy / secrets

Location (`WEATHER_LAT/LON`) and the fallback IP are **git-ignored `board.rs` consts** (environment-specific, per the public-repo rule); committed code references the consts only. `board.rs.example` ships the watch reference's public Seattle demo values. Coordinates are never logged; lat/lon precision guidance (~1 decimal ≈ 11 km) documented in the example. Diff scanned: `beginagain` = 0, no real coordinates, no gitignored files staged.

## Gate (4-tier, all green)

- **clippy `-D warnings`**: default · wifi · espnow · cast · io ✓
- **release builds**: espnow (**1.06 MB vs the 1.94 MB OTA slot**) · default (Phase-1 no-regression) ✓
- **host tests**: `dns_verify` (golden A-query + CNAME/pointer response + hostile rejection) · `wx_verify` (Open-Meteo scrape incl. the `current_units` string-skip trap + `WX|` round-trip + WMO table bounds) · `relay_compat` (byte-compat guard still green) ✓
- **HW-HELD** (train TBD, not v345): the on-air proof (fetch over a real AP, WX2 flood adoption, screen render) waits for its train's canary.

## Blast radius

`net/wire.rs` (one const) · `net/dns.rs` + `net/wx.rs` (new, pure) · `net/wifi.rs` (`fetch_weather`, +1 socket, DHCP DNS capture, `run_mqtt_burst` +wx param) · `net/mode.rs` (`Frame::Wx2` + arms, tracker/offer, `broadcast_wx`, `flush_telemetry` +wx) · `weather.rs` (new screen) · `app.rs`/`main.rs` (registration + wiring) · `board.rs.example` · `experiments/{dns,wx}_verify` (new harnesses). No OTA-path files touched (`ota.rs`/`ota_mesh.rs` untouched — no #217/#237 collision).

Refs #227 #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
