### PR TITLE
fw: #237 slice-1 — peer-sourced relay (primitives + holder receive path) [WIP/HW-HELD]

### DIFF
--- a/experiments/arb_verify/Cargo.toml
+++ b/experiments/arb_verify/Cargo.toml
@@ -1,0 +1,18 @@
+# #237 host-test harness for the peer-sourced-relay ARBITRATION contract (ODEL/ODON codec +
+# the baton / split-brain-term / outcome-mapping decision logic). Runs OFF-target on the host
+# (std) via `cargo run` — the firmware crate is no_std/riscv32imc AND `ota_mesh.rs` can't be
+# `#[path]`-included on host (it carries `#[esp_hal::ram]` attrs + `crate::ota::{LeafImageWriter,
+# Announce,verify_signature}` HAL deps), so this VENDORS the pure arb codec verbatim (relay_compat
+# pattern) and pins the exact §8/§10 WIRE layout with GOLDEN-BYTE assertions — a real encoder drift
+# then diverges from these goldens (and the firmware↔leaf OTAM) at the next canary/review.
+# Mirrors experiments/relay_compat. Run: `cargo run` — panics on any mismatch.
+[package]
+name = "arb_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "arb_verify"
+path = "src/main.rs"
+[profile.dev]
+opt-level = 0

--- a/experiments/arb_verify/src/main.rs
+++ b/experiments/arb_verify/src/main.rs
@@ -1,0 +1,369 @@
+//! #237 host verification of the peer-sourced-relay ARBITRATION contract (spec
+//! `docs/superpowers/design/peer-sourced-mesh-ota.md` §8/§10):
+//!   (1) the ODEL/ODON codec round-trips every field + REJECTS (fail-closed) oversize/short/zero-M;
+//!   (2) GOLDEN-BYTE assertions pin the exact §10 wire layout (LE fields, 3-ASCII id, M_len,
+//!       M+sig) so a real `ota_mesh.rs` encoder drift diverges from these bytes (and from a leaf's
+//!       OTAM sig-over-M) at the next canary/review;
+//!   (3) the split-brain `term` guard (§5.3): a holder rejects a `term` older than the highest seen;
+//!   (4) the baton source-pick (§8.2): delegate iff the last-confirmed holder runs the exact build
+//!       and isn't the target;
+//!   (5) the outcome→ODON mapping is FAIL-CLOSED — only a build-matched Confirmed is Ok, so any
+//!       other outcome (corrupt-holder sha-reject included) makes the crown fall back to #40.
+//!
+//! `ota_mesh.rs` cannot be `#[path]`-included on host (its `#[esp_hal::ram]` attrs + HAL/`crate::ota`
+//! deps don't exist off-target), so the codec + decision logic below are VENDORED verbatim from the
+//! firmware — the relay_compat pattern. Keep them in sync with `ota_mesh.rs` / `net/mode.rs`; the
+//! GOLDEN-BYTE + logic assertions pin the CONTRACT that any drift must still satisfy.
+//! Run: `cargo run` — panics on failure.
+
+// ======================================================================================
+// VENDORED verbatim from rust/clock/src/ota_mesh.rs (arb codec) — keep in sync.
+// ======================================================================================
+const SIGNED_MSG_MAX: usize = 96; // ota::SIGNED_MSG_MAX (OTAM-shared cap; real M ≤ 86)
+const ODEL_PREFIX: &[u8] = b"SMOLv1 ODEL ";
+const ODON_PREFIX: &[u8] = b"SMOLv1 ODON ";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ServeResult {
+    Ok,
+    TargetUnreachable,
+    Aborted,
+    SelfSlotVerifyFailed,
+}
+impl ServeResult {
+    fn as_u8(self) -> u8 {
+        match self {
+            ServeResult::Ok => 0,
+            ServeResult::TargetUnreachable => 1,
+            ServeResult::Aborted => 2,
+            ServeResult::SelfSlotVerifyFailed => 3,
+        }
+    }
+    fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(ServeResult::Ok),
+            1 => Some(ServeResult::TargetUnreachable),
+            2 => Some(ServeResult::Aborted),
+            3 => Some(ServeResult::SelfSlotVerifyFailed),
+            _ => None,
+        }
+    }
+    // Mirrors ServeResult::from_leaf_outcome (ota_mesh.rs) — FAIL-CLOSED: only Confirmed → Ok.
+    fn from_leaf_outcome(o: LeafOtaOutcome) -> Self {
+        match o {
+            LeafOtaOutcome::Confirmed => ServeResult::Ok,
+            LeafOtaOutcome::MacUnknown | LeafOtaOutcome::RelayFailed => {
+                ServeResult::TargetUnreachable
+            }
+            LeafOtaOutcome::FetchFailed => ServeResult::SelfSlotVerifyFailed,
+            _ => ServeResult::Aborted,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArbFrame<'a> {
+    Odel {
+        target: u8,
+        build: u32,
+        session: u16,
+        term: u16,
+        m: &'a [u8],
+        sig: &'a [u8; 64],
+    },
+    Odon {
+        target: u8,
+        build: u32,
+        session: u16,
+        result: ServeResult,
+    },
+}
+
+fn parse_id3(b: &[u8]) -> Option<u8> {
+    if b.len() < 3 {
+        return None;
+    }
+    let mut v: u16 = 0;
+    for &c in &b[..3] {
+        if !c.is_ascii_digit() {
+            return None;
+        }
+        v = v * 10 + (c - b'0') as u16;
+    }
+    (v <= 255).then_some(v as u8)
+}
+
+fn write_id3(id: u8, out: &mut [u8]) {
+    out[0] = b'0' + id / 100;
+    out[1] = b'0' + (id / 10) % 10;
+    out[2] = b'0' + id % 10;
+}
+
+fn parse_arb_frame(data: &[u8]) -> Option<ArbFrame<'_>> {
+    if let Some(rest) = data.strip_prefix(ODEL_PREFIX) {
+        if rest.len() < 3 + 4 + 2 + 2 + 1 {
+            return None;
+        }
+        let target = parse_id3(&rest[0..3])?;
+        let build = u32::from_le_bytes([rest[3], rest[4], rest[5], rest[6]]);
+        let session = u16::from_le_bytes([rest[7], rest[8]]);
+        let term = u16::from_le_bytes([rest[9], rest[10]]);
+        let m_len = rest[11] as usize;
+        if m_len == 0 || m_len > SIGNED_MSG_MAX {
+            return None;
+        }
+        let m_start = 12;
+        let sig_start = m_start + m_len;
+        let end = sig_start + 64;
+        if rest.len() < end {
+            return None;
+        }
+        let m = &rest[m_start..sig_start];
+        let sig: &[u8; 64] = rest[sig_start..end].try_into().ok()?;
+        return Some(ArbFrame::Odel { target, build, session, term, m, sig });
+    }
+    if let Some(rest) = data.strip_prefix(ODON_PREFIX) {
+        if rest.len() < 3 + 4 + 2 + 1 {
+            return None;
+        }
+        let target = parse_id3(&rest[0..3])?;
+        let build = u32::from_le_bytes([rest[3], rest[4], rest[5], rest[6]]);
+        let session = u16::from_le_bytes([rest[7], rest[8]]);
+        let result = ServeResult::from_u8(rest[9])?;
+        return Some(ArbFrame::Odon { target, build, session, result });
+    }
+    None
+}
+
+fn encode_odel(
+    target_id: u8,
+    build: u32,
+    session: u16,
+    term: u16,
+    m: &[u8],
+    sig: &[u8; 64],
+    out: &mut [u8],
+) -> Option<usize> {
+    if m.is_empty() || m.len() > SIGNED_MSG_MAX {
+        return None;
+    }
+    let total = ODEL_PREFIX.len() + 3 + 4 + 2 + 2 + 1 + m.len() + 64;
+    if out.len() < total {
+        return None;
+    }
+    let mut n = 0;
+    out[..ODEL_PREFIX.len()].copy_from_slice(ODEL_PREFIX);
+    n += ODEL_PREFIX.len();
+    write_id3(target_id, &mut out[n..n + 3]);
+    n += 3;
+    out[n..n + 4].copy_from_slice(&build.to_le_bytes());
+    n += 4;
+    out[n..n + 2].copy_from_slice(&session.to_le_bytes());
+    n += 2;
+    out[n..n + 2].copy_from_slice(&term.to_le_bytes());
+    n += 2;
+    out[n] = m.len() as u8;
+    n += 1;
+    out[n..n + m.len()].copy_from_slice(m);
+    n += m.len();
+    out[n..n + 64].copy_from_slice(sig);
+    n += 64;
+    Some(n)
+}
+
+fn encode_odon(
+    target_id: u8,
+    build: u32,
+    session: u16,
+    result: ServeResult,
+    out: &mut [u8],
+) -> Option<usize> {
+    let total = ODON_PREFIX.len() + 3 + 4 + 2 + 1;
+    if out.len() < total {
+        return None;
+    }
+    let mut n = 0;
+    out[..ODON_PREFIX.len()].copy_from_slice(ODON_PREFIX);
+    n += ODON_PREFIX.len();
+    write_id3(target_id, &mut out[n..n + 3]);
+    n += 3;
+    out[n..n + 4].copy_from_slice(&build.to_le_bytes());
+    n += 4;
+    out[n..n + 2].copy_from_slice(&session.to_le_bytes());
+    n += 2;
+    out[n] = result.as_u8();
+    n += 1;
+    Some(n)
+}
+
+// ======================================================================================
+// VENDORED decision logic from net/mode.rs (baton + split-brain term guard) — keep in sync.
+// ======================================================================================
+
+// A minimal mirror of ota_mesh::LeafOtaOutcome (only the variants from_leaf_outcome distinguishes).
+#[derive(Debug, Clone, Copy)]
+enum LeafOtaOutcome {
+    Confirmed,
+    MacUnknown,
+    RelayFailed,
+    FetchFailed,
+    RolledBack,
+    RelayUnconfirmed,
+    Timeout,
+    IdMismatch,
+    Aborted,
+}
+
+/// Mirrors `handle_arb_frame`'s §5.3 replay guard: a holder ACCEPTS an ODEL iff its `term` is not
+/// older than the highest term it has seen (a dethroned crown's lower term is refused).
+fn arb_term_accepts(incoming_term: u16, highest_seen: u16) -> bool {
+    incoming_term >= highest_seen
+}
+
+/// Mirrors `baton_holder_for`'s core decision: the crown DELEGATES iff the last-confirmed holder is
+/// running the exact `want_build` and is not the target itself. (MAC resolvability is a runtime
+/// concern tested on hardware.)
+fn baton_delegates(last_confirmed: Option<(u8, u32)>, want_build: u32, target: u8) -> Option<u8> {
+    let (hid, hbuild) = last_confirmed?;
+    if hbuild != want_build || hid == target {
+        return None;
+    }
+    Some(hid)
+}
+
+// ======================================================================================
+// Assertions
+// ======================================================================================
+
+fn main() {
+    // A representative signed manifest (real M = "build|size|sha256hex", ≤ 86 B) + a sig.
+    let m: &[u8] = b"343|360448|9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+    assert!(m.len() <= SIGNED_MSG_MAX, "test manifest fits the shared cap");
+    let sig = [0xABu8; 64];
+
+    // --- (1) ODEL round-trip: every field survives encode → parse ----------------------
+    let mut buf = [0u8; 256];
+    let n = encode_odel(7, 343, 0x1234, 5, m, &sig, &mut buf).expect("encode ODEL");
+    assert_eq!(n, ODEL_PREFIX.len() + 3 + 4 + 2 + 2 + 1 + m.len() + 64, "ODEL length");
+    match parse_arb_frame(&buf[..n]) {
+        Some(ArbFrame::Odel { target, build, session, term, m: pm, sig: psig }) => {
+            assert_eq!(target, 7, "ODEL target");
+            assert_eq!(build, 343, "ODEL build");
+            assert_eq!(session, 0x1234, "ODEL session");
+            assert_eq!(term, 5, "ODEL term");
+            assert_eq!(pm, m, "ODEL M round-trips byte-identically (leaf sig-over-M depends on it)");
+            assert_eq!(psig, &sig, "ODEL sig round-trips");
+        }
+        other => panic!("ODEL did not round-trip: {other:?}"),
+    }
+
+    // --- (2a) GOLDEN ODEL bytes: pin the exact §10 wire layout -------------------------
+    // target=7 build=343(0x0157) session=0x1234 term=5 with a fixed 3-byte M="ABC", sig=0xCD*64.
+    let gm: &[u8] = b"ABC";
+    let gsig = [0xCDu8; 64];
+    let gn = encode_odel(7, 343, 0x1234, 5, gm, &gsig, &mut buf).expect("golden ODEL");
+    assert_eq!(&buf[0..12], b"SMOLv1 ODEL ", "golden: tag");
+    assert_eq!(&buf[12..15], b"007", "golden: 3-ASCII target id");
+    assert_eq!(&buf[15..19], &[0x57, 0x01, 0x00, 0x00], "golden: build u32 LE");
+    assert_eq!(&buf[19..21], &[0x34, 0x12], "golden: session u16 LE");
+    assert_eq!(&buf[21..23], &[0x05, 0x00], "golden: term u16 LE");
+    assert_eq!(buf[23], 3, "golden: M_len");
+    assert_eq!(&buf[24..27], b"ABC", "golden: M");
+    assert_eq!(&buf[27..27 + 64], &gsig, "golden: 64-byte sig");
+    assert_eq!(gn, 27 + 64, "golden: total ODEL = 91 B (< 250 MTU)");
+
+    // --- (2b) GOLDEN ODON bytes --------------------------------------------------------
+    let on = encode_odon(7, 343, 0x1234, ServeResult::Ok, &mut buf).expect("golden ODON");
+    assert_eq!(&buf[0..12], b"SMOLv1 ODON ", "golden: ODON tag");
+    assert_eq!(&buf[12..15], b"007", "golden: ODON target");
+    assert_eq!(&buf[15..19], &[0x57, 0x01, 0x00, 0x00], "golden: ODON build LE");
+    assert_eq!(&buf[19..21], &[0x34, 0x12], "golden: ODON session LE");
+    assert_eq!(buf[21], 0, "golden: ODON result=Ok");
+    assert_eq!(on, 22, "golden: total ODON = 22 B");
+
+    // --- (3) ODON round-trip across ALL result codes -----------------------------------
+    for (code, res) in [
+        (0u8, ServeResult::Ok),
+        (1, ServeResult::TargetUnreachable),
+        (2, ServeResult::Aborted),
+        (3, ServeResult::SelfSlotVerifyFailed),
+    ] {
+        let n = encode_odon(9, 400, 0xBEEF, res, &mut buf).expect("encode ODON");
+        assert_eq!(buf[21], code, "ODON result byte matches {res:?}");
+        match parse_arb_frame(&buf[..n]) {
+            Some(ArbFrame::Odon { target, build, session, result }) => {
+                assert_eq!((target, build, session, result), (9, 400, 0xBEEF, res), "ODON round-trip {res:?}");
+            }
+            other => panic!("ODON {res:?} did not round-trip: {other:?}"),
+        }
+    }
+    assert_eq!(ServeResult::from_u8(4), None, "unknown ODON result byte → None (fail-closed)");
+
+    // --- (4) FAIL-CLOSED codec: oversize / zero / short → None (never panic/over-read) --
+    let big = [b'x'; SIGNED_MSG_MAX + 1];
+    assert_eq!(encode_odel(1, 1, 1, 1, &big, &sig, &mut buf), None, "encode REJECTS M > cap (not clamp)");
+    assert_eq!(encode_odel(1, 1, 1, 1, b"", &sig, &mut buf), None, "encode REJECTS empty M");
+    // A hand-built ODEL claiming M_len=255 (→ 343 B) must be rejected by the parser, not over-read.
+    let mut hostile = Vec::new();
+    hostile.extend_from_slice(ODEL_PREFIX);
+    hostile.extend_from_slice(b"007");
+    hostile.extend_from_slice(&343u32.to_le_bytes());
+    hostile.extend_from_slice(&1u16.to_le_bytes());
+    hostile.extend_from_slice(&1u16.to_le_bytes());
+    hostile.push(255); // M_len way over the cap
+    hostile.extend_from_slice(&[0u8; 8]);
+    assert_eq!(parse_arb_frame(&hostile), None, "parse REJECTS M_len > cap (fail-closed, no over-read)");
+    let mut zero_m = Vec::new();
+    zero_m.extend_from_slice(ODEL_PREFIX);
+    zero_m.extend_from_slice(b"007");
+    zero_m.extend_from_slice(&343u32.to_le_bytes());
+    zero_m.extend_from_slice(&[0u8; 2 + 2]);
+    zero_m.push(0); // M_len = 0
+    zero_m.extend_from_slice(&[0u8; 64]);
+    assert_eq!(parse_arb_frame(&zero_m), None, "parse REJECTS M_len == 0");
+    // Truncated frames at EVERY prefix length must never panic (fail-closed) — a hostile mesh
+    // can deliver a frame cut anywhere. Build one fresh full ODEL + one full ODON and walk every cut.
+    let mut odel_full = [0u8; 256];
+    let odel_len = encode_odel(7, 343, 0x1234, 5, m, &sig, &mut odel_full).expect("full ODEL");
+    for cut in 0..=odel_len {
+        let _ = parse_arb_frame(&odel_full[..cut]); // must not panic at ANY cut
+    }
+    let mut odon_full = [0u8; 64];
+    let odon_len = encode_odon(7, 343, 0x1234, ServeResult::Ok, &mut odon_full).expect("full ODON");
+    for cut in 0..=odon_len {
+        let _ = parse_arb_frame(&odon_full[..cut]); // must not panic at ANY cut
+    }
+    assert_eq!(parse_arb_frame(b"SMOLv1 XXXX not-arb"), None, "non-arb prefix → None");
+
+    // --- (5) split-brain term guard (§5.3) --------------------------------------------
+    assert!(arb_term_accepts(5, 5), "equal term accepted (same crown re-issue)");
+    assert!(arb_term_accepts(6, 5), "newer term accepted (fresh crown out-terms)");
+    assert!(!arb_term_accepts(4, 5), "OLDER term REJECTED — dethroned crown cannot delegate");
+
+    // --- (6) baton source-pick (§8.2) -------------------------------------------------
+    assert_eq!(baton_delegates(None, 343, 7), None, "no baton → seed via gateway fetch");
+    assert_eq!(baton_delegates(Some((8, 343)), 343, 7), Some(8), "holder id8 on build 343 → delegate");
+    assert_eq!(baton_delegates(Some((8, 342)), 343, 7), None, "holder on OLD build → seed (no stale source)");
+    assert_eq!(baton_delegates(Some((7, 343)), 343, 7), None, "never delegate a leaf to ITSELF");
+
+    // --- (7) outcome → ODON mapping is FAIL-CLOSED (only Confirmed → Ok) ---------------
+    assert_eq!(ServeResult::from_leaf_outcome(LeafOtaOutcome::Confirmed), ServeResult::Ok);
+    assert_eq!(ServeResult::from_leaf_outcome(LeafOtaOutcome::FetchFailed), ServeResult::SelfSlotVerifyFailed);
+    assert_eq!(ServeResult::from_leaf_outcome(LeafOtaOutcome::RelayFailed), ServeResult::TargetUnreachable);
+    assert_eq!(ServeResult::from_leaf_outcome(LeafOtaOutcome::MacUnknown), ServeResult::TargetUnreachable);
+    // The corrupt-holder / rolled-back / stranded / brick / id-clash cases ALL map to non-Ok →
+    // the crown falls back to the trusted #40 gateway fetch (the safety floor), never advancing
+    // the baton onto an unconfirmed node.
+    for bad in [
+        LeafOtaOutcome::RolledBack,
+        LeafOtaOutcome::RelayUnconfirmed,
+        LeafOtaOutcome::Timeout,
+        LeafOtaOutcome::IdMismatch,
+        LeafOtaOutcome::Aborted,
+    ] {
+        assert_ne!(ServeResult::from_leaf_outcome(bad), ServeResult::Ok, "{bad:?} is non-Ok → fallback");
+    }
+
+    println!("arb_verify: ALL CHECKS PASSED (ODEL/ODON round-trip + golden §10 wire + fail-closed reject + \
+              split-brain term guard + baton source-pick + fail-closed outcome→ODON mapping)");
+}

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -1304,7 +1304,7 @@ fn main() -> ! {
                             let relay_prog = core::cell::Cell::new(ota::OtaProgress::default());
                             let relay_build = ann.build;
                             let mut relay_eta = ota_screen::OtaEta::new();
-                            let outcome = r.run_leaf_ota_relay(leaf_id, mac, &ann, &mut || {
+                            let outcome = r.run_leaf_ota_relay(crate::ota_mesh::ServeSource::GatewayFetch, leaf_id, mac, &ann, &mut || {
                                 let t = millis();
                                 led.apply(led::LedState::WifiSync, t);
                                 if matches!(button.poll(t), Some(input::Press::Long)) {

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -836,6 +836,91 @@ fn main() -> ! {
                     redraw = true; // a recovery burst ran → role may have changed; repaint
                 }
             }
+            // === #237 peer-relay HOLDER serve-driver =========================================
+            // A crown `ODEL` (validated + recorded as `pending_serve` in the RX drain,
+            // `handle_arb_frame`) delegates THIS node to serve leaf `ps.target` the byte-identical
+            // signed image FROM ITS OWN ACTIVE SLOT over ESP-NOW — no WiFi fetch (coexist-safe).
+            // The serve BLOCKS for minutes, so it runs HERE from the main loop (NEVER the RX drain,
+            // which would stall HELLO/MC/time). Placed BEFORE the self-OTA `do_install` below so a
+            // holder finishes serving the fleet before it updates ITSELF (the #40 leaves-first,
+            // gateway/self-last ordering). SAFETY FLOOR: every branch reports an `ODON` result (or
+            // the crown times out) → on any non-OK the crown falls back to the #40 gateway fetch, so
+            // worst-case == today's behavior.
+            if let Some(ps) = r.take_pending_serve() {
+                let result = match r.mac_for_id_sticky(ps.target) {
+                    // Never learned the target's MAC (no HELLO heard) → report unreachable; the
+                    // crown re-seeds this leaf via the trusted #40 gateway fetch (the safety floor).
+                    None => crate::ota_mesh::ServeResult::TargetUnreachable,
+                    Some(mac) => {
+                        // §5.2 pre-flight: readback-sha-verify OUR OWN active slot against the
+                        // ODEL's manifest sha BEFORE serving. A source must never offer a copy it
+                        // cannot itself reproduce → mismatch = self-slot-verify-failed → the crown
+                        // falls back to the trusted gateway fetch.
+                        if !crate::ota::verify_active_slot(ps.ann.size, &ps.ann.sha256) {
+                            log::warn!(
+                                "smol #237: holder active-slot verify FAILED for build {} — declining serve (crown falls back)",
+                                ps.ann.build
+                            );
+                            crate::ota_mesh::ServeResult::SelfSlotVerifyFailed
+                        } else {
+                            // Drive the existing #40 relay from the ACTIVE slot (byte-identical
+                            // OTAM from the crown-supplied M+sig). UI-alive tick + long-press abort,
+                            // same "feeding <leaf>" screen as the gateway relay.
+                            let mut relay_draw_ms = 0u64;
+                            let mut relay_abort = false;
+                            let relay_prog = core::cell::Cell::new(ota::OtaProgress::default());
+                            let relay_build = ps.ann.build;
+                            let serve_target = ps.target;
+                            let mut relay_eta = ota_screen::OtaEta::new();
+                            let outcome = r.run_leaf_ota_relay(
+                                crate::ota_mesh::ServeSource::HolderActiveSlot,
+                                ps.target,
+                                mac,
+                                &ps.ann,
+                                &mut || {
+                                    let t = millis();
+                                    led.apply(led::LedState::WifiSync, t);
+                                    if matches!(button.poll(t), Some(input::Press::Long)) {
+                                        relay_abort = true;
+                                    }
+                                    if t.saturating_sub(relay_draw_ms) >= SYNC_REDRAW_MS {
+                                        relay_draw_ms = t;
+                                        let p = relay_prog.get();
+                                        ota_screen::draw(&mut display, &ota_screen::OtaView {
+                                            kind: ota_screen::OtaKind::Feeding { leaf_id: serve_target },
+                                            build: relay_build,
+                                            done: p.done,
+                                            total: p.total,
+                                            eta_s: relay_eta.sample(p.done, p.total, t),
+                                            unit: if p.total > 10_000 {
+                                                ota_screen::OtaUnit::Bytes
+                                            } else {
+                                                ota_screen::OtaUnit::Blocks
+                                            },
+                                        });
+                                    }
+                                    relay_abort
+                                },
+                                &relay_prog,
+                            );
+                            redraw = true;
+                            crate::ota_mesh::ServeResult::from_leaf_outcome(outcome)
+                        }
+                    }
+                };
+                // ODON → crown: RAW esp_now unicast (NOT send_to — 190L item 1: the OTA family is
+                // parsed before the #248 group-MAC verify-then-strip, so a trailer would corrupt it).
+                let mut odon = [0u8; crate::ota_mesh::ODON_FRAME_MAX];
+                if let Some(n) =
+                    crate::ota_mesh::encode_odon(ps.target, ps.ann.build, ps.session, result, &mut odon)
+                {
+                    r.send_arb_raw(ps.crown_mac, &odon[..n]);
+                }
+                log::info!(
+                    "smol #237: holder served id{} build {} → ODON {:?}",
+                    ps.target, ps.ann.build, result
+                );
+            }
             // #6/#33 OTA: a burst (boot or gateway flush) surfaces a gated announce as the
             // "latest available" TARGET (its state is published to the HA Update entity by
             // the burst). Fetch it ONLY when an install was COMMANDED — the native HA

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -1386,10 +1386,13 @@ fn main() -> ! {
                             // then BLOCKS during the ESP-NOW relay, so the unit is auto-picked per
                             // paint (>10k ⇒ bytes) and the ETA re-anchors itself at the phase flip
                             // (done drops → OtaEta re-seeds), keeping the readout clean throughout.
+                            // #237: the SAME tick drives the crown-delegate wait (LED + abort stay
+                            // alive while a peer holder serves; the progress bar holds at the last
+                            // frame since the holder — not the crown — pushes the bytes).
                             let relay_prog = core::cell::Cell::new(ota::OtaProgress::default());
                             let relay_build = ann.build;
                             let mut relay_eta = ota_screen::OtaEta::new();
-                            let outcome = r.run_leaf_ota_relay(crate::ota_mesh::ServeSource::GatewayFetch, leaf_id, mac, &ann, &mut || {
+                            let mut relay_tick = || {
                                 let t = millis();
                                 led.apply(led::LedState::WifiSync, t);
                                 if matches!(button.poll(t), Some(input::Press::Long)) {
@@ -1412,10 +1415,55 @@ fn main() -> ! {
                                     });
                                 }
                                 relay_abort
-                            }, &relay_prog);
+                            };
+                            // === #237 CROWN BATON ==============================================
+                            // If a confirmed holder is running THIS exact build, DELEGATE the serve
+                            // to it (peer-source over ESP-NOW, zero gateway bulk-fetch); otherwise
+                            // SEED via the #40 gateway fetch. The delegate stamps term (= the crown's
+                            // election seq, §5.3 replay guard) and awaits the holder's ODON.
+                            let term = r.crown_term();
+                            let holder = r.baton_holder_for(ann.build, leaf_id);
+                            let delegated = if let Some((hid, hmac)) = holder {
+                                log::info!(
+                                    "smol #237: crown DELEGATE serve of id{} build {} → holder id{}",
+                                    leaf_id, ann.build, hid
+                                );
+                                r.run_crown_delegate(hid, hmac, leaf_id, &ann, term, &mut relay_tick)
+                            } else {
+                                None
+                            };
+                            // UNCONDITIONAL FALLBACK FLOOR: ONLY a holder ODON=OK skips the fetch;
+                            // NO holder, a non-OK ODON, or a serve-deadline timeout ALL fall through
+                            // to the trusted #40 gateway fetch → worst-case == today's behavior.
+                            let outcome = match delegated {
+                                Some(crate::ota_mesh::ServeResult::Ok) => {
+                                    crate::ota_mesh::LeafOtaOutcome::Confirmed
+                                }
+                                other => {
+                                    if let Some(res) = other {
+                                        log::warn!(
+                                            "smol #237: delegate of id{} → {:?} — FALLING BACK to #40 gateway fetch",
+                                            leaf_id, res
+                                        );
+                                    }
+                                    r.run_leaf_ota_relay(
+                                        crate::ota_mesh::ServeSource::GatewayFetch,
+                                        leaf_id,
+                                        mac,
+                                        &ann,
+                                        &mut relay_tick,
+                                        &relay_prog,
+                                    )
+                                }
+                            };
                             // #40: record the phase → published to smol/<leaf>/ota/diag on the
                             // next burst + drives the install clear/retry policy.
                             r.record_leaf_ota(leaf_id, outcome);
+                            // #237 baton advance: a CONFIRMED serve (delegated OR seeded) makes this
+                            // just-served leaf the SOURCE for the next target of this build.
+                            if matches!(outcome, crate::ota_mesh::LeafOtaOutcome::Confirmed) {
+                                r.note_confirmed_holder(leaf_id, ann.build);
+                            }
                             redraw = true;
                         } else {
                             // MAC not learned yet (no HELLO heard) → record MacUnknown; the

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -1423,7 +1423,11 @@ fn main() -> ! {
                             // election seq, §5.3 replay guard) and awaits the holder's ODON.
                             let term = r.crown_term();
                             let holder = r.baton_holder_for(ann.build, leaf_id);
+                            // #237 INC5 observability: the serve SOURCE for ota/diag — 0 = the
+                            // gateway/crown (a #40 seed fetch or a fallback), else the peer holder id.
+                            let mut serve_src = 0u8;
                             let delegated = if let Some((hid, hmac)) = holder {
+                                serve_src = hid;
                                 log::info!(
                                     "smol #237: crown DELEGATE serve of id{} build {} → holder id{}",
                                     leaf_id, ann.build, hid
@@ -1446,6 +1450,8 @@ fn main() -> ! {
                                             leaf_id, res
                                         );
                                     }
+                                    // The gateway sourced this serve (seed or fallback), not a peer.
+                                    serve_src = 0;
                                     r.run_leaf_ota_relay(
                                         crate::ota_mesh::ServeSource::GatewayFetch,
                                         leaf_id,
@@ -1457,8 +1463,8 @@ fn main() -> ! {
                                 }
                             };
                             // #40: record the phase → published to smol/<leaf>/ota/diag on the
-                            // next burst + drives the install clear/retry policy.
-                            r.record_leaf_ota(leaf_id, outcome);
+                            // next burst + drives the install clear/retry policy. #237: + serve src.
+                            r.record_leaf_ota(leaf_id, outcome, serve_src);
                             // #237 baton advance: a CONFIRMED serve (delegated OR seeded) makes this
                             // just-served leaf the SOURCE for the next target of this build.
                             if matches!(outcome, crate::ota_mesh::LeafOtaOutcome::Confirmed) {
@@ -1469,7 +1475,7 @@ fn main() -> ! {
                             // MAC not learned yet (no HELLO heard) → record MacUnknown; the
                             // install is LEFT retained (not cleared) → retried on a later flush
                             // once the leaf HELLOs. Diag published so it's visible headless.
-                            r.record_leaf_ota(leaf_id, crate::ota_mesh::LeafOtaOutcome::MacUnknown);
+                            r.record_leaf_ota(leaf_id, crate::ota_mesh::LeafOtaOutcome::MacUnknown, 0);
                         }
                     }
                     // Coexist soak (#23 PART 1): the during-window RX loss — how many

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1987,6 +1987,13 @@ pub struct RadioManager {
     /// gateway can't self-OTA (rebooting) in that gap — starving a second leaf + inverting the order.
     /// The gateway updates itself LAST, only once every leaf's install has cleared.
     leaf_installs_outstanding: bool,
+    /// #237 peer-relay HOLDER state: a crown-delegated serve accepted via ODEL, recorded in the RX
+    /// drain (`handle_arb_frame`) and consumed by main.rs (the serve blocks, so it can't run in the
+    /// drain). One at a time — a second ODEL while set is ignored (holder single-session).
+    pending_serve: Option<crate::ota_mesh::PendingServe>,
+    /// #237: highest ODEL `term` (= the crown's MC seq) ever seen — reject a stale/dethroned crown's
+    /// ODEL (term < this), the §5.3 split-brain guard.
+    highest_arb_term: u16,
     /// #40 #3 STICKY MAC: `(leaf_id, mac)` captured the moment an armed leaf became addressable,
     /// held for the whole install session (cleared on a terminal `record_leaf_ota`). The roster
     /// is a bounded 16-slot LRU that EVICTS this leaf while the mesh-deaf relay stops hearing it
@@ -2143,6 +2150,8 @@ impl RadioManager {
             self_ota_fail_build: 0,
             leaf_ota_pending: false,
             leaf_installs_outstanding: false,
+            pending_serve: None,
+            highest_arb_term: 0,
             leaf_ota_mac: None,
             leaf_relay_rx: None,
             config_offer: None,
@@ -3709,6 +3718,14 @@ impl RadioManager {
         self.leaf_installs_outstanding
     }
 
+    /// #237: take the crown-delegated serve accepted in the RX drain (if any). main.rs drives the
+    /// blocking `run_leaf_ota_relay(HolderActiveSlot, …)` + emits the ODON. One-shot (cleared on take).
+    #[cfg(feature = "espnow")]
+    #[allow(dead_code)] // consumed by main.rs's serve-driver (next dispatch increment)
+    pub fn take_pending_serve(&mut self) -> Option<crate::ota_mesh::PendingServe> {
+        self.pending_serve.take()
+    }
+
     /// #40 GATEWAY leaf-mesh-OTA orchestration (§B4). Fetch the staged image (WiFi) into
     /// THIS gateway's inactive slot → relay it over ESP-NOW to ONE leaf (windowed-NAK) →
     /// watch for the leaf's Tier-2 STAT reappearance at the NEW build. CANARY-ONE-LEAF:
@@ -4766,6 +4783,13 @@ impl RadioManager {
                 self.handle_ota_frame(otaf, src, rssi, now);
                 continue;
             }
+            // #237 peer-relay ARBITRATION (ODEL/ODON) — crown↔holder unicast, dispatched like the
+            // OTA frames above. handle_arb_frame is FAST (records the delegation into pending_serve);
+            // the blocking serve runs from main.rs, never in this drain.
+            if let Some(arb) = crate::ota_mesh::parse_arb_frame(recv.data()) {
+                self.handle_arb_frame(arb, src, now);
+                continue;
+            }
 
             match parse_frame(recv.data()) {
                 Some(Frame::Snk(f)) => {
@@ -5268,6 +5292,42 @@ impl RadioManager {
     /// valid SMOLv1 frame"), registers the sender for the unicast NAK back-channel, then
     /// drives the receive session. On `Complete` [`crate::ota::activate`] reboots into the
     /// new slot; on `Nak` we unicast the OTAN to the gateway; `Abort`/`None` do nothing.
+    /// #237 peer-relay ARBITRATION dispatch (crown↔holder ODEL/ODON). Runs in the RX drain, so it
+    /// MUST be fast: it validates + RECORDS the delegation into `pending_serve`; the actual serve
+    /// (minutes) runs later from main.rs. Never blocks, never serves here.
+    #[cfg(feature = "espnow")]
+    fn handle_arb_frame(&mut self, arb: crate::ota_mesh::ArbFrame<'_>, src: [u8; 6], _now: u64) {
+        use crate::ota_mesh::ArbFrame;
+        match arb {
+            ArbFrame::Odel { target, build: _, session, term, m, sig } => {
+                // §5.3 replay/stale guard: reject a dethroned crown's older-term delegation.
+                if term < self.highest_arb_term {
+                    return;
+                }
+                self.highest_arb_term = term;
+                // Holder single-session: don't clobber a serve already accepted / in flight.
+                if self.pending_serve.is_some() {
+                    return;
+                }
+                // Rebuild the signed Announce from the ODEL's (M,sig); malformed → ignore (the crown
+                // times out → falls back to the #40 gateway fetch, the safety floor). main.rs
+                // resolves target's MAC + runs verify_active_slot + the serve + the ODON.
+                if let Some(ann) = crate::ota::Announce::from_signed(m, sig) {
+                    self.pending_serve = Some(crate::ota_mesh::PendingServe {
+                        target,
+                        session,
+                        ann,
+                        crown_mac: src,
+                    });
+                }
+            }
+            ArbFrame::Odon { .. } => {
+                // Crown-side ODON handling (baton advance / fallback-to-#40) lands with the crown
+                // scheduler in the next dispatch increment; ignored here.
+            }
+        }
+    }
+
     fn handle_ota_frame(&mut self, f: crate::ota_mesh::OtaFrame<'_>, src: [u8; 6], rssi: i32, now: u64) {
         use crate::ota_mesh::{LeafAction, OtaFrame};
         // Benign "heard a frame" liveness — safe to record for ANY decoded OTA-shaped frame:

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1972,8 +1972,10 @@ pub struct RadioManager {
     /// The phase is stored as the rendered `&'static str` (not the espnow-only enum) so the
     /// shared `wifi::mqtt_session` signature stays buildable in the wifi-only profile. `retry_n`
     /// (#134) is the current consecutive-failure count for this outcome class — surfaced in the
-    /// retained payload (`fetch-failed retry=3`) so a stuck fetch is visible headlessly.
-    leaf_ota_diag: Option<(u8, &'static str, bool, u8)>,
+    /// retained payload (`fetch-failed retry=3`) so a stuck fetch is visible headlessly. #237: the
+    /// trailing `u8` is the serve SOURCE id — 0 = the gateway/crown (a #40 seed fetch or a
+    /// fallback), else the peer HOLDER that served it — surfaced as `src=` (spec §8.1 item 8).
+    leaf_ota_diag: Option<(u8, &'static str, bool, u8, u8)>,
     /// #139-followup/#147: on a failed SELF-fetch, `(chunk_k, chunk_n, retries, stalls, where)`
     /// buffered by `run_ota_update` → formatted + published retained to `smol/<id>/ota/diag` on the
     /// next gateway flush (fleet-visible failure diag; release images are serial-silent). `where` is
@@ -3664,7 +3666,14 @@ impl RadioManager {
     /// retained install (terminal — the leaf installed or rolled back — or the transient-retry
     /// cap is hit) vs LEAVE it retained to retry (mac-unknown / fetch / relay / timeout). The
     /// phase is published to `smol/<leaf>/ota/diag` on the next burst (headless observability).
-    pub fn record_leaf_ota(&mut self, leaf_id: u8, outcome: crate::ota_mesh::LeafOtaOutcome) {
+    /// #237: `source_id` is the serve SOURCE — 0 = the gateway/crown (a #40 seed fetch or a
+    /// fallback), else the peer HOLDER id that served this leaf — surfaced on `ota/diag` as `src=`.
+    pub fn record_leaf_ota(
+        &mut self,
+        leaf_id: u8,
+        outcome: crate::ota_mesh::LeafOtaOutcome,
+        source_id: u8,
+    ) {
         // #134 clear/retry policy — THREE cases, not two:
         //  1. terminal (leaf DEFINITIVELY acted: installed / rolled-back / id-mismatch) → CLEAR,
         //     reset both counters.
@@ -3697,7 +3706,7 @@ impl RadioManager {
             "smol #40/#134: leaf id{} OTA phase={} (clear_install={}, reached_leaf={}, retry={})",
             leaf_id, outcome.as_str(), clear, outcome.reached_leaf(), retry_n
         );
-        self.leaf_ota_diag = Some((leaf_id, outcome.as_str(), clear, retry_n));
+        self.leaf_ota_diag = Some((leaf_id, outcome.as_str(), clear, retry_n, source_id));
         // #1 DECOUPLE: the relay session is done for this install iff we're clearing it
         // (terminal outcome or retry cap). While NOT cleared (transient retry) it stays
         // pending so the gateway keeps suppressing its own self-OTA until the leaf resolves.

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -3721,9 +3721,25 @@ impl RadioManager {
     /// #237: take the crown-delegated serve accepted in the RX drain (if any). main.rs drives the
     /// blocking `run_leaf_ota_relay(HolderActiveSlot, …)` + emits the ODON. One-shot (cleared on take).
     #[cfg(feature = "espnow")]
-    #[allow(dead_code)] // consumed by main.rs's serve-driver (next dispatch increment)
     pub fn take_pending_serve(&mut self) -> Option<crate::ota_mesh::PendingServe> {
         self.pending_serve.take()
+    }
+
+    /// #237: send one crown↔holder ARBITRATION frame (`ODEL`/`ODON`) as a RAW ESP-NOW unicast.
+    /// Deliberately NOT routed through [`Self::send_to`]: once #248 (v346) lands, `send_to` appends a
+    /// 9-B group-MAC trailer on TX, but the OTA family (incl. these arbitration frames) is consumed
+    /// by the parser BEFORE any RX verify-then-strip, so a trailer would corrupt the frame (190L
+    /// review item 1). Registers the peer first (bounded-LRU evict if the HW table is full), then
+    /// fires + waits for the TX callback so we don't overrun the single in-flight send slot.
+    #[cfg(feature = "espnow")]
+    pub fn send_arb_raw(&mut self, dst: [u8; 6], frame: &[u8]) {
+        self.ensure_peer(dst, now_ms());
+        match self.esp_now.send(&dst, frame) {
+            Ok(waiter) => {
+                let _ = waiter.wait();
+            }
+            Err(e) => log::warn!("smol #237: arb-frame raw send failed: {:?}", e),
+        }
     }
 
     /// #40 GATEWAY leaf-mesh-OTA orchestration (§B4). Fetch the staged image (WiFi) into

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -3718,6 +3718,7 @@ impl RadioManager {
     /// outcome for the HA `smol/<leaf>/ota/state` publish. No-op on a non-gateway.
     pub fn run_leaf_ota_relay(
         &mut self,
+        source: crate::ota_mesh::ServeSource,
         leaf_id: u8,
         leaf_mac: [u8; 6],
         announce: &crate::ota::Announce,
@@ -3730,7 +3731,10 @@ impl RadioManager {
             self as om, LeafOtaOutcome, CHUNK_PAYLOAD, WINDOW_BYTES, WINDOW_CHUNKS,
         };
         use esp_bootloader_esp_idf::ota::Slot;
-        if !self.relay.is_gateway {
+        // #237: a GATEWAY-fetch serve needs the crown role (it does the WiFi fetch); a HOLDER
+        // active-slot serve is authorized by the crown's ODEL (term/session + serve-time
+        // readback-sha verified by the caller), so it does NOT require is_gateway.
+        if matches!(source, om::ServeSource::GatewayFetch) && !self.relay.is_gateway {
             return LeafOtaOutcome::RelayFailed;
         }
         let size = announce.size;
@@ -3813,30 +3817,41 @@ impl RadioManager {
             }
         }
 
-        // --- FETCH (WiFi) → stage+verify into THIS gateway's inactive slot (no activate).
-        // CRITICAL: `run_leaf_ota_relay` is called IMMEDIATELY after `flush_telemetry`, which
-        // leaves the radio in WifiSta. `switch()` is a NO-OP when already in-mode → it would
-        // NOT issue a fresh `connect()`, but `run_ota_fetch` ASSUMES the caller's switch just
-        // connect()'d (its own contract). If the flush's association has gone stale, the fetch
-        // then spins its whole 5-min budget waiting for `is_connected` (no SYN, mesh-deaf) —
-        // exactly the observed "no fetch + long offline". Self-OTA avoids this because it runs
-        // from EspNow mode (its switch DOES connect). So force a fresh association here:
-        // EspNow (drop the stale link) → WifiSta (issue a real connect), mirroring self-OTA.
-        let _ = self.switch(Mode::EspNow);
-        let _ = self.switch(Mode::WifiSta);
-        let rng = self.rng;
-        let mut staged: Option<Slot> = None;
-        let fetched = match self.sta.as_mut() {
-            Some(sta) => crate::net::wifi::run_ota_fetch(
-                &mut self.controller, sta, rng, announce, tick, true, &mut staged, &mut None,
-                progress,
-                Some(leaf_id), // #188: live progress → smol/<leaf>/ota/progress (crown relay-fetch)
-            ),
-            None => false,
+        // --- SOURCE the image slot: #40 gateway FETCH (WiFi → inactive slot) OR #237 peer-serve
+        // (read the build this holder is RUNNING from its ACTIVE slot — no WiFi, coexist-safe).
+        // The RELAY machinery below is source-AGNOSTIC (it reads via `reader`), so peer-sourcing
+        // only changes where these bytes come from.
+        let slot = match source {
+            om::ServeSource::GatewayFetch => {
+                // CRITICAL: run_leaf_ota_relay is called IMMEDIATELY after flush_telemetry, which
+                // leaves the radio in WifiSta. switch() is a NO-OP when already in-mode → it would
+                // NOT issue a fresh connect(), but run_ota_fetch ASSUMES the caller's switch just
+                // connect()'d (its contract). If the flush's association went stale, the fetch spins
+                // its whole budget waiting for is_connected. So force a fresh association here:
+                // EspNow (drop the stale link) → WifiSta (real connect), mirroring self-OTA.
+                let _ = self.switch(Mode::EspNow);
+                let _ = self.switch(Mode::WifiSta);
+                let rng = self.rng;
+                let mut staged: Option<Slot> = None;
+                let fetched = match self.sta.as_mut() {
+                    Some(sta) => crate::net::wifi::run_ota_fetch(
+                        &mut self.controller, sta, rng, announce, tick, true, &mut staged, &mut None,
+                        progress,
+                        Some(leaf_id), // #188: live progress → smol/<leaf>/ota/progress (relay-fetch)
+                    ),
+                    None => false,
+                };
+                if fetched { staged } else { None }
+            }
+            om::ServeSource::HolderActiveSlot => {
+                // #237: no WiFi fetch — the holder serves its RUNNING build from the ACTIVE slot.
+                // The ODEL handler (caller) already verified term/session + ran verify_active_slot
+                // against the manifest sha, so these bytes are the signed image the crown named.
+                crate::ota::active_slot()
+            }
         };
-        let staged = if fetched { staged } else { None };
-        let Some(slot) = staged else {
-            log::error!("smol #40: relay FETCH/stage failed — aborting (leaf untouched)");
+        let Some(slot) = slot else {
+            log::error!("smol #237/#40: relay source slot unavailable — aborting (leaf untouched)");
             let _ = self.switch(Mode::EspNow);
             return LeafOtaOutcome::FetchFailed;
         };

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -292,6 +292,12 @@ const GW_WINDOW_ROUNDS_MAX: u32 = 16;
 /// WINDOW_MS` ≈ 60 s) + a STAT cadence (~10 s) so a late self-test rollback is observed
 /// before the gateway declares Confirmed.
 const GW_CONFIRM_TIMEOUT_MS: u64 = 120_000;
+/// #237 crown-delegate serve deadline: a holder's full serve (pre-arm + wake + windowed relay +
+/// Tier-2 confirm) can run several minutes and ALWAYS ends with an `ODON` (OK or a failure code);
+/// this backstops the ONLY no-ODON case — holder death mid-serve → the crown falls back to the #40
+/// gateway fetch. Set WELL ABOVE the holder's worst-case serve (≈8 min) so a live serve is never
+/// pre-empted into a double-source (§5.3). Normal path returns on the ODON long before this.
+const CROWN_DELEGATE_DEADLINE_MS: u64 = 12 * 60_000;
 /// #40: max consecutive TRANSIENT (mac-unknown / fetch / relay / timeout) relay attempts
 /// for one retained install before the gateway gives up + clears it — bounds the auto-retry
 /// so a persistently-failing leaf can't loop the (mesh-deaf) relay every flush forever.
@@ -1994,6 +2000,12 @@ pub struct RadioManager {
     /// #237: highest ODEL `term` (= the crown's MC seq) ever seen — reject a stale/dethroned crown's
     /// ODEL (term < this), the §5.3 split-brain guard.
     highest_arb_term: u16,
+    /// #237 CROWN baton (§8.2): `(leaf_id, build)` of the leaf this crown LAST confirmed healthy on
+    /// a serve. It is, by definition, a valid SOURCE for the next target on the same build → the
+    /// crown delegates the next serve to it (`baton_holder_for`) instead of a WiFi bulk fetch. The
+    /// FIRST target of a build has no baton → the crown seeds it the #40 way, then the baton passes
+    /// down the canary sequence. Reset implicitly by a build change (`baton_holder_for` build match).
+    last_confirmed_holder: Option<(u8, u32)>,
     /// #40 #3 STICKY MAC: `(leaf_id, mac)` captured the moment an armed leaf became addressable,
     /// held for the whole install session (cleared on a terminal `record_leaf_ota`). The roster
     /// is a bounded 16-slot LRU that EVICTS this leaf while the mesh-deaf relay stops hearing it
@@ -2152,6 +2164,7 @@ impl RadioManager {
             leaf_installs_outstanding: false,
             pending_serve: None,
             highest_arb_term: 0,
+            last_confirmed_holder: None,
             leaf_ota_mac: None,
             leaf_relay_rx: None,
             config_offer: None,
@@ -3740,6 +3753,150 @@ impl RadioManager {
             }
             Err(e) => log::warn!("smol #237: arb-frame raw send failed: {:?}", e),
         }
+    }
+
+    /// #237 CROWN baton term (§5.3 split-brain): the crown stamps every `ODEL` with its election
+    /// generation so a dethroned crown's stale delegation is refused at the holder (it rejects a
+    /// `term` older than the highest it has seen). Sourced from the MC election seq (`mc_seen_seq`),
+    /// which advances each election → a newly-elected crown out-terms the old one. Low 16 bits (the
+    /// wire `term` is `u16`; the guard needs only relative ordering within a roll).
+    pub fn crown_term(&self) -> u16 {
+        (self.mc_seen_seq & 0xFFFF) as u16
+    }
+
+    /// #237 CROWN baton source-pick (§8.2): the holder to DELEGATE the next serve to — the leaf this
+    /// crown last confirmed healthy, IFF it is running the exact `want_build`, is not the `target`
+    /// itself, and its MAC is resolvable (sticky). `None` ⇒ no baton (first target of a build, a
+    /// build change, or the holder's MAC is unknown) ⇒ the caller SEEDS via the #40 gateway fetch.
+    /// Reading the sticky MAC keeps the holder addressable across the minutes-long serve.
+    pub fn baton_holder_for(&mut self, want_build: u32, target: u8) -> Option<(u8, [u8; 6])> {
+        let (hid, hbuild) = self.last_confirmed_holder?;
+        if hbuild != want_build || hid == target {
+            return None;
+        }
+        let mac = self.mac_for_id_sticky(hid)?;
+        Some((hid, mac))
+    }
+
+    /// #237 CROWN baton advance (§8.2): record `leaf_id` (now confirmed on `build`) as the source for
+    /// the NEXT target. Called after a CONFIRMED serve — delegated OR seeded.
+    pub fn note_confirmed_holder(&mut self, leaf_id: u8, build: u32) {
+        self.last_confirmed_holder = Some((leaf_id, build));
+    }
+
+    /// #237 CROWN delegate-and-await (§8.2): delegate the serve of `leaf_id` to peer `holder`
+    /// (confirmed running the target build) instead of a gateway WiFi bulk-fetch. Fires the `ODEL`
+    /// — carrying the crown-staged `(M, sig)` — via RAW esp_now (NOT `send_to`: the #248 group-MAC
+    /// trailer would corrupt the OTA family, 190L item 1), then AWAITS the holder's matching `ODON`
+    /// within the serve deadline, keeping the UI + mesh alive (~1 Hz HELLO) throughout. Returns the
+    /// reported `ServeResult` on a matching ODON, `Some(Aborted)` on a long-press, or `None` on a
+    /// serve-deadline timeout / un-encodable manifest. THE CALLER FALLS BACK to the #40 gateway
+    /// fetch on `None` OR any non-`Ok` — the UNCONDITIONAL safety floor. BLOCKS for minutes like
+    /// `run_leaf_ota_relay`, so it runs from main.rs's loop, never the RX drain.
+    pub fn run_crown_delegate(
+        &mut self,
+        holder_id: u8,
+        holder_mac: [u8; 6],
+        leaf_id: u8,
+        announce: &crate::ota::Announce,
+        term: u16,
+        tick: &mut dyn FnMut() -> bool,
+    ) -> Option<crate::ota_mesh::ServeResult> {
+        use crate::ota_mesh as om;
+        // session mirrors the OTAM discriminator the holder emits (build & 0xFFFF), so the crown↔
+        // holder ODON correlates 1:1 with the leaf-facing session.
+        let session: u16 = (announce.build & 0xFFFF) as u16;
+        let mut odel = [0u8; om::ODEL_FRAME_MAX];
+        let Some(n) = om::encode_odel(
+            leaf_id,
+            announce.build,
+            session,
+            term,
+            announce.signed_msg(),
+            announce.sig(),
+            &mut odel,
+        ) else {
+            log::error!(
+                "smol #237: crown could not encode ODEL for build {} (M too large?) — falling back",
+                announce.build
+            );
+            return None;
+        };
+        let _ = self.switch(Mode::EspNow);
+        self.ensure_peer(holder_mac, now_ms());
+        // Opening BURST: fire a few ODELs so the holder catches one before it goes serve-busy
+        // (mesh-deaf). Once accepted it single-sessions + ignores dups; a fast failure ODON
+        // short-circuits the burst.
+        const ODEL_BURST: u8 = 6;
+        const ODEL_GAP_MS: u64 = 200;
+        for _ in 0..ODEL_BURST {
+            if tick() {
+                return Some(om::ServeResult::Aborted);
+            }
+            let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
+            self.send_arb_raw(holder_mac, &odel[..n]);
+            let gap = now_ms() + ODEL_GAP_MS;
+            while now_ms() < gap {
+                if let Some(res) = self.poll_odon(holder_mac, leaf_id, session) {
+                    return Some(res);
+                }
+            }
+        }
+        // AWAIT the ODON. The holder's serve ALWAYS ends with an ODON (OK or a failure code); the
+        // only no-ODON case is holder death → the deadline backstops it → fall back. Keep a ~1 Hz
+        // HELLO so leaves don't re-elect while the crown waits (same posture as the #40 confirm).
+        let deadline = now_ms() + CROWN_DELEGATE_DEADLINE_MS;
+        let mut last_hello_ms = 0u64;
+        while now_ms() < deadline {
+            if tick() {
+                return Some(om::ServeResult::Aborted);
+            }
+            let t = now_ms();
+            if t.saturating_sub(last_hello_ms) >= 1000 {
+                let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
+                self.broadcast_hello();
+                last_hello_ms = t;
+            }
+            if let Some(res) = self.poll_odon(holder_mac, leaf_id, session) {
+                log::info!(
+                    "smol #237: crown got ODON id{} build {} → {:?}",
+                    leaf_id, announce.build, res
+                );
+                return Some(res);
+            }
+        }
+        log::warn!(
+            "smol #237: crown DELEGATE serve-deadline elapsed (no ODON from holder id{}) — falling back to #40",
+            holder_id
+        );
+        None
+    }
+
+    /// #237: one bounded RX drain step for [`Self::run_crown_delegate`] — return a `ServeResult`
+    /// iff a matching `ODON` (from `holder_mac`, for `(leaf_id, session)`) is queued. Non-matching
+    /// frames are discarded (same direct-drain posture as the #40 relay). Bounded so it never
+    /// stalls the caller's tick.
+    fn poll_odon(
+        &mut self,
+        holder_mac: [u8; 6],
+        leaf_id: u8,
+        session: u16,
+    ) -> Option<crate::ota_mesh::ServeResult> {
+        use crate::ota_mesh as om;
+        for _ in 0..8 {
+            let recv = self.esp_now.receive()?;
+            if recv.info.src_address != holder_mac {
+                continue;
+            }
+            if let Some(om::ArbFrame::Odon { target, session: s, result, .. }) =
+                om::parse_arb_frame(recv.data())
+            {
+                if target == leaf_id && s == session {
+                    return Some(result);
+                }
+            }
+        }
+        None
     }
 
     /// #40 GATEWAY leaf-mesh-OTA orchestration (§B4). Fetch the staged image (WiFi) into
@@ -5338,8 +5495,10 @@ impl RadioManager {
                 }
             }
             ArbFrame::Odon { .. } => {
-                // Crown-side ODON handling (baton advance / fallback-to-#40) lands with the crown
-                // scheduler in the next dispatch increment; ignored here.
+                // Crown-side ODON is consumed DIRECTLY by `run_crown_delegate` (it drains the RX
+                // queue itself while awaiting the serve outcome, like `run_leaf_ota_relay` drains
+                // OTANs) — never through this async drain. A stray/late ODON reaching here (outside
+                // a delegate wait) has no session to advance, so ignoring it is correct.
             }
         }
     }

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -2059,7 +2059,7 @@ fn mqtt_session(
     // PUBLISHED to `smol/<leaf>/ota/diag` here, and drives the retained-install clear (on a
     // terminal/exhausted phase) vs retry (transient). Consumed (set None) after publish.
     // `&mut None` off-gateway.
-    leaf_diag: &mut Option<(u8, &'static str, bool, u8)>,
+    leaf_diag: &mut Option<(u8, &'static str, bool, u8, u8)>,
     // #3 RELAY RX-DIAG: the last relay's `(leaf_id, rx_any, otan_valid, last_wb, total)`.
     // PUBLISHED to retained `smol/<leaf>/ota/relaydiag` here, consumed after. `&mut None` off-gw.
     leaf_relay_rx: &mut Option<RelayDiag>,
@@ -3081,7 +3081,7 @@ fn mqtt_session(
     // = the leaf installed/rolled-back, or the transient-retry cap was hit) or LEAVE it
     // retained to retry. On a clear, also null `pending_leaf` for THIS flush so we don't
     // re-arm a just-finished leaf. Runs BEFORE the arm below. Consumed after publish.
-    if let Some((lid, phase, clear, retry)) = *leaf_diag {
+    if let Some((lid, phase, clear, retry, src)) = *leaf_diag {
         let mut dtopic = MqttScratch::new();
         let _ = write!(dtopic, "smol/{}/ota/diag", lid);
         // #134: surface the consecutive-failure count in the retained payload ("fetch-failed
@@ -3092,6 +3092,14 @@ fn mqtt_session(
             let _ = write!(dpayload, "{} retry={}", phase, retry);
         } else {
             let _ = write!(dpayload, "{}", phase);
+        }
+        // #237 (spec §8.1 item 8): append the serve SOURCE — `src=gw` (the crown WiFi-fetched or
+        // fell back to it) vs `src=id<n>` (a peer HOLDER served it over ESP-NOW, zero bulk fetch).
+        // That distinction is the metric proving peer-sourcing actually saved a fetch.
+        if src == 0 {
+            let _ = write!(dpayload, " src=gw");
+        } else {
+            let _ = write!(dpayload, " src=id{}", src);
         }
         if let Some(n) =
             crate::net::mqtt::encode_publish(&mut pkt, dtopic.as_bytes(), dpayload.as_bytes(), true)
@@ -3809,7 +3817,7 @@ pub fn run_mqtt_burst(
     staged_raw: &mut Option<crate::ota::Announce>,
     // #40: last relay attempt's `(leaf_id, phase, clear)` → published to `smol/<leaf>/ota/diag`
     // (see `mqtt_session`). `&mut None` on boot/leaf bursts.
-    leaf_diag: &mut Option<(u8, &'static str, bool, u8)>,
+    leaf_diag: &mut Option<(u8, &'static str, bool, u8, u8)>,
     // #3: last relay attempt's RX evidence → published to `smol/<leaf>/ota/relaydiag` (see
     // `mqtt_session`). `&mut None` on boot/leaf bursts.
     leaf_relay_rx: &mut Option<RelayDiag>,

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -1186,6 +1186,50 @@ pub fn active_slot() -> Option<Slot> {
     })
 }
 
+/// #237 slice-1 serve-time SELF-VERIFY (spec §10.1 item 4 / §5.2 pre-flight): read the ACTIVE slot's
+/// first `size` bytes and confirm their SHA-256 == `sha256` (the manifest sha the crown supplied in
+/// the ODEL). A peer-relay holder MUST pass this before serving — on mismatch it replies
+/// `ODON = self-slot-verify-failed` and the crown falls back to the #40 gateway fetch (§5.2). A
+/// source must never offer a copy it cannot itself reproduce. Read-only, fail-closed (ANY
+/// partition/flash/slot error ⇒ `false`).
+///
+/// The read buffer lives in a `static` (NOT the stack — the serve task budget is tight; same F2
+/// discipline as #217's OTA_STAGE) and reads in `CHUNK` spans so `SlotReader::read`'s per-call
+/// partition-table reparse amortizes over few calls. Single-caller + one-shot per ODEL (a serve is
+/// never re-entrant), so the `&'static mut` borrow is alias-safe; `addr_of_mut!` avoids the
+/// ref-to-`static mut` lint. Word-alignment: `off` steps by `CHUNK` (aligned) except the final
+/// partial (which ends the loop); the tail read length is rounded up to a word and only the real
+/// `size` bytes are hashed (the slot beyond `size` is inert 0xFF pad).
+#[cfg(feature = "espnow")]
+#[allow(dead_code)] // #237: wired by the ODEL-receipt handler (INC4 dispatch)
+pub fn verify_active_slot(size: u32, sha256: &[u8; 32]) -> bool {
+    use sha2::{Digest, Sha256};
+    static mut VERIFY_BUF: [u8; CHUNK] = [0u8; CHUNK];
+    let slot = match active_slot() {
+        Some(s) => s,
+        None => return false,
+    };
+    let reader = match SlotReader::open(slot) {
+        Some(r) => r,
+        None => return false,
+    };
+    // Alias-safe: one-shot, single-caller, non-re-entrant (see doc).
+    let buf: &mut [u8; CHUNK] = unsafe { &mut *core::ptr::addr_of_mut!(VERIFY_BUF) };
+    let mut hasher = Sha256::new();
+    let mut off: u32 = 0;
+    while off < size {
+        let take = core::cmp::min(CHUNK as u32, size - off) as usize;
+        let read_len = take.next_multiple_of(4); // SlotReader wants a word-aligned len (≤ CHUNK)
+        if !reader.read(off, &mut buf[..read_len]) {
+            return false;
+        }
+        hasher.update(&buf[..take]);
+        off += take as u32;
+    }
+    let digest = hasher.finalize();
+    digest[..] == sha256[..]
+}
+
 // ---------------------------------------------------------------------------
 // #40 §3C — the persistent signed-freshness FLOOR (NVS-backed).
 //

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -1163,6 +1163,29 @@ impl SlotReader {
     }
 }
 
+/// #237 slice-1 (serve-reads-active-slot): the ACTIVE/running slot — the build this node is
+/// executing, and a peer-relay holder's serve SOURCE. `SlotReader::open` already reads any slot;
+/// the #40 gateway relay passes the just-staged INACTIVE slot, whereas a holder serves the build it
+/// is RUNNING, so it needs the active one. Mirrors `inactive_slot` but returns `current_slot`
+/// directly. Blank otadata ⇒ the ROM booted `ota_0` (no factory partition in partitions-ota.csv)
+/// ⇒ `Slot0` — the same mapping as #226's inactive_slot fix. `None` on any partition/flash error.
+#[cfg(feature = "espnow")]
+#[allow(dead_code)] // #237: wired by the crown/holder serve arbiter (later slice-1 increment)
+pub fn active_slot() -> Option<Slot> {
+    let mut flash = FlashStorage::new();
+    let mut buf = [0u8; PT_SCRATCH];
+    let pt = read_partition_table(&mut flash, &mut buf).ok()?;
+    let od = pt
+        .find_partition(PartitionType::Data(DataPartitionSubType::Ota))
+        .ok()??;
+    let mut region = od.as_embedded_storage(&mut flash);
+    let mut ota = Ota::new(&mut region).ok()?;
+    Some(match ota.current_slot().ok()? {
+        Slot::None => Slot::Slot0, // blank ⇒ ROM booted ota_0 (mirrors inactive_slot, #226)
+        s => s,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // #40 §3C — the persistent signed-freshness FLOOR (NVS-backed).
 //

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -189,6 +189,39 @@ impl Announce {
     pub fn sig(&self) -> &[u8; 64] {
         &self.sig
     }
+
+    /// #237: reconstruct an `Announce` from a signed manifest `m` = `"build|size|sha256hex"` + its
+    /// 64-byte ed25519 `sig`, WITHOUT the MQTT `OTA|…|url` wrapper. A peer-relay HOLDER receives
+    /// `(M, sig)` in the crown's ODEL (not from `smol/ota/staged`), so it rebuilds the `Announce`
+    /// here to drive `run_leaf_ota_relay(HolderActiveSlot, …)`. `url` is empty — a holder never
+    /// fetches. `signed_msg` is set to the EXACT `m` bytes so the leaf's sig-over-M verify stays
+    /// byte-identical to a gateway-sourced OTAM. Panic-free — `None` on any malformed field or
+    /// `m` > `SIGNED_MSG_MAX`. (`splitn(3)` fail-closes a 4th field: trailing bytes land in the sha
+    /// slot and fail the 64-hex parse.)
+    #[cfg(feature = "espnow")]
+    #[allow(dead_code)] // #237: wired by the ODEL-receipt handler (next dispatch increment)
+    pub fn from_signed(m: &[u8], sig: &[u8; 64]) -> Option<Announce> {
+        if m.is_empty() || m.len() > SIGNED_MSG_MAX {
+            return None;
+        }
+        let s = core::str::from_utf8(m).ok()?;
+        let mut it = s.splitn(3, '|');
+        let build: u32 = it.next()?.parse().ok()?;
+        let size: u32 = it.next()?.parse().ok()?;
+        let sha256 = parse_hex_n::<32>(it.next()?)?;
+        let mut signed_msg = [0u8; SIGNED_MSG_MAX];
+        signed_msg[..m.len()].copy_from_slice(m);
+        Some(Announce {
+            build,
+            size,
+            sha256,
+            sig: *sig,
+            signed_msg,
+            signed_len: m.len(),
+            url: [0u8; URL_MAX],
+            url_len: 0,
+        })
+    }
 }
 
 /// Parse `OTA|build|size|sha256hex|sighex|url` (#32: `sighex` = 128-hex Ed25519 sig; url

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -95,7 +95,6 @@ pub const OTAD_FRAME_MAX: usize = 12 + 3 + 2 + 2 + CHUNK_PAYLOAD;
 pub const OTAN_FRAME_MAX: usize = 12 + 3 + 2 + 2 + OTAN_BITMAP_BYTES;
 /// #237 max `ODEL` frame: 12 + 3 (target) + 4 (build) + 2 (session) + 2 (term) + 1 (M_len) +
 /// `SIGNED_MSG_MAX` (M) + 64 (sig) = 184 B — < the 250 B ESP-NOW MTU (spec §8/§10, real M ≤86).
-#[allow(dead_code)] // #237: wired by the crown baton (Piece 2, next commit)
 pub const ODEL_FRAME_MAX: usize = 12 + 3 + 4 + 2 + 2 + 1 + ota::SIGNED_MSG_MAX + 64;
 /// #237 max `ODON` frame: 12 + 3 (target) + 4 (build) + 2 (session) + 1 (result) = 22 B.
 pub const ODON_FRAME_MAX: usize = 12 + 3 + 4 + 2 + 1;
@@ -423,9 +422,9 @@ pub fn parse_arb_frame(data: &[u8]) -> Option<ArbFrame<'_>> {
     None
 }
 
-/// Encode an `ODEL` (crown→holder delegate-to-serve). Fixed-width (no manifest) → always fits one
-/// ESP-NOW frame. Returns the byte length written, or `None` if `out` is too small.
-#[allow(dead_code)] // #237 INC1: wired later
+/// Encode an `ODEL` (crown→holder delegate-to-serve, carrying the signed manifest `m` + `sig`).
+/// REJECTS (not clamps) an empty or oversized `m` (> `SIGNED_MSG_MAX`). Returns the byte length
+/// written, or `None` if `out` is too small.
 pub fn encode_odel(
     target_id: u8,
     build: u32,

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -188,6 +188,21 @@ pub enum ArbFrame<'a> {
     Odon { target: u8, build: u32, session: u16, result: ServeResult },
 }
 
+/// #237 slice-1: where a leaf-OTA serve sources its image bytes (selects the source arm inside
+/// `run_leaf_ota_relay`). `GatewayFetch` = the #40 path (the crown WiFi-fetches into its inactive
+/// slot then serves) — the seed + the fallback floor. `HolderActiveSlot` = peer-sourcing: a holder
+/// serves the build it is RUNNING from its ACTIVE slot over ESP-NOW with NO WiFi fetch
+/// (coexist-safe), authorized by the crown's ODEL (term/session + serve-time readback-sha verified
+/// by the caller before it invokes the serve).
+// HolderActiveSlot is constructed by the ODEL-receipt handler (next #237 increment); GatewayFetch
+// is live now (the #40 caller). Allow until that handler wires the holder-serve path.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServeSource {
+    GatewayFetch,
+    HolderActiveSlot,
+}
+
 /// Parse one #40 OTA frame. Returns `None` on ANY malformed input (never panics,
 /// never indexes past the slice) — the caller treats `None` as "not an OTA frame".
 // #69 IRAM: on the per-chunk RX hot path (parsed for every OTAD during a leaf mesh-OTA). Placed in

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -93,6 +93,12 @@ pub const OTAM_FRAME_MAX: usize = 12 + 3 + 2 + 1 + ota::SIGNED_MSG_MAX + 64;
 pub const OTAD_FRAME_MAX: usize = 12 + 3 + 2 + 2 + CHUNK_PAYLOAD;
 /// Max `OTAN` frame: 12 + 3 + 2 + 2 + 8.
 pub const OTAN_FRAME_MAX: usize = 12 + 3 + 2 + 2 + OTAN_BITMAP_BYTES;
+/// #237 max `ODEL` frame: 12 + 3 (target) + 4 (build) + 2 (session) + 2 (term) + 1 (M_len) +
+/// `SIGNED_MSG_MAX` (M) + 64 (sig) = 184 B — < the 250 B ESP-NOW MTU (spec §8/§10, real M ≤86).
+#[allow(dead_code)] // #237: wired by the crown baton (Piece 2, next commit)
+pub const ODEL_FRAME_MAX: usize = 12 + 3 + 4 + 2 + 2 + 1 + ota::SIGNED_MSG_MAX + 64;
+/// #237 max `ODON` frame: 12 + 3 (target) + 4 (build) + 2 (session) + 1 (result) = 22 B.
+pub const ODON_FRAME_MAX: usize = 12 + 3 + 4 + 2 + 1;
 
 // ---------------------------------------------------------------------------
 // Parsed frames (borrow the RX buffer; used immediately in `service()`)
@@ -158,6 +164,25 @@ impl ServeResult {
             2 => Some(ServeResult::Aborted),
             3 => Some(ServeResult::SelfSlotVerifyFailed),
             _ => None,
+        }
+    }
+    /// #237: map a #40 [`LeafOtaOutcome`] (what a HOLDER's `run_leaf_ota_relay` returns) → the
+    /// `ODON` result it reports to the crown. FAIL-CLOSED: **only** a build-matched `Confirmed` is
+    /// `Ok`; EVERY other outcome — including any future variant (the `_` arm) — is a non-`Ok` the
+    /// crown treats as "fall back to the #40 gateway fetch" (the safety floor) and must NEVER
+    /// advance the baton onto. `FetchFailed` on a holder means its own active-slot source was
+    /// unavailable → `SelfSlotVerifyFailed`; a leaf that never answered → `TargetUnreachable`;
+    /// delivered-but-unconfirmed / rolled-back / id-mismatch / operator-abort → `Aborted`. The
+    /// precise non-`Ok` code is observability only — the crown falls back on all of them.
+    #[allow(dead_code)] // #237: wired by the holder serve-driver (main.rs)
+    pub fn from_leaf_outcome(o: LeafOtaOutcome) -> Self {
+        match o {
+            LeafOtaOutcome::Confirmed => ServeResult::Ok,
+            LeafOtaOutcome::MacUnknown | LeafOtaOutcome::RelayFailed => {
+                ServeResult::TargetUnreachable
+            }
+            LeafOtaOutcome::FetchFailed => ServeResult::SelfSlotVerifyFailed,
+            _ => ServeResult::Aborted,
         }
     }
 }

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -203,6 +203,19 @@ pub enum ServeSource {
     HolderActiveSlot,
 }
 
+/// #237: a crown-delegated serve a HOLDER accepted via ODEL and will run from main.rs — the serve
+/// blocks for minutes, so it must NOT run in the mesh RX drain (it'd stall HELLO/MC/etc.). Recorded
+/// by `handle_arb_frame` in the drain; consumed by main.rs, which resolves `target`'s MAC
+/// (mac_for_id_sticky), runs `verify_active_slot`, drives `run_leaf_ota_relay(HolderActiveSlot,…)`,
+/// and emits the ODON (target/build/session/result) back to `crown_mac`.
+#[allow(dead_code)] // fields read by main.rs's serve-driver (next dispatch increment)
+pub struct PendingServe {
+    pub target: u8,
+    pub session: u16,
+    pub ann: crate::ota::Announce,
+    pub crown_mac: [u8; 6],
+}
+
 /// Parse one #40 OTA frame. Returns `None` on ANY malformed input (never panics,
 /// never indexes past the slice) — the caller treats `None` as "not an OTA frame".
 // #69 IRAM: on the per-chunk RX hot path (parsed for every OTAD during a leaf mesh-OTA). Placed in

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -61,6 +61,9 @@ pub const OTAN_PREFIX: &[u8] = b"SMOLv1 OTAN "; // leaf→gateway (UNICAST): win
 /// sent[2 LE]. Broadcast on the HELLO cadence so the gateway's relay RX loop CAPTURES it while
 /// the leaf is provably online (rx>0), naming WHY a `relay-failed` had `otan=0` (see `RelayDiag`).
 pub const LDBG_PREFIX: &[u8] = b"SMOLv1 LDBG "; // leaf→broadcast: OTA receive-side self-report
+// #237 peer-sourced relay — crown↔holder ARBITRATION (unicast; NOT on the receiver hot path).
+pub const ODEL_PREFIX: &[u8] = b"SMOLv1 ODEL "; // crown→holder (UNICAST): delegate-to-serve
+pub const ODON_PREFIX: &[u8] = b"SMOLv1 ODON "; // holder→crown (UNICAST): serve outcome
 /// `LDBG` payload: id[3 ASCII] + otam_heard[2 LE] + verdict[1] + otan_sent[2 LE] + ch[1].
 /// #3b `ch` = the leaf's `current_channel()` at beacon time (0 = SCANNING/unlocked, else the
 /// locked channel 1/6/11). Decisive for the H0 fork: ch=6 means the leaf was ON ch6 yet still
@@ -120,6 +123,58 @@ pub enum OtaFrame<'a> {
         window_base: u16,
         bitmap: &'a [u8],
     },
+}
+
+/// #237 ODON serve outcome (wire `result[1]`). Pure u8 ⇄ enum; host-testable.
+#[allow(dead_code)] // #237 INC1: wired by the crown/holder dispatch in a later slice-1 increment
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServeResult {
+    /// All windows served — last-window exhaustion IS the #40 confirm.
+    Ok,
+    /// The target never answered (no NAKs) — crown re-delegates / falls back.
+    TargetUnreachable,
+    /// Serve aborted mid-flight (e.g. the holder drifted off ch6).
+    Aborted,
+    /// The holder's own `slot[..size]` readback-sha did not match the manifest → it must not serve;
+    /// the crown falls back to the gateway fetch (spec §5.2 pre-flight catch).
+    SelfSlotVerifyFailed,
+}
+
+impl ServeResult {
+    #[allow(dead_code)] // #237 INC1: wired later
+    pub fn as_u8(self) -> u8 {
+        match self {
+            ServeResult::Ok => 0,
+            ServeResult::TargetUnreachable => 1,
+            ServeResult::Aborted => 2,
+            ServeResult::SelfSlotVerifyFailed => 3,
+        }
+    }
+    #[allow(dead_code)] // #237 INC1: wired later
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(ServeResult::Ok),
+            1 => Some(ServeResult::TargetUnreachable),
+            2 => Some(ServeResult::Aborted),
+            3 => Some(ServeResult::SelfSlotVerifyFailed),
+            _ => None,
+        }
+    }
+}
+
+/// #237 crown↔holder ARBITRATION frames. Distinct from [`OtaFrame`] (the receiver demux, which
+/// stays `#[esp_hal::ram]`/lean and UNTOUCHED per the spec invariant): a holder handles `Odel`, the
+/// crown handles `Odon`. Parsed by [`parse_arb_frame`], off the per-chunk hot path.
+#[allow(dead_code)] // #237 INC1: wired by the crown/holder dispatch in a later slice-1 increment
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArbFrame {
+    /// crown→holder: serve `build` to leaf `target` under `session`, gated by `term` (a holder
+    /// rejects a `term` older than the highest it has seen → a dethroned crown cannot delegate).
+    /// ODEL only STARTS a serve of an already-signed image — it cannot cause a flash (the leaf still
+    /// verifies the image sig) — so it needs replay/stale protection, not a signature.
+    Odel { target: u8, build: u32, session: u16, term: u16 },
+    /// holder→crown: outcome of the delegated serve (so the crown advances or falls back).
+    Odon { target: u8, build: u32, session: u16, result: ServeResult },
 }
 
 /// Parse one #40 OTA frame. Returns `None` on ANY malformed input (never panics,
@@ -254,6 +309,90 @@ pub fn encode_otan(origin_id: u8, session: u16, window_base: u16, bitmap: &[u8],
     out[n..n + blen].copy_from_slice(&bitmap[..blen]);
     n += blen;
     n
+}
+
+// ---------------------------------------------------------------------------
+// #237 arbitration codec (crown↔holder) — pure, host-testable, NOT IRAM (rare, off the hot path)
+// ---------------------------------------------------------------------------
+
+/// Parse one #237 arbitration frame (`ODEL`/`ODON`). `None` on ANY malformed input (never panics,
+/// never over-reads) — the caller treats `None` as "not an arbitration frame". Deliberately NOT
+/// `#[esp_hal::ram]`: arbitration is rare and off the receiver's per-chunk hot path, so it must not
+/// spend `parse_ota_frame`'s IRAM budget.
+#[allow(dead_code)] // #237 INC1: wired by the crown/holder dispatch in a later slice-1 increment
+pub fn parse_arb_frame(data: &[u8]) -> Option<ArbFrame> {
+    if let Some(rest) = data.strip_prefix(ODEL_PREFIX) {
+        // target[3] build[u32 LE] session[2] term[u16 LE]
+        if rest.len() < 3 + 4 + 2 + 2 {
+            return None;
+        }
+        let target = parse_id3(&rest[0..3])?;
+        let build = u32::from_le_bytes([rest[3], rest[4], rest[5], rest[6]]);
+        let session = u16::from_le_bytes([rest[7], rest[8]]);
+        let term = u16::from_le_bytes([rest[9], rest[10]]);
+        return Some(ArbFrame::Odel { target, build, session, term });
+    }
+    if let Some(rest) = data.strip_prefix(ODON_PREFIX) {
+        // target[3] build[u32 LE] session[2] result[1]
+        if rest.len() < 3 + 4 + 2 + 1 {
+            return None;
+        }
+        let target = parse_id3(&rest[0..3])?;
+        let build = u32::from_le_bytes([rest[3], rest[4], rest[5], rest[6]]);
+        let session = u16::from_le_bytes([rest[7], rest[8]]);
+        let result = ServeResult::from_u8(rest[9])?;
+        return Some(ArbFrame::Odon { target, build, session, result });
+    }
+    None
+}
+
+/// Encode an `ODEL` (crown→holder delegate-to-serve). Fixed-width (no manifest) → always fits one
+/// ESP-NOW frame. Returns the byte length written, or `None` if `out` is too small.
+#[allow(dead_code)] // #237 INC1: wired later
+pub fn encode_odel(target_id: u8, build: u32, session: u16, term: u16, out: &mut [u8]) -> Option<usize> {
+    let total = ODEL_PREFIX.len() + 3 + 4 + 2 + 2;
+    if out.len() < total {
+        return None;
+    }
+    let mut n = 0;
+    out[..ODEL_PREFIX.len()].copy_from_slice(ODEL_PREFIX);
+    n += ODEL_PREFIX.len();
+    write_id3(target_id, &mut out[n..n + 3]);
+    n += 3;
+    out[n..n + 4].copy_from_slice(&build.to_le_bytes());
+    n += 4;
+    out[n..n + 2].copy_from_slice(&session.to_le_bytes());
+    n += 2;
+    out[n..n + 2].copy_from_slice(&term.to_le_bytes());
+    n += 2;
+    Some(n)
+}
+
+/// Encode an `ODON` (holder→crown serve outcome). Returns the byte length, `None` if `out` too small.
+#[allow(dead_code)] // #237 INC1: wired later
+pub fn encode_odon(
+    target_id: u8,
+    build: u32,
+    session: u16,
+    result: ServeResult,
+    out: &mut [u8],
+) -> Option<usize> {
+    let total = ODON_PREFIX.len() + 3 + 4 + 2 + 1;
+    if out.len() < total {
+        return None;
+    }
+    let mut n = 0;
+    out[..ODON_PREFIX.len()].copy_from_slice(ODON_PREFIX);
+    n += ODON_PREFIX.len();
+    write_id3(target_id, &mut out[n..n + 3]);
+    n += 3;
+    out[n..n + 4].copy_from_slice(&build.to_le_bytes());
+    n += 4;
+    out[n..n + 2].copy_from_slice(&session.to_le_bytes());
+    n += 2;
+    out[n] = result.as_u8();
+    n += 1;
+    Some(n)
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -167,12 +167,23 @@ impl ServeResult {
 /// crown handles `Odon`. Parsed by [`parse_arb_frame`], off the per-chunk hot path.
 #[allow(dead_code)] // #237 INC1: wired by the crown/holder dispatch in a later slice-1 increment
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ArbFrame {
+pub enum ArbFrame<'a> {
     /// crown→holder: serve `build` to leaf `target` under `session`, gated by `term` (a holder
     /// rejects a `term` older than the highest it has seen → a dethroned crown cannot delegate).
-    /// ODEL only STARTS a serve of an already-signed image — it cannot cause a flash (the leaf still
-    /// verifies the image sig) — so it needs replay/stale protection, not a signature.
-    Odel { target: u8, build: u32, session: u16, term: u16 },
+    /// Carries the signed manifest `m` + 64-byte ed25519 `sig` (spec §8 final): the crown staged the
+    /// build, so it ships (M,sig) HERE and the holder pairs them with image bytes read from its own
+    /// ACTIVE slot to emit a byte-identical OTAM — ZERO persisted manifest, and the offline sig
+    /// travels crown→holder→leaf so the holder cannot forge. ODEL only STARTS a serve of an
+    /// already-signed image (cannot cause a flash — the leaf still verifies sig), so it needs only
+    /// replay/stale protection (`term`+`session`), not its own signature.
+    Odel {
+        target: u8,
+        build: u32,
+        session: u16,
+        term: u16,
+        m: &'a [u8],
+        sig: &'a [u8; 64],
+    },
     /// holder→crown: outcome of the delegated serve (so the crown advances or falls back).
     Odon { target: u8, build: u32, session: u16, result: ServeResult },
 }
@@ -320,17 +331,30 @@ pub fn encode_otan(origin_id: u8, session: u16, window_base: u16, bitmap: &[u8],
 /// `#[esp_hal::ram]`: arbitration is rare and off the receiver's per-chunk hot path, so it must not
 /// spend `parse_ota_frame`'s IRAM budget.
 #[allow(dead_code)] // #237 INC1: wired by the crown/holder dispatch in a later slice-1 increment
-pub fn parse_arb_frame(data: &[u8]) -> Option<ArbFrame> {
+pub fn parse_arb_frame(data: &[u8]) -> Option<ArbFrame<'_>> {
     if let Some(rest) = data.strip_prefix(ODEL_PREFIX) {
-        // target[3] build[u32 LE] session[2] term[u16 LE]
-        if rest.len() < 3 + 4 + 2 + 2 {
+        // target[3] build[u32 LE] session[2] term[u16 LE] M_len[1] M[M_len] sig[64]
+        if rest.len() < 3 + 4 + 2 + 2 + 1 {
             return None;
         }
         let target = parse_id3(&rest[0..3])?;
         let build = u32::from_le_bytes([rest[3], rest[4], rest[5], rest[6]]);
         let session = u16::from_le_bytes([rest[7], rest[8]]);
         let term = u16::from_le_bytes([rest[9], rest[10]]);
-        return Some(ArbFrame::Odel { target, build, session, term });
+        let m_len = rest[11] as usize;
+        // Bound M by the shared cap so a hostile M_len can't over-read or blow buffers (mirrors OTAM).
+        if m_len == 0 || m_len > ota::SIGNED_MSG_MAX {
+            return None;
+        }
+        let m_start = 12;
+        let sig_start = m_start + m_len;
+        let end = sig_start + 64;
+        if rest.len() < end {
+            return None;
+        }
+        let m = &rest[m_start..sig_start];
+        let sig: &[u8; 64] = rest[sig_start..end].try_into().ok()?;
+        return Some(ArbFrame::Odel { target, build, session, term, m, sig });
     }
     if let Some(rest) = data.strip_prefix(ODON_PREFIX) {
         // target[3] build[u32 LE] session[2] result[1]
@@ -349,8 +373,19 @@ pub fn parse_arb_frame(data: &[u8]) -> Option<ArbFrame> {
 /// Encode an `ODEL` (crown→holder delegate-to-serve). Fixed-width (no manifest) → always fits one
 /// ESP-NOW frame. Returns the byte length written, or `None` if `out` is too small.
 #[allow(dead_code)] // #237 INC1: wired later
-pub fn encode_odel(target_id: u8, build: u32, session: u16, term: u16, out: &mut [u8]) -> Option<usize> {
-    let total = ODEL_PREFIX.len() + 3 + 4 + 2 + 2;
+pub fn encode_odel(
+    target_id: u8,
+    build: u32,
+    session: u16,
+    term: u16,
+    m: &[u8],
+    sig: &[u8; 64],
+    out: &mut [u8],
+) -> Option<usize> {
+    if m.is_empty() || m.len() > ota::SIGNED_MSG_MAX {
+        return None;
+    }
+    let total = ODEL_PREFIX.len() + 3 + 4 + 2 + 2 + 1 + m.len() + 64;
     if out.len() < total {
         return None;
     }
@@ -365,6 +400,12 @@ pub fn encode_odel(target_id: u8, build: u32, session: u16, term: u16, out: &mut
     n += 2;
     out[n..n + 2].copy_from_slice(&term.to_le_bytes());
     n += 2;
+    out[n] = m.len() as u8;
+    n += 1;
+    out[n..n + m.len()].copy_from_slice(m);
+    n += m.len();
+    out[n..n + 64].copy_from_slice(sig);
+    n += 64;
     Some(n)
 }
 


### PR DESCRIPTION
## What — #237 slice-1, peer-sourced leaf-mesh-OTA (COMPLETE — ready for review)

Peer-sourcing (spec: `docs/superpowers/design/peer-sourced-mesh-ota.md`, final §8): once one node holds a verified build, the crown **delegates serving** to it and it relays the **byte-identical signed image** to the next leaf over ESP-NOW using the **unchanged #40 receiver path** — no WiFi bulk fetch for followers (coexist-safe, sidesteps the #204/#53 disease). Crown stays sole canary arbiter. No new trust: the holder is untrusted; the leaf verifies the ed25519 sig before any flash, so a bad holder can only DoS.

**Slice-1 is now feature-complete: primitives + holder receive path + holder serve-driver + crown baton + fallback floor + observability + host tests.** Still **HW-CANARY-HELD** (not flashed) pending a rig canary.

## Landed (each KATANA 4-tier green: clippy -D espnow,cast,io / default / wifi + 3 release builds; secret-scan 0)
Primitives + holder receive path (`e53d0ee`…`34b0e7e`) — see history. Then the remaining wiring:
- `5faabe5` **holder serve-driver** (main.rs): poll `take_pending_serve()` in the LEAF-reachable loop (before self-OTA `do_install`, never the RX drain) → `verify_active_slot` → `run_leaf_ota_relay(HolderActiveSlot)` → map outcome via fail-closed `ServeResult::from_leaf_outcome` → ODON via RAW esp_now (`send_arb_raw`, not `send_to` — 190L item 1).
- `7ba1a9c` **crown baton + UNCONDITIONAL fallback-to-#40**: `baton_holder_for` (last-confirmed holder on the exact build) → `run_crown_delegate` (RAW ODEL burst carrying M+sig, stamped `crown_term()`=MC seq §5.3, awaits ODON w/ 12-min deadline > holder worst-case) → `note_confirmed_holder` on OK. The delegate result feeds ONE match: only `Some(ServeResult::Ok)` skips the fetch; NO holder / any non-OK ODON / timeout / un-encodable manifest ALL fall through to `run_leaf_ota_relay(GatewayFetch)`. Worst-case == today's #40 on every branch.
- `e765605` **INC5**: `src=gw`|`src=id<n>` on `smol/<leaf>/ota/diag` (§8.1 item 8 — the fetch-saved metric) + `experiments/arb_verify` host harness (vendored codec + golden §10 bytes + fail-closed reject + split-brain term guard + baton pick + fail-closed outcome mapping; `cargo run`, ALL CHECKS PASSED).

## Design notes / reviewer pre-empts
- codec bound = OTAM-shared `SIGNED_MSG_MAX(96)`; real M ≤86, the spec's 174 B figure reflects the real M (TL ruling). Parser REJECTS oversize (fail-closed), never clamps.
- ODEL/ODON use the **RAW esp_now send** throughout (`send_arb_raw`), bypassing the #248 group-MAC trailer — the OTA family is parsed before any RX verify-then-strip (190L item 1).
- session = `build & 0xFFFF` (matches the OTAM discriminator the holder emits, so crown↔holder ODON correlates 1:1 with the leaf-facing session — no separate minting).
- crown-side ODON is drained directly inside `run_crown_delegate` (like `run_leaf_ota_relay` drains OTANs); the `handle_arb_frame` ODON no-op is final, not a stub.

## ⚠️ HW-CANARY-HELD
Boot/OTA-critical + the scan/serve radio path needs JP's rig. NOT flashed. Merges after review (190L) + a canary proves a holder-served leaf completes with **zero gateway fetch** (`src=id<n>` on `ota/diag` + fetch-silence on the image-host pcap). Cut v345 + canary Nexus (id8).

Refs #237 #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
