### PR TITLE
feat(net): #185 mesh-ledger L4 — delta-state OR-Set/G-Set CRDT (host-testable inert core)

### DIFF
--- a/experiments/185_crdt_verify/Cargo.toml
+++ b/experiments/185_crdt_verify/Cargo.toml
@@ -1,0 +1,18 @@
+# #185 host-test harness for the PURE mesh-ledger L4 core (net/crdt.rs) — the delta-state
+# OR-Set / G-Set CRDT for multi-writer RPG shared state (loot / gravestone). Runs OFF-target
+# (std) via `cargo run`; #[path]-includes the real crdt.rs (no drift) and exercises the CvRDT
+# laws (convergence, commutativity, idempotence, delta-merge, add-wins) + the injected-sha256
+# order-independent set digest. Mirrors flood_verify/etx_verify/ledger_verify/treehead_verify/
+# sth_verify. sha2 supplies the injected hash — the core is dependency-free.
+[package]
+name = "crdt_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "crdt_verify"
+path = "src/main.rs"
+[dependencies]
+sha2 = "0.10"
+[profile.dev]
+opt-level = 0

--- a/experiments/185_crdt_verify/src/main.rs
+++ b/experiments/185_crdt_verify/src/main.rs
@@ -1,0 +1,195 @@
+//! Host verification of the PURE #185 mesh-ledger L4 core: the delta-state **OR-Set / G-Set**
+//! CRDT for multi-writer shared RPG state (loot pickup, gravestones). Includes the real
+//! `net/crdt.rs` verbatim (#[path], no drift). Run: `cargo run` — panics on failure.
+//!
+//! What L4 adds to the ledger substrate (L1 #182 chain · L2 #183 anchor · L3 #184 STH): those
+//! give a *single-writer* tamper-evident history; RPG loot/gravestones are **multi-writer shared
+//! state** edited concurrently over a lossy, order-scrambling, duplicating mesh with no
+//! coordinator. A CRDT converges regardless: its merge is a **join-semilattice** — commutative,
+//! idempotent, associative — so message order/loss/dup can't diverge two replicas. *Delta*-state
+//! means a node gossips only the small change-set (fits the 250 B ESP-NOW MTU), and the join of a
+//! delta is the same op as the join of full state. sha256 is INJECTED (the core is dep-free); here
+//! it powers an order-independent live-set **digest** — the O(1) "are we converged?" check that
+//! also feeds the L2/L3 anchor/signature.
+
+#[path = "../../../rust/clock/src/net/crdt.rs"]
+mod crdt;
+
+use crdt::{ElemId, OrSet};
+use sha2::{Digest, Sha256};
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    h.finalize().into()
+}
+
+/// A deterministic element id (loot/gravestone content hashed to 16 B in real use).
+fn eid(n: u8) -> ElemId {
+    let mut x = [0u8; 16];
+    x[0] = n;
+    x[15] = n ^ 0x5a;
+    x
+}
+
+const CAP: usize = 32;
+type Set = OrSet<CAP>;
+
+fn dg(s: &Set) -> [u8; 16] {
+    s.digest(sha256)
+}
+
+fn main() {
+    // ---- empty ------------------------------------------------------------
+    let e0 = Set::new();
+    assert!(e0.is_empty(), "fresh set is empty");
+    assert_eq!(e0.len(), 0, "fresh set has len 0");
+    assert!(!e0.contains(&eid(1)), "empty contains nothing");
+    let e0b = Set::new();
+    assert_eq!(dg(&e0), dg(&e0b), "two empty sets share a digest (deterministic)");
+
+    // ---- add / contains / remove / re-add (add-wins re-add) --------------
+    let mut s = Set::new();
+    let t1 = s.add(eid(1), 1, 1).expect("add ok");
+    assert!(s.contains(&eid(1)) && s.len() == 1 && !s.is_empty(), "added elem is present");
+    assert_eq!(s.remove(&eid(1)), 1, "remove tombstones the 1 live tag");
+    assert!(!s.contains(&eid(1)), "removed elem gone");
+    assert_eq!(s.len(), 0, "removed elem drops the count");
+    let t2 = s.add(eid(1), 1, 2).expect("re-add ok");
+    assert!(s.contains(&eid(1)), "re-add with a fresh tag revives the elem (its tag isn't tombed)");
+    assert_ne!(t1.seq, t2.seq, "each add mints a distinct tag");
+    assert_eq!(s.remove(&eid(99)), 0, "removing an absent elem tombstones nothing");
+
+    // ---- idempotent add of the exact same (elem,tag) ---------------------
+    let mut d = Set::new();
+    d.add(eid(7), 3, 10).unwrap();
+    let before = d.len();
+    // merging a set that already equals a subset must not double-count (same tags).
+    let mut d2 = Set::new();
+    d2.add(eid(7), 3, 10).unwrap();
+    d.merge(&d2).unwrap();
+    assert_eq!(d.len(), before, "merging an identical tag is idempotent (no duplication)");
+
+    // ---- COMMUTATIVITY: merge(a,b) ≡ merge(b,a) --------------------------
+    let mut a = Set::new();
+    a.add(eid(1), 1, 1).unwrap();
+    a.add(eid(2), 1, 2).unwrap();
+    a.remove(&eid(2)); // a: {1}
+    let mut b = Set::new();
+    b.add(eid(3), 2, 1).unwrap();
+    b.add(eid(2), 2, 2).unwrap(); // concurrent re-add of 2 by node 2 (add-wins vs a's remove of node1's tag)
+    let mut ab = a.clone();
+    ab.merge(&b).unwrap();
+    let mut ba = b.clone();
+    ba.merge(&a).unwrap();
+    assert_eq!(dg(&ab), dg(&ba), "merge is commutative (same digest either order)");
+    assert!(ab.contains(&eid(1)) && ab.contains(&eid(2)) && ab.contains(&eid(3)),
+        "add-wins: 2 survives because node2's fresh tag was never tombed");
+
+    // ---- IDEMPOTENCE: merge(x,x) ≡ x  and  re-merging a delta is a no-op -
+    let mut x = ab.clone();
+    let x_dg = dg(&x);
+    x.merge(&ab).unwrap();
+    assert_eq!(dg(&x), x_dg, "merge(x,x) leaves the state unchanged");
+    x.merge(&b).unwrap();
+    assert_eq!(dg(&x), x_dg, "re-merging an already-absorbed delta changes nothing");
+
+    // ---- DELTA-MERGE ≡ STATE-MERGE ---------------------------------------
+    let mut base = Set::new();
+    base.add(eid(5), 4, 1).unwrap();
+    let mut adv = base.clone();
+    adv.add(eid(6), 4, 2).unwrap();
+    adv.add(eid(7), 4, 3).unwrap();
+    adv.remove(&eid(5));
+    let delta = adv.delta_vs(&base); // only what `base` is missing
+    let mut via_delta = base.clone();
+    via_delta.merge(&delta).unwrap();
+    let mut via_full = base.clone();
+    via_full.merge(&adv).unwrap();
+    assert_eq!(dg(&via_delta), dg(&via_full), "merging the delta ≡ merging full state (digest)");
+    for n in [5u8, 6, 7] {
+        assert_eq!(via_delta.contains(&eid(n)), via_full.contains(&eid(n)),
+            "delta vs full agree on elem {n}");
+    }
+    assert!(delta.len() <= adv.len(), "a delta is no larger than the full state");
+
+    // ---- CONVERGENCE: 3 replicas, local ops, arbitrary-order gossip ------
+    let mut r1 = Set::new();
+    let mut r2 = Set::new();
+    let mut r3 = Set::new();
+    r1.add(eid(10), 1, 1).unwrap();
+    r1.add(eid(11), 1, 2).unwrap();
+    r2.add(eid(20), 2, 1).unwrap();
+    r2.add(eid(10), 2, 2).unwrap(); // 10 concurrently added by two nodes
+    r3.add(eid(30), 3, 1).unwrap();
+    r1.remove(&eid(11)); // r1 kills its own 11
+    // gossip in a deliberately ugly order, with duplicates (mesh reality):
+    let d1 = r1.clone();
+    let d2 = r2.clone();
+    let d3 = r3.clone();
+    r2.merge(&d1).unwrap();
+    r3.merge(&d2).unwrap();
+    r1.merge(&d3).unwrap();
+    r2.merge(&d3).unwrap();
+    r1.merge(&r2.clone()).unwrap();
+    r3.merge(&r1.clone()).unwrap();
+    r2.merge(&r3.clone()).unwrap();
+    r1.merge(&r2.clone()).unwrap(); // extra round + duplicate deliveries
+    r3.merge(&r2.clone()).unwrap();
+    assert_eq!(dg(&r1), dg(&r2), "r1 and r2 converge");
+    assert_eq!(dg(&r2), dg(&r3), "r2 and r3 converge");
+    for n in [10u8, 20, 30] {
+        assert!(r1.contains(&eid(n)) && r2.contains(&eid(n)) && r3.contains(&eid(n)),
+            "all replicas agree elem {n} is live");
+    }
+    assert!(!r1.contains(&eid(11)) && !r3.contains(&eid(11)), "the removed 11 stays gone everywhere");
+
+    // ---- ADD-WINS (canonical concurrent add vs remove) -------------------
+    // rA adds e; rB independently adds e; rB removes e (tombs only rB's own tag).
+    let mut ra = Set::new();
+    let ta = ra.add(eid(50), 1, 1).unwrap();
+    let mut rb = Set::new();
+    rb.add(eid(50), 2, 1).unwrap();
+    rb.remove(&eid(50)); // tombs node2's tag only — never saw node1's tag ta
+    let mut merged = ra.clone();
+    merged.merge(&rb).unwrap();
+    assert!(merged.contains(&eid(50)), "add-wins: rA's un-observed tag keeps elem 50 alive");
+    let _ = ta;
+
+    // ---- GROW-ONLY (G-Set) mode: never remove ⇒ pure union ---------------
+    let mut g1 = Set::new();
+    let mut g2 = Set::new();
+    g1.add(eid(60), 1, 1).unwrap();
+    g2.add(eid(61), 2, 1).unwrap();
+    g1.merge(&g2).unwrap();
+    g2.merge(&g1.clone()).unwrap();
+    assert_eq!(dg(&g1), dg(&g2), "G-Set (no removes) converges");
+    assert!(g1.contains(&eid(60)) && g1.contains(&eid(61)), "grow-only union has both");
+
+    // ---- DIGEST order-independence ---------------------------------------
+    let mut o1 = Set::new();
+    o1.add(eid(1), 1, 1).unwrap();
+    o1.add(eid(2), 1, 2).unwrap();
+    o1.add(eid(3), 1, 3).unwrap();
+    let mut o2 = Set::new();
+    o2.add(eid(3), 1, 3).unwrap();
+    o2.add(eid(1), 1, 1).unwrap();
+    o2.add(eid(2), 1, 2).unwrap();
+    assert_eq!(dg(&o1), dg(&o2), "live-set digest is independent of insertion order");
+    // and the digest tracks the LIVE set, not the tag history:
+    let mut o3 = o1.clone();
+    o3.remove(&eid(2));
+    assert_ne!(dg(&o1), dg(&o3), "removing a live elem changes the digest");
+
+    // ---- BOUNDED capacity ------------------------------------------------
+    let mut full: OrSet<4> = OrSet::new();
+    for i in 0..4u8 {
+        full.add(eid(i), 1, i as u32 + 1).unwrap();
+    }
+    assert!(full.add(eid(200), 1, 99).is_err(), "adding past CAP ⇒ Err (bounded)");
+
+    // ---- const-constructible (a node holds one in .bss) ------------------
+    const _C: OrSet<8> = OrSet::new();
+
+    println!("crdt_verify: all assertions passed");
+}

--- a/experiments/185_crdt_verify/src/main.rs
+++ b/experiments/185_crdt_verify/src/main.rs
@@ -39,7 +39,7 @@ fn dg(s: &Set) -> [u8; 16] {
     s.digest(sha256)
 }
 
-fn main() {
+fn run() {
     // ---- empty ------------------------------------------------------------
     let e0 = Set::new();
     assert!(e0.is_empty(), "fresh set is empty");
@@ -192,4 +192,19 @@ fn main() {
     const _C: OrSet<8> = OrSet::new();
 
     println!("crdt_verify: all assertions passed");
+}
+
+fn main() {
+    run();
+}
+
+#[cfg(test)]
+mod tests {
+    /// `cargo test` entry — runs the full CvRDT-law suite (identical asserts to `cargo run`), so
+    /// neither invocation is a false-green. (A bin with no `#[test]` reports "0 passed" under
+    /// `cargo test` — this wrapper prevents that.)
+    #[test]
+    fn crdt_laws() {
+        super::run();
+    }
 }

--- a/rust/clock/src/net/crdt.rs
+++ b/rust/clock/src/net/crdt.rs
@@ -1,0 +1,246 @@
+//! #185 mesh-ledger L4 — the PURE delta-state **OR-Set / G-Set** CRDT for multi-writer shared state.
+//!
+//! ## What this is (design of record: `docs/superpowers/research/mesh-ledger-study.md`, #181)
+//! L1–L3 ([`super::ledger`] · [`super::treehead`] · [`super::sth`]) give a **single-writer**
+//! tamper-evident history: each node's own chain, anchored and signed. RPG **loot** and
+//! **gravestones** are the opposite shape — *multi-writer shared state* edited concurrently by
+//! any node, over a lossy, order-scrambling, duplicating mesh with **no coordinator**. That is
+//! the CRDT problem. This is a delta-state observed-remove set (OR-Set), which degenerates to a
+//! grow-only set (**G-Set**) when nothing is ever removed (gravestones: append-only; loot: add +
+//! remove-on-pickup).
+//!
+//! ## Why it converges (the CvRDT laws)
+//! State is two **grow-only** sets: `adds` (each an `(elem, tag)` where `tag` is globally unique)
+//! and `tombs` (removed tags). `merge` is their **union** — a join over a semilattice, hence
+//! **commutative, idempotent, associative**. So any order / loss / duplication of gossip
+//! converges every replica to the identical state (see `experiments/185_crdt_verify`). An element
+//! is **live** iff it has some add-tag that is not tombed → **add-wins**: a concurrent add whose
+//! fresh tag a remover never observed keeps the element alive.
+//!
+//! ## Delta-state (why not state-based)
+//! A full state doesn't fit a 250 B ESP-NOW frame. Because the join is set-union, a **delta** is
+//! just an `OrSet` fragment carrying only the entries a peer lacks ([`OrSet::delta_vs`]); merging
+//! the delta is byte-for-byte equivalent to merging the whole state. Nodes gossip deltas; the same
+//! [`OrSet::merge`] absorbs them.
+//!
+//! ## L4 scope (this module)
+//! - **Pure + host-testable** (the `flood`/`etx`/`ledger`/`treehead`/`sth` pattern): no
+//!   `esp-hal`/`esp-wifi`, no `std`, no alloc, **no hash-crate dep**. sha256 is **injected**
+//!   (`F: Fn(&[u8]) -> [u8; 32]`) and powers only [`OrSet::digest`] — an order-independent
+//!   live-set summary for O(1) convergence checks that also feeds the L2/L3 anchor/signature.
+//! - **Bounded + const-constructible** — `OrSet<CAP>` is fixed arrays in `.bss` (`const fn new`),
+//!   `Err(Error::Full)` past `CAP`. RAM ≈ `CAP × (16 + 5) + CAP × 5` ≈ `CAP × 26` B.
+//! - **NOT wired into the radio path** — the world-state gossip/relay is a later HW-gated rung;
+//!   this module is deliberately *not declared in `net.rs`* (else dead-code under `-D warnings`,
+//!   the #164 lesson). Firmware build unaffected.
+//! - **Known bound:** tombstones are grow-only (the classic OR-Set cost); `CAP` caps them. Causal
+//!   compaction (dot-store / version-vector GC of tombs) is a documented v2 optimization.
+
+/// Element-id width — loot/gravestone content is hashed to 16 B by the caller.
+pub const ID_LEN: usize = 16;
+/// A content-addressed element id (a hashed loot/gravestone identity).
+pub type ElemId = [u8; ID_LEN];
+/// Domain-separation prefix for the set digest (distinct from L1/L2 `0x00`/`0x01` and L3 `0x02`).
+pub const DOMAIN: u8 = 0x04;
+
+/// A globally-unique add-event identity: the node that added and its per-node monotonic seq.
+/// Uniqueness is what makes add-wins work — a re-add mints a *new* tag a prior remover can't have
+/// tombed.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Tag {
+    pub node: u8,
+    pub seq: u32,
+}
+
+/// Capacity exhausted (a new add/merge would exceed `CAP`).
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    Full,
+}
+
+/// A bounded delta-state OR-Set / G-Set. `adds` and `tombs` are both grow-only; an element is live
+/// iff it holds an add-tag absent from `tombs`.
+#[derive(Clone)]
+pub struct OrSet<const CAP: usize> {
+    adds: [Option<(ElemId, Tag)>; CAP],
+    tombs: [Option<Tag>; CAP],
+}
+
+impl<const CAP: usize> Default for OrSet<CAP> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const CAP: usize> OrSet<CAP> {
+    /// A fresh empty set (const-constructible — a node holds one in `.bss`).
+    pub const fn new() -> Self {
+        Self {
+            adds: [None; CAP],
+            tombs: [None; CAP],
+        }
+    }
+
+    // --- internal helpers --------------------------------------------------
+    fn has_add(&self, e: &ElemId, t: &Tag) -> bool {
+        self.adds
+            .iter()
+            .flatten()
+            .any(|(ae, at)| ae == e && at == t)
+    }
+    fn tombed(&self, t: &Tag) -> bool {
+        self.tombs.iter().flatten().any(|tt| tt == t)
+    }
+    fn has_tomb(&self, t: &Tag) -> bool {
+        self.tombed(t)
+    }
+    fn push_add(&mut self, e: ElemId, t: Tag) -> Result<(), Error> {
+        if self.has_add(&e, &t) {
+            return Ok(()); // idempotent
+        }
+        let slot = self.adds.iter_mut().find(|s| s.is_none());
+        match slot {
+            Some(s) => {
+                *s = Some((e, t));
+                Ok(())
+            }
+            None => Err(Error::Full),
+        }
+    }
+    fn push_tomb(&mut self, t: Tag) -> Result<(), Error> {
+        if self.tombed(&t) {
+            return Ok(());
+        }
+        let slot = self.tombs.iter_mut().find(|s| s.is_none());
+        match slot {
+            Some(s) => {
+                *s = Some(t);
+                Ok(())
+            }
+            None => Err(Error::Full),
+        }
+    }
+    /// True iff the add at `i` is live AND is the first live occurrence of its element (so
+    /// distinct-live iteration counts/hashes each element exactly once, even with concurrent adds).
+    fn is_first_live(&self, i: usize) -> bool {
+        let (e, t) = match self.adds[i] {
+            Some(v) => v,
+            None => return false,
+        };
+        if self.tombed(&t) {
+            return false;
+        }
+        for j in 0..i {
+            if let Some((ej, tj)) = self.adds[j] {
+                if ej == e && !self.tombed(&tj) {
+                    return false; // an earlier live tag already represents this element
+                }
+            }
+        }
+        true
+    }
+
+    // --- public API --------------------------------------------------------
+    /// Add `elem` under a fresh tag `(node, seq)`. Idempotent for an identical `(elem, tag)`.
+    /// `Err(Full)` if no add-slot remains. The caller supplies a per-node monotonic `seq`.
+    pub fn add(&mut self, elem: ElemId, node: u8, seq: u32) -> Result<Tag, Error> {
+        let t = Tag { node, seq };
+        self.push_add(elem, t)?;
+        Ok(t)
+    }
+
+    /// Observed-remove: tombstone every currently-live tag of `elem`. Returns the number of tags
+    /// newly tombed (0 if the element is absent). Concurrent adds elsewhere (tags not yet observed
+    /// here) are untouched → add-wins.
+    pub fn remove(&mut self, elem: &ElemId) -> usize {
+        let mut victims: [Option<Tag>; CAP] = [None; CAP];
+        let mut n = 0;
+        for slot in self.adds.iter().flatten() {
+            let (ae, at) = slot;
+            if ae == elem && !self.tombed(at) {
+                victims[n] = Some(*at);
+                n += 1;
+            }
+        }
+        let mut tombed = 0;
+        for v in victims.iter().flatten() {
+            if self.push_tomb(*v).is_ok() {
+                tombed += 1;
+            }
+        }
+        tombed
+    }
+
+    /// True iff `elem` has at least one add-tag that is not tombed.
+    pub fn contains(&self, elem: &ElemId) -> bool {
+        self.adds
+            .iter()
+            .flatten()
+            .any(|(ae, at)| ae == elem && !self.tombed(at))
+    }
+
+    /// Merge another set (full state OR a delta — same op). Union of `adds` and `tombs`.
+    /// `Err(Full)` if absorbing new entries would exceed `CAP` (size `CAP` for the expected fleet).
+    pub fn merge(&mut self, other: &Self) -> Result<(), Error> {
+        for (e, t) in other.adds.iter().flatten() {
+            self.push_add(*e, *t)?;
+        }
+        for t in other.tombs.iter().flatten() {
+            self.push_tomb(*t)?;
+        }
+        Ok(())
+    }
+
+    /// The minimal fragment `other` is missing: `self`'s adds/tombs not already in `other`.
+    /// Merging this delta into `other` is equivalent to merging all of `self` (anti-entropy).
+    /// The result is a subset of `self`, so it always fits `CAP`.
+    pub fn delta_vs(&self, other: &Self) -> Self {
+        let mut d = Self::new();
+        for (e, t) in self.adds.iter().flatten() {
+            if !other.has_add(e, t) {
+                let _ = d.push_add(*e, *t);
+            }
+        }
+        for t in self.tombs.iter().flatten() {
+            if !other.has_tomb(t) {
+                let _ = d.push_tomb(*t);
+            }
+        }
+        d
+    }
+
+    /// Order-independent digest of the **live** element set (domain-separated `0x04`). Two replicas
+    /// that converged on the same live set produce the same digest — the O(1) "are we converged?"
+    /// check, and the value L2/L3 anchor/sign. Computed as `truncate16( XOR over live elems of
+    /// sha(0x04 ‖ elem) )`: XOR is commutative/associative (order-independent) and each *distinct*
+    /// live element contributes exactly once. Empty set ⇒ all-zero.
+    pub fn digest<F: Fn(&[u8]) -> [u8; 32]>(&self, sha: F) -> [u8; ID_LEN] {
+        let mut acc = [0u8; 32];
+        let mut buf = [0u8; 1 + ID_LEN];
+        buf[0] = DOMAIN;
+        for i in 0..CAP {
+            if self.is_first_live(i) {
+                if let Some((e, _)) = self.adds[i] {
+                    buf[1..].copy_from_slice(&e);
+                    let h = sha(&buf);
+                    for (a, hb) in acc.iter_mut().zip(h.iter()) {
+                        *a ^= *hb;
+                    }
+                }
+            }
+        }
+        let mut out = [0u8; ID_LEN];
+        out.copy_from_slice(&acc[..ID_LEN]);
+        out
+    }
+
+    /// Count of distinct live elements.
+    pub fn len(&self) -> usize {
+        (0..CAP).filter(|&i| self.is_first_live(i)).count()
+    }
+
+    /// True iff no element is live.
+    pub fn is_empty(&self) -> bool {
+        !(0..CAP).any(|i| self.is_first_live(i))
+    }
+}


### PR DESCRIPTION
## What
The **L4 capstone** of the mesh-ledger substrate (#181): a PURE, host-testable, inert delta-state **OR-Set / G-Set CRDT** for *multi-writer shared state* — RPG loot (add + remove-on-pickup) and gravestones (append-only). L1/L2/L3 (#182/#183/#184, merged) gave *single-writer* tamper-evident history; L4 gives concurrent, coordinator-free shared state that converges over a lossy mesh.

`rust/clock/src/net/crdt.rs` + `experiments/185_crdt_verify/`.

## Design — why it converges
State = two **grow-only** sets: `adds` (`(elem, unique-tag)`) + `tombs` (removed tags). `merge` = their **union** → a join-semilattice, hence **commutative · idempotent · associative**, so any gossip order / loss / duplication converges every replica. An element is live iff it has an un-tombed tag → **add-wins**. *Delta*-state: a delta is just an `OrSet` fragment (`delta_vs`); the same `merge` absorbs full state or a delta, so nodes gossip only the small change-set (fits the 250 B ESP-NOW MTU). `sha256` is **injected** → an order-independent live-set **digest** (O(1) convergence check + the value L2/L3 anchor/sign; domain-sep `0x04`).

## Pattern (same as the merged trilogy)
`no_std` · no alloc · no hash-crate dep · const-constructible (`.bss`) · **undeclared in `net.rs`** so the fw build never compiles it (no dead-code under `-D warnings`, the #164 lesson). Not wired to the radio path — world-state gossip is a later HW-gated rung.

## Verification (built/tested on **familiar** per JP)
`experiments/185_crdt_verify` — RED→GREEN TDD. Exercises the CvRDT laws: **convergence** (3 replicas, deliberately ugly-order + duplicate gossip → identical digests + live sets), **commutativity**, **idempotence**, **delta ≡ state merge**, plus **add-wins** (concurrent add vs remove), **G-Set** (grow-only) mode, **digest order-independence**, and **bounded capacity**. All assertions pass; **0 clippy warnings**.

## Known bound
Tombstones are grow-only (the classic OR-Set cost), `CAP`-capped. Causal compaction (dot-store / version-vector tomb-GC) is a documented v2 optimization.

Refs #185, #181. Spec/substrate only — no firmware wiring.
