### PR TITLE
#68 meshscope: render v345 telemetry — HMAC health + ledger tamper canary

### DIFF
--- a/rust/viz/mesh-model/src/parse.rs
+++ b/rust/viz/mesh-model/src/parse.rs
@@ -301,4 +301,37 @@ mod tests {
         assert_eq!(d.led(), Some(("status".to_string(), true)));
         assert_eq!(d.u64("fwd"), Some(0));
     }
+
+    #[test]
+    fn diag_v345_hmac_and_ledger() {
+        // #190 HMAC health + #181/#249 ledger head, exactly as the v345 fw appends them (leaf:
+        // all-node keys; crown: + folded L2 anchor / L3 signed-tree-head). Pins the wire keys the
+        // meshscope panel/graph render against so a fw rename can't silently blank the tiles.
+        let leaf = parse_diag(
+            "DIAG|slot=0|boot=3|up=99|heap=41000|mo=1500|mf=0|lgt=a1b2c3d4|lgn=42|lgok=1|lgk=1",
+        )
+        .unwrap();
+        assert_eq!(leaf.u64("mo"), Some(1500)); // frames authenticated
+        assert_eq!(leaf.u64("mf"), Some(0)); // forgeries rejected
+        assert_eq!(leaf.get("lgt"), Some("a1b2c3d4")); // chain tip (tamper canary)
+        assert_eq!(leaf.u64("lgn"), Some(42)); // chain length
+        assert_eq!(leaf.u64("lgok"), Some(1)); // self-verify OK
+        assert_eq!(leaf.u64("lgk"), Some(1)); // signing key held
+        assert_eq!(leaf.get("lgan"), None); // anchor is crown-only
+
+        // Crown with a signed L3 tree-head (lgsg=1).
+        let crown = parse_diag(
+            "DIAG|slot=0|mo=9|mf=0|lgt=aa|lgn=5|lgok=1|lgk=1|lgan=deadbeef|lgep=7|lgsz=233|lgsg=1",
+        )
+        .unwrap();
+        assert_eq!(crown.get("lgan"), Some("deadbeef"));
+        assert_eq!(crown.u64("lgep"), Some(7));
+        assert_eq!(crown.u64("lgsz"), Some(233));
+        assert_eq!(crown.u64("lgsg"), Some(1));
+
+        // The two alert conditions the render keys on: tamper canary (lgok=0) + HMAC forgeries.
+        let bad = parse_diag("DIAG|slot=0|mo=10|mf=4|lgt=ff|lgn=1|lgok=0|lgk=0").unwrap();
+        assert_eq!(bad.u64("lgok"), Some(0)); // → "✖ ledger self-verify FAILED"
+        assert!(bad.u64("mf").is_some_and(|f| f > 0)); // → "⚠ N HMAC failures"
+    }
 }

--- a/rust/viz/meshscope/src/ui/graph.rs
+++ b/rust/viz/meshscope/src/ui/graph.rs
@@ -250,6 +250,29 @@ impl GraphLayout {
             painter.circle_filled(ndot, 4.0, sync_color(node.sync_freshness()));
             painter.circle_stroke(ndot, 4.0, Stroke::new(1.0_f32, Color32::from_black_alpha(130)));
 
+            // #190/#249 — fleet-visible security alert at the top-LEFT (mirrors the sync dot).
+            // Red = ledger tamper canary tripped (lgok=0); amber = HMAC forgeries rejected (mf>0).
+            // Pulses so it reads across the whole graph without opening the inspector; tamper wins.
+            if let Some(d) = &node.diag {
+                let tamper = d.u64("lgok") == Some(0);
+                let forgery = d.u64("mf").is_some_and(|f| f > 0);
+                if tamper || forgery {
+                    let pulse = (0.5 + 0.5 * (now_s * 5.0).sin() as f32).clamp(0.3, 1.0);
+                    let col = if tamper {
+                        Color32::from_rgb(240, 70, 70)
+                    } else {
+                        Color32::from_rgb(235, 175, 80)
+                    };
+                    painter.text(
+                        sp + Vec2::new(-r * 0.72, -r * 0.72),
+                        Align2::CENTER_CENTER,
+                        "⚠",
+                        FontId::proportional(13.0),
+                        col.gamma_multiply(if stale { 0.45 } else { pulse }),
+                    );
+                }
+            }
+
             // #188 — LIVE OTA transfer. A real progress ARC (%+phase) now that the firmware publishes
             // smol/<id>/ota/progress, OR a LOUD death-point when that record goes stale mid-flight
             // (the transfer stopped AT `done` bytes — exactly the diagnostic we lacked). Falls back to

--- a/rust/viz/meshscope/src/ui/panel.rs
+++ b/rust/viz/meshscope/src/ui/panel.rs
@@ -155,9 +155,67 @@ pub fn show(ui: &mut egui::Ui, model: &Model, selected: Option<u8>, now_s: f64) 
                 _ => None,
             });
             row(ui, "cfg echo", d.get("cfg").map(|s| s.to_string()));
+            // #190 group-HMAC transport auth (v345 train): mo = frames authenticated, mf =
+            // frames rejected as forgeries / wrong group key. Absent on pre-v345 fw → row skipped.
+            row(ui, "HMAC ok/fail", match (d.u64("mo"), d.u64("mf")) {
+                (Some(ok), Some(fail)) => Some(format!("{ok} / {fail}")),
+                _ => None,
+            });
         });
         if d.u64("heap").is_some_and(|h| h <= LOW_HEAP_B) {
             ui.label(RichText::new("⚠ low heap").color(Color32::from_rgb(230, 120, 90)));
+        }
+        // #190: any nonzero HMAC-fail count is worth a look — a rejected forgery, or a board
+        // running the wrong group key. The counter is monotonic, so it's a cumulative tally.
+        if let Some(mf) = d.u64("mf").filter(|f| *f > 0) {
+            ui.label(
+                RichText::new(format!("⚠ {mf} HMAC failures — rejected forgeries / key mismatch"))
+                    .color(Color32::from_rgb(230, 160, 90)),
+            );
+        }
+        // #181/#249 mesh-ledger head (v345): the chain tip is a tamper canary; lgok=0 means this
+        // node's own provenance chain failed self-verify. The crown additionally folds in the L2
+        // anchor / L3 signed-tree-head (lgan present only on the gateway). Defensive: the whole
+        // block is skipped on pre-v345 fw that doesn't publish `lgt`.
+        if let Some(tip) = d.get("lgt") {
+            let recs = d.u64("lgn").unwrap_or(0);
+            ui.horizontal(|ui| {
+                ui.label(RichText::new("ledger").weak());
+                ui.label(
+                    RichText::new(format!("{tip} · {recs} rec{}", if recs == 1 { "" } else { "s" }))
+                        .monospace()
+                        .color(Color32::from_rgb(150, 200, 235)),
+                );
+                if d.u64("lgk") == Some(1) {
+                    ui.label(RichText::new("· 🔑 key").small().weak());
+                }
+            });
+            if d.u64("lgok") == Some(0) {
+                ui.label(
+                    RichText::new("✖ ledger self-verify FAILED — tamper canary tripped")
+                        .strong()
+                        .color(Color32::from_rgb(255, 110, 110)),
+                );
+            }
+            if let Some(anchor) = d.get("lgan") {
+                let signed = d.u64("lgsg") == Some(1);
+                let (detail, col) = if signed {
+                    (
+                        format!(
+                            "anchor {anchor} · epoch {} · {} leaves · ✍ signed",
+                            d.u64("lgep").unwrap_or(0),
+                            d.u64("lgsz").unwrap_or(0),
+                        ),
+                        Color32::from_rgb(150, 200, 150),
+                    )
+                } else {
+                    (format!("anchor {anchor} · unsigned (L2)"), Color32::from_rgb(205, 190, 140))
+                };
+                ui.horizontal(|ui| {
+                    ui.label(RichText::new("↳ crown STH").weak().small());
+                    ui.label(RichText::new(detail).small().color(col));
+                });
+            }
         }
         // #204: the crown's associated AP (which AP/channel/RSSI a deaf crown is on — the
         // forensics gap that cost hours of pcap), and crown dead-downstream health.


### PR DESCRIPTION
Meshscope consume-side for the new v345/v346 telemetry. Two stacked commits, both **render-only** (the viz `Diag`/`ota_diag` parsing is generic) and **defensive/dormant** on fw that doesn't yet emit the fields.

## #68 — v345 telemetry (HMAC health + ledger tamper canary)
Renders the diag_record fields the fw appends in `feat/181-ledger-wiring` (stacks **#190** group-HMAC over **#181** ledger-wiring; tasks #63/#64). The generic `Diag` KV map auto-parses any `|k=v`, so this is render-only.

| key | meaning | scope |
|-----|---------|-------|
| `mo` / `mf` | HMAC frames authenticated / rejected (#190) | all nodes |
| `lgt` / `lgn` | ledger chain tip (tamper canary) / length (#249) | all nodes |
| `lgok` / `lgk` | chain self-verify (1/0) / signing-key held | all nodes |
| `lgan` `lgep` `lgsz` `lgsg` | folded L2 anchor / L3 STH epoch·size·signed | **crown only** |

- **panel.rs** — "HMAC ok/fail" row; amber alert when `mf>0`; a ledger block (tip · len · 🔑), a LOUD `✖ ledger self-verify FAILED — tamper canary tripped` on `lgok=0`, and the crown's L2/L3 anchor (signed vs unsigned).
- **graph.rs** — a fleet-visible pulsing top-left security badge: red on tamper (`lgok=0`), amber on forgeries (`mf>0`).

## #72 — v346 peer-source attribution (#237)
Renders the `src=` field the fw appends to `smol/<leaf>/ota/diag` (`<phase>[ retry=N] src=gw|src=id<n>`) — verified from `feat/237-peer-relay` (slice-1 #65). The fw's own comment calls it "the metric proving peer-sourcing actually saved a fetch."

- **mesh-model** — `OtaSource {Gateway, Peer(u8)}` + `parse_ota_src()`; `Node.ota_src`; dispatch extraction that also strips `src=` off the stored phase line so it stays clean.
- **panel.rs** — `source: gateway fetch` (muted) vs bold green `source: ⇄ peer id<n> (baton · ESP-NOW serve)`.
- **graph.rs** — a `⇄id<n>` baton tag on a peer-sourced disc, visually distinct from a plain gateway fetch.

## Descoped (no MQTT wire — honest, not faked)
- **#227 weather** is on-glass only (never `encode_publish`'d) — corroborated by task #66's "weather-**on-glass**" title. Surfaces via the existing #159 screen mirror; no dedicated tile possible.
- **ODEL/ODON** (#237) are raw ESP-NOW unicast frames, serial-logged only. Their sole broker-visible artifact is the `src=` outcome (rendered above); no separate tile without a fw publish-side.

## Dependency
Both renders are dormant until their fw ships: #68 → v345 (#63/#64), #72 → v346 peer-roll. Safe to land now (viz-only, gate-green) so the consume side is ready when the fleet flashes.

## Gate (familiar, cargo 1.97.1, disk-backed target)
- ✅ `clippy --workspace --all-targets -- -D warnings`
- ✅ `cargo test -p mesh-model` — 25 passed + doc-test
- ✅ `cargo build --workspace --release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
