### PR TITLE
#72 meshscope: render #237 peer-source attribution (src=gw / src=id<n>)

### DIFF
--- a/rust/viz/mesh-model/src/model.rs
+++ b/rust/viz/mesh-model/src/model.rs
@@ -13,7 +13,7 @@
 use std::collections::{BTreeMap, VecDeque};
 
 use crate::names;
-use crate::parse::{self, Diag, OtaProgress, OtaState, PeerLink};
+use crate::parse::{self, Diag, OtaProgress, OtaSource, OtaState, PeerLink};
 
 // --- Semantic thresholds — the SINGLE SOURCE OF DERIVATION TRUTH (HA parity) ---
 // Every derived signal is defined ONCE here; the HA dashboard mirrors these (and
@@ -112,6 +112,9 @@ pub struct Node {
     pub ota: Option<OtaState>,
     pub ota_armed: bool,
     pub ota_phase: Option<String>, // latest smol/<id>/ota/diag phase (e.g. "fetch-failed retry=3")
+    /// #237 peer-sourcing: WHO served the last OTA — `gw` (gateway fetch) vs a peer HOLDER that
+    /// served it over ESP-NOW (the baton). Parsed from the ` src=` suffix on `ota/diag`.
+    pub ota_src: Option<OtaSource>,
     /// #188 live transfer progress (smol/<id>/ota/progress) + the frame-time it last updated. A
     /// stale record with done<total is the DEATH-POINT — the transfer stopped AT `done` bytes. See
     /// [`Node::ota_progress_view`].
@@ -138,6 +141,7 @@ impl Node {
             ota: None,
             ota_armed: false,
             ota_phase: None,
+            ota_src: None,
             ota_progress: None,
             ota_progress_at: 0.0,
             links: Vec::new(),
@@ -441,7 +445,11 @@ impl Model {
                     // The transfer PHASE ("fetch-failed retry=3", terminal outcomes) lands on
                     // ota/diag — keep the latest for the inspector; the others stay ticker-only.
                     if suffix == "ota/diag" {
-                        n.ota_phase = Some(short.clone());
+                        // #237: split the ` src=` attribution out into its own field so the phase
+                        // line stays clean; the source renders as a distinct peer-source/baton tile.
+                        n.ota_src = parse::parse_ota_src(&short);
+                        let phase = short.split(" src=").next().unwrap_or_default().trim_end();
+                        n.ota_phase = Some(phase.to_string());
                     }
                     self.event(now_s, EventKind::Ota, format!("id{id} {suffix}: {short}"));
                 }
@@ -555,9 +563,24 @@ mod tests {
         let mut model = m();
         model.ingest(1.0, "smol/8/ota/diag", b"fetch-failed retry=3");
         assert_eq!(model.nodes[&8].ota_phase.as_deref(), Some("fetch-failed retry=3"));
+        assert_eq!(model.nodes[&8].ota_src, None); // no src= on this record
         // relaydiag stays ticker-only (not the transfer phase).
         model.ingest(2.0, "smol/8/ota/relaydiag", b"leaf=H2V1N0");
         assert_eq!(model.nodes[&8].ota_phase.as_deref(), Some("fetch-failed retry=3"));
+    }
+
+    #[test]
+    fn ota_diag_src_attribution_237() {
+        use crate::parse::OtaSource;
+        let mut model = m();
+        // Peer-sourced: the ` src=id7` splits out into ota_src; the phase line stays clean.
+        model.ingest(1.0, "smol/9/ota/diag", b"installed src=id7");
+        assert_eq!(model.nodes[&9].ota_src, Some(OtaSource::Peer(7)));
+        assert_eq!(model.nodes[&9].ota_phase.as_deref(), Some("installed"));
+        // Gateway fetch attribution.
+        model.ingest(2.0, "smol/9/ota/diag", b"self-fetch-failed retry=2 src=gw");
+        assert_eq!(model.nodes[&9].ota_src, Some(OtaSource::Gateway));
+        assert_eq!(model.nodes[&9].ota_phase.as_deref(), Some("self-fetch-failed retry=2"));
     }
 
     #[test]

--- a/rust/viz/mesh-model/src/parse.rs
+++ b/rust/viz/mesh-model/src/parse.rs
@@ -151,6 +151,29 @@ pub fn parse_ota_progress(payload: &str) -> Option<OtaProgress> {
     Some(OtaProgress { done, total, phase })
 }
 
+/// #237 peer-sourcing: WHO served a leaf's last OTA, parsed from the ` src=` suffix the fw
+/// appends to the retained `smol/<id>/ota/diag` payload (`<phase>[ retry=N] src=gw|src=id<n>`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OtaSource {
+    /// `src=gw` — the crown WiFi-fetched it (or fell back to a gateway fetch).
+    Gateway,
+    /// `src=id<n>` — a peer HOLDER served it over ESP-NOW (zero bulk fetch): the #237 baton,
+    /// i.e. the visible outcome of the crown's `ODEL` delegation + the holder's `ODON` result.
+    Peer(u8),
+}
+
+/// Parse the trailing ` src=` attribution off an `ota/diag` payload. `None` when the field is
+/// absent (pre-#237 fw / older records). Tolerant of trailing tokens — takes the first word.
+pub fn parse_ota_src(payload: &str) -> Option<OtaSource> {
+    let (_, tail) = payload.rsplit_once(" src=")?;
+    let tok = tail.split_whitespace().next()?;
+    if tok == "gw" {
+        Some(OtaSource::Gateway)
+    } else {
+        tok.strip_prefix("id")?.parse().ok().map(OtaSource::Peer)
+    }
+}
+
 /// Extract the device noun from an HA discovery config JSON, e.g. device.name
 /// `"smol 7 Draconic"` -> `"Draconic"`. Belt-and-suspenders next to the vendored
 /// `names` table (works even if the firmware corpus ever drifts).
@@ -333,5 +356,17 @@ mod tests {
         let bad = parse_diag("DIAG|slot=0|mo=10|mf=4|lgt=ff|lgn=1|lgok=0|lgk=0").unwrap();
         assert_eq!(bad.u64("lgok"), Some(0)); // → "✖ ledger self-verify FAILED"
         assert!(bad.u64("mf").is_some_and(|f| f > 0)); // → "⚠ N HMAC failures"
+    }
+
+    #[test]
+    fn ota_src_237() {
+        // #237 src= attribution, exactly as the fw appends it to ota/diag.
+        assert_eq!(parse_ota_src("done src=gw"), Some(OtaSource::Gateway));
+        assert_eq!(parse_ota_src("self-fetch-failed retry=3 src=id7"), Some(OtaSource::Peer(7)));
+        assert_eq!(parse_ota_src("installed src=id12"), Some(OtaSource::Peer(12)));
+        // Pre-#237 records (no src=) → None, so the tile simply doesn't render.
+        assert_eq!(parse_ota_src("fetch-failed retry=3"), None);
+        // Malformed source token → None, never a panic.
+        assert_eq!(parse_ota_src("done src=bogus"), None);
     }
 }

--- a/rust/viz/meshscope/src/ui/graph.rs
+++ b/rust/viz/meshscope/src/ui/graph.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use egui::{Align2, Color32, FontId, Pos2, Rect, Sense, Stroke, Vec2};
 
 use mesh_model::model::{Model, SyncFreshness, WEAK_LINK_DBM};
+use mesh_model::parse::OtaSource;
 
 const GOLDEN_ANGLE: f32 = 2.399_963_2; // radians, spreads initial placement
 const K_REP: f32 = 90_000.0; // repulsion strength
@@ -329,6 +330,20 @@ impl GraphLayout {
                         );
                     }
                 }
+            }
+
+            // #237 peer-source baton: tag a node whose last OTA was served by a peer HOLDER
+            // (src=id<n>) over ESP-NOW — a small "⇄id<n>" to the right of the disc so a
+            // peer-sourced board reads as visually distinct from a plain gateway fetch (which is
+            // the default and stays untagged). The visible outcome of the ODEL→serve→ODON baton.
+            if let Some(OtaSource::Peer(pid)) = node.ota_src {
+                painter.text(
+                    sp + Vec2::new(r + 6.0, r * 0.55),
+                    Align2::LEFT_CENTER,
+                    format!("⇄id{pid}"),
+                    FontId::proportional(10.5),
+                    if stale { Color32::from_gray(120) } else { Color32::from_rgb(170, 220, 120) },
+                );
             }
 
             // Tiny heap sparkline beneath the screen line.

--- a/rust/viz/meshscope/src/ui/panel.rs
+++ b/rust/viz/meshscope/src/ui/panel.rs
@@ -5,6 +5,7 @@ use egui::{Color32, RichText};
 use egui_plot::{Line, Plot, PlotPoints};
 
 use mesh_model::model::{Model, Node, SyncFreshness, LOW_HEAP_B};
+use mesh_model::parse::OtaSource;
 
 pub fn show(ui: &mut egui::Ui, model: &Model, selected: Option<u8>, now_s: f64) {
     let Some(id) = selected.filter(|i| model.nodes.contains_key(i)) else {
@@ -115,6 +116,27 @@ pub fn show(ui: &mut egui::Ui, model: &Model, selected: Option<u8>, now_s: f64) 
         // completion are the honest "watch it happen" signals.
         if let Some(phase) = &node.ota_phase {
             ui.label(RichText::new(format!("phase: {phase}")).small().monospace().color(Color32::from_rgb(190, 165, 220)));
+        }
+        // #237 peer-sourcing — WHO served this node's last OTA. `gateway` is the normal WiFi
+        // fetch; a peer `id<n>` means a HOLDER served it over ESP-NOW (the baton — the visible
+        // outcome of the crown's ODEL delegation + the holder's ODON), a fetch the gateway never
+        // had to make. The distinction is the metric that proves peer-sourcing saved a fetch.
+        match node.ota_src {
+            Some(OtaSource::Gateway) => {
+                ui.label(
+                    RichText::new("source: gateway fetch")
+                        .small()
+                        .color(Color32::from_rgb(150, 170, 195)),
+                );
+            }
+            Some(OtaSource::Peer(pid)) => {
+                ui.label(
+                    RichText::new(format!("source: ⇄ peer id{pid}  (baton · ESP-NOW serve)"))
+                        .strong()
+                        .color(Color32::from_rgb(170, 220, 120)),
+                );
+            }
+            None => {}
         }
         ui.separator();
     }


### PR DESCRIPTION
## What
Meshscope consume-side for **#237 peer-sourcing** source attribution. Renders the `src=` field the fw appends to `smol/<leaf>/ota/diag` (`<phase>[ retry=N] src=gw|src=id<n>`) — verified from `feat/237-peer-relay` (slice-1 #65). The fw's own comment calls it *"the metric proving peer-sourcing actually saved a fetch."* Follows #68 (merged in #253); the `ota/diag` parse is already generic, so this is render-only + defensive (absent on pre-#237 records → no tile).

## Contract (verified, not guessed)
`src=gw` → the crown WiFi-fetched / fell back to a gateway fetch. `src=id<n>` → a peer HOLDER served it over ESP-NOW (zero bulk fetch) — the baton, i.e. the visible outcome of the crown's `ODEL` delegation + the holder's `ODON` result.

## Renders
- **mesh-model** — `OtaSource {Gateway, Peer(u8)}` + `parse_ota_src()` (splits the trailing ` src=` off `ota/diag`); `Node.ota_src`; dispatch extraction that also strips `src=` from the stored phase line so it stays clean. Tests: `ota_src_237` (parser) + `ota_diag_src_attribution_237` (ingest → field).
- **panel.rs** — `source: gateway fetch` (muted) vs bold green `source: ⇄ peer id<n> (baton · ESP-NOW serve)`.
- **graph.rs** — a `⇄id<n>` baton tag to the right of a peer-sourced disc so it reads as visually distinct from a plain gateway fetch at a glance.

## Descoped (no MQTT wire — honest, not faked)
**ODEL/ODON** handshake frames are raw ESP-NOW unicast, serial-logged only (no `encode_publish`). Their sole broker-visible artifact is this `src=` outcome — so that's what's rendered; a separate ODEL/ODON tile isn't possible without a fw publish-side. (Same discipline as #227 weather being OLED-only.)

## Dependency
Dormant until v346 peer-rolls; safe to land now (viz-only, gate-green) so the consume side is ready when the fleet flashes.

## Gate (familiar, cargo 1.97.1, disk-backed target, rebased on latest main)
- ✅ `clippy --workspace --all-targets -- -D warnings`
- ✅ `cargo test -p mesh-model` — 25 passed + doc-test
- ✅ `cargo build --workspace --release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
