### PR TITLE
fix(build): drop -Zbuild-std for riscv32imc (portable-atomic host-leak)

### DIFF
--- a/rust/clock/.cargo/config.toml
+++ b/rust/clock/.cargo/config.toml
@@ -33,9 +33,17 @@ rustflags = [
     "-C", "force-frame-pointers",
 ]
 
-[unstable]
-# esp-hal / esp-wifi build core+alloc from source for the exact target.
-build-std = ["core", "alloc"]
+# build-std REMOVED (2026-07-20, morpheus): riscv32imc-unknown-none-elf is a TIER-2 target with a
+# prebuilt core/alloc, so `-Zbuild-std` was unnecessary here. It was also actively HARMFUL: build-std
+# forces resolver-1-style feature unification across the host/target boundary, which leaked esp-hal's
+# `portable-atomic/unsafe-assume-single-core` (a riscv-only cfg) into the HOST (x86_64) proc-macro/
+# build compile of portable-atomic — where portable-atomic's arch guard rejects it with a
+# `compile_error!`. That broke EVERY fresh (cold-cache) fw build; v345's ELF only linked because its
+# target/ was warm. Dropping build-std = prebuilt core (no host portable-atomic recompile) → fixed.
+# Verified: cold build of espnow,cast,io + default + wifi all green. REVISIT if a future esp-hal/
+# esp-wifi requires a from-source core (xtensa-only concern; N/A for the riscv C3).
+# [unstable]
+# build-std = ["core", "alloc"]
 
 [registries.crates-io]
 protocol = "sparse"


### PR DESCRIPTION
## What
Removes `build-std = ["core", "alloc"]` from `rust/clock/.cargo/config.toml`.

## Why (un-reds main for ALL fresh fw builds)
`-Zbuild-std` forced resolver-1-style **feature unification across the host/target boundary**, leaking esp-hal's `portable-atomic/unsafe-assume-single-core` (a riscv-only cfg) into the **HOST (x86_64)** proc-macro/build compile of portable-atomic — whose arch guard rejects it with a `compile_error!`. Every **cold-cache** fw build died on this; v345's ELF only linked because its `target/` was warm.

`riscv32imc-unknown-none-elf` is a **tier-2** target with a prebuilt `core`/`alloc`, so build-std was unnecessary. Dropping it → prebuilt core → no host portable-atomic recompile → fixed. (Reasoned exception + revisit trigger commented in-file, per the latest-versions policy.)

## Verified (cold builds, fresh target dir)
- `cargo clippy --features espnow,cast,io -- -D warnings` ✅
- `cargo build --release --features espnow,cast,io` ✅
- `cargo build --release` (default) ✅
- `cargo build --release --features wifi` ✅
- host verifiers (mac/relay_compat/ledger/sth/treehead/wx/dns) all pass ✅

Ruled out (all failed): portable-atomic 1.13.1/1.14.0, rustc 1.96.1/1.97.1, reverting #52's lock, explicit resolver=2. This is the real fix.

Standalone so main builds NOW, independent of the v346 canary. #233's esp-hal-1.1 migration rebases on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)