### PR TITLE
feat(meshscope): #82 crown coexist-channel-health indicator

### DIFF
--- a/rust/viz/meshscope/src/ui/graph.rs
+++ b/rust/viz/meshscope/src/ui/graph.rs
@@ -375,6 +375,50 @@ fn rssi_rest_len(rssi: i32) -> f32 {
 }
 
 /// Green (strong) -> amber -> red (weak).
+/// Coexist-channel-health (#204/#217): the crown's WiFi-uplink AP channel MUST equal the
+/// elected ESP-NOW mesh channel, or the crown goes bulk-RX-deaf mid-fetch and OTA dies (the
+/// ch1-AP-vs-ch6-mesh bug that cost a night of pcap). `Weak` = channels match but the uplink
+/// is at/under `WEAK_LINK_DBM` (−80 dBm), the stacked factor seen in the disease. `Unknown` =
+/// no crown seen yet, or the crown hasn't published its `ap=` association. Shared by the
+/// top-bar chip and the crown detail line so both read identically — and by design matched to
+/// the HA coexist tile (luna-notify): green ==, red !=, amber weak.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Coexist {
+    Healthy { ch: u8 },
+    Weak { ch: u8, rssi: i32 },
+    Violated { ap_ch: u8, mesh_ch: u8 },
+    Unknown,
+}
+
+/// Classify the CURRENT crown's coexist health. The crown is the MC `owner`; we read that
+/// node's DIAG `ap=` and compare its channel to the elected mesh channel. (A future fw `cc=`
+/// flag — morpheus — could override this as the board's own verdict; the computed comparison
+/// is the ground truth available today.)
+pub fn crown_coexist(m: &Model) -> Coexist {
+    let Some(crown) = m.crown else {
+        return Coexist::Unknown;
+    };
+    let Some(ap) = m.nodes.get(&crown.owner).and_then(|n| n.ap()) else {
+        return Coexist::Unknown;
+    };
+    if ap.channel != crown.channel {
+        Coexist::Violated { ap_ch: ap.channel, mesh_ch: crown.channel }
+    } else if ap.rssi <= WEAK_LINK_DBM {
+        Coexist::Weak { ch: ap.channel, rssi: ap.rssi }
+    } else {
+        Coexist::Healthy { ch: ap.channel }
+    }
+}
+
+pub fn coexist_color(c: Coexist) -> Color32 {
+    match c {
+        Coexist::Healthy { .. } => Color32::from_rgb(90, 210, 120),
+        Coexist::Weak { .. } => Color32::from_rgb(230, 200, 70),
+        Coexist::Violated { .. } => Color32::from_rgb(224, 90, 90),
+        Coexist::Unknown => Color32::from_rgb(130, 130, 140),
+    }
+}
+
 pub fn rssi_color(rssi: i32) -> Color32 {
     let t = ((rssi + 90) as f32 / 60.0).clamp(0.0, 1.0);
     let (r, g, b) = if t > 0.5 {
@@ -425,4 +469,48 @@ pub fn draw_sparkline(painter: &egui::Painter, origin: Pos2, size: Vec2, hist: &
         })
         .collect();
     painter.add(egui::Shape::line(pts, Stroke::new(1.2_f32, color)));
+}
+
+#[cfg(test)]
+mod coexist_tests {
+    use super::*;
+    use mesh_model::model::Model;
+
+    fn crown_model(mc: &str, crown_diag: &str) -> Model {
+        let mut m = Model::new("test".into());
+        m.ingest(1.0, "smol/mesh/channel", mc.as_bytes());
+        m.ingest(1.0, "smol/7/diag", crown_diag.as_bytes());
+        m
+    }
+
+    #[test]
+    fn healthy_when_ap_channel_matches_mesh() {
+        let m = crown_model("MC|7|6|10", "DIAG|boot=1|heap=40000|ap=6:-58:a1b2c3d4e5f6");
+        assert_eq!(crown_coexist(&m), Coexist::Healthy { ch: 6 });
+    }
+
+    #[test]
+    fn violated_on_channel_mismatch() {
+        // The exact ch1-AP-vs-ch6-mesh bug that made the crown bulk-RX-deaf → OTA-dead.
+        let m = crown_model("MC|7|6|10", "DIAG|boot=1|heap=40000|ap=1:-58:a1b2c3d4e5f6");
+        assert_eq!(crown_coexist(&m), Coexist::Violated { ap_ch: 1, mesh_ch: 6 });
+    }
+
+    #[test]
+    fn weak_when_matched_but_faint_uplink() {
+        // Channels agree but the uplink is at/under WEAK_LINK_DBM (−80) — the stacked factor.
+        let m = crown_model("MC|7|6|10", "DIAG|boot=1|heap=40000|ap=6:-82:a1b2c3d4e5f6");
+        assert_eq!(crown_coexist(&m), Coexist::Weak { ch: 6, rssi: -82 });
+    }
+
+    #[test]
+    fn unknown_without_crown_or_ap() {
+        // No crown record → unknown.
+        let mut m = Model::new("test".into());
+        m.ingest(1.0, "smol/7/diag", b"DIAG|boot=1|heap=40000|ap=6:-58:a1b2c3d4e5f6");
+        assert_eq!(crown_coexist(&m), Coexist::Unknown);
+        // Crown known but the crown node hasn't published an ap= yet → unknown, not a false green.
+        let m2 = crown_model("MC|7|6|10", "DIAG|boot=1|heap=40000");
+        assert_eq!(crown_coexist(&m2), Coexist::Unknown);
+    }
 }

--- a/rust/viz/meshscope/src/ui/mod.rs
+++ b/rust/viz/meshscope/src/ui/mod.rs
@@ -111,6 +111,21 @@ fn top_bar(ui: &mut egui::Ui, m: &Model, now_s: f64) {
         };
         ui.separator();
 
+        // #204/#217 coexist-channel-health — the fleet-critical at-a-glance chip: the crown's
+        // uplink AP channel MUST equal the mesh channel or the crown goes bulk-RX-deaf and OTA
+        // dies. Mirrors luna-notify's HA coexist tile (green ==, red !=, amber weak-uplink).
+        let cx = graph::crown_coexist(m);
+        let cx_chip = match cx {
+            graph::Coexist::Healthy { ch } => Some(format!("✓ coexist ch{ch}")),
+            graph::Coexist::Weak { ch, rssi } => Some(format!("⚠ coexist ch{ch} · uplink {rssi} dBm")),
+            graph::Coexist::Violated { ap_ch, mesh_ch } => Some(format!("✖ OFF-CHANNEL · AP ch{ap_ch} ≠ mesh ch{mesh_ch}")),
+            graph::Coexist::Unknown => None,
+        };
+        if let Some(text) = cx_chip {
+            ui.label(RichText::new(text).strong().color(graph::coexist_color(cx)));
+            ui.separator();
+        }
+
         let gateways = m.nodes.values().filter(|n| n.gateway).count();
         ui.label(format!("{} node(s) · {} gateway", m.nodes.len(), gateways));
 

--- a/rust/viz/meshscope/src/ui/panel.rs
+++ b/rust/viz/meshscope/src/ui/panel.rs
@@ -244,6 +244,29 @@ pub fn show(ui: &mut egui::Ui, model: &Model, selected: Option<u8>, now_s: f64) 
         if let Some(ap) = node.ap() {
             kv(ui, "AP", &format!("ch{} · {} dBm · {}", ap.channel, ap.rssi, fmt_bssid(ap.bssid)));
         }
+        // #204/#217 coexist verdict for the crown: its uplink AP channel vs the elected mesh
+        // channel. A mismatch is the bulk-RX-deaf OTA-death bug (ch1-AP vs ch6-mesh); a weak
+        // uplink is the stacked factor. Only meaningful on the crown (the WiFi-fetching node).
+        if Some(node.id) == model.crown.map(|c| c.owner) {
+            let cx = super::graph::crown_coexist(model);
+            let verdict = match cx {
+                super::graph::Coexist::Healthy { ch } => {
+                    Some((format!("✓ coexist healthy — AP & mesh both on ch{ch}"), false))
+                }
+                super::graph::Coexist::Weak { ch, rssi } => {
+                    Some((format!("⚠ coexist ch{ch} — uplink weak ({rssi} dBm), degraded not dead"), true))
+                }
+                super::graph::Coexist::Violated { ap_ch, mesh_ch } => Some((
+                    format!("✖ COEXIST BROKEN — AP ch{ap_ch} ≠ mesh ch{mesh_ch} · crown off-channel → OTA-dead"),
+                    true,
+                )),
+                super::graph::Coexist::Unknown => None,
+            };
+            if let Some((text, strong)) = verdict {
+                let t = RichText::new(text).color(super::graph::coexist_color(cx));
+                ui.label(if strong { t.strong() } else { t });
+            }
+        }
         if let Some(cd) = node.crown_deaf() {
             let col = if cd.shed {
                 Color32::from_rgb(224, 90, 90)


### PR DESCRIPTION
Surfaces the **crown's coexist-channel-health** in meshscope — the crown's WiFi-uplink AP channel vs the elected ESP-NOW mesh channel. A mismatch is the bulk-RX-deaf OTA-death bug (crown on ch1 AP, mesh on ch6) that cost a night of pcap. Companion to luna-notify's HA coexist tile; the green/red/amber semantics are **agreed identical** across both surfaces.

## What it shows
- **Top-bar chip** (`ui/mod.rs`) — at-a-glance next to the crown label: `✓ coexist ch6` / `⚠ coexist ch6 · uplink −82 dBm` / `✖ OFF-CHANNEL · AP ch1 ≠ mesh ch6`.
- **Per-crown verdict line** (`ui/panel.rs`) — under the existing AP row (which already shows ap ch/rssi/bssid): a plain-language healthy / degraded / **COEXIST BROKEN → OTA-dead** verdict.
- **Shared classifier** (`ui/graph.rs`): `Coexist{Healthy,Weak,Violated,Unknown}` + `crown_coexist(&Model)` + `coexist_color()` so both surfaces read identically.

## Semantics (shared with the HA tile)
- GREEN: crown ap channel == mesh channel.
- RED: mismatch (crown off-channel → coexist broken → OTA-dead).
- AMBER: channels match but crown uplink `<= WEAK_LINK_DBM` (−80 dBm) — the stacked factor from tonight's disease.
- GREY/hidden: no crown seen, or the crown hasn't published `ap=` yet.

## Wire
Parses existing DIAG `ap=<ch>:<rssi>:<bssid>` (via `Node::ap()`) + the `smol/mesh/channel` MC record (`crown.owner`/`crown.channel`) — both already in the model, no parser changes. A future fw `cc=` explicit-verdict flag (morpheus) can fold in later as the board's own opinion; the computed comparison is today's ground truth.

## Verification (on familiar, `/var/tmp` target per the viz build note)
- `cargo check -p meshscope` clean.
- `cargo test -p meshscope` → **10/10 pass**, incl. 4 new `coexist_tests` (healthy / violated / weak / unknown) locking the semantics; no regression in the 6 existing operator tests.
- `cargo clippy -p meshscope` clean.

site/HA/fw untouched — `rust/viz` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)