### PR TITLE
fix(ota): #267 cross-burst OTA-fetch resume — resume the Range, not restart from 0

### DIFF
--- a/experiments/267_resume_verify/Cargo.toml
+++ b/experiments/267_resume_verify/Cargo.toml
@@ -1,0 +1,19 @@
+# #267 host-test harness for the PURE cross-burst OTA-resume key logic (net/ota_resume.rs).
+# Runs OFF-target (std) via `cargo run` AND `cargo test`; #[path]-includes the real
+# ota_resume.rs (no drift). Proves the resume keying (match → offset, any mismatch → 0) and the
+# segmentation-invariance property the fix rests on: an image written in one shot vs resumed in
+# N segments (boundaries driven by the real `resume_offset`) yields byte-identical flash → an
+# identical finalize readback-SHA. Mirrors etx_verify/ledger_verify/crdt_verify. sha2 supplies
+# the readback hash — the core is dependency-free.
+[package]
+name = "resume_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "resume_verify"
+path = "src/main.rs"
+[dependencies]
+sha2 = "0.10"
+[profile.dev]
+opt-level = 0

--- a/experiments/267_resume_verify/src/main.rs
+++ b/experiments/267_resume_verify/src/main.rs
@@ -1,0 +1,136 @@
+//! Host verification of the PURE #267 cross-burst OTA-resume key logic (`net/ota_resume.rs`),
+//! included verbatim (#[path], no drift). Run: `cargo run` — panics on failure. `cargo test` runs
+//! the same suite (no false-green).
+//!
+//! Two things must hold for #267 to be correct:
+//!  1. **Keying** — a resume cursor is honored ONLY for the exact staged image + slot it belongs
+//!     to (build + sha16 + slot); any mismatch (re-stage, slot flip, different image) → fetch from
+//!     byte 0. This is the guard against resuming onto a stale/wrong flash prefix.
+//!  2. **Segmentation-invariance** — an image written in one shot vs resumed across N bursts (each
+//!     resuming from the last committed offset via the real `resume_offset`) leaves BYTE-IDENTICAL
+//!     flash, hence an identical finalize readback-SHA. This is the property the whole fix rests on:
+//!     a fetch that keeps dying mid-body ACCUMULATES instead of restarting.
+
+#[path = "../../../rust/clock/src/net/ota_resume.rs"]
+mod ota_resume;
+
+use ota_resume::{resume_offset, sha_key16, ResumeKey};
+use sha2::{Digest, Sha256};
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    h.finalize().into()
+}
+
+fn key(build: u32, sha: &[u8; 32], slot: u8) -> ResumeKey {
+    ResumeKey { build, sha_key: sha_key16(sha), slot }
+}
+
+/// A deterministic pseudo-image of `n` bytes (not all-equal, so a mis-offset write would corrupt it).
+fn image(n: usize) -> Vec<u8> {
+    (0..n).map(|i| ((i * 2654435761usize) >> 13) as u8 ^ (i as u8)).collect()
+}
+
+/// Model the flash writer's resume behaviour against a mock slot: fetch `img` in segments whose
+/// boundaries are the "death points" `deaths`; each new segment resumes from the last COMMITTED
+/// (flushed, sector-aligned) offset as the real `resume_offset` would return it. Returns the mock
+/// slot bytes — which must equal a one-shot write for any death pattern.
+fn fetch_with_deaths(img: &[u8], deaths: &[usize], build: u32, sha: &[u8; 32], slot: u8) -> Vec<u8> {
+    const SECTOR: usize = 4096;
+    let size = img.len() as u32;
+    let want = key(build, sha, slot);
+    let mut flash = vec![0xFFu8; img.len()];
+    let mut saved: Option<(ResumeKey, u32)> = None; // the .bss cursor across bursts
+    let mut cut = 0usize; // absolute death index into `deaths`
+    loop {
+        // A fresh burst: begin() consults the saved cursor for the resume offset.
+        let start = resume_offset(saved, &want, size) as usize;
+        if start >= img.len() {
+            break;
+        }
+        // This burst writes until it "dies" at the next death point past `start`, else to the end.
+        let die_at = deaths.get(cut).copied().unwrap_or(img.len());
+        cut += 1;
+        let end = die_at.min(img.len()).max(start);
+        // Commit only whole sectors (mid-sector RAM stage is lost on burst death — mirrors flush).
+        let committed_end = start + ((end - start) / SECTOR) * SECTOR;
+        // ...but the FINAL burst (reaching the end) flushes the padded tail too.
+        let (write_end, flush_end) = if end >= img.len() {
+            (img.len(), img.len())
+        } else {
+            (committed_end, committed_end)
+        };
+        flash[start..write_end].copy_from_slice(&img[start..write_end]);
+        if flush_end > 0 {
+            saved = Some((want, flush_end as u32)); // persist the on-flash (flushed) cursor
+        }
+        if flush_end >= img.len() {
+            break;
+        }
+        if flush_end == start && die_at <= start {
+            // no forward progress this burst (death before a full sector) — avoid an infinite loop
+            // in the model; a real fetch would stall-cap. Nudge past this death point.
+            if cut > deaths.len() + 2 {
+                break;
+            }
+        }
+    }
+    flash
+}
+
+fn run() {
+    // ---- 1. KEYING --------------------------------------------------------
+    let sha = sha256(b"image-A");
+    let other = sha256(b"image-B");
+    let k = key(42, &sha, 1);
+    assert_eq!(resume_offset(Some((k, 49152)), &k, 590_304), 49152, "exact-match key resumes at committed");
+    assert_eq!(resume_offset(None, &k, 590_304), 0, "no saved cursor → fresh fetch");
+    assert_eq!(resume_offset(Some((key(43, &sha, 1), 49152)), &k, 590_304), 0, "build mismatch → 0 (re-stage)");
+    assert_eq!(resume_offset(Some((key(42, &other, 1), 49152)), &k, 590_304), 0, "sha mismatch → 0 (different image, same build)");
+    assert_eq!(resume_offset(Some((key(42, &sha, 0), 49152)), &k, 590_304), 0, "slot mismatch → 0 (slot flipped)");
+    assert_eq!(resume_offset(Some((k, 0)), &k, 590_304), 0, "committed 0 → 0");
+    assert_eq!(resume_offset(Some((k, 700_000)), &k, 590_304), 0, "committed > size → 0 (corrupt cursor)");
+    assert_eq!(resume_offset(Some((k, 590_304)), &k, 590_304), 590_304, "committed == size resumes (finalize will size-check)");
+
+    // ---- 2. SEGMENTATION-INVARIANCE (the load-bearing property) -----------
+    let img = image(590_304); // ~ a real image size, not sector-multiple (tail exercised)
+    let sha_img: [u8; 32] = sha256(&img);
+    let build = 344;
+    let slot = 1u8;
+
+    // one-shot fetch (no deaths)
+    let one_shot = fetch_with_deaths(&img, &[], build, &sha_img, slot);
+    assert_eq!(one_shot, img, "one-shot fetch reconstructs the image");
+    assert_eq!(sha256(&one_shot), sha_img, "one-shot readback-SHA matches");
+
+    // 3-segment resume: die at 49152 (1 chunk) and 262144, mirroring the coexist ≈1-chunk/burst reality
+    let three_seg = fetch_with_deaths(&img, &[49152, 262144], build, &sha_img, slot);
+    assert_eq!(three_seg, one_shot, "3-segment resumed fetch is BYTE-IDENTICAL to one-shot");
+    assert_eq!(sha256(&three_seg), sha_img, "3-segment readback-SHA == one-shot (segmentation-invariant)");
+
+    // the pathological coexist case: die every single 48 KB chunk (≈13 bursts) — must STILL complete
+    let per_chunk_deaths: Vec<usize> = (1..13).map(|i| i * 49152).collect();
+    let sawtooth = fetch_with_deaths(&img, &per_chunk_deaths, build, &sha_img, slot);
+    assert_eq!(sawtooth, img, "die-every-chunk still accumulates the full image (the #267 fix)");
+    assert_eq!(sha256(&sawtooth), sha_img, "die-every-chunk readback-SHA matches");
+
+    // a re-stage mid-fetch (different image, same build) must NOT resume onto the stale prefix
+    let stale = resume_offset(Some((key(build, &sha_img, slot), 49152)), &key(build, &other, slot), img.len() as u32);
+    assert_eq!(stale, 0, "a re-staged (different-sha) image ignores the stale cursor → fresh fetch");
+
+    println!("resume_verify: all assertions passed");
+}
+
+fn main() {
+    run();
+}
+
+#[cfg(test)]
+mod tests {
+    /// `cargo test` entry — runs the full suite (identical to `cargo run`); no false-green.
+    #[test]
+    fn ota_resume_laws() {
+        super::run();
+    }
+}

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -63,6 +63,13 @@ pub mod mode;
 #[cfg(feature = "espnow")]
 pub mod etx;
 
+// #267 cross-burst OTA-fetch resume: the PURE resume-key logic (does a saved cursor match this
+// staged image + slot → what offset to resume from). Host-testable (experiments/267_resume_verify),
+// no HAL deps. Consumed by `crate::ota::ImageWriter` (the HW flash writer + the .bss cursor), which
+// is espnow-gated — so gate it the same, byte-free of the default/wifi builds like `etx`/`flood`.
+#[cfg(feature = "espnow")]
+pub mod ota_resume;
+
 // #13 routed multi-hop mesh: the PURE managed-flood decision core (SeenSet + forward
 // decision + HopLatch escalation state machine), host-testable, no HAL deps. Driven by
 // the relay path in `mode`, so espnow-gated.

--- a/rust/clock/src/net/ota_resume.rs
+++ b/rust/clock/src/net/ota_resume.rs
@@ -1,0 +1,50 @@
+//! #267 — the PURE resume-key logic for cross-burst OTA-fetch resume.
+//!
+//! ## What this is
+//! The OTA self-fetch / relay-fetch downloads the image as sequential HTTP `Range` chunks; a
+//! broken chunk resumes from `ImageWriter::written()` — but that cursor only lived for one
+//! `run_ota_fetch` call. The #195 retry is **per burst within one boot** (the #100 in-RAM idiom),
+//! so each burst re-invoked `ImageWriter::begin()`, which reset the cursor (and the streaming SHA)
+//! to 0 → every retry re-`Range`d from byte 0. Under the coexist bulk-RX disease (≈1 chunk/burst)
+//! a multi-chunk image never accumulated (#267).
+//!
+//! The fix keeps a same-boot, cross-burst resume cursor (in `.bss` — **no NVS**, since the retry
+//! never crosses a reboot; a reboot legitimately restarts from 0). This module is the **pure,
+//! host-testable brain**: given a saved cursor and the current `(build, sha, slot)`, what offset
+//! is it safe to resume from? Keying it to the exact staged image + target slot means a *re-stage*
+//! or a slot flip forces a fresh fetch from byte 0 (never resume onto a stale/wrong prefix). The
+//! HW flash writer + the `.bss` static live in `crate::ota`; this module holds only the decision.
+//! Host-tested in `experiments/267_resume_verify` (the `flood`/`etx`/`ledger` pattern).
+
+/// Identifies the staged image + target slot a resume cursor belongs to. A resume is honored only
+/// when the current fetch's key equals the saved one — so a newer staged build, a different image
+/// with the same build number, or a flipped inactive slot all invalidate the cursor.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ResumeKey {
+    /// Monotonic build number from the signed manifest.
+    pub build: u32,
+    /// First 16 bytes of the announced sha256 — ample to disambiguate two images (2⁻¹²⁸).
+    pub sha_key: [u8; 16],
+    /// Target (inactive) slot: `0` = Slot0, `1` = Slot1.
+    pub slot: u8,
+}
+
+/// The first 16 bytes of an announced sha256 — the resume key's image discriminator.
+pub fn sha_key16(sha: &[u8; 32]) -> [u8; 16] {
+    let mut k = [0u8; 16];
+    k.copy_from_slice(&sha[..16]);
+    k
+}
+
+/// The offset a fresh `ImageWriter::begin` may resume from.
+///
+/// Returns `committed` iff a cursor is saved, its key **exactly** matches `want`, and
+/// `0 < committed <= size` (the committed prefix fits the slot). Otherwise `0` — a fresh fetch from
+/// byte 0. `committed` is expected to be a flush boundary (sector-aligned) by construction; this
+/// pure decision does not depend on that, but the caller must only *save* on-flash (flushed) bytes.
+pub fn resume_offset(saved: Option<(ResumeKey, u32)>, want: &ResumeKey, size: u32) -> u32 {
+    match saved {
+        Some((key, committed)) if key == *want && committed > 0 && committed <= size => committed,
+        _ => 0,
+    }
+}

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -4423,7 +4423,9 @@ pub fn run_ota_fetch(
 
     // Open the inactive-slot writer ONCE (image is streamed here across chunks, never buffered
     // whole). `writer.written()` doubles as the RESUME cursor and the running-SHA position.
-    let Some(mut writer) = crate::ota::ImageWriter::begin() else {
+    // #267: pass (build, sha) so the writer can resume a same-boot prior burst's committed offset
+    // instead of restarting the Range from byte 0 (see ImageWriter::begin / net::ota_resume).
+    let Some(mut writer) = crate::ota::ImageWriter::begin(announce.build, &announce.sha256) else {
         *fail = Some((0, 0, 0, 0, ota_fail::SLOT)); // #139/#147: died before the download (slot open)
         log::error!("smol OTA: cannot open inactive slot (no OTA partition table?)");
         return false;

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -428,6 +428,59 @@ pub fn content_length(headers: &[u8]) -> Option<u32> {
 #[cfg(feature = "espnow")]
 static mut OTA_STAGE: [u8; CHUNK] = [0xFF; CHUNK];
 
+// #267: cross-burst OTA-fetch resume cursor. SAME-BOOT, resets on reboot (the #100 in-RAM idiom) —
+// the #195 OTA retry is per-burst WITHIN one boot, so NO NVS is needed (this deliberately sidesteps
+// the near-full `nvs` partition; a reboot legitimately restarts the fetch from byte 0). Without it,
+// each burst's `ImageWriter::begin` reset the write cursor to 0 and the fetch re-`Range`d from byte
+// 0; under the coexist bulk-RX disease (≈1 chunk/burst) a multi-chunk image never accumulated
+// (#267). The PURE keying (does a saved cursor match this staged image + slot?) lives in
+// `crate::net::ota_resume` (host-tested); this holds only the `.bss` cursor + thin accessors.
+#[cfg(feature = "espnow")]
+struct OtaResumeState {
+    saved: Option<(crate::net::ota_resume::ResumeKey, u32)>,
+}
+#[cfg(feature = "espnow")]
+static mut OTA_RESUME: OtaResumeState = OtaResumeState { saved: None };
+
+/// Target-slot discriminator for the resume key (`0` = Slot0, `1` = Slot1).
+#[cfg(feature = "espnow")]
+fn slot_key(s: Slot) -> u8 {
+    if s == Slot::Slot1 {
+        1
+    } else {
+        0
+    }
+}
+
+/// The resume offset for a fresh fetch of `(build, sha)` into `slot` — `0` if none matches (a fresh
+/// fetch from byte 0). Delegates the match to the pure `net::ota_resume::resume_offset`.
+#[cfg(feature = "espnow")]
+fn ota_resume_lookup(build: u32, sha: &[u8; 32], slot: Slot, size: u32) -> u32 {
+    let want = crate::net::ota_resume::ResumeKey {
+        build,
+        sha_key: crate::net::ota_resume::sha_key16(sha),
+        slot: slot_key(slot),
+    };
+    let saved = unsafe { (*core::ptr::addr_of!(OTA_RESUME)).saved };
+    crate::net::ota_resume::resume_offset(saved, &want, size)
+}
+
+/// Record the on-flash (flushed, sector-aligned) committed offset for the in-progress fetch, so the
+/// next burst's `begin` resumes here instead of restarting from 0.
+#[cfg(feature = "espnow")]
+fn ota_resume_save(key: crate::net::ota_resume::ResumeKey, committed: u32) {
+    let r = unsafe { &mut *core::ptr::addr_of_mut!(OTA_RESUME) };
+    r.saved = Some((key, committed));
+}
+
+/// Drop the resume cursor (a fetch is terminal: finalize success OR failure → a fresh attempt
+/// starts from byte 0). A newer/ different staged image is handled by keying, not this.
+#[cfg(feature = "espnow")]
+pub fn ota_resume_clear() {
+    let r = unsafe { &mut *core::ptr::addr_of_mut!(OTA_RESUME) };
+    r.saved = None;
+}
+
 #[cfg(feature = "espnow")]
 pub struct ImageWriter {
     flash: FlashStorage,
@@ -448,7 +501,9 @@ pub struct ImageWriter {
     /// the array did). Alias-safe: one OTA at a time (`begin` is single-caller, one-shot).
     stage: &'static mut [u8; CHUNK],
     stage_len: usize,
-    hasher: sha2::Sha256,
+    /// #267: identifies the staged image + slot this fetch belongs to, so each sector flush can
+    /// persist the resume cursor keyed to it (a re-stage / slot flip then can't resume onto it).
+    resume_key: crate::net::ota_resume::ResumeKey,
     target: Slot,
 }
 
@@ -456,8 +511,7 @@ pub struct ImageWriter {
 impl ImageWriter {
     /// Open a writer for the inactive slot (the one `otadata`'s current slot is NOT).
     /// `None` on any partition/flash error (e.g. a board without the OTA table).
-    pub fn begin() -> Option<ImageWriter> {
-        use sha2::Digest;
+    pub fn begin(build: u32, expected_sha: &[u8; 32]) -> Option<ImageWriter> {
         let target = inactive_slot()?;
         let sub = if target == Slot::Slot1 {
             AppPartitionSubType::Ota1
@@ -473,20 +527,31 @@ impl ImageWriter {
             let app = pt.find_partition(PartitionType::App(sub)).ok()??;
             (app.offset(), app.len())
         };
+        // #267: resume from a same-boot prior burst's committed (flushed, sector-aligned) offset iff
+        // this staged image + slot match the saved cursor; else 0 (fresh fetch). Bytes [0..resume)
+        // are already on flash from earlier bursts, so `erased_upto = base + resume` — begin never
+        // re-erases the committed prefix; the resumed feed erases-ahead only past it. Integrity is a
+        // finalize READBACK-SHA over `slot[..size]` (below), which is burst-count invariant — no
+        // streaming hasher to restore, so resume needs only the offset.
+        let resume = ota_resume_lookup(build, expected_sha, target, size);
         Some(ImageWriter {
             flash,
             base,
             size,
-            written: 0,
-            flushed: 0,
-            erased_upto: base,
+            written: resume,
+            flushed: resume,
+            erased_upto: base + resume,
             // F2: borrow the static stage buffer (off the stack). Alias-safe — one OTA
             // at a time. No stale-data risk: `flush_stage` re-pads `[len..padded]` to
             // 0xFF and writes only `stage[..padded]`, so a reused buffer never leaks
             // prior bytes to flash. `stage_len: 0` starts the accumulation fresh.
             stage: unsafe { &mut *core::ptr::addr_of_mut!(OTA_STAGE) },
             stage_len: 0,
-            hasher: sha2::Sha256::new(),
+            resume_key: crate::net::ota_resume::ResumeKey {
+                build,
+                sha_key: crate::net::ota_resume::sha_key16(expected_sha),
+                slot: slot_key(target),
+            },
             target,
         })
     }
@@ -505,11 +570,11 @@ impl ImageWriter {
     /// Returns `false` on overflow past the slot or any flash error (caller aborts;
     /// otadata untouched → good slot stays active).
     pub fn feed(&mut self, bytes: &[u8]) -> bool {
-        use sha2::Digest;
+        // #267: no streaming hash here anymore — integrity is a finalize READBACK-SHA over the slot
+        // (burst-count invariant), so a resumed multi-burst fetch verifies like a one-shot fetch.
         if self.written.saturating_add(bytes.len() as u32) > self.size {
             return false; // image claims more than a slot — refuse
         }
-        self.hasher.update(bytes);
         self.written += bytes.len() as u32;
         let mut off = 0;
         while off < bytes.len() {
@@ -552,6 +617,10 @@ impl ImageWriter {
             return false;
         }
         self.flushed += len as u32;
+        // #267: persist the on-flash cursor so the next burst's `begin` resumes here (not from 0).
+        // Fetch-loop flushes are full sectors (aligned); the finalize tail flush is non-aligned but
+        // finalize clears the cursor immediately after, so a non-aligned value never persists.
+        ota_resume_save(self.resume_key, self.flushed);
         self.stage_len = 0;
         true
     }
@@ -560,14 +629,37 @@ impl ImageWriter {
     /// AND running SHA-256 == announced hash. `true` ⇒ the whole image landed intact
     /// and [`activate`] is safe. otadata is still untouched here.
     pub fn finalize(mut self, expected_size: u32, expected_sha: &[u8; 32]) -> bool {
+        use embedded_storage::nor_flash::ReadNorFlash;
         use sha2::Digest;
         if !self.flush_stage() {
+            ota_resume_clear();
             return false;
         }
         if self.written != expected_size {
+            ota_resume_clear();
             return false;
         }
-        self.hasher.finalize().as_slice() == &expected_sha[..]
+        // #267/#40: READBACK-SHA over `slot[..size]` — the exact bytes that will boot — instead of a
+        // streaming hash. Burst-count invariant, so a fetch resumed across N bursts verifies
+        // identically to a one-shot fetch. Uses OTA_READBACK (a distinct static from `self.stage` →
+        // no aliasing). Reads absolute flash at `base + off` (length word-rounded; extra tail bytes
+        // are read legally but not hashed), mirroring `LeafImageWriter::finalize`.
+        let buf = unsafe { &mut *core::ptr::addr_of_mut!(OTA_READBACK) };
+        let mut hasher = sha2::Sha256::new();
+        let mut off = 0u32;
+        let mut read_ok = true;
+        while off < expected_size {
+            let want = core::cmp::min(buf.len() as u32, expected_size - off);
+            let read_len = (want.div_ceil(4) * 4) as usize;
+            if self.flash.read(self.base + off, &mut buf[..read_len]).is_err() {
+                read_ok = false;
+                break;
+            }
+            hasher.update(&buf[..want as usize]);
+            off += want;
+        }
+        ota_resume_clear(); // fetch terminal (success OR fail) → a fresh attempt starts from 0
+        read_ok && hasher.finalize().as_slice() == &expected_sha[..]
     }
 }
 


### PR DESCRIPTION
## What
Fixes **#267** (co-critical, my root-cause): the OTA fetch restarts from byte 0 on each retry instead of Range-resuming, so under the coexist bulk-RX disease (≈1 chunk/burst) a multi-chunk image **never accumulates**. Without this, #217's own cross-burst retry also restarts from 0 — no OTA completes.

## Root cause
The HTTP Range-chunk resume worked chunk-to-chunk *within* one fetch burst (`off = writer.written()`), but `ImageWriter::begin()` reset `written` **and** the streaming SHA to 0 every call. The #195 OTA retry is per-burst within one boot (the #100 in-RAM idiom), so each burst re-invoked `begin()` → re-`Range`d from byte 0. `OTA_CHUNK = 49152` = the observed offset; retry 1→9 = 9 bursts each `0→49152→die`.

## Fix
- **Cross-burst resume cursor in a `.bss` static** — SAME-BOOT (resets on reboot, the #100 idiom). **No NVS** → sidesteps the near-full `nvs` partition (the retry never crosses a reboot). Keyed to `(build, sha16, slot)` so a re-stage / slot flip forces a fresh fetch.
- **`ImageWriter::begin(build, sha)`** resumes `written=flushed=committed`, `erased_upto` past the committed prefix (never re-erases it); each sector flush persists the on-flash offset; `finalize` clears the cursor.
- **Integrity → finalize READBACK-SHA** over `slot[..size]` (ports `LeafImageWriter`'s pattern) — burst-count invariant, so resume needs only the offset (no streaming hasher to restore, no per-burst re-hash).
- **Pure keying** in `net/ota_resume.rs` (host-tested, the flood/etx/ledger pattern).

## Verification (on familiar)
- **Host test** `experiments/267_resume_verify` — `cargo test` (1 passed) **and** `cargo run` GREEN: keying (build/sha/slot mismatch → 0) + segmentation-invariance (one-shot vs 3-segment vs **die-every-chunk** → byte-identical → identical finalize SHA).
- **`cargo clippy -D warnings` + release build** (`espnow,cast,io`, the canonical fleet image) GREEN.

## Coordination / notes
- The **one wifi.rs touch** is the `begin()` call site — coordinate with #217 / morpheus per the sequencing plan. This base already carries #217's fetch-leg (`OTA_BODY_STALL`), so it composes directly (no rebase conflict expected).
- ⚠️ **Build-env flags for the docs:** (1) familiar `/tmp` is a **512 M tmpfs** — the esp-hal build overflows it; use a home-disk `CARGO_TARGET_DIR` (+ `TMPDIR`). (2) JP's `board.rs`/`secrets.rs` carry **unconsumed WIP consts** (#227 `WEATHER_*`, #190 `GROUP_KEY_*`) that fail `-D warnings` in this tree (present in origin/main too — a pre-existing config skew, not #267); I isolated them in the scratch build to gate #267.

Fixes #267. Refs #217, #195, #204, #53.
