### PR TITLE
feat(net): configurable best-gateway election + all-nodes-WiFi debug + co-channel crown-migration

### DIFF
--- a/experiments/267_resume_verify/Cargo.toml
+++ b/experiments/267_resume_verify/Cargo.toml
@@ -1,0 +1,19 @@
+# #267 host-test harness for the PURE cross-burst OTA-resume key logic (net/ota_resume.rs).
+# Runs OFF-target (std) via `cargo run` AND `cargo test`; #[path]-includes the real
+# ota_resume.rs (no drift). Proves the resume keying (match → offset, any mismatch → 0) and the
+# segmentation-invariance property the fix rests on: an image written in one shot vs resumed in
+# N segments (boundaries driven by the real `resume_offset`) yields byte-identical flash → an
+# identical finalize readback-SHA. Mirrors etx_verify/ledger_verify/crdt_verify. sha2 supplies
+# the readback hash — the core is dependency-free.
+[package]
+name = "resume_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "resume_verify"
+path = "src/main.rs"
+[dependencies]
+sha2 = "0.10"
+[profile.dev]
+opt-level = 0

--- a/experiments/267_resume_verify/src/main.rs
+++ b/experiments/267_resume_verify/src/main.rs
@@ -1,0 +1,136 @@
+//! Host verification of the PURE #267 cross-burst OTA-resume key logic (`net/ota_resume.rs`),
+//! included verbatim (#[path], no drift). Run: `cargo run` — panics on failure. `cargo test` runs
+//! the same suite (no false-green).
+//!
+//! Two things must hold for #267 to be correct:
+//!  1. **Keying** — a resume cursor is honored ONLY for the exact staged image + slot it belongs
+//!     to (build + sha16 + slot); any mismatch (re-stage, slot flip, different image) → fetch from
+//!     byte 0. This is the guard against resuming onto a stale/wrong flash prefix.
+//!  2. **Segmentation-invariance** — an image written in one shot vs resumed across N bursts (each
+//!     resuming from the last committed offset via the real `resume_offset`) leaves BYTE-IDENTICAL
+//!     flash, hence an identical finalize readback-SHA. This is the property the whole fix rests on:
+//!     a fetch that keeps dying mid-body ACCUMULATES instead of restarting.
+
+#[path = "../../../rust/clock/src/net/ota_resume.rs"]
+mod ota_resume;
+
+use ota_resume::{resume_offset, sha_key16, ResumeKey};
+use sha2::{Digest, Sha256};
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    h.finalize().into()
+}
+
+fn key(build: u32, sha: &[u8; 32], slot: u8) -> ResumeKey {
+    ResumeKey { build, sha_key: sha_key16(sha), slot }
+}
+
+/// A deterministic pseudo-image of `n` bytes (not all-equal, so a mis-offset write would corrupt it).
+fn image(n: usize) -> Vec<u8> {
+    (0..n).map(|i| ((i * 2654435761usize) >> 13) as u8 ^ (i as u8)).collect()
+}
+
+/// Model the flash writer's resume behaviour against a mock slot: fetch `img` in segments whose
+/// boundaries are the "death points" `deaths`; each new segment resumes from the last COMMITTED
+/// (flushed, sector-aligned) offset as the real `resume_offset` would return it. Returns the mock
+/// slot bytes — which must equal a one-shot write for any death pattern.
+fn fetch_with_deaths(img: &[u8], deaths: &[usize], build: u32, sha: &[u8; 32], slot: u8) -> Vec<u8> {
+    const SECTOR: usize = 4096;
+    let size = img.len() as u32;
+    let want = key(build, sha, slot);
+    let mut flash = vec![0xFFu8; img.len()];
+    let mut saved: Option<(ResumeKey, u32)> = None; // the .bss cursor across bursts
+    let mut cut = 0usize; // absolute death index into `deaths`
+    loop {
+        // A fresh burst: begin() consults the saved cursor for the resume offset.
+        let start = resume_offset(saved, &want, size) as usize;
+        if start >= img.len() {
+            break;
+        }
+        // This burst writes until it "dies" at the next death point past `start`, else to the end.
+        let die_at = deaths.get(cut).copied().unwrap_or(img.len());
+        cut += 1;
+        let end = die_at.min(img.len()).max(start);
+        // Commit only whole sectors (mid-sector RAM stage is lost on burst death — mirrors flush).
+        let committed_end = start + ((end - start) / SECTOR) * SECTOR;
+        // ...but the FINAL burst (reaching the end) flushes the padded tail too.
+        let (write_end, flush_end) = if end >= img.len() {
+            (img.len(), img.len())
+        } else {
+            (committed_end, committed_end)
+        };
+        flash[start..write_end].copy_from_slice(&img[start..write_end]);
+        if flush_end > 0 {
+            saved = Some((want, flush_end as u32)); // persist the on-flash (flushed) cursor
+        }
+        if flush_end >= img.len() {
+            break;
+        }
+        if flush_end == start && die_at <= start {
+            // no forward progress this burst (death before a full sector) — avoid an infinite loop
+            // in the model; a real fetch would stall-cap. Nudge past this death point.
+            if cut > deaths.len() + 2 {
+                break;
+            }
+        }
+    }
+    flash
+}
+
+fn run() {
+    // ---- 1. KEYING --------------------------------------------------------
+    let sha = sha256(b"image-A");
+    let other = sha256(b"image-B");
+    let k = key(42, &sha, 1);
+    assert_eq!(resume_offset(Some((k, 49152)), &k, 590_304), 49152, "exact-match key resumes at committed");
+    assert_eq!(resume_offset(None, &k, 590_304), 0, "no saved cursor → fresh fetch");
+    assert_eq!(resume_offset(Some((key(43, &sha, 1), 49152)), &k, 590_304), 0, "build mismatch → 0 (re-stage)");
+    assert_eq!(resume_offset(Some((key(42, &other, 1), 49152)), &k, 590_304), 0, "sha mismatch → 0 (different image, same build)");
+    assert_eq!(resume_offset(Some((key(42, &sha, 0), 49152)), &k, 590_304), 0, "slot mismatch → 0 (slot flipped)");
+    assert_eq!(resume_offset(Some((k, 0)), &k, 590_304), 0, "committed 0 → 0");
+    assert_eq!(resume_offset(Some((k, 700_000)), &k, 590_304), 0, "committed > size → 0 (corrupt cursor)");
+    assert_eq!(resume_offset(Some((k, 590_304)), &k, 590_304), 590_304, "committed == size resumes (finalize will size-check)");
+
+    // ---- 2. SEGMENTATION-INVARIANCE (the load-bearing property) -----------
+    let img = image(590_304); // ~ a real image size, not sector-multiple (tail exercised)
+    let sha_img: [u8; 32] = sha256(&img);
+    let build = 344;
+    let slot = 1u8;
+
+    // one-shot fetch (no deaths)
+    let one_shot = fetch_with_deaths(&img, &[], build, &sha_img, slot);
+    assert_eq!(one_shot, img, "one-shot fetch reconstructs the image");
+    assert_eq!(sha256(&one_shot), sha_img, "one-shot readback-SHA matches");
+
+    // 3-segment resume: die at 49152 (1 chunk) and 262144, mirroring the coexist ≈1-chunk/burst reality
+    let three_seg = fetch_with_deaths(&img, &[49152, 262144], build, &sha_img, slot);
+    assert_eq!(three_seg, one_shot, "3-segment resumed fetch is BYTE-IDENTICAL to one-shot");
+    assert_eq!(sha256(&three_seg), sha_img, "3-segment readback-SHA == one-shot (segmentation-invariant)");
+
+    // the pathological coexist case: die every single 48 KB chunk (≈13 bursts) — must STILL complete
+    let per_chunk_deaths: Vec<usize> = (1..13).map(|i| i * 49152).collect();
+    let sawtooth = fetch_with_deaths(&img, &per_chunk_deaths, build, &sha_img, slot);
+    assert_eq!(sawtooth, img, "die-every-chunk still accumulates the full image (the #267 fix)");
+    assert_eq!(sha256(&sawtooth), sha_img, "die-every-chunk readback-SHA matches");
+
+    // a re-stage mid-fetch (different image, same build) must NOT resume onto the stale prefix
+    let stale = resume_offset(Some((key(build, &sha_img, slot), 49152)), &key(build, &other, slot), img.len() as u32);
+    assert_eq!(stale, 0, "a re-staged (different-sha) image ignores the stale cursor → fresh fetch");
+
+    println!("resume_verify: all assertions passed");
+}
+
+fn main() {
+    run();
+}
+
+#[cfg(test)]
+mod tests {
+    /// `cargo test` entry — runs the full suite (identical to `cargo run`); no false-green.
+    #[test]
+    fn ota_resume_laws() {
+        super::run();
+    }
+}

--- a/experiments/ap_select_verify/Cargo.toml
+++ b/experiments/ap_select_verify/Cargo.toml
@@ -1,0 +1,15 @@
+# #217 rung-3 host guard for the co-channel crown-AP selector + strand-guard state machine
+# (net/coexist.rs). The firmware crate is no_std/riscv32imc and can't host-test, so this
+# `#[path]`-includes the REAL coexist.rs (no drift) and asserts: co-channel preference over a
+# stronger off-channel AP (the id5 bug), usable-floor exclusion, hysteresis, off-channel fallback,
+# and the NEVER-CROWNLESS strand-guard transition table. Permanent guard for #217 rung-3.
+[package]
+name = "ap_select_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "ap_select_verify"
+path = "src/main.rs"
+[profile.dev]
+opt-level = 0

--- a/experiments/ap_select_verify/src/main.rs
+++ b/experiments/ap_select_verify/src/main.rs
@@ -1,0 +1,85 @@
+//! #217 rung-3 host guard. `#[path]`-includes the REAL `net/coexist.rs` (no drift) and asserts
+//! the co-channel selector + the never-crownless strand-guard state machine. `cargo run`.
+
+#[path = "../../../rust/clock/src/net/coexist.rs"]
+mod coexist;
+
+use coexist::*;
+
+fn ap(b: u8, ch: u8, rssi: i8) -> ApView {
+    ApView { bssid: [b, b, b, b, b, b], channel: ch, rssi }
+}
+
+fn main() {
+    const MESH: u8 = 6;
+
+    // ---- selector -------------------------------------------------------------------------
+    // 1. co-channel present → pick it EVEN THOUGH stronger ch1 APs exist (the exact id5 bug).
+    let scan = [ap(1, 1, -67), ap(2, 1, -69), ap(3, 6, -60)];
+    assert_eq!(
+        select_crown_ap(&scan, MESH, None),
+        CrownApDecision::CoChannel { bssid: [3; 6], ch: 6 },
+        "prefer the ch6 AP over stronger ch1 APs"
+    );
+    // 2. best-RSSI AMONG co-channel.
+    let scan2 = [ap(3, 6, -70), ap(4, 6, -58), ap(5, 6, -75)];
+    assert_eq!(
+        select_crown_ap(&scan2, MESH, None),
+        CrownApDecision::CoChannel { bssid: [4; 6], ch: 6 },
+        "best-rssi co-channel"
+    );
+    // 3. only off-channel → OffChannelFallback (strand signal), best rssi.
+    let scan3 = [ap(1, 1, -67), ap(2, 11, -55)];
+    assert_eq!(
+        select_crown_ap(&scan3, MESH, None),
+        CrownApDecision::OffChannelFallback { bssid: [2; 6], ch: 11 },
+        "no co-channel → best off-channel"
+    );
+    // 4. empty → NoAp.
+    assert_eq!(select_crown_ap(&[], MESH, None), CrownApDecision::NoAp, "no aps");
+    // 5. co-channel below the usable floor is excluded → off-channel fallback.
+    let scan5 = [ap(3, 6, -88), ap(1, 1, -60)];
+    assert_eq!(
+        select_crown_ap(&scan5, MESH, None),
+        CrownApDecision::OffChannelFallback { bssid: [1; 6], ch: 1 },
+        "co-channel below AP_USABLE_MIN excluded"
+    );
+    // 6. hysteresis: incumbent co-channel, new co-channel within margin → STAY (no flap).
+    let scan6 = [ap(3, 6, -70), ap(4, 6, -66)]; // +4 dB < 6 dB margin
+    assert_eq!(
+        select_crown_ap(&scan6, MESH, Some(ap(3, 6, -70))),
+        CrownApDecision::CoChannel { bssid: [3; 6], ch: 6 },
+        "hysteresis: stay on incumbent within margin"
+    );
+    // 7. hysteresis: new co-channel beats incumbent by > margin → SWITCH.
+    let scan7 = [ap(3, 6, -74), ap(4, 6, -60)]; // +14 dB > 6
+    assert_eq!(
+        select_crown_ap(&scan7, MESH, Some(ap(3, 6, -74))),
+        CrownApDecision::CoChannel { bssid: [4; 6], ch: 6 },
+        "hysteresis: switch when new beats incumbent by margin"
+    );
+
+    // ---- strand-guard state machine -------------------------------------------------------
+    let no_ctx = CrownCtx { reassoc_exhausted: false, better_successor_cc: false };
+    let exhausted = CrownCtx { reassoc_exhausted: true, better_successor_cc: false };
+    let succ = CrownCtx { reassoc_exhausted: false, better_successor_cc: true };
+    let co = CrownApDecision::CoChannel { bssid: [3; 6], ch: 6 };
+    let off = CrownApDecision::OffChannelFallback { bssid: [1; 6], ch: 1 };
+
+    assert_eq!(crown_next_state(CrownState::Normal, co, 0, no_ctx), CrownState::Normal, "co-channel stays normal");
+    assert_eq!(crown_next_state(CrownState::Normal, off, 0, no_ctx), CrownState::Normal, "off-channel + not-exhausted: keep trying");
+    assert_eq!(crown_next_state(CrownState::Normal, off, 0, exhausted), CrownState::Shed, "off-channel + exhausted → shed");
+    assert_eq!(crown_next_state(CrownState::Shed, off, 1, no_ctx), CrownState::Shed, "shed, reclaims<MAX → shed");
+    assert_eq!(crown_next_state(CrownState::Shed, off, SHED_RECLAIM_MAX, no_ctx), CrownState::Degraded, "STRAND-GUARD: reclaims>=MAX → degraded (never crownless)");
+    assert_eq!(crown_next_state(CrownState::Shed, co, 5, no_ctx), CrownState::Normal, "shed but co-channel appeared → recover to normal");
+    assert_eq!(crown_next_state(CrownState::Degraded, co, 0, no_ctx), CrownState::Normal, "degraded + co-channel returns → normal");
+    assert_eq!(crown_next_state(CrownState::Degraded, off, 9, succ), CrownState::Shed, "degraded yields to a cc=1 successor");
+    assert_eq!(crown_next_state(CrownState::Degraded, off, 9, no_ctx), CrownState::Degraded, "degraded + no co-channel + no successor → STAY (never crownless)");
+
+    // ---- OTA-enable gate ------------------------------------------------------------------
+    assert!(ota_enabled(CrownState::Normal), "OTA only when normal");
+    assert!(!ota_enabled(CrownState::Degraded), "OTA disabled when degraded");
+    assert!(!ota_enabled(CrownState::Shed), "OTA disabled when shed");
+
+    println!("ap_select_verify: ALL CHECKS PASSED (co-channel preference + usable floor + hysteresis + strand-guard state machine + OTA-enable gate)");
+}

--- a/experiments/ap_select_verify/src/main.rs
+++ b/experiments/ap_select_verify/src/main.rs
@@ -28,6 +28,20 @@ fn main() {
         CrownApDecision::CoChannel { bssid: [4; 6], ch: 6 },
         "best-rssi co-channel"
     );
+    // 2b. STABLE tie-break: equal-RSSI co-channel APs → the SAME (lowest-bssid) pick regardless of
+    // scan order, so two crown candidates never diverge/oscillate (nebula-ota review item).
+    let tie_a = [ap(2, 6, -60), ap(5, 6, -60)];
+    let tie_b = [ap(5, 6, -60), ap(2, 6, -60)]; // reversed scan order
+    assert_eq!(
+        select_crown_ap(&tie_a, MESH, None),
+        select_crown_ap(&tie_b, MESH, None),
+        "tie-break is order-independent"
+    );
+    assert_eq!(
+        select_crown_ap(&tie_a, MESH, None),
+        CrownApDecision::CoChannel { bssid: [2; 6], ch: 6 },
+        "tie → deterministic lowest bssid"
+    );
     // 3. only off-channel → OffChannelFallback (strand signal), best rssi.
     let scan3 = [ap(1, 1, -67), ap(2, 11, -55)];
     assert_eq!(

--- a/experiments/election_verify/Cargo.toml
+++ b/experiments/election_verify/Cargo.toml
@@ -1,0 +1,15 @@
+# Host guard for the configurable best-gateway election core (net/election.rs). The firmware crate
+# is no_std/riscv32imc and can't host-test, so this `#[path]`-includes the REAL election.rs (no
+# drift) and asserts: co-channel dominance over a stronger OFF-channel board (the id5 bug), the
+# weighted fitness, the bounded/monotonic fitness→backoff tiering, the config parser (default /
+# legacy / re-weight / malformed), and the byte-faithful `Legacy` recovery backoff. Permanent guard.
+[package]
+name = "election_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "election_verify"
+path = "src/main.rs"
+[profile.dev]
+opt-level = 0

--- a/experiments/election_verify/src/main.rs
+++ b/experiments/election_verify/src/main.rs
@@ -123,6 +123,18 @@ fn main() {
     // owner is self → never yield.
     assert!(!yield_to_co_channel_owner(true, false, MESH, 7, 7, MESH, true), "never yield to self");
 
+    // ---- reliability: refuse leaf-lock to a known off-channel owner (fixes the racy ~2/3 seize) ---
+    // co-channel board (ap ch6) + owner on ch1 → REFUSE the lock (keep re-electing until seize).
+    assert!(refuse_leaf_lock_off_channel(MESH, MESH, 1), "co-channel refuses lock to off-channel owner");
+    // owner is co-channel (ch == mesh) → lock normally.
+    assert!(!refuse_leaf_lock_off_channel(MESH, MESH, MESH), "lock to a co-channel owner");
+    // owner channel unknown (0) → lock normally (fail-safe).
+    assert!(!refuse_leaf_lock_off_channel(MESH, MESH, 0), "unknown owner channel → lock normally");
+    // WE are not co-channel (ap ch1) → lock normally (we're not the better crown; follow the mesh).
+    assert!(!refuse_leaf_lock_off_channel(1, MESH, 1), "non-co-channel board locks normally");
+    // our AP channel unknown (0) → lock normally.
+    assert!(!refuse_leaf_lock_off_channel(0, MESH, 1), "unknown own channel → lock normally");
+
     // ---- Legacy backoff is a byte-faithful 1:1 of the historical reelect_backoff_ms ---------
     assert_eq!(legacy_recovery_backoff_ms(-60, 5), 0 * ELECT_TIER_STEP_MS + 5 * 200, "legacy strong bucket 0");
     assert_eq!(legacy_recovery_backoff_ms(-70, 5), 1 * ELECT_TIER_STEP_MS + 5 * 200, "legacy mid bucket 1");

--- a/experiments/election_verify/src/main.rs
+++ b/experiments/election_verify/src/main.rs
@@ -94,6 +94,21 @@ fn main() {
     // garbage → default (fail toward the intended default behavior).
     assert_eq!(parse_elect_config(b"????"), ElectConfig::BestGateway(MetricWeights::DEFAULT), "garbage → default");
 
+    // ---- LAYER 2: co-channel seizes a proven off-channel owner (crown migration) -----------
+    const MESH: u8 = 6;
+    // co-channel board (mesh 6) vs owner on ch1 (the id5-was-ch1-crown ghost) → SEIZE.
+    assert!(seize_off_channel_owner(true, MESH, 7, 5, 1), "co-channel seizes off-channel owner id5@ch1");
+    // co-channel owner (ch == mesh) → do NOT seize (it's a valid crown).
+    assert!(!seize_off_channel_owner(true, MESH, 7, 5, MESH), "never seize a co-channel owner");
+    // owner channel unknown (0) → do NOT seize (fall through to liveness arms).
+    assert!(!seize_off_channel_owner(true, MESH, 7, 5, 0), "unknown owner channel → no seize");
+    // we are NOT co-channel → never seize (only the better board preempts).
+    assert!(!seize_off_channel_owner(false, MESH, 7, 5, 1), "non-co-channel board never seizes");
+    // our mesh channel unknown → never seize (safe).
+    assert!(!seize_off_channel_owner(true, 0, 7, 5, 1), "unknown mesh channel → no seize");
+    // owner is self → never seize.
+    assert!(!seize_off_channel_owner(true, MESH, 7, 7, 1), "never seize self");
+
     // ---- Legacy backoff is a byte-faithful 1:1 of the historical reelect_backoff_ms ---------
     assert_eq!(legacy_recovery_backoff_ms(-60, 5), 0 * ELECT_TIER_STEP_MS + 5 * 200, "legacy strong bucket 0");
     assert_eq!(legacy_recovery_backoff_ms(-70, 5), 1 * ELECT_TIER_STEP_MS + 5 * 200, "legacy mid bucket 1");

--- a/experiments/election_verify/src/main.rs
+++ b/experiments/election_verify/src/main.rs
@@ -1,0 +1,103 @@
+//! Best-gateway election host guard. `#[path]`-includes the REAL `net/election.rs` (no drift) and
+//! asserts the configurable fitness, the bounded fitness→backoff tiering, co-channel dominance (the
+//! id5 ch1-vs-ch6 bug), and the config parser. `cargo run`.
+
+#[path = "../../../rust/clock/src/net/election.rs"]
+mod election;
+
+use election::*;
+
+fn inp(co_channel: bool, ap_rssi: i8, ntp_holder: bool, uptime_ms: u64) -> FitnessInputs {
+    FitnessInputs { co_channel, ap_rssi, ntp_holder, uptime_ms }
+}
+
+fn main() {
+    let w = MetricWeights::DEFAULT;
+
+    // ---- gateway_fitness (weighted, higher = better) --------------------------------------
+    // co-channel dominates: a co-channel board with the WORST usable RSSI still outscores the
+    // BEST off-channel board (co=100 vs off-channel max = rssi 2·10 + ntp 5 + uptime 2·1 = 27).
+    let co_weak = gateway_fitness(&inp(true, -82, false, 0), &w);
+    let off_best = gateway_fitness(&inp(false, -60, true, 10 * 60_000), &w);
+    assert!(co_weak > off_best, "co-channel dominance: {co_weak} !> {off_best}");
+    // full-signal co-channel board = max fitness for the default weights.
+    assert_eq!(
+        gateway_fitness(&inp(true, -60, true, 10 * 60_000), &w),
+        MetricWeights::DEFAULT.max_fitness(),
+        "full-signal co-channel = max fitness"
+    );
+    // RSSI + uptime + ntp order WITHIN co-channel.
+    let co_strong = gateway_fitness(&inp(true, -60, false, 0), &w);
+    assert!(co_strong > co_weak, "stronger rssi scores higher among co-channel");
+
+    // ---- elect_backoff_ms: higher fitness → shorter wait; co-channel ALWAYS beats off-channel --
+    // The exact id5 bug, numerically: a co-channel HIGH-id board must claim BEFORE a stronger
+    // OFF-channel LOW-id board (backoff strictly smaller despite the higher node id).
+    let co_hi_id = elect_backoff_ms(&inp(true, -70, false, 0), &w, 9);
+    let off_lo_id = elect_backoff_ms(&inp(false, -55, true, 10 * 60_000), &w, 3);
+    assert!(
+        co_hi_id < off_lo_id,
+        "co-channel id9 ({co_hi_id}ms) must claim before off-channel id3 ({off_lo_id}ms) — the id5 bug"
+    );
+    // Bounded: no board EVER waits longer than the legacy 0–30 s envelope (+ the sub-tier id term).
+    let worst = elect_backoff_ms(&inp(false, -90, false, 0), &w, 254);
+    assert!(
+        worst <= MAX_ELECT_TIERS * ELECT_TIER_STEP_MS + 254 * 200,
+        "backoff bounded to MAX_ELECT_TIERS: {worst}"
+    );
+    // Best board (co-channel, strong, ntp, long uptime) = tier 0 → only the sub-tier id term.
+    assert_eq!(
+        elect_backoff_ms(&inp(true, -55, true, 10 * 60_000), &w, 5),
+        5 * 200,
+        "best board waits only the node-id tiebreak"
+    );
+    // Monotonic in fitness: stronger co-channel never waits LONGER than a weaker co-channel (same id).
+    let s = elect_backoff_ms(&inp(true, -60, false, 0), &w, 7);
+    let x = elect_backoff_ms(&inp(true, -82, false, 0), &w, 7);
+    assert!(s <= x, "monotonic: stronger ({s}) !<= weaker ({x})");
+    // Tier gap ≥ one step so a weaker board gets an adopt-burst before its own claim window.
+    let co_tier = elect_backoff_ms(&inp(true, -82, false, 0), &w, 0);
+    let off_tier = elect_backoff_ms(&inp(false, -55, false, 0), &w, 0);
+    assert!(
+        off_tier.saturating_sub(co_tier) >= ELECT_TIER_STEP_MS,
+        "co-channel vs off-channel separated by >= one tier ({co_tier} .. {off_tier})"
+    );
+
+    // ---- re-weighting via config changes ordering -----------------------------------------
+    // RSSI-dominant with co-channel OFF: now the stronger board wins regardless of channel.
+    let rssi_only = match parse_elect_config(b"c0r100") {
+        ElectConfig::BestGateway(w) => w,
+        _ => panic!("expected BestGateway"),
+    };
+    let a = elect_backoff_ms(&inp(true, -85, false, 0), &rssi_only, 1); // co-channel but WEAK
+    let b = elect_backoff_ms(&inp(false, -55, false, 0), &rssi_only, 1); // off-channel but STRONG
+    assert!(b < a, "rssi-dominant config: strong off-channel now beats weak co-channel");
+
+    // ---- parse_elect_config ----------------------------------------------------------------
+    assert_eq!(parse_elect_config(b""), ElectConfig::BestGateway(MetricWeights::DEFAULT), "empty → default (best-gateway ON)");
+    assert_eq!(parse_elect_config(b"   "), ElectConfig::BestGateway(MetricWeights::DEFAULT), "whitespace → default");
+    assert_eq!(parse_elect_config(b"legacy"), ElectConfig::Legacy, "legacy keyword → escape hatch");
+    assert_eq!(parse_elect_config(b"LEGACY"), ElectConfig::Legacy, "case-insensitive legacy");
+    assert_eq!(parse_elect_config(b"c100r10n5u1"), ElectConfig::BestGateway(MetricWeights::DEFAULT), "explicit default weights");
+    // subset: missing keys inherit DEFAULT.
+    assert_eq!(
+        parse_elect_config(b"r20"),
+        ElectConfig::BestGateway(MetricWeights { co_channel: 100, rssi: 20, ntp: 5, uptime: 1 }),
+        "subset inherits default for missing keys"
+    );
+    // clamp + ignore junk.
+    assert_eq!(
+        parse_elect_config(b"c999x7r3"),
+        ElectConfig::BestGateway(MetricWeights { co_channel: 255, rssi: 3, ntp: 5, uptime: 1 }),
+        "clamp to 255 + ignore unknown key 'x'"
+    );
+    // garbage → default (fail toward the intended default behavior).
+    assert_eq!(parse_elect_config(b"????"), ElectConfig::BestGateway(MetricWeights::DEFAULT), "garbage → default");
+
+    // ---- Legacy backoff is a byte-faithful 1:1 of the historical reelect_backoff_ms ---------
+    assert_eq!(legacy_recovery_backoff_ms(-60, 5), 0 * ELECT_TIER_STEP_MS + 5 * 200, "legacy strong bucket 0");
+    assert_eq!(legacy_recovery_backoff_ms(-70, 5), 1 * ELECT_TIER_STEP_MS + 5 * 200, "legacy mid bucket 1");
+    assert_eq!(legacy_recovery_backoff_ms(-85, 5), 2 * ELECT_TIER_STEP_MS + 5 * 200, "legacy weak bucket 2");
+
+    println!("election_verify: ALL CHECKS PASSED (co-channel dominance + weighted fitness + bounded/monotonic backoff tiering + config parser + legacy backoff)");
+}

--- a/experiments/election_verify/src/main.rs
+++ b/experiments/election_verify/src/main.rs
@@ -109,6 +109,20 @@ fn main() {
     // owner is self → never seize.
     assert!(!seize_off_channel_owner(true, MESH, 7, 7, 1), "never seize self");
 
+    // ---- LAYER 2 symmetric YIELD: off-channel board adopts a live co-channel owner (no flap) ----
+    // id5 (off-channel, ch known) reading MC|7|6 (co-channel owner, alive) → YIELD (adopt id7).
+    assert!(yield_to_co_channel_owner(true, false, MESH, 5, 7, MESH, true), "off-channel yields to live co-channel owner id7");
+    // a CO-channel board never yields (it seizes instead) — mutually exclusive on co_channel.
+    assert!(!yield_to_co_channel_owner(true, true, MESH, 5, 7, MESH, true), "co-channel board never yields");
+    // owner is off-channel (ch1) → do NOT yield (that's a seize case for a co-channel board).
+    assert!(!yield_to_co_channel_owner(true, false, MESH, 5, 7, 1, true), "don't yield to an off-channel owner");
+    // co-channel owner but DEAD → do NOT yield (never follow a dead crown; fall through to takeover).
+    assert!(!yield_to_co_channel_owner(true, false, MESH, 5, 7, MESH, false), "don't yield to a dead co-channel owner");
+    // channel not yet known → do NOT yield (fail-safe until learned).
+    assert!(!yield_to_co_channel_owner(false, false, MESH, 5, 7, MESH, true), "no yield until channel known");
+    // owner is self → never yield.
+    assert!(!yield_to_co_channel_owner(true, false, MESH, 7, 7, MESH, true), "never yield to self");
+
     // ---- Legacy backoff is a byte-faithful 1:1 of the historical reelect_backoff_ms ---------
     assert_eq!(legacy_recovery_backoff_ms(-60, 5), 0 * ELECT_TIER_STEP_MS + 5 * 200, "legacy strong bucket 0");
     assert_eq!(legacy_recovery_backoff_ms(-70, 5), 1 * ELECT_TIER_STEP_MS + 5 * 200, "legacy mid bucket 1");

--- a/experiments/ota_http_verify/Cargo.toml
+++ b/experiments/ota_http_verify/Cargo.toml
@@ -1,0 +1,15 @@
+# Host guard for the OTA fetch-leg HTTP/1.x response-head parsers (net/http.rs). The #[path]-include
+# is the SAME source the firmware links (no drift). Pins the #gateway-election byte-0 fetch bug: a
+# valid "HTTP/1.0 206 Partial Content" whose header + start of the BINARY body arrive in one TCP
+# segment MUST still parse st=206 (the old parser fed the whole buffer to from_utf8 → None → died at
+# byte 0). Also covers version-agnostic status, content-length, non-206, and incomplete headers.
+[package]
+name = "ota_http_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "ota_http_verify"
+path = "src/main.rs"
+[profile.dev]
+opt-level = 0

--- a/experiments/ota_http_verify/src/main.rs
+++ b/experiments/ota_http_verify/src/main.rs
@@ -1,0 +1,56 @@
+//! OTA fetch-leg HTTP parser host guard. `#[path]`-includes the REAL `net/http.rs` (no drift) and
+//! pins the #gateway-election byte-0 fetch bug + robustness. `cargo run`.
+
+#[path = "../../../rust/clock/src/net/http.rs"]
+mod http;
+
+use http::*;
+
+fn main() {
+    // ---- THE byte-0 bug: header + start of BINARY body coalesced into ONE TCP segment -----------
+    // rangeserver.py (Python BaseHTTPServer) answers "HTTP/1.0 206 …"; the response head + the first
+    // body bytes arrived together (rx=956B on HW). The OLD parser fed the WHOLE buffer to from_utf8,
+    // which fails on the binary body → status parsed None → the fetch aborted at byte 0.
+    let mut resp: Vec<u8> = Vec::new();
+    resp.extend_from_slice(
+        b"HTTP/1.0 206 Partial Content\r\n\
+          Server: SimpleHTTP/0.6 Python/3.12.3\r\n\
+          Content-Range: bytes 0-49151/1164864\r\n\
+          Content-Length: 49152\r\n\r\n",
+    );
+    let hdr_only = resp.len();
+    // …then the binary image body (invalid UTF-8: PNG-ish magic + high bytes).
+    resp.extend_from_slice(&[0x00, 0xFF, 0xFE, 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A]);
+
+    let be = header_end(&resp).expect("header_end must find \\r\\n\\r\\n");
+    assert_eq!(be, hdr_only, "body starts one past the terminator");
+
+    // The regression: status parses to 206 EVEN when the buffer carries trailing binary body.
+    assert_eq!(
+        status_code(&resp),
+        Some(206),
+        "HTTP/1.0 206 must parse with a trailing BINARY body in the same buffer (the byte-0 bug)"
+    );
+    // And on the header slice the fixed call site actually passes.
+    assert_eq!(status_code(&resp[..be]), Some(206), "206 on the header slice");
+    assert_eq!(content_length(&resp[..be]), Some(49152), "content-length on the header slice");
+    assert_eq!(
+        content_length(&resp),
+        Some(49152),
+        "content-length robust to trailing binary body (stops at the blank line)"
+    );
+
+    // ---- version-agnostic + other paths ---------------------------------------------------------
+    assert_eq!(status_code(b"HTTP/1.1 200 OK\r\n\r\n"), Some(200), "HTTP/1.1 200 (fallback path)");
+    assert_eq!(status_code(b"HTTP/1.0 206 Partial Content\r\n\r\n"), Some(206), "clean 1.0 206");
+    assert_eq!(status_code(b"HTTP/1.0 416 Range Not Satisfiable\r\n\r\n"), Some(416), "416 parses (caller rejects)");
+    assert_eq!(status_code(b"HTTP/1.0 404 Not Found\r\n\r\n"), Some(404), "404 parses");
+    // incomplete header block → header_end None (keep accumulating).
+    assert_eq!(header_end(b"HTTP/1.0 206 Partial\r\nServer: x\r\n"), None, "incomplete headers → None");
+    // content-length absent → None.
+    assert_eq!(content_length(b"HTTP/1.0 206 Partial\r\nServer: x\r\n\r\n"), None, "no content-length → None");
+    // case-insensitive header name.
+    assert_eq!(content_length(b"HTTP/1.0 200 OK\r\ncontent-length: 7\r\n\r\n"), Some(7), "case-insensitive");
+
+    println!("ota_http_verify: ALL CHECKS PASSED (HTTP/1.0 206 + coalesced binary body + content-length + version-agnostic + non-206 + incomplete)");
+}

--- a/rust/clock/.cargo/config.toml
+++ b/rust/clock/.cargo/config.toml
@@ -57,6 +57,13 @@ protocol = "sparse"
 # static RX buffer ≈ 1.6 KB, allocated at esp_wifi::init from the (now-grown) esp-alloc heap.
 # HW-GATE-HELD: throughput/stability win only provable on the deaf-list/fetch rig (pairs with #143).
 [env]
+# ALL-CHANNEL SCAN (association-layer fix, 2026-07-20): esp-wifi's default WIFI_FAST_SCAN stops at
+# the FIRST matching-SSID AP it hears, which made nodes associate to a WEAK ch1 AP (2c:56:dc @ -83)
+# over the STRONG ch6 office AP (a62bb0 @ -66) → off-channel → OTA-deaf (the #204/#217 root cause).
+# `1` = WIFI_ALL_CHANNEL_SCAN: scan every channel, then associate to the STRONGEST AP. This is the
+# prerequisite for the best-gateway election — the election's co_channel / ap_rssi inputs are only
+# meaningful once a board reliably associates to the right (strong, ch6) AP first.
+ESP_WIFI_CONFIG_SCAN_METHOD = "1"
 # 10→16: more 802.11 RX headroom (IDF throughput profile uses 16–25). +~9.6 KB permanent at init.
 ESP_WIFI_CONFIG_STATIC_RX_BUF_NUM = "16"
 # 32→40: on-demand ceiling; must be ≥ static_rx_buf_num. Freed as the TCP stack drains each frame.

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -1534,6 +1534,17 @@ fn main() -> ! {
                 }
             }
 
+            // #gateway-election: pull the relayed/gateway-own all-nodes-WiFi DEBUG flag (key `A`,
+            // fleet-global via broadcast target 255). `1`/`on`/`true` enables; anything else — incl.
+            // empty (retain-clear) or garbage — DISABLES, so clearing the retained topic turns debug
+            // off fleet-wide. Same unified relay/own path as UNITS (a leaf gets it relayed, the crown
+            // injects its own via GwOwnCfg).
+            if let Some(o) = r.take_cfg_offer(crate::net::CFG_KEY_WIFI_ALL) {
+                let v = core::str::from_utf8(&o.buf[..o.len]).unwrap_or("").trim();
+                let on = v == "1" || v.eq_ignore_ascii_case("on") || v.eq_ignore_ascii_case("true");
+                r.set_debug_wifi_all(on);
+            }
+
             // #55: pull the relayed/gateway-own plugin-visibility mask (key `P`) and update it.
             // Edge-safe: garbage/partial hex parses to None → keep the current mask (never blanks
             // the menu). The mask filters Home-menu rows; a masked-off LIVE screen is caught after

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -97,6 +97,13 @@ pub mod coexist;
 #[cfg(feature = "wifi")]
 pub mod election;
 
+// Minimal HTTP/1.x response-head parsers for the OTA fetch leg — PURE, host-tested verbatim by
+// `experiments/ota_http_verify` (#[path]-include). Extracted from `ota` so the #gateway-election
+// byte-0 fetch bug (a coalesced header+binary-body segment failing UTF-8 → status None) has ONE
+// definition with a regression test. `espnow`-gated (only `run_ota_fetch` uses it).
+#[cfg(feature = "espnow")]
+pub mod http;
+
 // #25 WLED WiZmote-emit (smol as a WLED "linked remote"). `wled = ["espnow"]`, so
 // this is present only in a wled build; the default/wifi/espnow builds are byte-free
 // of it (the module is `#![cfg(feature = "wled")]`). Referenced by `app` (the

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -90,6 +90,13 @@ pub mod wire;
 #[cfg(feature = "espnow")]
 pub mod coexist;
 
+// Configurable best-gateway election — PURE (no esp-hal/esp-wifi, no alloc), host-tested verbatim by
+// `experiments/election_verify` (#[path]-include, like `coexist`). Seeded by `wifi`'s MeshElect
+// resolver + `mode`'s flush/recovery paths; gated to `wifi` (where MeshElect lives — every election
+// path is built with WiFi present).
+#[cfg(feature = "wifi")]
+pub mod election;
+
 // #25 WLED WiZmote-emit (smol as a WLED "linked remote"). `wled = ["espnow"]`, so
 // this is present only in a wled build; the default/wifi/espnow builds are byte-free
 // of it (the module is `#![cfg(feature = "wled")]`). Referenced by `app` (the

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -76,6 +76,13 @@ pub mod flood;
 #[cfg(feature = "espnow")]
 pub mod wire;
 
+// #217 rung-3: co-channel-preferred crown AP selection + the never-crownless strand-guard state
+// machine. PURE (no esp-hal/esp-wifi, no alloc) so it's host-tested verbatim by
+// `experiments/ap_select_verify` (#[path]-include, like `wire`); `wifi`/`mode` build ApViews from
+// scan results + drive the WiFi association + crown state from its decisions.
+#[cfg(feature = "espnow")]
+pub mod coexist;
+
 // #25 WLED WiZmote-emit (smol as a WLED "linked remote"). `wled = ["espnow"]`, so
 // this is present only in a wled build; the default/wifi/espnow builds are byte-free
 // of it (the module is `#![cfg(feature = "wled")]`). Referenced by `app` (the

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -63,6 +63,13 @@ pub mod mode;
 #[cfg(feature = "espnow")]
 pub mod etx;
 
+// #267 cross-burst OTA-fetch resume: the PURE resume-key logic (does a saved cursor match this
+// staged image + slot → what offset to resume from). Host-testable (experiments/267_resume_verify),
+// no HAL deps. Consumed by `crate::ota::ImageWriter` (the HW flash writer + the .bss cursor), which
+// is espnow-gated — so gate it the same, byte-free of the default/wifi builds like `etx`/`flood`.
+#[cfg(feature = "espnow")]
+pub mod ota_resume;
+
 // #13 routed multi-hop mesh: the PURE managed-flood decision core (SeenSet + forward
 // decision + HopLatch escalation state machine), host-testable, no HAL deps. Driven by
 // the relay path in `mode`, so espnow-gated.

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -163,6 +163,10 @@ pub use wifi::CFG_KEY_OTA;
 // #197 herald NOTIFY key — espnow leaf-apply path (take_cfg_offer(M) → crate::toast::set).
 #[cfg(feature = "espnow")]
 pub use wifi::CFG_KEY_NOTIFY;
+// #gateway-election all-nodes-WiFi DEBUG key — espnow leaf/own apply path
+// (take_cfg_offer(A) → RadioManager::set_debug_wifi_all).
+#[cfg(feature = "espnow")]
+pub use wifi::CFG_KEY_WIFI_ALL;
 // #72 IO-registry key — the leaf/own apply path (take_cfg_offer(G) → io::apply_wire re-binds
 // the free GPIOs). `io`-gated (⊃ espnow): only the io apply path names it here.
 #[cfg(feature = "io")]

--- a/rust/clock/src/net/coexist.rs
+++ b/rust/clock/src/net/coexist.rs
@@ -1,0 +1,149 @@
+//! #217 rung-3 — co-channel-preferred crown AP selection + strand-guard (PURE core).
+//!
+//! Single-radio coexist (mode.rs §top): while associated to an AP the PHY sits on that AP's
+//! channel, so ESP-NOW works ONLY on that channel. The mesh runs on `ESP_NOW_FIXED_CHANNEL`
+//! (=6); if the crown associates to an off-channel AP (e.g. a strong ch1 AP), it is deaf to the
+//! mesh AND its own OTA fetch stalls at byte 0. Rung-3 makes the crown PREFER a `jplovescl` AP
+//! that is ALREADY on the mesh channel, keeping the mesh on ch6 (leaves unaffected).
+//!
+//! This module is PURE (no `esp-hal`/`esp-wifi`, no alloc, no float) so it is host-tested verbatim
+//! by `experiments/ap_select_verify` (`#[path]`-include, mirroring `wire`/`flood`/`etx`). The
+//! firmware (`net::wifi` / `net::mode`) constructs [`ApView`]s from `esp_wifi` scan results and
+//! feeds the decisions to the WiFi association + crown state machine.
+
+/// A scanned AP, already filtered to the target SSID by the caller. BSSID is the full 6 octets
+/// (used to PIN association via `ClientConfiguration.bssid`); `rssi` is dBm (negative).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ApView {
+    pub bssid: [u8; 6],
+    pub channel: u8,
+    pub rssi: i8,
+}
+
+/// Outcome of [`select_crown_ap`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CrownApDecision {
+    /// Pin association to this co-channel (== mesh) AP → a healthy, OTA-capable crown.
+    CoChannel { bssid: [u8; 6], ch: u8 },
+    /// No USABLE co-channel AP; the best off-channel AP (keeps WiFi/MQTT alive) — this is the
+    /// STRAND signal that feeds the [`crown_next_state`] shed→degraded ladder.
+    OffChannelFallback { bssid: [u8; 6], ch: u8 },
+    /// No target-SSID AP visible at all.
+    NoAp,
+}
+
+/// A co-channel AP weaker than this (dBm) is excluded — it can't sustain the ~1 MB pull. Best-RSSI
+/// selection already picks the strongest; this is only the exclusion floor. (#217 rung-3, Q6.)
+pub const AP_USABLE_MIN: i8 = -82;
+/// Only switch off the currently-associated co-channel AP if a DIFFERENT one beats it by this many
+/// dB — anti-flap hysteresis for the 2×ch1 + 1×ch6 topology.
+pub const HYST_MARGIN_DB: i8 = 6;
+
+/// Pick the crown's AP. Prefers the best-RSSI co-channel (== `mesh_ch`) AP; hysteresis-latches the
+/// current co-channel AP unless a different one clears [`HYST_MARGIN_DB`]. Falls back to the best
+/// off-channel AP ONLY when no usable co-channel AP exists (→ strand ladder). Pure + deterministic.
+///
+/// `current` is the incumbent association (use the live `get_rssi()` for its `rssi`, not a stale
+/// scan entry — nebula caveat 3).
+pub fn select_crown_ap(aps: &[ApView], mesh_ch: u8, current: Option<ApView>) -> CrownApDecision {
+    let best_co = aps
+        .iter()
+        .filter(|a| a.channel == mesh_ch && a.rssi >= AP_USABLE_MIN)
+        .max_by_key(|a| a.rssi);
+    if let Some(co) = best_co {
+        if let Some(cur) = current {
+            if cur.channel == mesh_ch && cur.rssi >= AP_USABLE_MIN {
+                // Latch the incumbent co-channel AP unless a DIFFERENT one clears the margin.
+                if co.bssid != cur.bssid && co.rssi.saturating_sub(cur.rssi) > HYST_MARGIN_DB {
+                    return CrownApDecision::CoChannel { bssid: co.bssid, ch: mesh_ch };
+                }
+                return CrownApDecision::CoChannel { bssid: cur.bssid, ch: mesh_ch };
+            }
+        }
+        return CrownApDecision::CoChannel { bssid: co.bssid, ch: mesh_ch };
+    }
+    // No usable co-channel AP → best usable off-channel, else strongest of anything, else none.
+    let best_any = aps
+        .iter()
+        .filter(|a| a.rssi >= AP_USABLE_MIN)
+        .max_by_key(|a| a.rssi)
+        .or_else(|| aps.iter().max_by_key(|a| a.rssi));
+    match best_any {
+        Some(a) => CrownApDecision::OffChannelFallback { bssid: a.bssid, ch: a.channel },
+        None => CrownApDecision::NoAp,
+    }
+}
+
+/// Crown coexist state (extends the existing claim/hold/shed).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CrownState {
+    /// Associated to a co-channel AP; OTA enabled; DIAG `cc=1`.
+    Normal,
+    /// Abdicated (existing #204 2b shed path); waiting for a successor.
+    Shed,
+    /// STRAND-GUARD latch: associated to the best off-channel AP; MQTT bridge + mesh KEPT ALIVE;
+    /// OTA disabled; DIAG `cc=0 degraded=1`. The fleet is NEVER left crownless.
+    Degraded,
+}
+
+/// After this many shed→re-claim cycles with no co-channel AP (no better successor took over), a
+/// board LATCHES [`CrownState::Degraded`] instead of shed-looping into a crownless gap.
+pub const SHED_RECLAIM_MAX: u8 = 3;
+
+/// Inputs to [`crown_next_state`] the selector decision doesn't carry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CrownCtx {
+    /// This off-channel episode exhausted its bounded co-channel reassoc cycles (#204 2b).
+    pub reassoc_exhausted: bool,
+    /// A co-channel-capable board (HELLO `cc=1`) is claiming — a degraded crown yields to it.
+    pub better_successor_cc: bool,
+}
+
+/// STRAND-GUARD transition (design §5.5). INVARIANT: never yields a path that leaves the fleet
+/// crownless — a sole off-channel board LATCHES `Degraded` rather than shed-loop. Drives the
+/// OTA-enable gate ([`ota_enabled`]) upstream. Pure.
+pub fn crown_next_state(
+    cur: CrownState,
+    dec: CrownApDecision,
+    shed_reclaims: u8,
+    ctx: CrownCtx,
+) -> CrownState {
+    match cur {
+        CrownState::Normal => match dec {
+            CrownApDecision::CoChannel { .. } => CrownState::Normal,
+            _ => {
+                if ctx.reassoc_exhausted {
+                    CrownState::Shed
+                } else {
+                    CrownState::Normal
+                }
+            }
+        },
+        CrownState::Shed => {
+            if matches!(dec, CrownApDecision::CoChannel { .. }) {
+                return CrownState::Normal;
+            }
+            if shed_reclaims >= SHED_RECLAIM_MAX {
+                CrownState::Degraded
+            } else {
+                CrownState::Shed
+            }
+        }
+        CrownState::Degraded => {
+            if matches!(dec, CrownApDecision::CoChannel { .. }) {
+                return CrownState::Normal;
+            }
+            if ctx.better_successor_cc {
+                return CrownState::Shed;
+            }
+            CrownState::Degraded
+        }
+    }
+}
+
+/// OTA is attempted ONLY as a healthy co-channel crown (`Normal`) — never while `Shed`/`Degraded`,
+/// so an off-channel crown keeps MQTT/mesh alive without firing offset-0 stall storms.
+#[inline]
+pub fn ota_enabled(state: CrownState) -> bool {
+    matches!(state, CrownState::Normal)
+}

--- a/rust/clock/src/net/coexist.rs
+++ b/rust/clock/src/net/coexist.rs
@@ -49,7 +49,7 @@ pub fn select_crown_ap(aps: &[ApView], mesh_ch: u8, current: Option<ApView>) -> 
     let best_co = aps
         .iter()
         .filter(|a| a.channel == mesh_ch && a.rssi >= AP_USABLE_MIN)
-        .max_by_key(|a| a.rssi);
+        .max_by_key(|a| (a.rssi, core::cmp::Reverse(a.bssid)));
     if let Some(co) = best_co {
         if let Some(cur) = current {
             if cur.channel == mesh_ch && cur.rssi >= AP_USABLE_MIN {
@@ -66,8 +66,8 @@ pub fn select_crown_ap(aps: &[ApView], mesh_ch: u8, current: Option<ApView>) -> 
     let best_any = aps
         .iter()
         .filter(|a| a.rssi >= AP_USABLE_MIN)
-        .max_by_key(|a| a.rssi)
-        .or_else(|| aps.iter().max_by_key(|a| a.rssi));
+        .max_by_key(|a| (a.rssi, core::cmp::Reverse(a.bssid)))
+        .or_else(|| aps.iter().max_by_key(|a| (a.rssi, core::cmp::Reverse(a.bssid))));
     match best_any {
         Some(a) => CrownApDecision::OffChannelFallback { bssid: a.bssid, ch: a.channel },
         None => CrownApDecision::NoAp,

--- a/rust/clock/src/net/election.rs
+++ b/rust/clock/src/net/election.rs
@@ -144,6 +144,23 @@ pub fn elect_backoff_ms(i: &FitnessInputs, w: &MetricWeights, node_id: u8) -> u6
     tiers.min(MAX_ELECT_TIERS) * ELECT_TIER_STEP_MS + (node_id as u64) * 200
 }
 
+/// LAYER 2 (crown-migration override): should a CO-CHANNEL board SEIZE an owner proven OFF-channel?
+/// True iff we are co-channel with a KNOWN mesh channel, the owner is not us, and its advertised
+/// MC channel is KNOWN (`!= 0`) and != the mesh channel. An off-channel crown is the OTA-deaf WRONG
+/// gateway (the #204/#217 disease), so the better (co-channel) board takes it over IMMEDIATELY rather
+/// than deferring to it (the dead/ghost or off-channel incumbent). A live co-channel owner
+/// (`owner_ch == mesh_ch`) or an unknown-channel owner (`owner_ch == 0`) is NOT seized — those go
+/// through the normal liveness/lowest-id arms. Pure + deterministic.
+pub fn seize_off_channel_owner(
+    co_channel: bool,
+    mesh_ch: u8,
+    node_id: u8,
+    owner_id: u8,
+    owner_ch: u8,
+) -> bool {
+    co_channel && mesh_ch != 0 && owner_id != node_id && owner_ch != 0 && owner_ch != mesh_ch
+}
+
 /// `Legacy` recovery backoff — reproduces the historical `reelect_backoff_ms(rssi, node_id)` EXACTLY
 /// (bucket 0/1/2 × 15 s + id·200 ms), so `ElectConfig::Legacy` is a byte-faithful rollback of the
 /// election timing. Kept here (pure) so the regression is host-pinned alongside best-gateway.

--- a/rust/clock/src/net/election.rs
+++ b/rust/clock/src/net/election.rs
@@ -1,0 +1,204 @@
+//! Configurable best-gateway election — PURE core (no `esp-hal`/`esp-wifi`, no alloc, no float).
+//!
+//! JP directive: "nodes join the mesh and elect the BEST gateway" + "what makes the best gateway
+//! must be configurable". The crown (coexist gateway) rides its AP's channel (single radio), so a
+//! crown on an OFF-channel AP (e.g. a strong ch1 AP while the mesh is on ch6) is deaf to the mesh
+//! AND its own OTA fetch stalls at byte 0 (#204/#217). The historical election keyed ONLY on
+//! lowest-node-id (with RSSI merely staggering *recovery* takeover timing, #51) — so a co-channel
+//! board was never PREFERRED at election time; a bad (off-channel) crown was only healed reactively
+//! by #204/#217 shed → strand-guard. This module makes co-channel capability (and RSSI / NTP /
+//! uptime, weighted by config) a FIRST-CLASS election input, so the best gateway is *elected*, not
+//! merely self-healed onto.
+//!
+//! MECHANISM (reuses the proven #51 stagger — NO wire change, NO preemption of a live owner):
+//! a board scores ITSELF into a `gateway_fitness`, and higher fitness → SHORTER claim backoff, so
+//! the best board claims a vacant/dead-owner slot FIRST; weaker boards observe its fresh retained
+//! `MC` and ADOPT it (the #51/#114/#122 no-flap stability contract is preserved verbatim — a board
+//! only ever compares its own score against a timing threshold, never a peer's). The same backoff
+//! gates the empty-MC (cold-boot) claim via the monotonic uptime clock, so at cold boot a
+//! co-channel board crowns first without waiting for a #204/#217 shed cycle. NEVER-CROWNLESS: the
+//! backoff is bounded ([`MAX_ELECT_TIERS`]), so a sole off-channel board still claims after its
+//! (capped) wait.
+//!
+//! PURE + host-tested verbatim by `experiments/election_verify` (`#[path]`-include, mirroring
+//! `coexist`/`wire`/`flood`/`etx`). The firmware (`net::wifi`) seeds [`FitnessInputs`] from the
+//! live `RadioManager` and feeds the backoff into the `mqtt_session` election resolver.
+
+/// The self-observed signals a candidate scores at claim time. Every field is already tracked on
+/// the `RadioManager` (see the seed sites in `net::mode`), so fitness costs no new radio work.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FitnessInputs {
+    /// The board's AP channel == the fixed mesh channel (`ESP_NOW_FIXED_CHANNEL`). THE disease-fix
+    /// signal: an off-channel crown is OTA-deaf regardless of RSSI (#217 rung-3), so co-channel
+    /// dominates the default weights.
+    pub co_channel: bool,
+    /// Live RSSI-to-AP (dBm, signed; weaker = more negative). Bucketed by [`rssi_score`].
+    pub ap_rssi: i8,
+    /// The board holds real (NTP-authoritative) time, not a free-running clock — a better gateway
+    /// can serve TIME frames. `synced_at != 0` upstream.
+    pub ntp_holder: bool,
+    /// Monotonic ms since boot (the loop clock == uptime). A longer-lived board is a more stable
+    /// crown; also the STATELESS deferral clock for the cold-boot empty-MC claim.
+    pub uptime_ms: u64,
+}
+
+/// Configurable per-signal weights (0 = ignore that signal). Fixed integer math (no_std, no float).
+/// The retained operator-lever topic `smol/mesh/elect` re-weights these; see [`parse_elect_config`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MetricWeights {
+    pub co_channel: u8,
+    pub rssi: u8,
+    pub ntp: u8,
+    pub uptime: u8,
+}
+
+impl MetricWeights {
+    /// The SHIPPED default (JP: "elect the BEST gateway" ⇒ best-gateway is the default behavior,
+    /// team-lead decision 2026-07-20). CO-CHANNEL-DOMINANT: `co_channel` (100) alone outranks the
+    /// maximum of every other signal combined (`rssi` 10·2 + `ntp` 5 + `uptime` 1·2 = 27), so a
+    /// co-channel board ALWAYS beats a stronger OFF-channel board (the id5 ch1-vs-ch6 bug). Absent /
+    /// empty / malformed config falls back to THIS (not to legacy) — best-gateway is on by default.
+    pub const DEFAULT: Self = Self { co_channel: 100, rssi: 10, ntp: 5, uptime: 1 };
+
+    /// Theoretical maximum fitness for these weights — the deficit reference in [`elect_backoff_ms`],
+    /// making the tiering scale-invariant to the weight magnitudes. `const` for use at call sites.
+    pub const fn max_fitness(&self) -> u16 {
+        self.co_channel as u16
+            + self.rssi as u16 * RSSI_SCORE_MAX
+            + self.ntp as u16
+            + self.uptime as u16 * UPTIME_SCORE_MAX
+    }
+}
+
+/// The election policy the retained `smol/mesh/elect` topic selects.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ElectConfig {
+    /// Best-gateway (default). Carries the (possibly re-weighted) metric.
+    BestGateway(MetricWeights),
+    /// The ESCAPE HATCH (team-lead decision): fall back to the historical lowest-id claim +
+    /// RSSI-only recovery stagger ([`legacy_recovery_backoff_ms`]). Selected by publishing the
+    /// literal payload `legacy` to `smol/mesh/elect`. A genuine 1:1 rollback (no fitness math).
+    Legacy,
+}
+
+/// Max RSSI bucket value (`rssi_score` ∈ 0..=2).
+const RSSI_SCORE_MAX: u16 = 2;
+/// Max uptime bucket value (`uptime_score` ∈ 0..=2).
+const UPTIME_SCORE_MAX: u16 = 2;
+/// One uptime bucket = 5 min (0: <5m, 1: <10m, 2: ≥10m). A crown that has held for tens of minutes
+/// scores full uptime; a just-booted board scores 0 (so a fresh board doesn't outrank a stable one
+/// on uptime alone).
+const UPTIME_STEP_MS: u64 = 300_000;
+
+/// Backoff step per fitness tier. MUST exceed the recovery-burst cadence (`REELECT_RETRY_MS` = 10 s,
+/// in `mode.rs`) so a weaker board always gets an adopt-burst BETWEEN the stronger board's claim and
+/// its own claim threshold — that's what keeps the winner stable (no competing claim; the lowest-id
+/// flush resolver never fires to undo it). Same value + rationale as the historical `RSSI_BUCKET_STEP_MS`.
+pub const ELECT_TIER_STEP_MS: u64 = 15_000;
+
+/// Max backoff tiers — BOUNDS worst-case takeover / cold-boot-crownless latency at
+/// `MAX_ELECT_TIERS × ELECT_TIER_STEP_MS` = 30 s (+ the sub-tier node-id term). Three tiers {0,1,2}
+/// = the same 0–30 s envelope as the historical 3-bucket RSSI backoff, so best-gateway never waits
+/// longer than legacy did. Co-channel boards land in {0,1}, off-channel in {2} (see [`elect_backoff_ms`]).
+pub const MAX_ELECT_TIERS: u64 = 2;
+
+/// RSSI → 0..=2 bucket (higher = stronger). Thresholds match the historical `reelect_backoff_ms`
+/// buckets (−65 / −78 dBm) so `Legacy` and the RSSI term of best-gateway agree on the STA range.
+#[inline]
+pub fn rssi_score(rssi: i8) -> u16 {
+    if rssi >= -65 {
+        2
+    } else if rssi >= -78 {
+        1
+    } else {
+        0
+    }
+}
+
+/// Uptime(ms) → 0..=`UPTIME_SCORE_MAX` bucket (higher = longer-lived).
+#[inline]
+fn uptime_score(uptime_ms: u64) -> u16 {
+    (uptime_ms / UPTIME_STEP_MS).min(UPTIME_SCORE_MAX as u64) as u16
+}
+
+/// Higher = better gateway. Pure, saturating, integer. Also the advisory value a future MC field
+/// could carry for observability (Phase 1 keeps the wire unchanged — fitness is purely local).
+pub fn gateway_fitness(i: &FitnessInputs, w: &MetricWeights) -> u16 {
+    (w.co_channel as u16) * (i.co_channel as u16)
+        + (w.rssi as u16) * rssi_score(i.ap_rssi)
+        + (w.ntp as u16) * (i.ntp_holder as u16)
+        + (w.uptime as u16) * uptime_score(i.uptime_ms)
+}
+
+/// Best-gateway claim backoff (ms). Higher fitness → SHORTER wait, so the best board claims a
+/// vacant/dead slot first. The fitness DEFICIT (below the weights' max) is normalized to
+/// 0..=[`MAX_ELECT_TIERS`] (ceil), making the ordering scale-invariant to the weight magnitudes;
+/// `node_id·200 ms` is the sub-tier final tiebreak (fleet ids are single/low-double-digit, so it
+/// never separates tiers — same convention as the historical backoff). Pure + deterministic.
+pub fn elect_backoff_ms(i: &FitnessInputs, w: &MetricWeights, node_id: u8) -> u64 {
+    let maxf = w.max_fitness().max(1) as u64;
+    let fit = gateway_fitness(i, w) as u64;
+    let deficit = maxf.saturating_sub(fit);
+    // ceil(deficit * MAX_ELECT_TIERS / maxf), clamped — best board (deficit 0) → tier 0 → no wait.
+    let tiers = ((deficit * MAX_ELECT_TIERS) + (maxf - 1)) / maxf;
+    tiers.min(MAX_ELECT_TIERS) * ELECT_TIER_STEP_MS + (node_id as u64) * 200
+}
+
+/// `Legacy` recovery backoff — reproduces the historical `reelect_backoff_ms(rssi, node_id)` EXACTLY
+/// (bucket 0/1/2 × 15 s + id·200 ms), so `ElectConfig::Legacy` is a byte-faithful rollback of the
+/// election timing. Kept here (pure) so the regression is host-pinned alongside best-gateway.
+pub fn legacy_recovery_backoff_ms(rssi: i8, node_id: u8) -> u64 {
+    let bucket: u64 = if rssi >= -65 {
+        0
+    } else if rssi >= -78 {
+        1
+    } else {
+        2
+    };
+    bucket * ELECT_TIER_STEP_MS + (node_id as u64) * 200
+}
+
+/// Parse the retained `smol/mesh/elect` payload → policy. Panic-free (checked UTF-8, no indexing):
+///   * empty / whitespace / non-UTF-8 / no recognized token ⇒ `BestGateway(DEFAULT)` — best-gateway
+///     is ON by default, and the retain-clear restores it (team-lead decision).
+///   * `legacy` (case-insensitive) ⇒ `Legacy` (the escape hatch).
+///   * keyed weights `c<n>r<n>n<n>u<n>` (any order, any subset; missing keys inherit `DEFAULT`;
+///     values clamp to 255; unknown letters + their digits are ignored) ⇒ `BestGateway(weights)`.
+///     e.g. `c100r10n5u1` = the default; `c0r100` = RSSI-dominant with co-channel off.
+pub fn parse_elect_config(payload: &[u8]) -> ElectConfig {
+    let s = match core::str::from_utf8(payload) {
+        Ok(s) => s.trim(),
+        Err(_) => return ElectConfig::BestGateway(MetricWeights::DEFAULT),
+    };
+    if s.is_empty() {
+        return ElectConfig::BestGateway(MetricWeights::DEFAULT);
+    }
+    if s.eq_ignore_ascii_case("legacy") {
+        return ElectConfig::Legacy;
+    }
+    let mut w = MetricWeights::DEFAULT;
+    let b = s.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        let key = b[i];
+        i += 1;
+        let mut val: u16 = 0;
+        let mut got = false;
+        while i < b.len() && b[i].is_ascii_digit() {
+            got = true;
+            val = (val * 10 + (b[i] - b'0') as u16).min(255);
+            i += 1;
+        }
+        if got {
+            let v = val as u8;
+            match key {
+                b'c' | b'C' => w.co_channel = v,
+                b'r' | b'R' => w.rssi = v,
+                b'n' | b'N' => w.ntp = v,
+                b'u' | b'U' => w.uptime = v,
+                _ => {}
+            }
+        }
+    }
+    ElectConfig::BestGateway(w)
+}

--- a/rust/clock/src/net/election.rs
+++ b/rust/clock/src/net/election.rs
@@ -161,6 +161,31 @@ pub fn seize_off_channel_owner(
     co_channel && mesh_ch != 0 && owner_id != node_id && owner_ch != 0 && owner_ch != mesh_ch
 }
 
+/// LAYER 2 (symmetric YIELD — makes the seize STICK): should an OFF-channel board ADOPT a LIVE
+/// co-channel owner regardless of node-id? True iff we are NOT co-channel (and know it), the owner is
+/// not us, its MC channel == the mesh channel (a co-channel crown), and it is alive. Without this the
+/// historical lowest-id rule lets a LOWER-id off-channel crown (id5) re-claim the crown from the
+/// co-channel board (id7) every flush → endless flap; with it the off-channel board yields, so the
+/// co-channel seize converges to a stable co-channel crown. Pure + deterministic. (A co-channel board
+/// never yields — it seizes instead; the two predicates are mutually exclusive on `co_channel`.)
+#[allow(clippy::too_many_arguments)]
+pub fn yield_to_co_channel_owner(
+    co_channel_known: bool,
+    co_channel: bool,
+    mesh_ch: u8,
+    node_id: u8,
+    owner_id: u8,
+    owner_ch: u8,
+    owner_alive: bool,
+) -> bool {
+    co_channel_known
+        && !co_channel
+        && mesh_ch != 0
+        && owner_id != node_id
+        && owner_ch == mesh_ch
+        && owner_alive
+}
+
 /// `Legacy` recovery backoff — reproduces the historical `reelect_backoff_ms(rssi, node_id)` EXACTLY
 /// (bucket 0/1/2 × 15 s + id·200 ms), so `ElectConfig::Legacy` is a byte-faithful rollback of the
 /// election timing. Kept here (pure) so the regression is host-pinned alongside best-gateway.

--- a/rust/clock/src/net/election.rs
+++ b/rust/clock/src/net/election.rs
@@ -186,6 +186,17 @@ pub fn yield_to_co_channel_owner(
         && owner_alive
 }
 
+/// LAYER 2 reliability: should a CO-CHANNEL-capable board REFUSE to leaf-lock to (settle under) an
+/// owner whose MC channel is a KNOWN off-channel? True iff our AP channel == the mesh channel AND the
+/// owner's channel is known (`!= 0`) AND != the mesh channel. Refusing the lock (skip the
+/// scan-lock + owner-silence reset) keeps the leaf RE-ELECTING, so the co-channel SEIZE re-runs each
+/// recovery burst and fires RELIABLY — fixing the racy ~2/3 seize where a happy leaf-lock (co_channel
+/// transiently unknown at the boot tick) stopped the bursts that would have seized. A co-channel owner
+/// (`owner_ch == mesh`) or an unknown owner channel (`0`) → lock normally (false). Pure + deterministic.
+pub fn refuse_leaf_lock_off_channel(my_ap_ch: u8, mesh_ch: u8, owner_ch: u8) -> bool {
+    mesh_ch != 0 && my_ap_ch == mesh_ch && owner_ch != 0 && owner_ch != mesh_ch
+}
+
 /// `Legacy` recovery backoff — reproduces the historical `reelect_backoff_ms(rssi, node_id)` EXACTLY
 /// (bucket 0/1/2 × 15 s + id·200 ms), so `ElectConfig::Legacy` is a byte-faithful rollback of the
 /// election timing. Kept here (pure) so the regression is host-pinned alongside best-gateway.

--- a/rust/clock/src/net/http.rs
+++ b/rust/clock/src/net/http.rs
@@ -1,0 +1,63 @@
+//! Minimal HTTP/1.x response-head parsers for the OTA fetch leg — PURE (no deps, no cfg, no alloc),
+//! so the firmware and `experiments/ota_http_verify` share ONE definition (no drift), mirroring the
+//! `coexist`/`election` pattern.
+//!
+//! #gateway-election byte-0 fetch BUG these fix: a valid `HTTP/1.0 206 Partial Content` response
+//! whose header AND the start of the (binary) image body arrive in ONE TCP segment was fed WHOLE to
+//! `from_utf8` — which fails on the binary body → the status parsed as `None` → the fetch aborted at
+//! byte 0 with `bad=true`, even though the link was fine (rx=956B, valid 206 head on serial). It was
+//! segmentation-dependent (passed when the header arrived in its own segment), which is why it hid.
+//! FIX: every parser slices to the relevant ASCII span on BYTES *before* any `from_utf8`, so a
+//! coalesced binary body can never break header parsing; and the status parser accepts ANY minor
+//! version (1.0/1.1). Callers additionally pass only the header slice (`..header_end`).
+
+/// Index one-past the header terminator (`\r\n\r\n`) — the body start. `None` if incomplete.
+pub fn header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n").map(|i| i + 4)
+}
+
+/// Status code from an HTTP/1.x status line, e.g. `HTTP/1.0 206 Partial Content` → `206`. Version-
+/// agnostic (the code is the 2nd whitespace token). ROBUST when `buf` also carries trailing header /
+/// BODY bytes (incl. binary): only the FIRST line is considered, sliced on BYTES before `from_utf8`,
+/// so a coalesced binary body can never make it return `None` (the byte-0 bug).
+pub fn status_code(buf: &[u8]) -> Option<u16> {
+    let end = buf
+        .iter()
+        .position(|&b| b == b'\r' || b == b'\n')
+        .unwrap_or(buf.len());
+    let line = core::str::from_utf8(&buf[..end]).ok()?;
+    line.split_whitespace().nth(1)?.parse().ok()
+}
+
+/// `Content-Length` (case-insensitive) from the header block. ROBUST: walks line-by-line on BYTES
+/// (a stray non-UTF-8 / body byte in a later line can't abort the search) and UTF-8-decodes only
+/// each candidate line; stops at the blank line (end of headers). `None` if absent/unparseable.
+pub fn content_length(buf: &[u8]) -> Option<u32> {
+    let mut start = 0;
+    while start < buf.len() {
+        let nl = buf[start..]
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|i| start + i)
+            .unwrap_or(buf.len());
+        let mut end = nl;
+        if end > start && buf[end - 1] == b'\r' {
+            end -= 1; // strip the trailing CR
+        }
+        if end == start {
+            break; // blank line → end of headers
+        }
+        if let Ok(line) = core::str::from_utf8(&buf[start..end]) {
+            if let Some((name, val)) = line.split_once(':') {
+                if name.eq_ignore_ascii_case("content-length") {
+                    return val.trim().parse().ok();
+                }
+            }
+        }
+        if nl >= buf.len() {
+            break;
+        }
+        start = nl + 1;
+    }
+    None
+}

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -6120,6 +6120,10 @@ pub fn start(
     let mut elect = crate::net::wifi::MeshElect::new(id);
     elect.now_ms = now_ms(); // seed the ONE clock the stale-owner timeout runs on
     elect.boot = true; // #51 return-flap: never displace a different owner already in the MC
+    // #gateway-election LAYER 2: seed the mesh channel so the BOOT election can recompute co_channel
+    // from the LIVE AP (mqtt_session reads current_ap_info) — WITHOUT this the boot resolver's
+    // co_channel stayed false and the co-channel seize could never fire at boot (the regression).
+    elect.mesh_channel = ESP_NOW_FIXED_CHANNEL;
     let mut ota_offer: Option<crate::ota::Announce> = None;
     let mut config_offer: Option<crate::app::DefaultScreen> = None;
     let mut install_requested = false;

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2054,6 +2054,18 @@ pub struct RadioManager {
     /// Seeded into the recovery `MeshElect` so the strongest-uplink survivor wins the
     /// re-election. Weak default until the first burst measures it.
     my_rssi_to_ap: i8,
+    /// #217 rung-3: the channel of the currently-associated AP (the channel the co-channel
+    /// selector last PINNED, or the fallback AP's channel). 0 = unknown (fresh SSID-only assoc that
+    /// esp-wifi chose) → treated as off-channel so the first pre-fetch runs the co-channel scan.
+    /// `off-channel` ⇔ `my_ap_channel != ESP_NOW_FIXED_CHANNEL`.
+    my_ap_channel: u8,
+    /// #217 rung-3: crown coexist state (Normal = co-channel + OTA-enabled; Degraded = off-channel
+    /// but MQTT/mesh KEPT ALIVE + OTA disabled; Shed = abdicated). Drives the OTA-enable gate + the
+    /// never-crownless strand-guard (`net::coexist::crown_next_state`).
+    crown_state: crate::net::coexist::CrownState,
+    /// #217 rung-3 strand-guard: shed→reclaim cycles with no co-channel AP available. At
+    /// `SHED_RECLAIM_MAX` the crown LATCHES `Degraded` rather than shed-loop into a crownless gap.
+    shed_reclaims: u8,
     /// #57 Mesh Familiar: the ALWAYS-ON living-creature state machine (holder /
     /// heartbeat / seq-arbitration / handoff / RSSI-weighted orphan-takeover). Lives
     /// here beside the `roster` it elects from; ticked every main loop by `fam_tick`
@@ -2173,6 +2185,9 @@ impl RadioManager {
             install_requested: false,
             silent_until_relock: false,
             my_rssi_to_ap: -99,
+            my_ap_channel: 0, // #217 rung-3: unknown until a co-channel scan pins it
+            crown_state: crate::net::coexist::CrownState::Normal, // #217 rung-3
+            shed_reclaims: 0, // #217 rung-3 strand-guard
             // #57: seed the familiar with our id (heartbeat phase + arbitration id).
             // No creature exists until one is heard or first-birthed on a cold mesh.
             fam: FamState::new(id),
@@ -2876,26 +2891,43 @@ impl RadioManager {
     /// re-measures downstream on the next flush; #155 channel-follow re-advertises the new channel.
     /// ⚠️ HW-CANARY-GATED: the scan + reassociate radio path — and whether ESP-NOW coexist follows
     /// the new STA channel — cannot be verified without hardware (same discipline as `run_scan`/OTA).
-    fn reassoc_ch6_prefer(&mut self) {
+    fn reassoc_ch6_prefer(&mut self) -> crate::net::coexist::CrownApDecision {
+        use crate::net::coexist::{select_crown_ap, ApView, CrownApDecision};
         // COEXIST hard gate: never leave the mesh channel mid mesh-OTA transfer (mirrors run_scan).
         if self.ota_leaf.is_active() {
-            return;
+            return CrownApDecision::NoAp;
         }
         let net = &crate::secrets::WIFI_NETWORK;
-        // Strongest ch6 BSSID if any; else strongest overall; else None (plain reconnect on creds).
-        let (bssid, pin_ch6): (Option<[u8; 6]>, bool) = match self.controller.scan_n(16) {
+        // #217 rung-3: incumbent view for the ≥6 dB hysteresis (live rssi via `rssi()` — nebula
+        // caveat 3 — at the channel we last pinned; bssid is immaterial to the channel+rssi compare).
+        let cur = if self.my_ap_channel != 0 {
+            self.controller
+                .rssi()
+                .ok()
+                .map(|r| ApView { bssid: [0; 6], channel: self.my_ap_channel, rssi: r.clamp(-127, 0) as i8 })
+        } else {
+            None
+        };
+        // Full scan (needs co-channel AND off-channel visibility so `select_crown_ap` can decide
+        // co-channel vs the strand fallback in ONE pass). Filter to our SSID; feed the pure selector.
+        let decision = match self.controller.scan_n(16) {
             Ok(aps) => {
-                if let Some(a) = aps
-                    .iter()
-                    .filter(|a| a.channel == 6)
-                    .max_by_key(|a| a.signal_strength)
-                {
-                    (Some(a.bssid), true)
-                } else {
-                    (aps.iter().max_by_key(|a| a.signal_strength).map(|a| a.bssid), false)
+                let mut views: alloc::vec::Vec<ApView> = alloc::vec::Vec::new();
+                for a in aps.iter() {
+                    if a.ssid.as_str() == net.ssid {
+                        views.push(ApView { bssid: a.bssid, channel: a.channel, rssi: a.signal_strength });
+                    }
                 }
+                select_crown_ap(&views, ESP_NOW_FIXED_CHANNEL, cur)
             }
-            Err(_) => (None, false),
+            Err(_) => CrownApDecision::NoAp,
+        };
+        // Pin the chosen AP (bssid + channel). A vanished pinned BSSID is recovered by the #195
+        // retry re-scan (connect is async — no synchronous fail here); select_crown_ap then re-picks.
+        let (bssid, chan): (Option<[u8; 6]>, Option<u8>) = match decision {
+            CrownApDecision::CoChannel { bssid, ch }
+            | CrownApDecision::OffChannelFallback { bssid, ch } => (Some(bssid), Some(ch)),
+            CrownApDecision::NoAp => (None, None),
         };
         let _ = self.controller.disconnect();
         let _ = self
@@ -2905,16 +2937,44 @@ impl RadioManager {
                     ssid: net.ssid.into(),
                     password: net.pass.into(),
                     bssid,
-                    channel: if pin_ch6 { Some(6) } else { None },
+                    channel: chan,
                     ..Default::default()
                 },
             ));
         let _ = self.controller.connect();
+        // Track the resulting channel so `off-channel` (!= ESP_NOW_FIXED_CHANNEL) is detectable
+        // pre-fetch without a live controller query (0 = NoAp → still off-channel → retry next arm).
+        self.my_ap_channel = match decision {
+            CrownApDecision::CoChannel { ch, .. } | CrownApDecision::OffChannelFallback { ch, .. } => ch,
+            CrownApDecision::NoAp => 0,
+        };
         log::warn!(
-            "smol #204: crown deaf → ch6-prefer reassoc (ch6_found={}, bssid_set={})",
-            pin_ch6,
-            bssid.is_some()
+            "smol #217r3: crown reassoc → co_channel={} ap_ch={} mesh_ch={}",
+            matches!(decision, CrownApDecision::CoChannel { .. }),
+            self.my_ap_channel,
+            ESP_NOW_FIXED_CHANNEL
         );
+        decision
+    }
+
+    /// #217 rung-3 strand-guard bookkeeping: folds a `reassoc_ch6_prefer` decision into the crown
+    /// state via the pure `crown_next_state`. Co-channel resets the reclaim counter and marks
+    /// `Normal`; otherwise it increments reclaims and walks the guard from `Shed`, latching
+    /// `Degraded` at `SHED_RECLAIM_MAX` (serve off-channel, OTA off, MQTT/mesh alive, never crownless).
+    fn note_crown_ap(&mut self, decision: crate::net::coexist::CrownApDecision) {
+        use crate::net::coexist::{crown_next_state, CrownApDecision, CrownCtx, CrownState};
+        if matches!(decision, CrownApDecision::CoChannel { .. }) {
+            self.shed_reclaims = 0;
+            self.crown_state = CrownState::Normal;
+        } else {
+            self.shed_reclaims = self.shed_reclaims.saturating_add(1);
+            // The reassoc already TRIED and failed to reach co-channel, so evaluate from `Shed` with
+            // `reassoc_exhausted`. `better_successor_cc` (yield to a cc=1 peer) is a follow-up that
+            // needs the HELLO `cc` bit; Tier-1 stays crown-in-place, which holds the never-crownless
+            // invariant (safety) — yielding is an optimization, not a safety requirement.
+            let ctx = CrownCtx { reassoc_exhausted: true, better_successor_cc: false };
+            self.crown_state = crown_next_state(CrownState::Shed, decision, self.shed_reclaims, ctx);
+        }
     }
 
     /// #70: sample the live free-heap and lower the min-heap watermark. Cheap (one `HEAP.free()`);
@@ -3112,6 +3172,16 @@ impl RadioManager {
                 ap_ch, ap_rssi, b[0], b[1], b[2], b[3], b[4], b[5]
             ));
         }
+        // #217 rung-3 coexist-channel health (luna tile #82). `cc` = crown is CO-CHANNEL (live
+        // associated AP channel == the mesh channel) — the direct OTA-capability + off-ch6-
+        // starvation signal; `degraded` = strand-guard latched off-channel (MQTT alive, OTA off,
+        // never crownless). Both always present (0 on a leaf / non-associated). Appended LAST —
+        // positional parse of the fixed DIAG fields intact.
+        let cc = crate::net::current_ap_info()
+            .map(|(ch, _, _)| u8::from(ch == ESP_NOW_FIXED_CHANNEL))
+            .unwrap_or(0);
+        let degraded = u8::from(self.crown_state == crate::net::coexist::CrownState::Degraded);
+        rec.push_str(&alloc::format!("|cc={}|degraded={}", cc, degraded));
         // #204: crown dead-downstream telemetry — <deaf-streak>:<reassoc-cycles>:<deaf_shed 0/1>.
         // Named `cdeaf` (crown-deaf) to NOT collide with the mesh-test-only `deaf=` (an ESP-NOW
         // deaf-LIST count). Reads 0:0:0 on a healthy crown or any leaf; the shed flag latches 1 after
@@ -3586,12 +3656,29 @@ impl RadioManager {
         // reassoc-then-fetch, NOT a defer: run_ota_update's `false` return is a self-fetch FAILURE
         // that feeds the #195/#225 fail-cap, so a defer-as-failure would poison the cap. Cap-neutral
         // true-defer = rung-2D follow-up.
-        if self.my_rssi_to_ap < CROWN_AP_RSSI_MIN {
+        // #217 rung-3: co-channel-FIRST pre-fetch gate. Off-channel (ap_ch != mesh — RSSI-
+        // INDEPENDENT, the id5 ch1-vs-ch6 bug the rung-2 rssi gate missed) OR weak → co-channel-
+        // prefer reassoc before the fetch; fold the outcome into the strand-guard.
+        let off_channel = self.my_ap_channel != ESP_NOW_FIXED_CHANNEL;
+        if off_channel || self.my_rssi_to_ap < CROWN_AP_RSSI_MIN {
             log::warn!(
-                "smol #217: pre-fetch AP weak (rssi {}) — ch6-reassoc before fetch",
+                "smol #217r3: pre-fetch off_ch={} rssi={} — co-channel-prefer reassoc",
+                off_channel,
                 self.my_rssi_to_ap
             );
-            self.reassoc_ch6_prefer();
+            let decision = self.reassoc_ch6_prefer();
+            self.note_crown_ap(decision);
+        }
+        // Strand-guard OTA-enable: attempt OTA ONLY as a healthy co-channel (Normal) crown. If no
+        // co-channel AP is reachable (Degraded/Shed), SKIP the fetch CAP-NEUTRALLY (`true` = "not
+        // attempted", NOT a self-fetch failure that would poison the #195/#225 fail-cap) and STAY
+        // crown (never crownless). A fresh announce / arm re-check retries once co-channel returns.
+        if !crate::net::coexist::ota_enabled(self.crown_state) {
+            log::warn!(
+                "smol #217r3: crown off-channel (state={:?}) — OTA skipped cap-neutrally, staying crown",
+                self.crown_state
+            );
+            return true;
         }
         let rng = self.rng;
         let mut fail: Option<(u32, u32, u32, u32, u32)> = None;
@@ -4630,7 +4717,20 @@ impl RadioManager {
             if escalate {
                 let shed_justified = self.relay.deaf_bulk_seen
                     || self.relay.crown_deaf_streak >= DEAF_SHED_DEEP_STREAK;
-                if self.relay.reassoc_cycles >= DEAF_SHED_M && shed_justified {
+                // #217 rung-3 STRAND-GUARD: never shed into a crownless gap. If the co-channel
+                // selector has LATCHED `Degraded` (M reclaims proved NO co-channel AP is reachable),
+                // a successor would be off-channel too → shedding only starts crownless churn. Stay
+                // crown, degraded (MQTT/mesh alive, OTA off). A ch6-heal → `Normal` clears the latch
+                // and normal #204 shedding resumes. (Deafness on a ch6 AP keeps crown_state=Normal,
+                // so this never suppresses a legitimate #204 self-heal shed.)
+                let strand_latched =
+                    self.crown_state == crate::net::coexist::CrownState::Degraded;
+                if strand_latched {
+                    log::warn!(
+                        "smol #217r3: deaf-shed SUPPRESSED — strand-latched (no co-channel AP); staying crown (never crownless)"
+                    );
+                }
+                if self.relay.reassoc_cycles >= DEAF_SHED_M && shed_justified && !strand_latched {
                     // SHED / abdicate. Mirrors the #155 channel-yield abdication shape (leaf-scan +
                     // HELLO-silent) but tags `deaf_shed` — NOT flush_fail_latch: our UPLINK is fine (we
                     // just flushed `ok`); we're RX-deaf, not flush-incapable. The frozen MC lets the
@@ -5980,14 +6080,29 @@ pub fn start(
     // guarantees the #204 bulk-RX-deaf disease. reassoc_ch6_prefer no-ops mid mesh-OTA (ota_leaf).
     // rssi trigger only this rung; ch-mismatch is a follow-up (no trivial current-AP-channel
     // accessor at this site yet). Re-capture rssi after so #51 election + coexist use the new value.
-    if radio.relay.is_gateway && radio.my_rssi_to_ap < CROWN_AP_RSSI_MIN {
-        log::warn!(
-            "smol #217: crown-assumption on a weak AP (rssi {}) — proactive ch6-reassoc",
-            radio.my_rssi_to_ap
-        );
-        radio.reassoc_ch6_prefer();
-        if let Ok(r) = radio.controller.rssi() {
-            radio.my_rssi_to_ap = r.clamp(-127, 0) as i8;
+    // #217 rung-3: the ch-mismatch trigger the rung-2 comment deferred ("no trivial current-AP-
+    // channel accessor yet") is now `my_ap_channel`. Off-channel (ap_ch != mesh — RSSI-INDEPENDENT,
+    // the id5 ch1-vs-ch6 bug) OR weak → co-channel-prefer reassoc BEFORE the coexist gateway
+    // commits, then fold into the never-crownless strand-guard. Leaves stay on ESP_NOW_FIXED_CHANNEL.
+    if radio.relay.is_gateway {
+        let off_channel = radio.my_ap_channel != ESP_NOW_FIXED_CHANNEL;
+        if off_channel || radio.my_rssi_to_ap < CROWN_AP_RSSI_MIN {
+            log::warn!(
+                "smol #217r3: crown-assumption off_ch={} rssi={} — co-channel-prefer reassoc",
+                off_channel,
+                radio.my_rssi_to_ap
+            );
+            let decision = radio.reassoc_ch6_prefer();
+            radio.note_crown_ap(decision);
+            if let Ok(r) = radio.controller.rssi() {
+                radio.my_rssi_to_ap = r.clamp(-127, 0) as i8;
+            }
+        } else {
+            // Already co-channel + strong → healthy crown; clear any prior strand latch.
+            radio.note_crown_ap(crate::net::coexist::CrownApDecision::CoChannel {
+                bssid: [0; 6],
+                ch: ESP_NOW_FIXED_CHANNEL,
+            });
         }
     }
     // #23 fix: persist the boot election's staleness observation → a leaf's later

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2069,6 +2069,15 @@ pub struct RadioManager {
     /// perturbs the crown election) and may self-fetch OTA on its own install command. DEBUG lever,
     /// default false (normal operation = crown-only WiFi).
     debug_wifi_all: bool,
+    /// #gateway-election LAYER 3 (fetch-quiet): true while THIS node is running an OTA self-fetch
+    /// (`run_ota_update`). Suppresses this node's own downlink RE-FLOOD so its ESP-NOW TX never
+    /// competes with the co-channel WiFi bulk-RX. NOTE: `run_ota_fetch` itself does ZERO mesh TX and
+    /// the fetch's tick doesn't service the mesh, so a crown is ALREADY TX-silent during its blocking
+    /// fetch — the real RX-starvation is the FLEET's reflood storm from an election split-brain
+    /// (multiple GRID2 origins → climbing seq defeats the strict-newer dedup), which the LAYER 2
+    /// single-stable-co-channel-crown fix removes. This flag is the belt-and-suspenders that also
+    /// covers a debug (all-nodes-WiFi) LEAF self-fetch. Default false → zero behavior change.
+    ota_fetching: bool,
     /// #217 rung-3: crown coexist state (Normal = co-channel + OTA-enabled; Degraded = off-channel
     /// but MQTT/mesh KEPT ALIVE + OTA disabled; Shed = abdicated). Drives the OTA-enable gate + the
     /// never-crownless strand-guard (`net::coexist::crown_next_state`).
@@ -2197,6 +2206,7 @@ impl RadioManager {
             my_rssi_to_ap: -99,
             my_ap_channel: 0, // #217 rung-3: unknown until a co-channel scan pins it
             debug_wifi_all: false, // #gateway-election: all-nodes-WiFi debug flag, default OFF
+            ota_fetching: false, // #gateway-election LAYER 3: fetch-quiet flag, default OFF
             crown_state: crate::net::coexist::CrownState::Normal, // #217 rung-3
             shed_reclaims: 0, // #217 rung-3 strand-guard
             // #57: seed the familiar with our id (heartbeat phase + arbitration id).
@@ -2343,6 +2353,7 @@ impl RadioManager {
         // zero ordering effect; wire from `my_synced_at` in a follow-up).
         elect.co_channel = self.my_ap_channel == ESP_NOW_FIXED_CHANNEL;
         elect.co_channel_known = self.my_ap_channel != 0;
+        elect.mesh_channel = ESP_NOW_FIXED_CHANNEL; // LAYER 2: detect an off-channel owner in the MC
         elect.ntp_holder = false;
         elect.seen_owner = self.mc_seen_owner;
         elect.seen_seq = self.mc_seen_seq;
@@ -3688,6 +3699,10 @@ impl RadioManager {
     ) -> bool {
         log::info!("smol OTA: opening update burst (mesh deaf for the whole download)");
         let _ = self.switch(Mode::WifiSta);
+        // #gateway-election LAYER 3 (fetch-quiet): mark the self-fetch active so this node's own
+        // downlink re-flood is suppressed (see the Batt2/Grid2 service arms). A SUCCESS reboots inside
+        // the fetch (flag reset by the reboot); both non-activating returns below clear it.
+        self.ota_fetching = true;
         // #217 rung-2B: pre-fetch AP-quality gate. If the current AP is weak (rssi < -75 — the pcap
         // deaf-AP class that never ACKs response byte 0), steer to a stronger ch6 AP BEFORE the
         // fetch (run_ota_fetch's own assoc-wait absorbs the reconnect latency). BEST-EFFORT
@@ -3716,6 +3731,7 @@ impl RadioManager {
                 "smol #217r3: crown off-channel (state={:?}) — OTA skipped cap-neutrally, staying crown",
                 self.crown_state
             );
+            self.ota_fetching = false; // LAYER 3: fetch not attempted → clear the quiet flag
             return true;
         }
         let rng = self.rng;
@@ -3757,6 +3773,7 @@ impl RadioManager {
                 }
             }
         }
+        self.ota_fetching = false; // LAYER 3: self-fetch attempt done → lift the quiet flag
         ok
     }
 
@@ -4638,6 +4655,7 @@ impl RadioManager {
         // fitness backoff are fully active. ntp_holder v1-stubbed false (follow-up).
         elect.co_channel = self.my_ap_channel == ESP_NOW_FIXED_CHANNEL;
         elect.co_channel_known = self.my_ap_channel != 0;
+        elect.mesh_channel = ESP_NOW_FIXED_CHANNEL; // LAYER 2: detect an off-channel owner in the MC
         elect.ntp_holder = false;
         // #gateway-election all-nodes-WiFi DEBUG: a NON-gateway node only reaches this flush because
         // its debug flag is set. It must NEVER claim the crown (that would let every debug node fight
@@ -5497,6 +5515,7 @@ impl RadioManager {
                     self.peers.last_hello_ms = now;
                     self.roster.heard(src, None, rssi, now);
                     if !self.relay.is_gateway
+                        && !self.ota_fetching // #gateway-election LAYER 3: fetch-quiet — no reflood TX mid-self-fetch
                         && payload.starts_with(b"BATT|")
                         && self.batt.set_fresh(payload, seq)
                     {
@@ -5518,6 +5537,7 @@ impl RadioManager {
                     self.peers.last_hello_ms = now;
                     self.roster.heard(src, None, rssi, now);
                     if !self.relay.is_gateway
+                        && !self.ota_fetching // #gateway-election LAYER 3: fetch-quiet — no reflood TX mid-self-fetch
                         && payload.starts_with(b"GRID|")
                         && self.grid.set_fresh(payload, seq)
                     {

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -1920,6 +1920,11 @@ pub struct RadioManager {
     /// #23: the elected mesh owner's id (the single coexist gateway). Set at boot from
     /// the broker election; a leaf scans for THIS id's HELLO to find the mesh channel.
     elected_owner: u8,
+    /// #gateway-election reliability: the elected owner's MC channel (`<ch>`; 0 = unknown). Recorded
+    /// from the election each burst. A CO-CHANNEL-capable leaf REFUSES to leaf-lock to an owner whose
+    /// channel is a KNOWN off-channel (!= mesh) — so it keeps re-electing until the co-channel SEIZE
+    /// fires reliably (fixes the racy ~2/3 seize where a happy leaf-lock stopped the recovery bursts).
+    elected_owner_channel: u8,
     /// #23 leaf scan-discovery state (stage 2): locked onto the owner's channel, the
     /// current 1/6/11 scan index, last channel-hop time, last time the owner was heard.
     scan_locked: bool,
@@ -2172,6 +2177,7 @@ impl RadioManager {
             #[cfg(feature = "wled")]
             wled_seq: 0,
             elected_owner: id,
+            elected_owner_channel: 0, // #gateway-election reliability: set from the election each burst
             scan_locked: false,
             scan_idx: 0,
             learned_channel: 0, // #29: unknown until the first frame is heard
@@ -2464,6 +2470,7 @@ impl RadioManager {
             self.owner_hello_seen = false;
         }
         self.elected_owner = elect.owner_id;
+        self.elected_owner_channel = elect.owner_channel; // #gateway-election reliability (leaf-lock guard)
         self.scan_locked = false;
         if elect.i_am_owner {
             // Took over a dead/stale owner (or empty topic): become the coexist GATEWAY.
@@ -3729,8 +3736,15 @@ impl RadioManager {
         // #217 rung-3: co-channel-FIRST pre-fetch gate. Off-channel (ap_ch != mesh — RSSI-
         // INDEPENDENT, the id5 ch1-vs-ch6 bug the rung-2 rssi gate missed) OR weak → co-channel-
         // prefer reassoc before the fetch; fold the outcome into the strand-guard.
-        let off_channel = self.my_ap_channel != ESP_NOW_FIXED_CHANNEL;
-        if off_channel || self.my_rssi_to_ap < CROWN_AP_RSSI_MIN {
+        // #gateway-election reliability (issue 2): my_ap_channel can be transiently 0 here — the
+        // switch(WifiSta) above just (re)issued connect() and the association may not have settled, so
+        // a stale/0 channel would read as "off-channel" and trigger a NEEDLESS reassoc that scanned
+        // away from a good AP and came back ap_ch=0 → OTA aborted. Only reassoc when the channel is
+        // KNOWN (nonzero) and genuinely off-channel/weak; a 0 (unknown/settling) SKIPS the reassoc and
+        // lets run_ota_fetch's own assoc-wait establish the strongest AP (SCAN_METHOD=1 → ch6).
+        let ap_known = self.my_ap_channel != 0;
+        let off_channel = ap_known && self.my_ap_channel != ESP_NOW_FIXED_CHANNEL;
+        if ap_known && (off_channel || self.my_rssi_to_ap < CROWN_AP_RSSI_MIN) {
             log::warn!(
                 "smol #217r3: pre-fetch off_ch={} rssi={} — co-channel-prefer reassoc",
                 off_channel,
@@ -3738,6 +3752,10 @@ impl RadioManager {
             );
             let decision = self.reassoc_ch6_prefer();
             self.note_crown_ap(decision);
+        } else if !ap_known {
+            log::info!(
+                "smol #gateway-election: pre-fetch AP channel unknown (transient after switch) — skipping reassoc, letting the fetch's assoc-wait pick the strongest AP"
+            );
         }
         // Strand-guard OTA-enable: attempt OTA ONLY as a healthy co-channel (Normal) crown. If no
         // co-channel AP is reachable (Degraded/Shed), SKIP the fetch CAP-NEUTRALLY (`true` = "not
@@ -4990,6 +5008,7 @@ impl RadioManager {
                 self.owner_hello_seen = false;
             }
             self.elected_owner = elect.owner_id;
+            self.elected_owner_channel = elect.owner_channel; // #gateway-election reliability (leaf-lock guard)
             if !elect.i_am_owner {
                 self.relay.is_gateway = false;
                 self.scan_locked = false;
@@ -5222,7 +5241,19 @@ impl RadioManager {
                     // #23 leaf channel-lock: a leaf that hears the ELECTED OWNER's
                     // HELLO has found the mesh channel — lock (stop scanning) + stamp
                     // the time (silence re-scan is driven by `leaf_scan_tick`).
-                    if !self.relay.is_gateway && peer_id == self.elected_owner {
+                    // #gateway-election reliability: a CO-CHANNEL-capable board must NOT settle as a
+                    // happy leaf under a PROVEN OFF-CHANNEL owner. Locking (+ resetting owner-silence)
+                    // would stop the recovery bursts that RE-EVALUATE the co-channel SEIZE — making the
+                    // seize racy (it fired only ~2/3, when co_channel happened to be known before the
+                    // leaf-lock). So for a known-off-channel owner we SKIP the lock/silence-reset: the
+                    // leaf keeps re-electing (each recovery burst re-runs the seize with co_channel
+                    // reliably known from my_ap_channel) until it seizes the off-channel crown for good.
+                    let owner_off_channel = crate::net::election::refuse_leaf_lock_off_channel(
+                        self.my_ap_channel,
+                        ESP_NOW_FIXED_CHANNEL,
+                        self.elected_owner_channel,
+                    );
+                    if !self.relay.is_gateway && peer_id == self.elected_owner && !owner_off_channel {
                         self.scan_locked = true;
                         self.last_owner_heard_ms = now;
                         // #114 H1: our elected owner is provably ALIVE on the mesh (heard its
@@ -5231,6 +5262,12 @@ impl RadioManager {
                         // #51 A1: re-locked a valid owner's HELLO → resume normal HELLO
                         // (we are a healthy leaf again, no longer an abdicated ghost).
                         self.silent_until_relock = false;
+                    } else if !self.relay.is_gateway && peer_id == self.elected_owner && owner_off_channel {
+                        log::info!(
+                            "smol: #gateway-election — heard off-channel owner id{} (ch{}); NOT leaf-locking (co-channel, will re-elect to seize)",
+                            peer_id,
+                            self.elected_owner_channel
+                        );
                     }
 
                     // Register the broadcaster so the ACK below can be unicast (#28: bounded LRU).
@@ -6180,6 +6217,7 @@ pub fn start(
     // `synced` stays best-effort for TIME (mesh-time adoption handles an unsynced GW).
     radio.relay.is_gateway = reached_dhcp && elect.i_am_owner;
     radio.elected_owner = elect.owner_id;
+    radio.elected_owner_channel = elect.owner_channel; // #gateway-election reliability (leaf-lock guard)
     // #51 B: if we associated, seed the initial RSSI-to-AP so the first recovery
     // election already has a real signal-strength reading to compare on.
     if reached_dhcp {

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2326,6 +2326,13 @@ impl RadioManager {
         elect.recovery = true;
         elect.my_rssi = self.my_rssi_to_ap;
         elect.my_channel = self.learned_channel; // #29: seed the MC record's <ch> (0 until learned)
+        // #gateway-election: seed the best-gateway fitness signals. co_channel (my AP == the fixed
+        // mesh channel) is the DOMINANT default-weighted input; co_channel_known fail-opens the
+        // empty-MC deferral until the channel is learned. ntp_holder is v1-stubbed false (uniform →
+        // zero ordering effect; wire from `my_synced_at` in a follow-up).
+        elect.co_channel = self.my_ap_channel == ESP_NOW_FIXED_CHANNEL;
+        elect.co_channel_known = self.my_ap_channel != 0;
+        elect.ntp_holder = false;
         elect.seen_owner = self.mc_seen_owner;
         elect.seen_seq = self.mc_seen_seq;
         elect.seen_ms = self.mc_seen_ms;
@@ -4598,6 +4605,12 @@ impl RadioManager {
         // until the first good flush, which mqtt_session's publish guard skips.
         elect.my_rssi = self.my_rssi_to_ap;
         elect.my_channel = self.learned_channel; // #29: seed the MC record's <ch> (0 until learned)
+        // #gateway-election: seed the best-gateway fitness signals (see maybe_leaf_reelect). On the
+        // flush path my_ap_channel is known (a running gateway is associated), so the deferral +
+        // fitness backoff are fully active. ntp_holder v1-stubbed false (follow-up).
+        elect.co_channel = self.my_ap_channel == ESP_NOW_FIXED_CHANNEL;
+        elect.co_channel_known = self.my_ap_channel != 0;
+        elect.ntp_holder = false;
         // #6 OTA: capture any gated retained announce this flush surfaces.
         let mut ota_offer: Option<crate::ota::Announce> = None;
         // #21: capture any default-screen config this flush surfaces.

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2957,6 +2957,23 @@ impl RadioManager {
             }
             Err(_) => CrownApDecision::NoAp,
         };
+        // #gateway-election issue 2: a transient scan that MISSED our co-channel incumbent must NOT
+        // reassociate us to a WORSE off-channel AP. HW bug: after a fetch-leg-deaf fail, this reassoc
+        // jumped id7 from a62bb0 ch6 -63 to a ch11 -78 AP → off-channel → MC|7|11 → retries then
+        // failed OFF-channel. If we are CURRENTLY co-channel and the selector only found an
+        // off-channel fallback / no AP (the co-channel AP just wasn't in THIS scan), STAY PUT: return
+        // a co-channel decision WITHOUT disconnecting, so note_crown_ap keeps us Normal on the good
+        // ch6 AP and the next attempt re-scans + re-picks. A genuine CoChannel decision proceeds below.
+        if self.my_ap_channel == ESP_NOW_FIXED_CHANNEL
+            && !matches!(decision, CrownApDecision::CoChannel { .. })
+        {
+            log::info!(
+                "smol #gateway-election: reassoc scan missed co-channel ({:?}) — STAYING on current ch{} AP (no off-channel downgrade)",
+                decision,
+                self.my_ap_channel
+            );
+            return CrownApDecision::CoChannel { bssid: [0u8; 6], ch: ESP_NOW_FIXED_CHANNEL };
+        }
         // Pin the chosen AP (bssid + channel). A vanished pinned BSSID is recovered by the #195
         // retry re-scan (connect is async — no synchronous fail here); select_crown_ap then re-picks.
         let (bssid, chan): (Option<[u8; 6]>, Option<u8>) = match decision {

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -194,7 +194,7 @@ const CFG_PREFIX: &[u8] = b"SMOLv1 CFG "; // + "NNN" + KEY + verbatim "<value>"
 /// (a `take_cfg_offer(key)` + apply) and a gateway fill site in `mqtt_session`. Sized `[_; N]`
 /// (not `&[u8]`) so [`CfgTracker`] can allocate exactly one `.bss` buffer slot per key.
 /// An inbound key not listed is dropped at [`CfgTracker::set`] (never buffered/applied).
-const CFG_APPLY_KEYS: [u8; 13] = [
+const CFG_APPLY_KEYS: [u8; 14] = [
     crate::net::wifi::CFG_KEY_SCREEN,
     crate::net::wifi::CFG_KEY_LED,
     crate::net::wifi::CFG_KEY_UNITS,
@@ -221,6 +221,10 @@ const CFG_APPLY_KEYS: [u8; 13] = [
     // #197 herald NOTIFY: M — a COMMAND like R/W (buffered/applied via take_cfg_offer(M), NEVER
     // cached: a cached toast would re-show on every boot). One-shot; the leaf toasts + auto-dismisses.
     crate::net::wifi::CFG_KEY_NOTIFY,
+    // #gateway-election all-nodes-WiFi DEBUG flag: A — cached + relayed like U/N (a leaf takes it via
+    // take_cfg_offer(A) → sets debug_wifi_all). Fleet-global; the crown relays the retained value to
+    // every leaf so a node can enable its own WiFi bursts without first reaching the broker.
+    crate::net::wifi::CFG_KEY_WIFI_ALL,
 ];
 /// #50b leaf-status UPLINK tag: `"SMOLv1 STAT "` (12 B, trailing space) then `"NNN"`
 /// (3-ASCII zero-padded SENDER leaf id) then the verbatim live `<AppKind>:<page>` value
@@ -2059,6 +2063,12 @@ pub struct RadioManager {
     /// esp-wifi chose) → treated as off-channel so the first pre-fetch runs the co-channel scan.
     /// `off-channel` ⇔ `my_ap_channel != ESP_NOW_FIXED_CHANNEL`.
     my_ap_channel: u8,
+    /// #gateway-election ALL-NODES-WiFi DEBUG flag (from the retained `smol/config/wifi_all`, key
+    /// `A`, relayed to leaves). When true, THIS node runs its own periodic WiFi telemetry burst even
+    /// as a leaf (`relay_ready_to_flush` ungate — the debug flush claim-SUPPRESSES so it never
+    /// perturbs the crown election) and may self-fetch OTA on its own install command. DEBUG lever,
+    /// default false (normal operation = crown-only WiFi).
+    debug_wifi_all: bool,
     /// #217 rung-3: crown coexist state (Normal = co-channel + OTA-enabled; Degraded = off-channel
     /// but MQTT/mesh KEPT ALIVE + OTA disabled; Shed = abdicated). Drives the OTA-enable gate + the
     /// never-crownless strand-guard (`net::coexist::crown_next_state`).
@@ -2186,6 +2196,7 @@ impl RadioManager {
             silent_until_relock: false,
             my_rssi_to_ap: -99,
             my_ap_channel: 0, // #217 rung-3: unknown until a co-channel scan pins it
+            debug_wifi_all: false, // #gateway-election: all-nodes-WiFi debug flag, default OFF
             crown_state: crate::net::coexist::CrownState::Normal, // #217 rung-3
             shed_reclaims: 0, // #217 rung-3 strand-guard
             // #57: seed the familiar with our id (heartbeat phase + arbitration id).
@@ -3374,6 +3385,17 @@ impl RadioManager {
         self.relay.is_gateway
     }
 
+    /// #gateway-election: set the all-nodes-WiFi DEBUG flag (applied by `main` from the relayed /
+    /// gateway-own `A` config, `take_cfg_offer(CFG_KEY_WIFI_ALL)`). When true, THIS node does its own
+    /// periodic WiFi bursts even as a leaf (`relay_ready_to_flush` / `flush_telemetry` ungate) and may
+    /// self-fetch OTA; the debug flush claim-SUPPRESSES so it never perturbs the crown election.
+    pub fn set_debug_wifi_all(&mut self, on: bool) {
+        if self.debug_wifi_all != on {
+            log::info!("smol #gateway-election: all-nodes-WiFi debug -> {}", on);
+        }
+        self.debug_wifi_all = on;
+    }
+
     /// #27/#29: this node's current ESP-NOW channel for the peers + MC publish. Leaf = its
     /// locked scan channel (`CANDIDATES[scan_idx]` while `scan_locked`), else 0 (scanning);
     /// gateway = its `learned_channel` (#29 — the channel `rx_control` last saw a frame on;
@@ -3587,7 +3609,10 @@ impl RadioManager {
     /// Gateway only: are there buffered messages due for a flush burst (queue full,
     /// or the flush interval has elapsed with a non-empty queue)?
     pub fn relay_ready_to_flush(&self, now: u64) -> bool {
-        if !self.relay.is_gateway {
+        // #gateway-election all-nodes-WiFi DEBUG: normally only the crown flushes. When the debug flag
+        // is set, a NON-gateway node also flushes on the interval (reads the broker + publishes its own
+        // telemetry + can self-fetch OTA) — the debug flush claim-SUPPRESSES so it never claims the crown.
+        if !self.relay.is_gateway && !self.debug_wifi_all {
             return false;
         }
         let pending = self.relay.queue.iter().filter(|q| q.used).count();
@@ -4566,7 +4591,10 @@ impl RadioManager {
         leaf_ota: &mut Option<(u8, crate::ota::Announce)>,
         tick: &mut dyn FnMut() -> bool,
     ) -> bool {
-        if !self.relay.is_gateway {
+        // #gateway-election all-nodes-WiFi DEBUG: a NON-gateway reaches here only with the debug flag
+        // set (relay_ready_to_flush gates the same way). It bursts telemetry + reads the broker + can
+        // self-fetch, then returns to the mesh below; the election claim is suppressed (see the seed).
+        if !self.relay.is_gateway && !self.debug_wifi_all {
             return false;
         }
         log::info!("smol: relay flush -> MQTT burst (mesh deaf on ch6 during it)");
@@ -4611,6 +4639,14 @@ impl RadioManager {
         elect.co_channel = self.my_ap_channel == ESP_NOW_FIXED_CHANNEL;
         elect.co_channel_known = self.my_ap_channel != 0;
         elect.ntp_holder = false;
+        // #gateway-election all-nodes-WiFi DEBUG: a NON-gateway node only reaches this flush because
+        // its debug flag is set. It must NEVER claim the crown (that would let every debug node fight
+        // for ownership) — suppress the claim exactly like the #146 flush-incapable guard, so the
+        // debug flush publishes telemetry + reads the broker + can self-fetch, but leaves the real
+        // election untouched. A genuine crown (is_gateway) is unaffected (flush_incapable stays false).
+        if !self.relay.is_gateway {
+            elect.flush_incapable = true;
+        }
         // #6 OTA: capture any gated retained announce this flush surfaces.
         let mut ota_offer: Option<crate::ota::Announce> = None;
         // #21: capture any default-screen config this flush surfaces.
@@ -4826,6 +4862,11 @@ impl RadioManager {
         if let Some((buf, len)) = gw_own.ota {
             self.cfg.set(crate::net::wifi::CFG_KEY_OTA, &buf[..len]);
         }
+        // #gateway-election: the crown's OWN all-nodes-WiFi debug flag — same self-apply path
+        // (take_cfg_offer(A) → set debug_wifi_all).
+        if let Some((buf, len)) = gw_own.wifi_all {
+            self.cfg.set(crate::net::wifi::CFG_KEY_WIFI_ALL, &buf[..len]);
+        }
         // #72: the gateway's OWN io pin-map — same self-apply path (take_cfg_offer(G)).
         #[cfg(feature = "io")]
         if let Some((buf, len)) = gw_own.io {
@@ -4999,6 +5040,14 @@ impl RadioManager {
                 self.relay.flush_fails,
                 RELAY_FLUSH_INTERVAL_MS
             );
+        }
+        // #gateway-election all-nodes-WiFi DEBUG: a non-gateway debug node bursts then RETURNS to the
+        // mesh (a real crown STAYS associated for coexist). The ok-path above only drops to EspNow when
+        // it adopts a live owner; ensure a debug leaf returns to ch6 after EVERY burst — including a
+        // FAILED one — so it stays a functional mesh member between its periodic debug bursts.
+        // `switch` is a no-op when already in the mode, so this never double-switches.
+        if !self.relay.is_gateway {
+            let _ = self.switch(Mode::EspNow);
         }
         ok
     }

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2420,6 +2420,12 @@ impl RadioManager {
         if let Ok(r) = self.controller.rssi() {
             self.my_rssi_to_ap = r.clamp(-127, 0) as i8;
         }
+        // #217 rung-3: refresh the REAL associated AP channel at this stable association point so
+        // `off_channel` (my_ap_channel != mesh) drives the pre-fetch 2B co-channel gate + DIAG
+        // accurately — no boot-time reassoc needed.
+        if let Some((ap_ch, _, _)) = crate::net::current_ap_info() {
+            self.my_ap_channel = ap_ch;
+        }
         // Persist the refreshed staleness observation (so takeover accrues across bursts).
         self.mc_seen_owner = elect.seen_owner;
         self.mc_seen_seq = elect.seen_seq;
@@ -6078,35 +6084,18 @@ pub fn start(
             radio.my_rssi_to_ap = r.clamp(-127, 0) as i8;
         }
     }
-    // #217 rung-2A: PROACTIVE reassoc at CROWN-ASSUMPTION. If this board just won the crown on a
-    // WEAK AP (rssi < -75 — the pcap deaf-AP class), steer to a strong ch6 AP BEFORE the coexist
-    // gateway commits below ("mesh rides my AP channel"). Crowning on a doomed link otherwise
-    // guarantees the #204 bulk-RX-deaf disease. reassoc_ch6_prefer no-ops mid mesh-OTA (ota_leaf).
-    // rssi trigger only this rung; ch-mismatch is a follow-up (no trivial current-AP-channel
-    // accessor at this site yet). Re-capture rssi after so #51 election + coexist use the new value.
-    // #217 rung-3: the ch-mismatch trigger the rung-2 comment deferred ("no trivial current-AP-
-    // channel accessor yet") is now `my_ap_channel`. Off-channel (ap_ch != mesh — RSSI-INDEPENDENT,
-    // the id5 ch1-vs-ch6 bug) OR weak → co-channel-prefer reassoc BEFORE the coexist gateway
-    // commits, then fold into the never-crownless strand-guard. Leaves stay on ESP_NOW_FIXED_CHANNEL.
+    // #217 rung-3 (HW-fix v900): do NOT reassoc at crown-assumption. burst_ntp's boot association
+    // (used for DHCP/NTP/boot-MQTT) must NOT be torn down here — `start()` time-share-switches to
+    // ESP-NOW immediately after, so a disconnect + pinned-reconnect would never complete → the crown
+    // ends un-associated → no telemetry. (v900 regression: `my_ap_channel` defaulted to 0, so the
+    // off_channel gate fired for EVERY crown, not just off-channel ones.) Co-channel is only required
+    // in the OTA/coexist window (crown fetching WHILE serving the mesh) — achieved JUST-IN-TIME at
+    // the pre-fetch 2B gate, where run_ota_fetch's assoc-wait absorbs the reconnect and the
+    // strand-guard gates OTA. Here we ONLY capture the REAL associated channel so off_channel is
+    // accurate for 2B + DIAG; crown stays Normal at boot (not pre-judged).
     if radio.relay.is_gateway {
-        let off_channel = radio.my_ap_channel != ESP_NOW_FIXED_CHANNEL;
-        if off_channel || radio.my_rssi_to_ap < CROWN_AP_RSSI_MIN {
-            log::warn!(
-                "smol #217r3: crown-assumption off_ch={} rssi={} — co-channel-prefer reassoc",
-                off_channel,
-                radio.my_rssi_to_ap
-            );
-            let decision = radio.reassoc_ch6_prefer();
-            radio.note_crown_ap(decision);
-            if let Ok(r) = radio.controller.rssi() {
-                radio.my_rssi_to_ap = r.clamp(-127, 0) as i8;
-            }
-        } else {
-            // Already co-channel + strong → healthy crown; clear any prior strand latch.
-            radio.note_crown_ap(crate::net::coexist::CrownApDecision::CoChannel {
-                bssid: [0; 6],
-                ch: ESP_NOW_FIXED_CHANNEL,
-            });
+        if let Some((ap_ch, _, _)) = crate::net::current_ap_info() {
+            radio.my_ap_channel = ap_ch;
         }
     }
     // #23 fix: persist the boot election's staleness observation → a leaf's later

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -4717,14 +4717,18 @@ impl RadioManager {
             if escalate {
                 let shed_justified = self.relay.deaf_bulk_seen
                     || self.relay.crown_deaf_streak >= DEAF_SHED_DEEP_STREAK;
-                // #217 rung-3 STRAND-GUARD: never shed into a crownless gap. If the co-channel
-                // selector has LATCHED `Degraded` (M reclaims proved NO co-channel AP is reachable),
-                // a successor would be off-channel too → shedding only starts crownless churn. Stay
-                // crown, degraded (MQTT/mesh alive, OTA off). A ch6-heal → `Normal` clears the latch
-                // and normal #204 shedding resumes. (Deafness on a ch6 AP keeps crown_state=Normal,
-                // so this never suppresses a legitimate #204 self-heal shed.)
+                // #217 rung-3 STRAND-GUARD: never shed into a crownless gap. Suppress the deaf-shed
+                // abdication whenever the crown is NOT co-channel (state != Normal = Shed OR Degraded).
+                // Gating on `!= Normal` (not `== Degraded`) closes a RACE: DEAF_SHED_M fires the
+                // abdication at reassoc_cycles>=2, but the Degraded latch needs shed_reclaims>=3 — so
+                // `== Degraded` left a shed_reclaims=1,2 window (state=Shed) where a sole off-channel
+                // crown could abdicate ~1 cycle BEFORE latching → a bounded crownless gap. `!= Normal`
+                // engages the instant the co-channel selector confirms no co-channel AP (Shed), so the
+                // never-crownless invariant holds BY CONSTRUCTION, not by a timing race. SAFE for #204:
+                // a co-channel decision resets crown_state to Normal, so a legitimate ch6-AP deaf-shed
+                // (deaf for non-channel reasons) stays Normal → NOT suppressed.
                 let strand_latched =
-                    self.crown_state == crate::net::coexist::CrownState::Degraded;
+                    self.crown_state != crate::net::coexist::CrownState::Normal;
                 if strand_latched {
                     log::warn!(
                         "smol #217r3: deaf-shed SUPPRESSED — strand-latched (no co-channel AP); staying crown (never crownless)"

--- a/rust/clock/src/net/ota_resume.rs
+++ b/rust/clock/src/net/ota_resume.rs
@@ -1,0 +1,50 @@
+//! #267 — the PURE resume-key logic for cross-burst OTA-fetch resume.
+//!
+//! ## What this is
+//! The OTA self-fetch / relay-fetch downloads the image as sequential HTTP `Range` chunks; a
+//! broken chunk resumes from `ImageWriter::written()` — but that cursor only lived for one
+//! `run_ota_fetch` call. The #195 retry is **per burst within one boot** (the #100 in-RAM idiom),
+//! so each burst re-invoked `ImageWriter::begin()`, which reset the cursor (and the streaming SHA)
+//! to 0 → every retry re-`Range`d from byte 0. Under the coexist bulk-RX disease (≈1 chunk/burst)
+//! a multi-chunk image never accumulated (#267).
+//!
+//! The fix keeps a same-boot, cross-burst resume cursor (in `.bss` — **no NVS**, since the retry
+//! never crosses a reboot; a reboot legitimately restarts from 0). This module is the **pure,
+//! host-testable brain**: given a saved cursor and the current `(build, sha, slot)`, what offset
+//! is it safe to resume from? Keying it to the exact staged image + target slot means a *re-stage*
+//! or a slot flip forces a fresh fetch from byte 0 (never resume onto a stale/wrong prefix). The
+//! HW flash writer + the `.bss` static live in `crate::ota`; this module holds only the decision.
+//! Host-tested in `experiments/267_resume_verify` (the `flood`/`etx`/`ledger` pattern).
+
+/// Identifies the staged image + target slot a resume cursor belongs to. A resume is honored only
+/// when the current fetch's key equals the saved one — so a newer staged build, a different image
+/// with the same build number, or a flipped inactive slot all invalidate the cursor.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ResumeKey {
+    /// Monotonic build number from the signed manifest.
+    pub build: u32,
+    /// First 16 bytes of the announced sha256 — ample to disambiguate two images (2⁻¹²⁸).
+    pub sha_key: [u8; 16],
+    /// Target (inactive) slot: `0` = Slot0, `1` = Slot1.
+    pub slot: u8,
+}
+
+/// The first 16 bytes of an announced sha256 — the resume key's image discriminator.
+pub fn sha_key16(sha: &[u8; 32]) -> [u8; 16] {
+    let mut k = [0u8; 16];
+    k.copy_from_slice(&sha[..16]);
+    k
+}
+
+/// The offset a fresh `ImageWriter::begin` may resume from.
+///
+/// Returns `committed` iff a cursor is saved, its key **exactly** matches `want`, and
+/// `0 < committed <= size` (the committed prefix fits the slot). Otherwise `0` — a fresh fetch from
+/// byte 0. `committed` is expected to be a flush boundary (sector-aligned) by construction; this
+/// pure decision does not depend on that, but the caller must only *save* on-flash (flushed) bytes.
+pub fn resume_offset(saved: Option<(ResumeKey, u32)>, want: &ResumeKey, size: u32) -> u32 {
+    match saved {
+        Some((key, committed)) if key == *want && committed > 0 && committed <= size => committed,
+        _ => 0,
+    }
+}

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -4932,8 +4932,12 @@ pub fn run_ota_fetch(
                             header_buf[header_len..header_len + take]
                                 .copy_from_slice(&data[..take]);
                             header_len += take;
-                            if let Some(bstart) = crate::ota::header_end(&header_buf[..header_len]) {
-                                match crate::ota::status_code(&header_buf[..header_len]) {
+                            if let Some(bstart) = crate::net::http::header_end(&header_buf[..header_len]) {
+                                // #gateway-election byte-0 FIX: parse the HEADER SLICE (`..bstart`),
+                                // NOT the whole buffer — when the header + start of the binary body
+                                // coalesce into one segment, feeding the body to from_utf8 made the
+                                // status parse None → the fetch died at byte 0 on a perfectly good 206.
+                                match crate::net::http::status_code(&header_buf[..bstart]) {
                                     Some(206) => {} // Partial Content — Range honoured
                                     Some(200) if off == 0 => {
                                         // Server ignored Range → full-body fallback (the old
@@ -4941,7 +4945,7 @@ pub fn run_ota_fetch(
                                         // before; this GET is NOT resumable (checked after drain).
                                         range_ok = false;
                                         if let Some(cl) =
-                                            crate::ota::content_length(&header_buf[..header_len])
+                                            crate::net::http::content_length(&header_buf[..bstart])
                                         {
                                             if cl != announce.size {
                                                 bad = true;

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1360,6 +1360,21 @@ pub const CFG_KEY_IO_SET: u8 = b'g';
 #[allow(dead_code)]
 pub const CFG_KEY_NOTIFY: u8 = b'M';
 
+/// #gateway-election ALL-NODES-WiFi DEBUG flag (key `A`, verified free against the family
+/// `S L U P R Y W N B O G g M`). Fleet-GLOBAL, retained `smol/config/wifi_all`, value `0`/`1`.
+/// RETAINED/CACHED STATE (relayed like `U`/`N` under [`CFG_TARGET_ALL`]) — normally only the crown
+/// does WiFi bursts; when set, ANY node runs its own periodic telemetry burst (reads the broker +
+/// publishes its own telemetry) AND may self-fetch OTA on its own install command, so JP can verify
+/// each board's association / co-channel / OTA in isolation. Applied by setting
+/// `RadioManager::debug_wifi_all` (ungates `relay_ready_to_flush`; the debug flush claim-SUPPRESSES
+/// so it never perturbs the real crown election). DEBUG lever — default OFF; while ON every node
+/// periodically goes mesh-deaf + associates (the mesh fragments across channels), which is the
+/// intended test condition, not a normal-operation setting. Same wifi-tier/allow(dead_code)
+/// rationale as `R`/`W` (unused in a wifi-only build with no RadioManager).
+#[cfg(feature = "wifi")]
+#[allow(dead_code)]
+pub const CFG_KEY_WIFI_ALL: u8 = b'A';
+
 /// #48 (GwOwnCfg — approved arch): the GATEWAY's OWN per-node configs read from its own MQTT
 /// topics this burst. A leaf gets these RELAYED (→ its `CfgTracker`); the gateway reads them
 /// DIRECTLY. Bundled into ONE `run_mqtt_burst`/`mqtt_session` out-param (net +1, not +N) — after
@@ -1394,6 +1409,10 @@ pub struct GwOwnCfg {
     /// #100 Stage 3 the gateway's own `smol/<id>/config/ota_host` (or global `smol/config/ota_host`)
     /// OTA-host override value `(buf, len)`, or `None` if absent this burst.
     pub ota: Option<([u8; CFG_VALUE_MAX], usize)>,
+    /// #gateway-election the GLOBAL `smol/config/wifi_all` all-nodes-WiFi debug flag `(buf, len)`, or
+    /// `None` if absent this burst. The gateway self-applies it (sets its own `debug_wifi_all`) via
+    /// the CfgTracker inject, and relays it to leaves under `CFG_TARGET_ALL` (key `A`).
+    pub wifi_all: Option<([u8; CFG_VALUE_MAX], usize)>,
     /// #72 the gateway's own `smol/<id>/config/io` pin-map value `(buf, len)`, or `None` if
     /// absent this burst. `io`-gated so a non-io build's struct is byte-unchanged.
     #[cfg(feature = "io")]
@@ -1414,6 +1433,7 @@ impl GwOwnCfg {
             net: None,
             broker: None,
             ota: None,
+            wifi_all: None,
             #[cfg(feature = "io")]
             io: None,
             #[cfg(feature = "io")]
@@ -2252,6 +2272,13 @@ fn mqtt_session(
         if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 11, b"smol/config/units") {
             let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
         }
+        // #gateway-election all-nodes-WiFi debug flag (pid 27): the GLOBAL retained
+        // `smol/config/wifi_all` (`0`/`1`, no id). The crown caches it under CFG_TARGET_ALL so ONE
+        // relayed `<255>A<val>` frame reaches every leaf (they enable their own WiFi bursts without
+        // needing to read the broker themselves), and self-applies its own flag (gw_own.wifi_all).
+        if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 27, b"smol/config/wifi_all") {
+            let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+        }
         // #55 plugin visibility (pid 12): wildcard-subscribe every leaf's retained plugin mask so
         // the gateway caches + relays it (key `P`) over ESP-NOW, twin of the led wildcard.
         if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 12, b"smol/+/config/plugins") {
@@ -2819,6 +2846,20 @@ fn mqtt_session(
                         gw_own.units = Some(GwOwnCfg::val(payload));
                         log::info!(
                             "smol #43: global display units captured ({} B) — cached (255,U) + self",
+                            payload.len()
+                        );
+                    } else if topic == b"smol/config/wifi_all" {
+                        // #gateway-election all-nodes-WiFi DEBUG flag — GLOBAL (no id). Twin of the
+                        // units branch: (1) cache under CFG_TARGET_ALL so ONE relayed `<255>A<val>`
+                        // frame reaches every leaf; (2) capture into gw_own so `service()` self-applies
+                        // the crown's own flag. Value is `0`/`1` (parsed at apply time in main).
+                        if let Some(cache) = cfg_cache.as_deref_mut() {
+                            let now = Instant::now().duration_since_epoch().as_millis();
+                            cache.set(CFG_TARGET_ALL, CFG_KEY_WIFI_ALL, payload, [0u8; 6], now);
+                        }
+                        gw_own.wifi_all = Some(GwOwnCfg::val(payload));
+                        log::info!(
+                            "smol #gateway-election: all-nodes-WiFi flag captured ({} B) — cached (255,A) + self",
                             payload.len()
                         );
                     } else if let Some(leaf_id) = parse_leaf_config_topic(topic, b"/config/plugins") {

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -185,6 +185,12 @@ pub struct MeshElect {
     /// Best-gateway election: this board holds NTP-authoritative time (`synced_at != 0`) — a better
     /// gateway can serve TIME frames. Seeded by the caller (0-weight-equivalent while uniformly false).
     pub ntp_holder: bool,
+    /// #gateway-election LAYER 2: the fixed mesh channel (`ESP_NOW_FIXED_CHANNEL`), seeded by the
+    /// caller. Lets the resolver detect an OFF-channel owner (retained MC `<ch>` known and != this)
+    /// so a CO-CHANNEL board seizes the wrong (off-channel, OTA-deaf) crown IMMEDIATELY instead of
+    /// deferring to it (the dead/ghost or off-channel id5 case). 0 = unknown (unseeded / boot before
+    /// association) → the off-channel override never fires (safe).
+    pub mesh_channel: u8,
     /// Best-gateway election FAIL-OPEN guard: true iff this board's AP channel is KNOWN (`my_ap_channel
     /// != 0`), so `co_channel` is trustworthy. The empty-MC claim deferral fires ONLY when this is set —
     /// a freshly-booted board (pre-scan, channel unknown) claims a vacant crown IMMEDIATELY (fast
@@ -237,6 +243,7 @@ impl MeshElect {
             channel_hint: None, // #155: seeded by the caller from the retained smol/mesh/channel_hint
             co_channel: false, // best-gateway: seeded by the caller from my_ap_channel == mesh
             ntp_holder: false, // best-gateway: seeded by the caller from synced_at != 0
+            mesh_channel: 0, // LAYER 2: seeded by the caller (ESP_NOW_FIXED_CHANNEL); 0 → override off
             co_channel_known: false, // best-gateway: false at boot (channel unknown) → claim fast
             // best-gateway is ON by default (team-lead 2026-07-20); the retained smol/mesh/elect topic
             // re-weights or selects `legacy`. Absent/empty/garbage config keeps THIS default.
@@ -3372,7 +3379,7 @@ fn mqtt_session(
     // by `reset` (owner-changed OR seq-advanced this burst — see the alive branch + #114 churn
     // residual note), so no separate pre-observation snapshot of `seen_owner` is needed here.
     let claim_seq: Option<u32> = match mc {
-        Some((owner, _ch, seq)) => {
+        Some((owner, mc_ch, seq)) => {
             // Refresh the staleness observation: a *changed* (owner,seq) resets the first-seen
             // clock. Same rule on BOTH paths — an ADVANCING seq is the authoritative
             // broker-liveness signal (a dead board can't publish), so it MUST reset "alive"
@@ -3410,8 +3417,14 @@ fn mqtt_session(
             // over (#136 canary 1). A genuinely-dead owner's seq is frozen forever, so it is still
             // taken over at the window (#136 canary 2). Tracks #122 B1 automatically (at F=20 the
             // floor is 20+15=35, already covered). NEVER-heard keeps MC_STALE_MS (3×F, ≥ the floor).
+            // #gateway-election LAYER 2: a never-heard owner is normally taken over only after the
+            // CONSERVATIVE MC_STALE_MS (90 s = 3 missed flushes) so a live-but-unheard owner is never
+            // misjudged. But a CO-CHANNEL board is the legitimate best gateway — when it can't hear
+            // the named owner (ghost / off-channel incumbent it can't reach on ch6), it takes over on
+            // the FASTER RECOVERY_STALE_MS window (still frozen-seq-gated: a live owner's advancing
+            // seq resets `alive` and is adopted). Halves the "scanning for a dead owner" limbo.
             let stale_limit = if elect.recovery {
-                if elect.owner_never_heard {
+                if elect.owner_never_heard && !elect.co_channel {
                     MC_STALE_MS
                 } else {
                     RECOVERY_STALE_MS.max(elect.recovery_stale_floor_ms)
@@ -3420,7 +3433,35 @@ fn mqtt_session(
                 MC_STALE_MS
             };
             let alive = elect.now_ms.saturating_sub(elect.seen_ms) < stale_limit;
-            if elect.boot && owner != node_id {
+            // #gateway-election LAYER 2 OVERRIDE (the crown-migration fix): a CO-CHANNEL board seizes
+            // an owner PROVEN off-channel (its retained MC `<ch>` is KNOWN and != the mesh channel)
+            // IMMEDIATELY — an off-channel crown is the OTA-deaf WRONG gateway (the whole #204/#217
+            // disease), so the better board must win + hold, not defer to it (the id5-was-ch1-crown
+            // ghost). Bypasses the boot-defer + sticky-live-owner arms (it fires even against an
+            // "alive" off-channel owner — that IS the intended preemption). Once it crowns it publishes
+            // `MC|self|<mesh-ch>`, and no OTHER co-channel board preempts a co-channel owner → STABLE,
+            // no flap. Guarded: only a co-channel board (`co_channel`) with a KNOWN mesh channel, only
+            // a KNOWN-off-channel owner, never self. A live co-channel owner (MC `<ch> == mesh`) or an
+            // unknown-channel owner (`mc_ch == 0`) is untouched → resolved by the normal arms below.
+            let owner_off_channel = crate::net::election::seize_off_channel_owner(
+                elect.co_channel,
+                elect.mesh_channel,
+                node_id,
+                owner,
+                mc_ch,
+            );
+            if owner_off_channel {
+                log::info!(
+                    "smol: #gateway-election LAYER 2 — co-channel (ch{}) SEIZING off-channel owner id{} (its ch{}) — crown migration",
+                    elect.mesh_channel,
+                    owner,
+                    mc_ch
+                );
+                elect.owner_alive = false;
+                elect.i_am_owner = true;
+                elect.owner_id = node_id;
+                Some(seq.wrapping_add(1))
+            } else if elect.boot && owner != node_id {
                 // #51 return-flap fix: a FRESH-booting board never displaces a DIFFERENT owner
                 // already in the retained MC. Come up as a leaf and defer — leaf-scan locks a
                 // LIVE owner's HELLO in seconds (no re-claim bounce), and the recovery election

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -3378,6 +3378,32 @@ fn mqtt_session(
     // NB: the "same owner we're waiting out" vs "a live owner to grace" distinction is now made
     // by `reset` (owner-changed OR seq-advanced this burst — see the alive branch + #114 churn
     // residual note), so no separate pre-observation snapshot of `seen_owner` is needed here.
+    // #gateway-election LAYER 2 (regression fix): make `co_channel` AUTHORITATIVE at election time.
+    // The BOOT election runs inside `burst_ntp` BEFORE `my_ap_channel` is refreshed (mode.rs seeds it
+    // AFTER burst_ntp), so the boot resolver saw co_channel=FALSE and could never fire the co-channel
+    // seize — the node deferred to the off-channel owner, then a happy leaf (ESP-NOW-locked to that
+    // owner's channel, hearing its HELLO → owner-silence never accrues) never re-elected, so the
+    // seize never ran again. Fix: we ARE associated in EVERY broker burst (boot/recovery/flush), so
+    // read the LIVE AP channel here (`esp_wifi_sta_get_ap_info`) and recompute co_channel vs the
+    // seeded mesh channel — and LOG it so the co-channel decision is visible on serial. espnow-only
+    // (current_ap_info is espnow-gated); a wifi-only build keeps the caller's seed (no mesh/election).
+    #[cfg(feature = "espnow")]
+    if elect.mesh_channel != 0 {
+        match crate::net::current_ap_info() {
+            Some((ap_ch, ap_rssi, _)) => {
+                elect.co_channel = ap_ch == elect.mesh_channel;
+                elect.co_channel_known = true;
+                log::info!(
+                    "smol: #gateway-election AP ch={} rssi={} mesh_ch={} -> co_channel={}",
+                    ap_ch,
+                    ap_rssi,
+                    elect.mesh_channel,
+                    elect.co_channel
+                );
+            }
+            None => log::info!("smol: #gateway-election — current_ap_info None (not associated at election?)"),
+        }
+    }
     let claim_seq: Option<u32> = match mc {
         Some((owner, mc_ch, seq)) => {
             // Refresh the staleness observation: a *changed* (owner,seq) resets the first-seen
@@ -3461,6 +3487,30 @@ fn mqtt_session(
                 elect.i_am_owner = true;
                 elect.owner_id = node_id;
                 Some(seq.wrapping_add(1))
+            } else if crate::net::election::yield_to_co_channel_owner(
+                elect.co_channel_known,
+                elect.co_channel,
+                elect.mesh_channel,
+                node_id,
+                owner,
+                mc_ch,
+                alive,
+            ) {
+                // #gateway-election LAYER 2 (symmetric YIELD — makes the seize STICK): an OFF-channel
+                // board ADOPTS a LIVE co-channel owner (MC <ch> == mesh) regardless of id, instead of
+                // re-claiming via the lowest-id rule below. Without this a LOWER-id off-channel crown
+                // (id5) would re-take the crown from the co-channel board (id7) every flush → endless
+                // flap; with it the off-channel crown yields and the co-channel seize converges stable.
+                log::info!(
+                    "smol: #gateway-election LAYER 2 — off-channel YIELDING to co-channel owner id{} (its ch{}, mesh ch{})",
+                    owner,
+                    mc_ch,
+                    elect.mesh_channel
+                );
+                elect.owner_alive = true;
+                elect.i_am_owner = false;
+                elect.owner_id = owner;
+                None
             } else if elect.boot && owner != node_id {
                 // #51 return-flap fix: a FRESH-booting board never displaces a DIFFERENT owner
                 // already in the retained MC. Come up as a leaf and defer — leaf-scan locks a
@@ -3658,8 +3708,18 @@ fn mqtt_session(
         elect.seen_owner = node_id;
         elect.seen_seq = newseq;
         elect.seen_ms = elect.now_ms;
+        // #gateway-election LAYER 2: a CO-CHANNEL crown MUST advertise the MESH channel in its MC
+        // <ch> (not the possibly-still-0 learned ESP-NOW channel), so an OFF-channel board recognizes
+        // it as co-channel and YIELDS (yield_to_co_channel_owner) instead of re-claiming via lowest-id
+        // — THAT is what makes the seize STICK (id5 yields to id7 → no flap). A non-co-channel
+        // claimant keeps its real learned channel (#29 unchanged when co_channel is false/unknown).
+        let pub_ch = if elect.co_channel && elect.mesh_channel != 0 {
+            elect.mesh_channel
+        } else {
+            elect.my_channel
+        };
         let mut mcp = MqttScratch::new();
-        let _ = write!(mcp, "MC|{}|{}|{}", node_id, elect.my_channel, newseq); // #29: real ch (0 until learned)
+        let _ = write!(mcp, "MC|{}|{}|{}", node_id, pub_ch, newseq); // #29/#gateway-election: co-channel crown advertises mesh ch
         // #51 A2 — CLAIM-AFTER-PUBLISH: only actually hold ownership if the retained MC
         // write reached the broker (proof our uplink is alive). If the publish fails, we
         // are NOT a valid owner — revert to leaf so ownership can't land on a board whose
@@ -3723,7 +3783,7 @@ fn mqtt_session(
                     // the retained record names us (the lowest); it yields when it re-reads.
                     let reseq = seq2.wrapping_add(1);
                     let mut mcp2 = MqttScratch::new();
-                    let _ = write!(mcp2, "MC|{}|{}|{}", node_id, elect.my_channel, reseq);
+                    let _ = write!(mcp2, "MC|{}|{}|{}", node_id, pub_ch, reseq); // #gateway-election: co-channel crown advertises mesh ch
                     if let Some(n) =
                         crate::net::mqtt::encode_publish(&mut pkt, MESH_CHANNEL_TOPIC, mcp2.as_bytes(), true)
                     {

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -4638,6 +4638,16 @@ pub fn run_ota_fetch(
         };
         if let Some((addr, router)) = configured {
             apply_dhcp(&mut iface, addr, router);
+            // #gateway-election fetch-leg diag: our DHCP IP + the server we're about to hit — so serial
+            // confirms id7 landed on the right subnet to REACH the image host (rules out a routing/
+            // firewall/VLAN mismatch as the byte-0 cause vs an on-air RX deafness).
+            log::info!(
+                "smol OTA: DHCP lease {:?} router {:?} — connecting {}:{}",
+                addr,
+                router,
+                host,
+                port
+            );
             break;
         }
         if Instant::now() > deadline {
@@ -4878,12 +4888,24 @@ pub fn run_ota_fetch(
             }
         }
 
+        // #gateway-election fetch-leg instrumentation: the handshake COMPLETED (may_send true above),
+        // so a byte-0 failure is post-connect — log that the request went out so serial shows whether
+        // the RESPONSE arrives (rx_total below) vs the handshake (which we already passed).
+        log::info!(
+            "smol OTA: chunk range {}-{} GET sent (TCP up) — awaiting 206",
+            off,
+            end
+        );
         // Drain this chunk's response into the writer (streaming; headers validated once/chunk).
         let chunk_start = writer.written();
         let mut header_buf = [0u8; 512];
         let mut header_len = 0usize;
         let mut headers_done = false;
         let mut bad = false;
+        // #gateway-election fetch-leg RX instrumentation: total bytes the socket delivered this chunk.
+        // 0 at break ⇒ RX-DEAF (handshake ok but no response bytes — the coexist/RF starvation);
+        // >0 with bad ⇒ a NON-206 / garbled response (logged verbatim below). Distinguishes the two.
+        let mut rx_total = 0usize;
         // #217: per-body-progress stall timer (see OTA_BODY_STALL). Tracks body advance so a byte-0
         // hang on an RX-deaf, never-closing connection falls through to the outer stall guard FAST
         // instead of spinning to the global DEADLINE.
@@ -4900,6 +4922,7 @@ pub fn run_ota_fetch(
                 let s = sockets.get_mut::<tcp::Socket>(tcp_handle);
                 if s.can_recv() {
                     let outcome = s.recv(|data| {
+                        rx_total += data.len(); // #gateway-election: count every delivered byte
                         if !headers_done {
                             let take = core::cmp::min(header_buf.len() - header_len, data.len());
                             if take == 0 {
@@ -4926,7 +4949,20 @@ pub fn run_ota_fetch(
                                             }
                                         }
                                     }
-                                    _ => {
+                                    other => {
+                                        // #gateway-election fetch-leg diag: log the ACTUAL status + the
+                                        // raw response head so serial shows whether the server sent a
+                                        // non-206 (404/416/…) or a GARBLED header (partial RX). This is
+                                        // the definitive RX-deaf-vs-parse discriminator team-lead needs.
+                                        let n = header_len.min(96);
+                                        log::error!(
+                                            "smol OTA: NON-206 st={:?} range {}-{} rx={}B — head: {:?}",
+                                            other,
+                                            off,
+                                            end,
+                                            rx_total,
+                                            core::str::from_utf8(&header_buf[..n]).unwrap_or("<non-utf8>")
+                                        );
                                         bad = true; // non-206 range reply (or 200 mid-stream)
                                         return (take, false);
                                     }
@@ -4981,6 +5017,17 @@ pub fn run_ota_fetch(
             }
         }
 
+        // #gateway-election fetch-leg RX instrumentation: the decisive line. rx=0 ⇒ handshake ok but
+        // ZERO response bytes = RX-DEAF (coexist/RF starvation — the fetch-leg deafness). rx>0 + bad ⇒
+        // a real non-206/garbled reply (logged verbatim above). rx>0 + !headers_done ⇒ a truncated
+        // header (partial RX). Lets serial pinpoint the failure without a pcap.
+        log::info!(
+            "smol OTA: chunk drained — rx={}B body={}B headers_done={} bad={}",
+            rx_total,
+            writer.written().saturating_sub(chunk_start),
+            headers_done,
+            bad
+        );
         if bad {
             *fail = Some((writer.written() / OTA_CHUNK, chunk_n, chunk_retries, stall, ota_fail::STATUS));
             log::error!("smol OTA: bad HTTP status/length on range {off}-{end} (slot untouched)");

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -206,6 +206,10 @@ pub struct MeshElect {
     pub i_am_owner: bool,
     /// The elected owner's id (== my_id when I own it).
     pub owner_id: u8,
+    /// #gateway-election reliability: the adopted/deferred owner's MC channel (`<ch>`; 0 = unknown /
+    /// self-claim). The caller records it as `elected_owner_channel` so a co-channel leaf REFUSES to
+    /// leaf-lock to a proven off-channel owner (keeps re-electing until the seize fires reliably).
+    pub owner_channel: u8,
     /// #51: true iff the adopted owner was GENUINELY LIVE (fresh seq), false iff it
     /// was dead-but-inside-our-backoff (a deferred takeover). The caller grace-resets
     /// its owner-silence clock ONLY for a genuinely-live owner — a dead-deferred owner
@@ -252,6 +256,7 @@ impl MeshElect {
             ),
             i_am_owner: false,
             owner_id: my_id,
+            owner_channel: 0, // #gateway-election reliability: set from the MC <ch> in the resolver
             owner_alive: false,
             hint_blocked: false, // #155: set by the claim gate on a channel-hint yield
             downstream_seen: false, // #204 2a: set true in the drain on any retained downstream
@@ -3387,21 +3392,40 @@ fn mqtt_session(
     // read the LIVE AP channel here (`esp_wifi_sta_get_ap_info`) and recompute co_channel vs the
     // seeded mesh channel — and LOG it so the co-channel decision is visible on serial. espnow-only
     // (current_ap_info is espnow-gated); a wifi-only build keeps the caller's seed (no mesh/election).
+    // RELIABILITY: `esp_wifi_sta_get_ap_info` can transiently return None / a 0 primary channel in the
+    // first moments after association (the ~1/3 racy-seize cause). RETRY a bounded number of times
+    // (polling the iface to let the association settle) for a NONZERO channel; and on a persistent
+    // transient DON'T clobber co_channel to false — keep the caller's seed (recovery/flush seed it
+    // accurately from my_ap_channel; boot falls back to the leaf-lock guard, which keeps re-electing).
     #[cfg(feature = "espnow")]
     if elect.mesh_channel != 0 {
-        match crate::net::current_ap_info() {
-            Some((ap_ch, ap_rssi, _)) => {
-                elect.co_channel = ap_ch == elect.mesh_channel;
-                elect.co_channel_known = true;
-                log::info!(
-                    "smol: #gateway-election AP ch={} rssi={} mesh_ch={} -> co_channel={}",
-                    ap_ch,
-                    ap_rssi,
-                    elect.mesh_channel,
-                    elect.co_channel
-                );
+        let mut ap_ch = 0u8;
+        let mut ap_rssi = 0i8;
+        for _ in 0..24 {
+            if let Some((c, r, _)) = crate::net::current_ap_info() {
+                if c != 0 {
+                    ap_ch = c;
+                    ap_rssi = r;
+                    break;
+                }
             }
-            None => log::info!("smol: #gateway-election — current_ap_info None (not associated at election?)"),
+            iface.poll(smoltcp_now(), device, sockets); // give the association a beat to settle
+        }
+        if ap_ch != 0 {
+            elect.co_channel = ap_ch == elect.mesh_channel;
+            elect.co_channel_known = true;
+            log::info!(
+                "smol: #gateway-election AP ch={} rssi={} mesh_ch={} -> co_channel={}",
+                ap_ch,
+                ap_rssi,
+                elect.mesh_channel,
+                elect.co_channel
+            );
+        } else {
+            log::info!(
+                "smol: #gateway-election — AP channel unknown after retries (transient) — keeping co_channel={} (leaf-lock guard will re-elect)",
+                elect.co_channel
+            );
         }
     }
     let claim_seq: Option<u32> = match mc {
@@ -3419,6 +3443,9 @@ fn mqtt_session(
             }
             elect.seen_owner = owner;
             elect.seen_seq = seq;
+            // #gateway-election reliability: record the owner's MC channel so the caller knows whether
+            // the (adopted/deferred) owner is off-channel — read only when !i_am_owner (leaf).
+            elect.owner_channel = mc_ch;
             // #114 H3 (stale-self-reclaim fix): choose the dead-owner window by CORROBORATION.
             // `owner_never_heard` was introduced by H1 to mean "a forged/phantom retained MC no
             // board ever heard — take it over promptly". But it is ALSO true for EVERY freshly

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -4423,7 +4423,9 @@ pub fn run_ota_fetch(
 
     // Open the inactive-slot writer ONCE (image is streamed here across chunks, never buffered
     // whole). `writer.written()` doubles as the RESUME cursor and the running-SHA position.
-    let Some(mut writer) = crate::ota::ImageWriter::begin() else {
+    // #267: pass (build, sha) so the writer can resume a same-boot prior burst's committed offset
+    // instead of restarting the Range from byte 0 (see ImageWriter::begin / net::ota_resume).
+    let Some(mut writer) = crate::ota::ImageWriter::begin(announce.build, &announce.sha256) else {
         *fail = Some((0, 0, 0, 0, ota_fail::SLOT)); // #139/#147: died before the download (slot open)
         log::error!("smol OTA: cannot open inactive slot (no OTA partition table?)");
         return false;

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -91,6 +91,15 @@ const MESH_CHANNEL_TOPIC: &[u8] = b"smol/mesh/channel";
 #[cfg(feature = "wifi")]
 const MESH_CHANNEL_HINT_TOPIC: &[u8] = b"smol/mesh/channel_hint";
 
+/// #gateway-election OPERATOR LEVER: the retained best-gateway METRIC. Payload = keyed weights
+/// `c<n>r<n>n<n>u<n>` (co-channel / rssi / ntp / uptime), the literal `legacy` (escape hatch → the
+/// historical lowest-id + RSSI election), or empty (retain-clear → the on-by-default co-channel-
+/// dominant metric). Read in-burst by [`mqtt_session`] into `elect.elect_cfg` — the election consumes
+/// it in the SAME burst it claims in, so (unlike the CFG-relay family) no relay round-trip is needed.
+/// Twin transport of `channel_hint`; parsed by `election::parse_elect_config` (panic-free, fail-open).
+#[cfg(feature = "wifi")]
+const MESH_ELECT_TOPIC: &[u8] = b"smol/mesh/elect";
+
 /// #23 stage 3-4 boot ELECTION result, filled by [`mqtt_session`] from the retained
 /// `smol/mesh/channel`. A board that reached DHCP is a candidate; the lowest-id
 /// candidate is the OWNER (coexist gateway). Non-owners demote to leaf + scan for the
@@ -169,6 +178,23 @@ pub struct MeshElect {
     /// before, so a mesh is never left crownless while a channel is still being learned. `None` ⇒
     /// no gate ⇒ election unchanged. Same claim-guard shape as `flush_incapable` (#146).
     pub channel_hint: Option<u8>,
+    /// Best-gateway election (#gateway-election): this board's AP channel == the fixed mesh channel
+    /// (`ESP_NOW_FIXED_CHANNEL`) — the DOMINANT default-weighted fitness signal (an off-channel crown
+    /// is OTA-deaf regardless of RSSI, #217). Seeded by the caller from `self.my_ap_channel`.
+    pub co_channel: bool,
+    /// Best-gateway election: this board holds NTP-authoritative time (`synced_at != 0`) — a better
+    /// gateway can serve TIME frames. Seeded by the caller (0-weight-equivalent while uniformly false).
+    pub ntp_holder: bool,
+    /// Best-gateway election FAIL-OPEN guard: true iff this board's AP channel is KNOWN (`my_ap_channel
+    /// != 0`), so `co_channel` is trustworthy. The empty-MC claim deferral fires ONLY when this is set —
+    /// a freshly-booted board (pre-scan, channel unknown) claims a vacant crown IMMEDIATELY (fast
+    /// cold-start preserved, mirroring #155's `my_channel == 0` fail-open). Best-gateway preference then
+    /// engages on later bursts once the channel is learned. Seeded by the caller.
+    pub co_channel_known: bool,
+    /// Best-gateway election POLICY from the retained `smol/mesh/elect` topic (twin of `channel_hint`):
+    /// `BestGateway(weights)` (default = on-by-default co-channel-dominant) or `Legacy` (the escape
+    /// hatch → historical lowest-id + RSSI recovery). Seeded in [`mqtt_session`] from the broker.
+    pub elect_cfg: crate::net::election::ElectConfig,
     // --- outputs (applied to the live role by the caller) ---
     /// True iff I claimed / hold ownership (I am the coexist gateway).
     pub i_am_owner: bool,
@@ -209,6 +235,14 @@ impl MeshElect {
             boot: false,
             flush_incapable: false, // #146: seeded by the caller from the flush-fail abdication latch
             channel_hint: None, // #155: seeded by the caller from the retained smol/mesh/channel_hint
+            co_channel: false, // best-gateway: seeded by the caller from my_ap_channel == mesh
+            ntp_holder: false, // best-gateway: seeded by the caller from synced_at != 0
+            co_channel_known: false, // best-gateway: false at boot (channel unknown) → claim fast
+            // best-gateway is ON by default (team-lead 2026-07-20); the retained smol/mesh/elect topic
+            // re-weights or selects `legacy`. Absent/empty/garbage config keeps THIS default.
+            elect_cfg: crate::net::election::ElectConfig::BestGateway(
+                crate::net::election::MetricWeights::DEFAULT,
+            ),
             i_am_owner: false,
             owner_id: my_id,
             owner_alive: false,
@@ -216,44 +250,25 @@ impl MeshElect {
             downstream_seen: false, // #204 2a: set true in the drain on any retained downstream
         }
     }
+
+    /// Best-gateway election: build the pure [`election::FitnessInputs`] from this board's seeded
+    /// signals. `uptime_ms` = `now_ms` (the monotonic loop clock IS uptime-since-boot), so the
+    /// empty-MC claim deferral is stateless.
+    fn fitness_inputs(&self) -> crate::net::election::FitnessInputs {
+        crate::net::election::FitnessInputs {
+            co_channel: self.co_channel,
+            ap_rssi: self.my_rssi,
+            ntp_holder: self.ntp_holder,
+            uptime_ms: self.now_ms,
+        }
+    }
 }
 
-/// #51: map a board's RSSI-to-AP (dBm) → how long it must WAIT, beyond `RECOVERY_STALE_MS`,
-/// before it may take over a dead owner. Stronger signal → shorter wait, so the best-uplink
-/// survivor claims the vacated ownership FIRST and publishes a fresh (retained) `MC`; weaker
-/// survivors, still inside their (longer) backoff, then observe that LIVE owner and adopt it
-/// — the WiFi-strength election JP asked for in #51, node-id only breaking exact-bucket ties.
-///
-/// The bucket step (`RSSI_BUCKET_STEP_MS`) is deliberately LARGER than the recovery-burst
-/// cadence (`REELECT_RETRY_MS`), so a weaker board always has a recovery burst BETWEEN the
-/// stronger board's claim and its own claim threshold — it reads the stronger board's retained
-/// MC and adopts it, and thus NEVER claims. That is what keeps the RSSI winner STABLE: with no
-/// competing claim, the gateway-flush path's lowest-id resolver never fires to undo it. (Two
-/// boards in the SAME bucket can still co-claim in one window → resolved deterministically by
-/// that lowest-id flush path = the intended node-id tiebreak for equal signal.)
-/// No new `MC` wire field: a board only ever compares its OWN rssi against this threshold.
-#[cfg(feature = "wifi")]
-fn reelect_backoff_ms(rssi: i8, node_id: u8) -> u64 {
-    // Bucket by signal strength (typical STA range ≈ -30 strong … -90 weak dBm).
-    let bucket: u64 = if rssi >= -65 {
-        0
-    } else if rssi >= -78 {
-        1
-    } else {
-        2
-    };
-    // One bucket step per weaker bucket (> the burst cadence, see above) + a small per-id
-    // term so same-bucket boards prefer the lower id (final tiebreak; sub-cadence, so it
-    // only orders an already-converging same-window co-claim, never separates buckets).
-    bucket * RSSI_BUCKET_STEP_MS + (node_id as u64) * 200
-}
-
-/// #51 recovery: RSSI backoff step. MUST exceed `REELECT_RETRY_MS` (10 s) so a weaker board
-/// gets a recovery burst (→ reads the winner's retained MC → adopts) before its own claim
-/// threshold — that's what keeps the stronger board's win stable (no competing claim, so the
-/// lowest-id flush resolver never fires to undo it).
-#[cfg(feature = "wifi")]
-const RSSI_BUCKET_STEP_MS: u64 = 15_000;
+// #51 → #gateway-election: the RSSI-weighted dead-owner takeover stagger + its `RSSI_BUCKET_STEP_MS`
+// moved into the PURE `net::election` module and were GENERALIZED into the configurable best-gateway
+// fitness backoff (co-channel-dominant by default; `election::elect_backoff_ms`). The historical
+// RSSI-only rule survives byte-faithfully as `election::legacy_recovery_backoff_ms`, selected by the
+// `ElectConfig::Legacy` escape hatch. The recovery resolver below dispatches on `elect.elect_cfg`.
 
 /// OTA (#33 Model-A): the ONE retained fleet STAGING topic (`OTA|build|size|sha256|url`)
 /// published by `ota_publish.sh stage`. Every board subscribes it as its `latest_version`
@@ -2338,6 +2353,12 @@ fn mqtt_session(
     if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 25, MESH_CHANNEL_HINT_TOPIC) {
         let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
     }
+    // #gateway-election: subscribe the retained best-gateway metric (packet-id 26 — next free above
+    // #155's 25). Rides the SAME broker burst as MC/channel_hint so the resolver reads the operator's
+    // metric BEFORE it claims (the settle window after the primary downlinks catches it).
+    if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 26, MESH_ELECT_TOPIC) {
+        let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+    }
 
     // --- PUBLISH telemetry (transient) + discovery config (retained) per node ---
     for &(id, line) in telemetry {
@@ -2662,6 +2683,24 @@ fn mqtt_session(
                         elect.channel_hint = parse_channel_hint(payload);
                         if let Some(h) = elect.channel_hint {
                             log::info!("smol: #155 channel_hint = ch{} (retained)", h);
+                        }
+                    } else if topic == MESH_ELECT_TOPIC {
+                        // #gateway-election: capture the operator's best-gateway metric into the
+                        // election record. Empty/garbage → BestGateway(DEFAULT) (on-by-default);
+                        // `legacy` → the escape hatch. The recovery-backoff + empty-MC-deferral arms
+                        // dispatch on it. Consumed in THIS burst (no CFG-relay round-trip).
+                        elect.elect_cfg = crate::net::election::parse_elect_config(payload);
+                        match elect.elect_cfg {
+                            crate::net::election::ElectConfig::Legacy => {
+                                log::info!("smol: #gateway-election metric = LEGACY (lowest-id, retained)")
+                            }
+                            crate::net::election::ElectConfig::BestGateway(w) => log::info!(
+                                "smol: #gateway-election metric = best-gateway c{} r{} n{} u{} (retained)",
+                                w.co_channel,
+                                w.rssi,
+                                w.ntp,
+                                w.uptime
+                            ),
                         }
                     } else if topic == OTA_STAGED_TOPIC {
                         // #33 Model-A: parse + GATE the retained STAGED line (monotonicity +
@@ -3415,7 +3454,19 @@ fn mqtt_session(
                 let backoff = if elect.owner_never_heard {
                     (node_id as u64) * 200
                 } else {
-                    reelect_backoff_ms(elect.my_rssi, node_id)
+                    // #gateway-election: the dead-owner takeover stagger is now the CONFIGURABLE
+                    // best-gateway fitness backoff (co-channel-dominant by default) — so the
+                    // best-gateway survivor (co-channel > strong-RSSI > NTP > uptime) claims the
+                    // vacated crown FIRST and weaker survivors adopt its fresh MC. `Legacy` restores
+                    // the historical RSSI-only stagger byte-for-byte.
+                    match elect.elect_cfg {
+                        crate::net::election::ElectConfig::BestGateway(w) => {
+                            crate::net::election::elect_backoff_ms(&elect.fitness_inputs(), &w, node_id)
+                        }
+                        crate::net::election::ElectConfig::Legacy => {
+                            crate::net::election::legacy_recovery_backoff_ms(elect.my_rssi, node_id)
+                        }
+                    }
                 };
                 // #114 H3: gate on `stale_limit` (not a hardcoded RECOVERY_STALE_MS) so the
                 // never-heard takeover honours the SAME conservative 90s window used for `alive`
@@ -3436,12 +3487,45 @@ fn mqtt_session(
             }
         }
         None => {
-            // Empty/absent/unparseable topic → claim immediately (fast cold-start; a recovery
-            // that finds the record cleared also claims — sticky-adopt converges any race).
+            // Empty/absent/unparseable topic → the crown is VACANT.
             elect.owner_alive = false;
-            elect.i_am_owner = true;
-            elect.owner_id = node_id;
-            Some(1)
+            // #gateway-election: best-gateway DEFERS an empty-slot claim until this board's uptime
+            // clears its fitness backoff, so a co-channel board (short/zero backoff) crowns FIRST at
+            // cold boot and a weaker board re-reads its now-populated MC next burst and ADOPTS it —
+            // no #204/#217 shed cycle needed to migrate off a bad crown. STATELESS (uptime = now_ms);
+            // BOUNDED (MAX_ELECT_TIERS ⇒ ≤30 s) so a SOLE board still claims → never crownless. A
+            // long-lived board (high uptime) has a tiny backoff, so a running gateway re-claims a
+            // freshly-cleared MC without delay (the defer self-limits to boot-fresh boards). `Legacy`
+            // claims immediately (the historical fast cold-start).
+            // FAIL-OPEN: only defer once our AP channel is KNOWN (co_channel is trustworthy) — a
+            // pre-scan boot board claims immediately (fast cold-start, #155-style fail-open).
+            let defer = elect.co_channel_known
+                && match elect.elect_cfg {
+                    crate::net::election::ElectConfig::BestGateway(w) => {
+                        elect.now_ms
+                            < crate::net::election::elect_backoff_ms(
+                                &elect.fitness_inputs(),
+                                &w,
+                                node_id,
+                            )
+                    }
+                    crate::net::election::ElectConfig::Legacy => false,
+                };
+            if defer {
+                // Stay leaf this burst; owner_id == node_id (no foreign owner) → leaf-reelect retries
+                // on cadence until we claim (uptime clears backoff) or adopt a board that crowned.
+                elect.i_am_owner = false;
+                log::info!(
+                    "smol: best-gateway — deferring empty-MC claim (uptime {} ms < backoff, co_channel={})",
+                    elect.now_ms,
+                    elect.co_channel
+                );
+                None
+            } else {
+                elect.i_am_owner = true;
+                elect.owner_id = node_id;
+                Some(1)
+            }
         }
     };
     // #146 CLAIM guard: a board that abdicated on sustained flush failure (its WiFi uplink is

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -382,33 +382,10 @@ pub fn gate(a: &Announce) -> Result<(), Reject> {
 // HTTP response helpers (used by the fetch burst in net/wifi.rs)
 // ---------------------------------------------------------------------------
 
-/// Index one-past the header terminator (`\r\n\r\n`) — the body start. `None` if the
-/// headers are not yet complete in `buf`.
-#[cfg(feature = "espnow")]
-pub fn header_end(buf: &[u8]) -> Option<usize> {
-    buf.windows(4).position(|w| w == b"\r\n\r\n").map(|i| i + 4)
-}
-
-/// Status code from an HTTP/1.x status line (`HTTP/1.0 200 OK` → 200).
-#[cfg(feature = "espnow")]
-pub fn status_code(headers: &[u8]) -> Option<u16> {
-    let line = core::str::from_utf8(headers).ok()?.lines().next()?;
-    line.split_whitespace().nth(1)?.parse().ok()
-}
-
-/// `Content-Length` value (case-insensitive header name). `None` if absent/unparseable.
-#[cfg(feature = "espnow")]
-pub fn content_length(headers: &[u8]) -> Option<u32> {
-    let s = core::str::from_utf8(headers).ok()?;
-    for line in s.lines() {
-        if let Some((name, val)) = line.split_once(':') {
-            if name.eq_ignore_ascii_case("content-length") {
-                return val.trim().parse().ok();
-            }
-        }
-    }
-    None
-}
+// #gateway-election: the HTTP/1.x response-head parsers (header_end / status_code / content_length)
+// moved to the PURE, host-tested `net::http` module (a coalesced header+binary-body TCP segment was
+// failing UTF-8 → status parsed None → the fetch died at byte 0). `run_ota_fetch` now calls
+// `crate::net::http::*` directly on the header slice. See src/net/http.rs + experiments/ota_http_verify.
 
 // ---------------------------------------------------------------------------
 // Streaming image writer (HTTP body → inactive slot + running SHA-256)

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -428,6 +428,59 @@ pub fn content_length(headers: &[u8]) -> Option<u32> {
 #[cfg(feature = "espnow")]
 static mut OTA_STAGE: [u8; CHUNK] = [0xFF; CHUNK];
 
+// #267: cross-burst OTA-fetch resume cursor. SAME-BOOT, resets on reboot (the #100 in-RAM idiom) —
+// the #195 OTA retry is per-burst WITHIN one boot, so NO NVS is needed (this deliberately sidesteps
+// the near-full `nvs` partition; a reboot legitimately restarts the fetch from byte 0). Without it,
+// each burst's `ImageWriter::begin` reset the write cursor to 0 and the fetch re-`Range`d from byte
+// 0; under the coexist bulk-RX disease (≈1 chunk/burst) a multi-chunk image never accumulated
+// (#267). The PURE keying (does a saved cursor match this staged image + slot?) lives in
+// `crate::net::ota_resume` (host-tested); this holds only the `.bss` cursor + thin accessors.
+#[cfg(feature = "espnow")]
+struct OtaResumeState {
+    saved: Option<(crate::net::ota_resume::ResumeKey, u32)>,
+}
+#[cfg(feature = "espnow")]
+static mut OTA_RESUME: OtaResumeState = OtaResumeState { saved: None };
+
+/// Target-slot discriminator for the resume key (`0` = Slot0, `1` = Slot1).
+#[cfg(feature = "espnow")]
+fn slot_key(s: Slot) -> u8 {
+    if s == Slot::Slot1 {
+        1
+    } else {
+        0
+    }
+}
+
+/// The resume offset for a fresh fetch of `(build, sha)` into `slot` — `0` if none matches (a fresh
+/// fetch from byte 0). Delegates the match to the pure `net::ota_resume::resume_offset`.
+#[cfg(feature = "espnow")]
+fn ota_resume_lookup(build: u32, sha: &[u8; 32], slot: Slot, size: u32) -> u32 {
+    let want = crate::net::ota_resume::ResumeKey {
+        build,
+        sha_key: crate::net::ota_resume::sha_key16(sha),
+        slot: slot_key(slot),
+    };
+    let saved = unsafe { (*core::ptr::addr_of!(OTA_RESUME)).saved };
+    crate::net::ota_resume::resume_offset(saved, &want, size)
+}
+
+/// Record the on-flash (flushed, sector-aligned) committed offset for the in-progress fetch, so the
+/// next burst's `begin` resumes here instead of restarting from 0.
+#[cfg(feature = "espnow")]
+fn ota_resume_save(key: crate::net::ota_resume::ResumeKey, committed: u32) {
+    let r = unsafe { &mut *core::ptr::addr_of_mut!(OTA_RESUME) };
+    r.saved = Some((key, committed));
+}
+
+/// Drop the resume cursor (a fetch is terminal: finalize success OR failure → a fresh attempt
+/// starts from byte 0). A newer/ different staged image is handled by keying, not this.
+#[cfg(feature = "espnow")]
+pub fn ota_resume_clear() {
+    let r = unsafe { &mut *core::ptr::addr_of_mut!(OTA_RESUME) };
+    r.saved = None;
+}
+
 #[cfg(feature = "espnow")]
 pub struct ImageWriter {
     flash: FlashStorage,
@@ -448,7 +501,9 @@ pub struct ImageWriter {
     /// the array did). Alias-safe: one OTA at a time (`begin` is single-caller, one-shot).
     stage: &'static mut [u8; CHUNK],
     stage_len: usize,
-    hasher: sha2::Sha256,
+    /// #267: identifies the staged image + slot this fetch belongs to, so each sector flush can
+    /// persist the resume cursor keyed to it (a re-stage / slot flip then can't resume onto it).
+    resume_key: crate::net::ota_resume::ResumeKey,
     target: Slot,
 }
 
@@ -456,8 +511,7 @@ pub struct ImageWriter {
 impl ImageWriter {
     /// Open a writer for the inactive slot (the one `otadata`'s current slot is NOT).
     /// `None` on any partition/flash error (e.g. a board without the OTA table).
-    pub fn begin() -> Option<ImageWriter> {
-        use sha2::Digest;
+    pub fn begin(build: u32, expected_sha: &[u8; 32]) -> Option<ImageWriter> {
         let target = inactive_slot()?;
         let sub = if target == Slot::Slot1 {
             AppPartitionSubType::Ota1
@@ -473,20 +527,31 @@ impl ImageWriter {
             let app = pt.find_partition(PartitionType::App(sub)).ok()??;
             (app.offset(), app.len())
         };
+        // #267: resume from a same-boot prior burst's committed (flushed, sector-aligned) offset iff
+        // this staged image + slot match the saved cursor; else 0 (fresh fetch). Bytes [0..resume)
+        // are already on flash from earlier bursts, so `erased_upto = base + resume` — begin never
+        // re-erases the committed prefix; the resumed feed erases-ahead only past it. Integrity is a
+        // finalize READBACK-SHA over `slot[..size]` (below), which is burst-count invariant — no
+        // streaming hasher to restore, so resume needs only the offset.
+        let resume = ota_resume_lookup(build, expected_sha, target, size);
         Some(ImageWriter {
             flash,
             base,
             size,
-            written: 0,
-            flushed: 0,
-            erased_upto: base,
+            written: resume,
+            flushed: resume,
+            erased_upto: base + resume,
             // F2: borrow the static stage buffer (off the stack). Alias-safe — one OTA
             // at a time. No stale-data risk: `flush_stage` re-pads `[len..padded]` to
             // 0xFF and writes only `stage[..padded]`, so a reused buffer never leaks
             // prior bytes to flash. `stage_len: 0` starts the accumulation fresh.
             stage: unsafe { &mut *core::ptr::addr_of_mut!(OTA_STAGE) },
             stage_len: 0,
-            hasher: sha2::Sha256::new(),
+            resume_key: crate::net::ota_resume::ResumeKey {
+                build,
+                sha_key: crate::net::ota_resume::sha_key16(expected_sha),
+                slot: slot_key(target),
+            },
             target,
         })
     }
@@ -505,11 +570,11 @@ impl ImageWriter {
     /// Returns `false` on overflow past the slot or any flash error (caller aborts;
     /// otadata untouched → good slot stays active).
     pub fn feed(&mut self, bytes: &[u8]) -> bool {
-        use sha2::Digest;
+        // #267: no streaming hash here anymore — integrity is a finalize READBACK-SHA over the slot
+        // (burst-count invariant), so a resumed multi-burst fetch verifies like a one-shot fetch.
         if self.written.saturating_add(bytes.len() as u32) > self.size {
             return false; // image claims more than a slot — refuse
         }
-        self.hasher.update(bytes);
         self.written += bytes.len() as u32;
         let mut off = 0;
         while off < bytes.len() {
@@ -552,6 +617,10 @@ impl ImageWriter {
             return false;
         }
         self.flushed += len as u32;
+        // #267: persist the on-flash cursor so the next burst's `begin` resumes here (not from 0).
+        // Fetch-loop flushes are full sectors (aligned); the finalize tail flush is non-aligned but
+        // finalize clears the cursor immediately after, so a non-aligned value never persists.
+        ota_resume_save(self.resume_key, self.flushed);
         self.stage_len = 0;
         true
     }
@@ -560,14 +629,37 @@ impl ImageWriter {
     /// AND running SHA-256 == announced hash. `true` ⇒ the whole image landed intact
     /// and [`activate`] is safe. otadata is still untouched here.
     pub fn finalize(mut self, expected_size: u32, expected_sha: &[u8; 32]) -> bool {
+        use embedded_storage::nor_flash::ReadNorFlash;
         use sha2::Digest;
         if !self.flush_stage() {
+            ota_resume_clear();
             return false;
         }
         if self.written != expected_size {
+            ota_resume_clear();
             return false;
         }
-        self.hasher.finalize().as_slice() == &expected_sha[..]
+        // #267/#40: READBACK-SHA over `slot[..size]` — the exact bytes that will boot — instead of a
+        // streaming hash. Burst-count invariant, so a fetch resumed across N bursts verifies
+        // identically to a one-shot fetch. Uses OTA_READBACK (a distinct static from `self.stage` →
+        // no aliasing). Reads absolute flash at `base + off` (length word-rounded; extra tail bytes
+        // are read legally but not hashed), mirroring `LeafImageWriter::finalize`.
+        let buf = unsafe { &mut *core::ptr::addr_of_mut!(OTA_READBACK) };
+        let mut hasher = sha2::Sha256::new();
+        let mut off = 0u32;
+        let mut read_ok = true;
+        while off < expected_size {
+            let want = core::cmp::min(buf.len() as u32, expected_size - off);
+            let read_len = (want.div_ceil(4) * 4) as usize;
+            if self.flash.read(self.base + off, &mut buf[..read_len]).is_err() {
+                read_ok = false;
+                break;
+            }
+            hasher.update(&buf[..want as usize]);
+            off += want;
+        }
+        ota_resume_clear(); // fetch terminal (success OR fail) → a fresh attempt starts from 0
+        read_ok && hasher.finalize().as_slice() == &expected_sha[..]
     }
 }
 


### PR DESCRIPTION
Elect the mesh crown by a **configurable best-gateway metric** so a **co-channel board becomes crown** and completes OTA co-channel. **PROVEN ON HARDWARE**: id7 seized the crown co-channel, self-fetched the full **1,167,168 B v903** in ~24 Range chunks (0 retries), SHA-256 + ed25519 **VERIFIED**, activated ota_1, rebooted into v903 — the first complete over-the-air OTA. 7 commits, host-tested, lucid-reviewed.

## The chain (all proven end-to-end)
1. **`configurable best-gateway election + all-channel scan`** — pure `election.rs` (weighted co_channel/rssi/ntp/uptime fitness, co-channel-dominant default; bounded/monotonic claim backoff reusing the #51 stagger). `ESP_WIFI_CONFIG_SCAN_METHOD=1` (strongest-AP association). On-by-default; retained `smol/mesh/elect` re-weights or `legacy` = escape hatch.
2. **`all-nodes-WiFi debug CFG key (A)`** — global `smol/config/wifi_all`; any node can WiFi-burst + self-fetch for per-board debug. Claim-suppressed, default OFF.
3. **`L2 crown-migration + L3 fetch-quiet`** — a co-channel board **seizes a proven off-channel owner**; investigation showed the reflood storm was fleet-side split-brain (fixed by the single stable crown), not the fetch node.
4. **`L2 seize regression fix`** — `co_channel` authoritative at election time + symmetric **off-channel yield** (the off-channel owner yields → the seize sticks, no flap).
5. **`fetch-leg RX instrumentation + issue-2 reassoc no-downgrade`** — the retry no longer downgrades a co-channel crown to a worse off-channel AP.
6. **`THE byte-0 fetch bug`** — the transfer-completing fix: `status_code`/`content_length` were parsed on the whole buffer (header + coalesced binary body) → `from_utf8` failed → status `None` → abort at byte 0. Now parses the header slice only; parsers extracted to pure, host-tested `net::http` (byte-robust, version-agnostic).
7. **`seize reliability`** — co-channel seize fires **every boot** (not ~2/3): `co_channel` read retries past the post-association transient, and a co-channel board **refuses to leaf-lock to a proven off-channel owner** so it keeps re-electing until it seizes; pre-fetch `ap_ch=0` transient no longer triggers a needless reassoc.

## Verification
- Host guards: `experiments/election_verify` + `experiments/ota_http_verify` + `experiments/ap_select_verify` all pass.
- `cargo build --release --features espnow,cast,io` green on familiar + katana.
- Full co-channel OTA proven on id7 (v902 → v903).

## Deployment notes
- Fleet canary: id5/id8/id9 still run v900/v345 (no parser fix) — a fleet-wide OTA needs the hardened build rolled out first (USB, or OTA from a hardened crown).
- `ntp_holder` fitness input is v1-stubbed false (uniform → zero ordering effect); a dead co-channel ghost is aged out by existing MC-staleness (MC seq only advances via a live self-publish — no reflood-increment path), so no explicit origin-freshness age-out is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)