### PR TITLE
feat(ui): #276 persistent node-name header on the Clock — identity at a glance

### DIFF
--- a/rust/clock/src/clock.rs
+++ b/rust/clock/src/clock.rs
@@ -150,6 +150,17 @@ pub(crate) fn draw_clock<D>(
     // Center: "12:34" (5ch/50px) -> x=11; "1:34" (4ch/40px) -> x=16.
     let tx = if two_digit { 11 } else { 16 };
 
+    // #276 persistent identity: the node's OWN fantasy noun, top-left on its own row above the
+    // big digits (y=0, 5x8 — same row the AM/PM tag uses on the RIGHT, so they never collide).
+    // Always painted regardless of what the bottom line carries — under espnow the bottom line is
+    // mesh chatter, so this header is the ONE place an idle Clock always says WHICH node it is.
+    // Nouns are ≤8 chars (≤42 px from x=2) → clear of the AM/PM tag at x=59. Mirrors About's
+    // noun-top-left treatment for a consistent identity read across screens.
+    let my_noun = crate::net::names::name_for_id(crate::node_id()).1;
+    Text::with_baseline(my_noun, Point::new(2, 0), label_style, Baseline::Top)
+        .draw(display)
+        .ok();
+
     // AM/PM small in the top-right (its own row above the big digits — no overlap). 12h ONLY;
     // a 24-hour clock has no AM/PM tag.
     if !units.clk_24h {


### PR DESCRIPTION
Closes #276.

JP: "display the node sigil name on each screen" — tell boards apart at a glance.

## What
Draws the node's own **fantasy noun** (Aegis / Dominion / Nexus / Herald) as a persistent header on the **Clock** screen — top-left, `FONT_5X8`, `y=0`.

## Why the Clock
Identity was already shown by the boot splash (#6, transient) and by About/Custom (only while you're on them). The gap: on the **espnow fleet** the Clock's bottom line *starts* as the own noun but gets clobbered by mesh chatter (`main.rs:794`/`:1035`), so an idle board drifts to showing chatter — not its name. The Clock is the screen the fleet idles on, so a header there is the always-on identity anchor.

## Layout (no collisions)
- Header `y=0..8` (5x8). AM/PM tag is top-**right** at `x=59`; nouns are ≤8 chars (≤42px from `x=2`) → clear of it in both 12h/24h.
- Big time (`y=8..28`) and bottom line (`y=31`) untouched.
- Mirrors the About screen's noun-top-left treatment for a consistent identity read across screens.

## Scope / alternatives
- **Operational fast-win (no reflash, works during the OTA roll):** push a retained big-name custom-screen per board + set `default_screen=Custom`. Recipe in `scratch/wifi-resilience/screens.md` — handed to team-lead for the instant win. This PR is the durable fix that rolls with the next OTA.
- **Rejected:** a toast-pattern overlay on *every* screen — truest to "each screen" but occludes the 72×40 panel everywhere.
- Non-fleet (default/wifi) builds already show the noun in the bottom-line rotation, so they'll briefly show it twice; harmless, left as-is to keep the diff surgical.

## Verify
- `cargo check --release --features espnow,cast,io` — **green on katana** (`Finished` exit 0). `clock.rs` produced zero warnings. (The 5 warnings are pre-existing unused-`WEATHER_*` consts in a local, gitignored `board.rs` — not in this diff.)
- Not HW-flashed (team-lead owns boards; fleet is mid-OTA-roll). Renders next OTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)