### PR TITLE
chore(deps): Dependabot config + safe non-esp lockfile bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+# Dependabot — automated dependency currency for smol.
+#
+# Policy: JP's "latest-everything" — keep deps current, guard with the KATANA
+# 4-tier build gate (clippy -D warnings + release across espnow,cast,io / default
+# / wifi), NOT with version freezes. See rust/clock/rust-toolchain.toml.
+#
+# ┌─ CRITICAL: the esp-* matched set is IGNORED here ON PURPOSE ────────────────┐
+# │ esp-hal / esp-wifi / esp-backtrace / esp-println / esp-alloc / esp-storage / │
+# │ esp-bootloader-esp-idf / esp-wifi-sys  (+ smoltcp, which esp-wifi links      │
+# │ against) are an INTENTIONALLY version-LOCKED matched set — see the `=x.y.z`  │
+# │ pins + header comment in rust/clock/Cargo.toml. esp-wifi 0.15.x calls        │
+# │ esp-hal INTERNAL APIs (e.g. Rng::new(RNG)) whose signatures changed in       │
+# │ esp-hal 1.0.0-rc.1/1.0.0, so a naive individual bump FAILS to compile even   │
+# │ though Cargo's semver check passes; the same wave triggered the              │
+# │ portable-atomic host-leak build break. Upgrading the whole set is issue      │
+# │ #233's job — a HW-gated matched-set migration. Dependabot must never         │
+# │ auto-PR these, so they are in the `ignore` list below.                       │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
+version: 2
+updates:
+  # ---- Rust / Cargo — host + firmware workspaces --------------------------
+  # experiments/* are deliberately EXCLUDED: throwaway host-test harnesses
+  # (version 0.0.0, publish = false, no Cargo.lock) — zero shipping value,
+  # would only add PR noise.
+  - package-ecosystem: "cargo"
+    directories:
+      - "/rust/clock"    # ESP32-C3 firmware crate (holds the esp-* `=` pins)
+      - "/rust/viz"      # host visualizers workspace (mesh-model/meshscope/observatory)
+      - "/rust/web-emu"  # wasm host emulator (path-deps clock w/ hostsim; no esp-* deps)
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "rust"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # One consolidated PR per workspace per week for compatible bumps.
+      cargo-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # #233 matched set — do NOT auto-bump; breaks the firmware build.
+      - dependency-name: "esp-*"
+      - dependency-name: "smoltcp"
+
+  # ---- GitHub Actions (.github/workflows) ---------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      github-actions-all:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/rust/clock/Cargo.lock
+++ b/rust/clock/Cargo.lock
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.13"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
+checksum = "ccc5801fd11762e24d1e420d01d2ac518f2a2ca4329d4fbb6639f2412b6204e0"
 dependencies = [
  "enumset_derive",
 ]
@@ -1036,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
 
 [[package]]
 name = "linked_list_allocator"
@@ -1341,7 +1341,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.1",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1452,9 +1452,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edbec4ed188954a10c12c038215f8ce7606b2d5c973cd8dc43e8795065c5f2f"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1487,7 +1487,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.1",
+ "syn 3.0.2",
 ]
 
 [[package]]

--- a/rust/viz/Cargo.lock
+++ b/rust/viz/Cargo.lock
@@ -2462,9 +2462,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
 
 [[package]]
 name = "libloading"
@@ -3724,14 +3724,14 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.1",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3977,9 +3977,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edbec4ed188954a10c12c038215f8ce7606b2d5c973cd8dc43e8795065c5f2f"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4056,7 +4056,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.1",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -4105,9 +4105,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -5413,18 +5413,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Enables Dependabot for smol per JP's "use dependabot + keep packages current" directive.

- **`.github/dependabot.yml`**: weekly cargo updates for `/rust/clock`, `/rust/viz`, `/rust/web-emu` (+ github-actions), minor/patch grouped into one PR/workspace/week.
- **`esp-*` + `smoltcp` IGNORED on purpose** — the intentionally version-locked matched set (esp-wifi 0.15 calls esp-hal internal APIs; naive bumps break the firmware build). Upgrading that set is #233's HW-gated job.
- **Safe lockfile bumps**: non-esp patch bumps only (libc, serde, etc.), within existing semver ranges.

Policy = JP's latest-everything, guarded by the katana 4-tier build gate, not version freezes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>