### PR TITLE
feat(ui): #282 dedicated Sigil screen (node nameplate); revert #277 clock header

### DIFF
--- a/rust/clock/src/app.rs
+++ b/rust/clock/src/app.rs
@@ -179,6 +179,9 @@ pub enum AppKind {
     #[allow(dead_code)]
     Snake,
     About,
+    // #282 Sigil — the node's identity nameplate. Its OWN navigable screen (own Plugin + menu
+    // row). Compiled into EVERY build: identity needs no radio (like About/Clock), so no cfg gate.
+    Sigil,
     // Batt is LIVE whenever compiled (constructed by its REGISTRY row + `enter`),
     // so no `dead_code` allow is needed — unlike `Snake` under espnow. cfg(wifi):
     // the fetch path is wifi-only (espnow ⊃ wifi).
@@ -252,6 +255,8 @@ impl AppKind {
             // in the menu. ("MeshSnake" below is the explicit espnow-only alias.)
             "Snake" => SNAKE_KIND,
             "About" => AppKind::About,
+            // #282: a node's default screen can be set to its identity nameplate via #21.
+            "Sigil" => AppKind::Sigil,
             "Batt" => AppKind::Batt,
             "Grid" => AppKind::Grid,
             #[cfg(feature = "espnow")]
@@ -291,6 +296,7 @@ impl AppKind {
             AppKind::Clock => "Clock",
             AppKind::Snake => "Snake",
             AppKind::About => "About",
+            AppKind::Sigil => "Sigil",
             #[cfg(feature = "wifi")]
             AppKind::Batt => "Batt",
             #[cfg(feature = "wifi")]
@@ -362,6 +368,7 @@ pub enum App {
     #[allow(dead_code)]
     Snake(crate::snake::Snake),
     About(crate::about::About),
+    Sigil(crate::sigil::SigilState),
     #[cfg(feature = "wifi")]
     Batt(crate::batt::BattState),
     #[cfg(feature = "wifi")]
@@ -394,6 +401,7 @@ impl App {
             AppKind::Clock => App::Clock(crate::clock::ClockState::new()),
             AppKind::Snake => App::Snake(crate::snake::Snake::new(ctx.now_ms)),
             AppKind::About => App::About(crate::about::About::new(ctx.now_ms)),
+            AppKind::Sigil => App::Sigil(crate::sigil::SigilState::new()),
             #[cfg(feature = "wifi")]
             AppKind::Batt => App::Batt(crate::batt::BattState::new()),
             #[cfg(feature = "wifi")]
@@ -435,6 +443,7 @@ impl App {
             App::Clock(s) => Plugin::on_button(s, press, ctx),
             App::Snake(s) => Plugin::on_button(s, press, ctx),
             App::About(s) => Plugin::on_button(s, press, ctx),
+            App::Sigil(s) => Plugin::on_button(s, press, ctx),
             #[cfg(feature = "wifi")]
             App::Batt(s) => Plugin::on_button(s, press, ctx),
             #[cfg(feature = "wifi")]
@@ -465,6 +474,7 @@ impl App {
             App::Clock(s) => Plugin::update(s, ctx),
             App::Snake(s) => Plugin::update(s, ctx),
             App::About(s) => Plugin::update(s, ctx),
+            App::Sigil(s) => Plugin::update(s, ctx),
             #[cfg(feature = "wifi")]
             App::Batt(s) => Plugin::update(s, ctx),
             #[cfg(feature = "wifi")]
@@ -515,6 +525,7 @@ impl App {
             App::Clock(_) => (AppKind::Clock, 0),
             App::Snake(_) => (AppKind::Snake, 0),
             App::About(_) => (AppKind::About, 0),
+            App::Sigil(_) => (AppKind::Sigil, 0),
             #[cfg(feature = "wifi")]
             App::Batt(s) => (AppKind::Batt, s.page()),
             #[cfg(feature = "wifi")]
@@ -585,6 +596,9 @@ pub const REGISTRY: &[AppDesc] = &[
     #[cfg(feature = "wled")]
     AppDesc { title: "WLED", kind: AppKind::WledRemote },
     AppDesc { title: "About", kind: AppKind::About },
+    // #282 Sigil — the node's identity nameplate. Compiled into every build (identity needs no
+    // radio), so this row is always present; sits by About in the identity/provenance group.
+    AppDesc { title: "Sigil", kind: AppKind::Sigil },
     // #45 Custom — espnow-only (content arrives only over the radio config path). Last menu row,
     // matching luna's #81 screen input_select order (…About, Custom).
     #[cfg(feature = "espnow")]
@@ -627,6 +641,10 @@ pub const fn plugin_bit(kind: AppKind) -> Option<u8> {
         #[cfg(feature = "wled")]
         AppKind::WledRemote => Some(5),
         AppKind::About => Some(6),
+        // #282 Sigil is NON-maskable (like Menu/Custom): the #55 mask is the original 7 plugins
+        // (bits 0..6) and predates it — giving Sigil a bit would let a legacy all-on mask hide the
+        // node's own nameplate. `None` ⇒ always shown, no rework to the live #55 contract.
+        AppKind::Sigil => None,
         // #45 Custom is NON-maskable (like Menu): luna's #55 mask is the original 7 plugins
         // (bits 0..6, all-on 007F) and predates Custom — giving Custom bit 7 would let a 007F
         // mask HIDE it permanently. `None` ⇒ always shown, no rework to the live #55 contract.

--- a/rust/clock/src/clock.rs
+++ b/rust/clock/src/clock.rs
@@ -150,17 +150,6 @@ pub(crate) fn draw_clock<D>(
     // Center: "12:34" (5ch/50px) -> x=11; "1:34" (4ch/40px) -> x=16.
     let tx = if two_digit { 11 } else { 16 };
 
-    // #276 persistent identity: the node's OWN fantasy noun, top-left on its own row above the
-    // big digits (y=0, 5x8 — same row the AM/PM tag uses on the RIGHT, so they never collide).
-    // Always painted regardless of what the bottom line carries — under espnow the bottom line is
-    // mesh chatter, so this header is the ONE place an idle Clock always says WHICH node it is.
-    // Nouns are ≤8 chars (≤42 px from x=2) → clear of the AM/PM tag at x=59. Mirrors About's
-    // noun-top-left treatment for a consistent identity read across screens.
-    let my_noun = crate::net::names::name_for_id(crate::node_id()).1;
-    Text::with_baseline(my_noun, Point::new(2, 0), label_style, Baseline::Top)
-        .draw(display)
-        .ok();
-
     // AM/PM small in the top-right (its own row above the big digits — no overlap). 12h ONLY;
     // a 24-hour clock has no AM/PM tag.
     if !units.clk_24h {

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -98,6 +98,9 @@ mod toast;
 // plugins, compiled in EVERY build (identity/time need no radio).
 mod about;
 mod clock;
+// #282 SIGIL screen — the node's identity nameplate (fantasy name + version sigil). Its own
+// navigable plugin + menu row; compiled in EVERY build (identity needs no radio, like About).
+mod sigil;
 // BENCH mode (ESP-NOW link stats + mesh roster). ESP-NOW-only.
 #[cfg(feature = "espnow")]
 mod bench;

--- a/rust/clock/src/sigil.rs
+++ b/rust/clock/src/sigil.rs
@@ -1,0 +1,140 @@
+//! #282 SIGIL screen — the node's identity nameplate.
+//!
+//! A deliberate, navigable identity screen with its OWN [`Plugin`] + Home-menu row (issue
+//! #282) — NOT crammed into the Clock (the #276/#277 header was reverted) and NOT hijacking
+//! the Custom screen. It shows the node's full magical name (the "sigil"): the fantasy
+//! ADJECTIVE as a flourish over the NOUN handle (the identity every other screen uses), with
+//! the firmware's FORGE version sigil as a secondary provenance line — a real nameplate for
+//! telling boards apart at a glance.
+//!
+//! Compiled into EVERY build: identity needs no radio (like About/Clock). The content is
+//! fully static at runtime, so it paints ONCE (redraw-latched) and then idles — no per-tick
+//! cost. Heap-free so it runs in the alloc-free default build. Panic-free — every string is
+//! bounded ASCII and the version line is built into a fixed buffer.
+
+use core::fmt::Write;
+
+use embedded_graphics::{
+    mono_font::{ascii::FONT_5X8, ascii::FONT_6X10, MonoFont, MonoTextStyleBuilder},
+    pixelcolor::BinaryColor,
+    prelude::*,
+    primitives::{Line, PrimitiveStyle},
+    text::{Baseline, Text},
+};
+
+use crate::app::{AppKind, Ctx, Plugin, Transition};
+use crate::input::Press;
+
+/// The 72×40 OLED panel width used for centring (matches the other screens).
+const PANEL_W: i32 = 72;
+
+/// SIGIL state: a one-shot paint latch. Identity + firmware version never change at runtime,
+/// so we paint on the first `update` (or a forced `redraw` after a mode switch) and then idle
+/// — the same dedup shape as the Custom screen, minus the content hash (nothing changes).
+pub struct SigilState {
+    drawn: bool,
+}
+
+impl SigilState {
+    pub fn new() -> Self {
+        Self { drawn: false }
+    }
+}
+
+impl Plugin for SigilState {
+    fn on_button(&mut self, press: Press, _ctx: &mut Ctx) -> Transition {
+        match press {
+            // Uniform grammar: long press leaves to the menu. A static nameplate ignores taps.
+            Press::Long => Transition::Switch(AppKind::Menu),
+            Press::Short => Transition::Stay,
+        }
+    }
+
+    fn update(&mut self, ctx: &mut Ctx) {
+        // Static content: repaint only on the first entry or a forced redraw (menu switch).
+        if !(ctx.redraw || !self.drawn) {
+            return;
+        }
+        self.drawn = true;
+        ctx.display.clear(BinaryColor::Off).ok();
+        draw_sigil(ctx.display);
+        ctx.display.flush().ok();
+    }
+}
+
+/// Render the identity nameplate. Generic over the draw target (mirrors `draw_clock`) so it
+/// stays host-testable in principle. Panic-free.
+fn draw_sigil<D>(display: &mut D)
+where
+    D: DrawTarget<Color = BinaryColor>,
+{
+    // The node's full magical name: `.0` = adjective (the flourish), `.1` = noun (the handle
+    // every other screen shows). FONT_6X10 is the largest font that fits ALL fantasy nouns at
+    // 72 px — FONT_10X20 clips an 8-char noun (the boot-splash rationale) — so the noun uses it.
+    let (adj, noun) = crate::net::names::name_for_id(crate::node_id());
+
+    // Adjective — small, centred, top: a subtle flourish above the identity.
+    draw_centered(display, adj, &FONT_5X8, 2);
+    // Noun — the identity, prominent + centred.
+    draw_centered(display, noun, &FONT_6X10, 12);
+
+    // A hairline divider separating identity (WHO) from provenance (WHICH firmware).
+    Line::new(Point::new(8, 25), Point::new(PANEL_W - 9, 25))
+        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+        .draw(display)
+        .ok();
+
+    // Version sigil — "v<build> <forge-noun>" (e.g. "v903 Bellows"), matching the boot splash's
+    // compact form (no dev-hash, so it never overflows the row). Built heap-free into a fixed
+    // buffer since this screen compiles into the alloc-free default build.
+    let mut vbuf = Buf::new();
+    let _ = write!(
+        vbuf,
+        "v{} {}",
+        crate::net::names::build_number(),
+        crate::net::names::version_name().1
+    );
+    draw_centered(display, vbuf.as_str(), &FONT_5X8, 29);
+}
+
+/// Draw `text` horizontally centred in the 72 px row at baseline-top `y`, in `font`. The
+/// centre offset uses the font's own glyph width (ASCII mono → one glyph per char), so it
+/// stays correct if the font changes. Never negative (clamped), so it can't panic or wrap.
+fn draw_centered<D>(display: &mut D, text: &str, font: &MonoFont, y: i32)
+where
+    D: DrawTarget<Color = BinaryColor>,
+{
+    let style = MonoTextStyleBuilder::new().font(font).text_color(BinaryColor::On).build();
+    let cw = font.character_size.width as i32;
+    let tw = text.chars().count() as i32 * cw;
+    let x = ((PANEL_W - tw) / 2).max(0);
+    Text::with_baseline(text, Point::new(x, y), style, Baseline::Top).draw(display).ok();
+}
+
+/// Tiny heap-free line builder (Sigil compiles into the alloc-free default build, so no
+/// `String`). 24 bytes comfortably holds "v<5-digit> <forge-noun≤8>" (≤15 chars).
+struct Buf {
+    buf: [u8; 24],
+    len: usize,
+}
+
+impl Buf {
+    fn new() -> Self {
+        Self { buf: [0; 24], len: 0 }
+    }
+    fn as_str(&self) -> &str {
+        core::str::from_utf8(&self.buf[..self.len]).unwrap_or("")
+    }
+}
+
+impl Write for Buf {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        for &b in s.as_bytes() {
+            if self.len < self.buf.len() {
+                self.buf[self.len] = b;
+                self.len += 1;
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #282. Supersedes #276/#277 (JP course-correct: identity gets its **own** screen, not a clock header).

> JP: "regress the sigil on display replacing the clock. make it its own plugin and restore the clock."

## What
1. **Reverted the #277 Clock name-header** — `draw_clock` is restored byte-for-byte to its pre-#277 state (verified: empty diff vs parent `a209858`). Clean clock, no top-left noun.
2. **New dedicated Sigil plugin** (`src/sigil.rs`) — the node identity is now its own **navigable screen** (own `App`/`Plugin` + a BOOT-button **menu row**), not crammed into the Clock and not hijacking the Custom screen. Compiled into **every** build (identity needs no radio, like About/Clock).

## The nameplate (whole 72×40 panel)
```
      Spectral        <- fantasy ADJECTIVE  (FONT_5X8, centred — the flourish)
       Aegis          <- NOUN handle        (FONT_6X10, centred — the identity)
   ──────────────     <- hairline divider   (who │ which)
     v903 Bellows     <- FORGE version sigil (FONT_5X8, centred — provenance)
```
- `FONT_6X10` for the noun — the largest font that fits **all** 8-char fantasy nouns at 72px (10x20 clips them; same rationale as the boot splash).
- Full magical name = adjective + noun (what `sigil.generate_name` returns), so this literally shows "the node sigil name". Version line matches the boot splash's compact `v<build> <forge-noun>` (no dev-hash → never overflows).
- Static content → paints **once** (redraw-latched), no per-tick cost. Heap-free + panic-free for the alloc-free default build.

## Wiring (one screen = one arm each)
`AppKind::Sigil` through `enter` / `on_button` / `update` / `live_screen`, plus `from_wire` (#21 `default_screen` can target `Sigil`), `as_wire` (#50 status readback), the `REGISTRY` menu row (by About, in the identity group), and `plugin_bit` → `None` (non-maskable like Menu/Custom, so a legacy #55 all-on mask can't hide a board's own nameplate).

## Verify
- `cargo check --release --features espnow,cast,io` — **green** (`Finished`, exit 0).
- `cargo check --release` (default, no-radio) — **green** (exit 0).
- `sigil.rs` + `app.rs` are **clippy-clean**. (The one clippy `div_ceil` warning is pre-existing in `net/election.rs:143` from #275 — not this change.)
- Not HW-flashed (team-lead owns boards; fleet mid-roll). Renders on the next OTA. The operational live regression (`default_screen=Clock`) was handled separately by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)