### PR TITLE
fix(clippy): div_ceil in elect_backoff_ms (restore -D warnings gate)

### DIFF
--- a/rust/clock/src/net/election.rs
+++ b/rust/clock/src/net/election.rs
@@ -140,7 +140,7 @@ pub fn elect_backoff_ms(i: &FitnessInputs, w: &MetricWeights, node_id: u8) -> u6
     let fit = gateway_fitness(i, w) as u64;
     let deficit = maxf.saturating_sub(fit);
     // ceil(deficit * MAX_ELECT_TIERS / maxf), clamped — best board (deficit 0) → tier 0 → no wait.
-    let tiers = ((deficit * MAX_ELECT_TIERS) + (maxf - 1)) / maxf;
+    let tiers = (deficit * MAX_ELECT_TIERS).div_ceil(maxf);
     tiers.min(MAX_ELECT_TIERS) * ELECT_TIER_STEP_MS + (node_id as u64) * 200
 }
 


### PR DESCRIPTION
Pre-existing `manual_div_ceil` from #275 at net/election.rs:143 that would trip `clippy -D warnings` — the katana 4-tier gate the new dependabot config (#281) names as its safety mechanism. One-line, behavior-identical; election_verify host harness passes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>