### PR TITLE
chore(deps): mute egui family in dependabot (coordinated migration #292)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,13 @@ updates:
       # #233 matched set — do NOT auto-bump; breaks the firmware build.
       - dependency-name: "esp-*"
       - dependency-name: "smoltcp"
+      # egui family — coordinated migration only (tracked in #292). meshscope
+      # pins eframe+egui+egui_plot at 0.28; eframe hard-pins egui ^0.28, so a
+      # piecemeal bump of any one forces two incompatible egui crates into the
+      # graph and breaks the build (held PRs #287/#291). Bump all three together
+      # in one migration PR, not weekly dependabot lockstep bumps.
+      - dependency-name: "eframe"
+      - dependency-name: "egui*"
 
   # ---- GitHub Actions (.github/workflows) ---------------------------------
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Adds `eframe` + `egui*` to the cargo `ignore` list in `.github/dependabot.yml`.

Dependabot cannot produce a mergeable egui bump: meshscope pins eframe+egui+egui_plot at 0.28 and eframe hard-pins `egui ^0.28`, so any single-crate bump forces two incompatible egui crates into the graph and breaks the build (verified on held PRs #287 → 12 errors, #291 → 4 errors). The egui family will be upgraded as ONE coordinated migration, tracked in #292.

Mirror of the esp-*/smoltcp exclusion pattern (config-only, like #281).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>