### PR TITLE
feat(viz): #197 operator-dock custom-screen composer UI

### DIFF
--- a/rust/viz/meshscope/src/operator.rs
+++ b/rust/viz/meshscope/src/operator.rs
@@ -254,10 +254,10 @@ pub fn wrap_preview(msg: &str) -> Vec<String> {
 
 /// Glyph size for a custom row → the fw fonts (`custom.rs`): s=5x8, m=6x10, l=10x20. `width`/
 /// `max_rows` are luna's verified per-size capacities on the 72×40 panel (the #197 contract).
-#[derive(Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)] // constructed by the #197 operator-dock composer UI (deferred — needs a GUI)
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum HeraldSize {
     Small,
+    #[default]
     Medium,
     Large,
 }
@@ -286,10 +286,10 @@ impl HeraldSize {
 }
 
 /// Row alignment within the 72 px panel (`custom.rs`): left / centre / right.
-#[derive(Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)] // constructed by the #197 operator-dock composer UI (deferred — needs a GUI)
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum HeraldAlign {
     Left,
+    #[default]
     Center,
     Right,
 }
@@ -303,15 +303,17 @@ impl HeraldAlign {
     }
 }
 
-/// #197: compose the CUSTOM-screen wire from operator inputs — the pure, testable core the dock
-/// UI (deferred) will call before [`custom`]. Sanitises (strip `|`/`;`, collapse, trim, cap),
-/// word-wraps to the size's WIDTH/MAXROWS, and frames the rows as `<count>[!][~dur]|seg;seg…`
-/// where each `seg = <size><align>row`. Empty/blank message → empty wire (which clears the
-/// screen). Pure + panic-free.
-// Consumed by the #197 dock composer UI, which is deferred (a GUI is needed to verify it); the
-// wire logic + its tests land now so that UI is a thin wiring layer. Same `allow` rationale as
-// the fw's "dead in this tier" builders.
-#[allow(dead_code)]
+/// #197: the wrapped on-glass ROWS for `msg` at `size` — sanitised then word-wrapped to the
+/// size's WIDTH/MAXROWS. The dock composer previews these (WYSIWYG, exactly what renders) and
+/// [`compose_custom`] frames them into the wire. Pure + panic-free.
+pub fn compose_rows(msg: &str, size: HeraldSize) -> Vec<String> {
+    wrap_to(&sanitize(msg), size.width(), size.max_rows())
+}
+
+/// #197: compose the CUSTOM-screen wire from operator inputs — the pure core the dock UI calls
+/// before [`custom`]. Word-wraps via [`compose_rows`] and frames the rows as
+/// `<count>[!][~dur]|seg;seg…` where each `seg = <size><align>row`. Empty/blank message → empty
+/// wire (which clears the screen). Pure + panic-free.
 pub fn compose_custom(
     msg: &str,
     size: HeraldSize,
@@ -319,7 +321,7 @@ pub fn compose_custom(
     dur_s: Option<u16>,
     priority: bool,
 ) -> String {
-    let rows = wrap_to(&sanitize(msg), size.width(), size.max_rows());
+    let rows = compose_rows(msg, size);
     if rows.is_empty() {
         return String::new();
     }

--- a/rust/viz/meshscope/src/ui/opdock.rs
+++ b/rust/viz/meshscope/src/ui/opdock.rs
@@ -5,7 +5,7 @@
 
 use egui::{Color32, RichText};
 
-use crate::operator::{self, PublishReq, Publisher};
+use crate::operator::{self, HeraldAlign, HeraldSize, PublishReq, Publisher};
 use mesh_model::model::Node;
 
 /// Screen names = the exact `app.rs` `AppKind` wire spellings (single-source parity). Matches
@@ -26,7 +26,12 @@ pub struct OperatorState {
     screen_kind: String,
     screen_page: String,
     plugins_hex: String,
+    /// #197 custom-screen composer: the message text + its size/align/duration/priority.
     custom: String,
+    custom_size: HeraldSize,
+    custom_align: HeraldAlign,
+    custom_dur: String,
+    custom_priority: bool,
     io_map: String,
     io_set: String,
     broker: String,
@@ -131,12 +136,47 @@ pub fn show(ui: &mut egui::Ui, sel: Option<&Node>, publisher: &Publisher, st: &m
                     }
                 });
 
-                // Custom compose string.
+                // #197 Custom-screen composer — mirrors HA's herald composer; emits the fw #45
+                // wire via `compose_custom` so a board renders identically from HA or here.
+                ui.label(RichText::new("custom screen (composed)").small().weak());
+                ui.add(egui::TextEdit::singleline(&mut st.custom).desired_width(170.0).hint_text("message"));
                 ui.horizontal(|ui| {
-                    ui.label("Custom");
-                    ui.add(egui::TextEdit::singleline(&mut st.custom).desired_width(130.0));
-                    if ui.add_enabled(!st.custom.is_empty(), egui::Button::new("Set")).clicked() {
-                        action = Some(operator::custom(id, &st.custom.clone()));
+                    ui.label("size");
+                    ui.selectable_value(&mut st.custom_size, HeraldSize::Small, "S");
+                    ui.selectable_value(&mut st.custom_size, HeraldSize::Medium, "M");
+                    ui.selectable_value(&mut st.custom_size, HeraldSize::Large, "L");
+                    ui.separator();
+                    ui.label("align");
+                    ui.selectable_value(&mut st.custom_align, HeraldAlign::Left, "L");
+                    ui.selectable_value(&mut st.custom_align, HeraldAlign::Center, "C");
+                    ui.selectable_value(&mut st.custom_align, HeraldAlign::Right, "R");
+                });
+                ui.horizontal(|ui| {
+                    ui.label("secs");
+                    ui.add(egui::TextEdit::singleline(&mut st.custom_dur).desired_width(28.0).hint_text("0"));
+                    ui.checkbox(&mut st.custom_priority, "priority");
+                });
+                let cust_msg = st.custom.clone();
+                let have_cust = !cust_msg.trim().is_empty();
+                // WYSIWYG preview: the wrapped rows exactly as the fw renders them at this size.
+                if have_cust {
+                    let rows = operator::compose_rows(&cust_msg, st.custom_size);
+                    ui.label(RichText::new("preview (on glass):").small().weak());
+                    egui::Frame::NONE.fill(Color32::from_rgb(18, 20, 26)).inner_margin(3).show(ui, |ui| {
+                        for r in &rows {
+                            ui.label(RichText::new(r).monospace().color(Color32::from_rgb(215, 220, 230)));
+                        }
+                    });
+                }
+                ui.horizontal(|ui| {
+                    if ui.add_enabled(have_cust, egui::Button::new("Set custom")).clicked() {
+                        let dur = st.custom_dur.trim().parse::<u16>().ok();
+                        let wire = operator::compose_custom(&cust_msg, st.custom_size, st.custom_align, dur, st.custom_priority);
+                        action = Some(operator::custom(id, &wire));
+                    }
+                    // Empty retained payload clears the custom screen (retain-delete → noun fallback).
+                    if ui.button("Clear").clicked() {
+                        action = Some(operator::custom(id, ""));
                     }
                 });
 


### PR DESCRIPTION
Closes #197. Wires the operator-dock UI onto the merged `compose_custom()` core (#298).

## What
The meshscope operator dock's **Custom** control was raw-wire entry; this makes it a real composer that mirrors HA's herald composer (#24) — so a board renders identically whether driven from HA or meshscope.

- **Message** text + **size** (S/M/L) + **align** (L/C/R) + **duration** (secs; 0 = keep) + **priority** checkbox.
- **WYSIWYG preview**: the wrapped on-glass rows at the chosen size (`operator::compose_rows`), in the same framed idiom as the existing toast preview.
- **Set custom** → `compose_custom()` → `operator::custom(id, wire)` (retained, through the existing brick-safe publish path — the retained-command refusal already guards it).
- **Clear** → empty retained payload (retain-delete → the fw noun fallback).

## Supporting refactor (`operator.rs`)
- Extracted `compose_rows()` (shared by the preview and `compose_custom`).
- `HeraldSize`/`HeraldAlign` gain `Default` (Medium / Center) for the dock's `OperatorState`.
- Dropped the `#[allow(dead_code)]` from #298 — the UI is now the caller.

## Verify (headless)
- `cargo check --workspace` — green.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p meshscope` — **11/11** (the `compose_custom` tests survive the `compose_rows` extraction).
- `cargo build -p meshscope` — **links**.
- `beginagain` scan — 0.

## Visual verification pending
An eframe GUI can't be driven headless, so the **on-screen render is unverified** — this is pending JP's next `meshscope --operator` run. The wiring is complete and mirrors the dock's established idiom (same `selectable_value`/`TextEdit`/preview-frame patterns as the shipped toast section); any layout nit found on a real GUI run is a follow-up, not a reopen. Viz-side only — zero firmware/Embassy overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)