### PR TITLE
ci: #338 make the build-tier gate a gate, not prose

### DIFF
--- a/.github/workflows/fw-gate.yml
+++ b/.github/workflows/fw-gate.yml
@@ -1,0 +1,84 @@
+# #338 — the firmware gate, in CI.
+#
+# Before this, `.github/workflows/` held only `pages.yml`: nothing built any feature tier, ran
+# clippy, or ran the host suites. The "4-tier gate" cited in ONBOARDING.md and rust-toolchain.toml
+# was prose plus whoever remembered to run it. On 2026-08-01 that cost us main sitting red on its
+# own `-D warnings` rule unnoticed, a new feature (`ledger-provision`) with no matrix to add it to,
+# and two agents separately hand-building baselines to compute a clippy delta.
+#
+# DELIBERATELY THIN: every actual command lives in `tools/gate.sh`, which a developer runs verbatim
+# before pushing. If the gate logic lived here, the local instructions and CI would be two
+# definitions free to drift — the same failure in a new place. This file only supplies a machine.
+name: fw gate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# A force-push supersedes its own in-flight run; main runs are never cancelled.
+concurrency:
+  group: fw-gate-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  # Keep a runner's memory in bounds: these are LTO release builds of an embedded crate.
+  SMOL_GATE_JOBS: 2
+
+jobs:
+  # Split so a Rust-only breakage is distinguishable at a glance from a host-logic regression,
+  # and so the host suites still report when the riscv toolchain is the thing that broke.
+  host:
+    name: host verifier suites
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      # rust-toolchain.toml pins `stable` + the riscv target + clippy; rustup honours it
+      # automatically, so there is no version to restate here (and none to drift).
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: experiments
+          key: host
+      - run: tools/gate.sh host
+
+  firmware:
+    name: tiers + clippy + stack floor
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - name: Show resolved toolchain
+        working-directory: rust/clock
+        run: rustc -vV && cargo clippy --version
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust/clock
+          key: fw
+      # readelf reads _stack_start/_stack_end out of the riscv ELF (arch-independent); ubuntu-latest
+      # ships binutils, but assert it rather than discovering its absence as a confusing FATAL.
+      - name: Assert readelf present
+        run: readelf --version >/dev/null
+
+      - run: tools/gate.sh fw
+
+      # The single highest-value line in this workflow, surfaced where a reviewer sees it without
+      # opening logs. Both the #233 spike and the #266 rebase turned on this number and both found
+      # it at the last possible moment; it was previously computed only at package time.
+      - name: Stack number → job summary
+        if: always()
+        run: |
+          {
+            echo "### Canonical image stack"
+            if [ -s /tmp/gate-stack-report ]; then
+              echo '```'; cat /tmp/gate-stack-report; echo '```'
+            else
+              echo "_stack number unavailable — the canonical build did not reach the check._"
+            fi
+            echo ""
+            echo "⚠️ This bounds the linked **region**, not runtime high-water. A struct in a"
+            echo "stack-resident \`RadioManager\` can cost ~1.8 KB of real stack while moving this"
+            echo "number by ~32 B. Green here is not evidence of runtime headroom."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -127,11 +127,26 @@ Full toolchain + gotchas: **[`docs/BUILDING.md`](docs/BUILDING.md)**. TL;DR for 
    `DEFAULT_APP`, `DEFAULT_PAGE`) and `cp src/secrets.rs.example src/secrets.rs` (WiFi/MQTT creds —
    **placeholders in the example; never commit real values**). Per-board flashes edit only these
    ignored files, so every board stamps the same clean commit hash.
-2. **Build tiers:** `cargo build --release` (default, always-green) · `--features wifi` · `--features
-   espnow` (the fleet build). **Gate discipline:** every change must pass `build` + `clippy -D
-   warnings` across **all three** tiers, and the `default` build must stay behaviourally unaffected
-   (prove via cfg-gating, **not** ELF byte-equality — `build.rs` stamps a per-commit git hash, so the
-   default ELF changes every commit by design).
+2. **Build tiers and the gate: `tools/gate.sh`.** Run it before you push; CI (`.github/workflows/
+   fw-gate.yml`) runs the *same script*, so there is nothing here to fall out of step with it.
+   `tools/gate.sh` (or `host` / `fw` for one half) covers: `cargo check` across the tiers — default
+   (always-green) · `wifi` · `espnow` · the canonical fleet tier · any feature it finds in
+   `Cargo.toml` — plus `clippy -D warnings` on the canonical tier, the host `experiments/*_verify`
+   suites, and the #300 **stack floor** (printed on every PR).
+
+   **This list deliberately lives in the script, not here.** Until #338 it lived only in prose, and
+   the prose was wrong without anyone noticing: `main` sat red on its own `-D warnings` rule, and a
+   feature was added with no matrix to add it to. Add a tier to `gate.sh`, not to this paragraph.
+
+   **Known gaps** (`gate.sh` states them too): `clippy -D` runs on the canonical tier only —
+   `default`/`wifi` carry pre-existing dead-code findings and get `cargo check` alone; `mesh-test`
+   needs a real board's `DEAF_MACS`; image packaging and anything needing hardware are out of scope.
+   The stack check bounds the linked **region**, *not* runtime high-water — green there is not
+   evidence of headroom.
+
+   The `default` build must also stay behaviourally unaffected (prove via cfg-gating, **not** ELF
+   byte-equality — `build.rs` stamps a per-commit git hash, so the default ELF changes every commit
+   by design).
 3. **Version identity:** `build.rs` embeds `BUILD_HASH` + `BUILD_NUMBER` →
    `names.rs::version_name()`, a forge-realm sigil name. The number is the OTA monotonicity gate;
    the name is the boot-splash reveal. Two things to get right:

--- a/rust/clock/src/net/cfgsched.rs
+++ b/rust/clock/src/net/cfgsched.rs
@@ -57,6 +57,14 @@ pub const CFG_RELAY_MAX_BURST: usize = 16;
 /// Deliberately ignores priming (which covers everything in one tick): this is the WORST case, and
 /// a bound that assumed the optimisation would be wrong exactly when the optimisation fails, which
 /// is the only time anybody reads it.
+///
+/// `#[allow(dead_code)]` because this is the HOST-TEST half of the API: `cfg_relay_verify`
+/// `#[path]`-includes this module and asserts the anti-starvation contract against this bound, but
+/// the firmware binary only ever *cites* it (see the `broadcast_cached_configs` comment in
+/// `mode.rs`), so a binary-crate build sees it as unused. Same precedent as `net::{ledger, treehead,
+/// sth}`. The allow is on the ITEM, not the module, so the rest of `cfgsched` stays under `-D
+/// warnings` — deleting it instead would delete the test's bound, which is the property being proven.
+#[allow(dead_code)]
 pub const fn ticks_to_cover(count: usize) -> usize {
     if count == 0 {
         0
@@ -142,6 +150,11 @@ impl RelayCursor {
     }
 
     /// The next slot index this cursor will emit (test/observability only).
+    ///
+    /// `#[allow(dead_code)]` for the same reason as [`ticks_to_cover`]: `cfg_relay_verify` reads it
+    /// to prove the cursor ADVANCES between ticks and resets on an empty cache — a property with no
+    /// firmware caller by design (the firmware just calls `take`). Item-scoped, not module-scoped.
+    #[allow(dead_code)]
     pub fn peek(&self) -> usize {
         self.next
     }

--- a/tools/ci_provision.sh
+++ b/tools/ci_provision.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# #338: create the git-ignored per-board provisioning a firmware build needs, for a CLEAN CHECKOUT
+# (CI, or a fresh worktree). `src/secrets.rs` and `src/board.rs` are git-ignored by design — the repo
+# is public — so nothing in a fresh clone compiles the firmware until they exist. That is precisely
+# why no CI job ever built a tier: the build was impossible without a manual step nobody had written
+# down. This writes throwaway values good enough to COMPILE and never good enough to ship.
+#
+# NON-DESTRUCTIVE: an existing secrets.rs/board.rs is left ALONE. A developer's real WiFi creds and
+# fleet GROUP_KEY must survive running the gate locally — clobbering them would make `tools/gate.sh`
+# something people avoid, and a gate people avoid is the failure this issue is about.
+#
+# Usage: tools/ci_provision.sh [clock_dir]     (default: rust/clock)
+set -euo pipefail
+
+clock="${1:-rust/clock}"
+src="$clock/src"
+[ -d "$src" ] || { echo "ci_provision: no such dir: $src" >&2; exit 1; }
+
+for f in secrets board; do
+  if [ -f "$src/$f.rs" ]; then
+    echo "  $f.rs: present, left untouched"
+  elif [ -f "$src/$f.rs.example" ]; then
+    cp "$src/$f.rs.example" "$src/$f.rs"
+    echo "  $f.rs: created from $f.rs.example"
+  else
+    echo "ci_provision: missing $src/$f.rs.example" >&2; exit 1
+  fi
+done
+
+# #190/#336 forward-compatibility. Once the #266 core lands, `secrets.rs.example` ships
+# `GROUP_KEY = [0u8; 32]` AND `net/mode.rs` carries a compile-time assert that REFUSES the all-zero
+# key (the repo is public, so the example key is a published credential). A CI build from the
+# unedited example would therefore fail to compile — correctly, but uselessly. So if the key is
+# present and zeroed, substitute a random one.
+#
+# This key is a BUILD-LOCAL THROWAWAY and must never reach a board: it is regenerated every run, is
+# not the fleet key, and a node built with it cannot talk to the fleet. That is the intended
+# property — CI proves the code COMPILES and the guard WORKS, and cannot accidentally emit a
+# flashable image that would join the mesh.
+if [ -f "$src/secrets.rs" ] && grep -q "GROUP_KEY" "$src/secrets.rs"; then
+  if grep -qE 'GROUP_KEY: *\[u8; *32\] *= *\[0u8; *32\]' "$src/secrets.rs"; then
+    key=$(od -An -tu1 -N32 /dev/urandom | tr -s ' ' | tr ' ' '\n' | grep -E '^[0-9]+$' | paste -sd, -)
+    # Guarantee non-zero even in the (astronomically unlikely) all-zero draw — the point is the
+    # guard, and a gate that can emit the value it exists to reject is not a gate.
+    key="1,${key#*,}"
+    python3 - "$src/secrets.rs" "$key" <<'PY'
+import re, sys
+path, key = sys.argv[1], sys.argv[2]
+s = open(path).read()
+s = re.sub(r'(GROUP_KEY: *\[u8; *32\] *= *)\[0u8; *32\]',
+           lambda m: m.group(1) + '[' + key + ']', s)
+open(path, 'w').write(s)
+PY
+    echo "  secrets.rs: GROUP_KEY was the published all-zero example — substituted a random CI key"
+  else
+    echo "  secrets.rs: GROUP_KEY already set, left untouched"
+  fi
+fi

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# #338 THE GATE. One script, run identically by CI (.github/workflows/fw-gate.yml) and by a human
+# before pushing. It exists because the multi-tier gate everyone cited was PROSE in ONBOARDING.md —
+# and on 2026-08-01 main was found red on its own `clippy -D warnings` rule with nobody aware, a new
+# feature (`ledger-provision`) was added with no matrix to add it to, and two agents independently
+# hand-built baselines to compute a clippy delta. A gate that lives in prose has already stopped
+# running.
+#
+# ONBOARDING.md points AT this file rather than restating the commands, so the two cannot drift.
+#
+# WHAT IT COVERS
+#   1. cargo check --release across the build tiers (default / wifi / espnow / canonical fleet)
+#   2. cargo clippy --release -D warnings on the CANONICAL tier
+#   3. the host experiments/*_verify suites
+#   4. the #300 stack floor — the canonical ELF's .stack region vs the 73,728 B floor
+#
+# WHAT IT DOES NOT COVER — read this before trusting a green run:
+#   * clippy -D on `default`/`wifi`: those tiers carry PRE-EXISTING dead-code findings (symbols used
+#     only by espnow builds). They get `cargo check` (compile breaks caught, new warnings NOT). Fixing
+#     them is a separate change; until then this is a known hole, stated rather than hidden.
+#   * `mesh-test`: needs a per-board `DEAF_MACS` that only a real board.rs has.
+#   * espflash `save-image` packaging: not run (no espflash in CI). The stack number does not depend
+#     on it — it is read from the ELF — but image PACKAGING is therefore unproven here.
+#   * Anything requiring hardware: OTA, radio, election, the stack-paint HIGH-WATER measurement.
+#     ⚠️ The stack check bounds the linked REGION, not runtime high-water. A struct living in a
+#     stack-resident RadioManager can cost ~1.8 KB of real stack and move the region by ~32 B. A
+#     green stack line is NOT evidence of runtime headroom (see repro_stack_check's comment).
+#
+# Usage:  tools/gate.sh              # everything
+#         tools/gate.sh host         # host suites only (no riscv toolchain needed)
+#         tools/gate.sh fw           # tiers + clippy + stack only
+# Env:    CARGO_TARGET_DIR honoured; SMOL_GATE_JOBS caps cargo parallelism.
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+ROOT="$PWD"
+CLOCK="rust/clock"
+WHAT="${1:-all}"
+FAILED=()
+run_fw=1; run_host=1
+case "$WHAT" in
+  host) run_fw=0 ;;
+  fw)   run_host=0 ;;
+  all)  ;;
+  *) echo "usage: tools/gate.sh [all|host|fw]" >&2; exit 2 ;;
+esac
+
+# shellcheck source=/dev/null
+. "$ROOT/tools/repro_build.sh"   # REPRO_TARGET, REPRO_FLEET_FEATURES, repro_cargo_args, repro_stack_check
+
+JOBS=()
+[ -n "${SMOL_GATE_JOBS:-}" ] && JOBS=(-j "$SMOL_GATE_JOBS")
+
+# Where the stack verdict is left for a caller (CI lifts it into the PR job summary).
+STACK_REPORT="${SMOL_GATE_STACK_REPORT:-/tmp/gate-stack-report}"
+rm -f "$STACK_REPORT"
+
+step() { printf '\n\033[1m── %s\033[0m\n' "$1"; }
+ok()   { printf '   \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { printf '   \033[31mFAIL\033[0m %s\n' "$1"; FAILED+=("$1"); }
+
+if [ "$run_fw" = 1 ]; then
+  step "provisioning (git-ignored; existing files untouched)"
+  "$ROOT/tools/ci_provision.sh" "$CLOCK" || { echo "provisioning failed" >&2; exit 1; }
+
+  # The tiers. `default` is the always-green baseline; `wifi`/`espnow` are the documented rungs;
+  # the canonical fleet tier is what actually ships. A feature added to Cargo.toml and NOT added
+  # here is a code path nothing compiles — the `ledger-provision` case that motivated this issue.
+  # Any feature listed in Cargo.toml's [features] that is not covered below should be added.
+  step "cargo check — build tiers"
+  for tier in "default:" "wifi:wifi" "espnow:espnow" "fleet:$REPRO_FLEET_FEATURES" "ledger-provision:ledger-provision"; do
+    name="${tier%%:*}"; feats="${tier#*:}"
+    # A tier naming a feature this branch does not have (e.g. ledger-provision before #181 lands)
+    # is SKIPPED, not failed — the gate must work on both sides of that merge.
+    if [ -n "$feats" ] && ! grep -qE "^${feats%%,*} *=" "$CLOCK/Cargo.toml"; then
+      printf '   \033[33mSKIP\033[0m %-16s (feature not in Cargo.toml on this branch)\n' "$name"; continue
+    fi
+    args=(--release "${JOBS[@]}"); [ -n "$feats" ] && args+=(--features "$feats")
+    if (cd "$CLOCK" && cargo check "${args[@]}") >/tmp/gate-$name.log 2>&1; then
+      ok "check $name"
+    else
+      bad "check $name"; tail -15 /tmp/gate-$name.log | sed 's/^/        /'
+    fi
+  done
+
+  step "cargo clippy -D warnings — canonical tier ($REPRO_FLEET_FEATURES)"
+  if (cd "$CLOCK" && cargo clippy --release "${JOBS[@]}" --features "$REPRO_FLEET_FEATURES" -- -D warnings) \
+       >/tmp/gate-clippy.log 2>&1; then
+    ok "clippy canonical"
+  else
+    bad "clippy canonical"
+    grep -E "^(error|warning)" /tmp/gate-clippy.log | grep -v "could not compile" | sort -u | sed 's/^/        /' | head -20
+  fi
+
+  # #300 stack floor, measured with the SAME function the packaging path uses (repro_stack_check).
+  # Built with repro_cargo_args so the ELF matches the shipped one's geometry.
+  step "stack floor — canonical ELF vs ${REPRO_STACK_FLOOR:-73728} B"
+  if repro_cargo_args "$CLOCK" 2>/dev/null && \
+     (cd "$CLOCK" && cargo build --release "${JOBS[@]}" --features "$REPRO_FLEET_FEATURES" "${REPRO_CARGO_ARGS[@]}") \
+       >/tmp/gate-stack.log 2>&1; then
+    ELF="${CARGO_TARGET_DIR:-$ROOT/$CLOCK/target}/${REPRO_TARGET}/release/clock"
+    # Capture the verdict to a file as well as the console: CI lifts it into the job summary so the
+    # number is visible without opening logs. Written on FAILURE too — "the stack broke the floor"
+    # is the case a reader most needs surfaced, and a report that only exists when green would hide
+    # exactly that.
+    if out=$(repro_stack_check "$ELF" 2>&1); then
+      printf '%s\n' "$out"; printf '%s\n' "$out" > "$STACK_REPORT"; ok "stack floor"
+    else
+      printf '%s\n' "$out"; printf '%s\n' "$out" > "$STACK_REPORT"; bad "stack floor"
+    fi
+  else
+    bad "stack floor (canonical build failed)"
+    echo "canonical build failed before the stack could be measured" > "$STACK_REPORT"
+    tail -15 /tmp/gate-stack.log | sed 's/^/        /'
+  fi
+fi
+
+if [ "$run_host" = 1 ]; then
+  # Every experiments/*_verify is a standalone host crate that panics on failure. Discovered by
+  # GLOB, not by a hardcoded list: a new verifier is picked up automatically, which is the whole
+  # point — the last list-shaped gate silently stopped covering what was added after it.
+  step "host verifier suites"
+  for d in "$ROOT"/experiments/*/; do
+    [ -f "$d/Cargo.toml" ] || continue
+    n=$(basename "$d")
+    case "$n" in *_verify|relay_compat) ;; *) continue ;; esac
+    if (cd "$d" && cargo run --release -q "${JOBS[@]}") >/tmp/gate-$n.log 2>&1; then
+      ok "$n"
+    else
+      bad "$n"; tail -10 /tmp/gate-$n.log | sed 's/^/        /'
+    fi
+  done
+fi
+
+step "summary"
+if [ ${#FAILED[@]} -eq 0 ]; then
+  printf '   \033[32mGATE GREEN\033[0m\n'; exit 0
+fi
+printf '   \033[31mGATE RED — %d failure(s):\033[0m\n' "${#FAILED[@]}"
+printf '     • %s\n' "${FAILED[@]}"
+exit 1

--- a/tools/repro_build.sh
+++ b/tools/repro_build.sh
@@ -35,6 +35,12 @@
 # The bare-metal target the fleet builds for (matches .cargo/config.toml `build.target`).
 REPRO_TARGET="riscv32imc-unknown-none-elf"
 
+# #338: the CANONICAL fleet feature set, named once. `repro_build_bin` builds it and `tools/gate.sh`
+# gates it; before this was a variable the list lived only inside the build line below, so CI could
+# have gated a DIFFERENT tier than the one that ships and nothing would have said so. Changing this
+# forks the #44 reproducible-image sha lineage — see the note at the build call.
+REPRO_FLEET_FEATURES="${REPRO_FLEET_FEATURES:-espnow,cast,io,bard}"
+
 # Resolve the rustc sysroot for the toolchain that will ACTUALLY build — rustup picks it from
 # the crate's rust-toolchain.toml, so this MUST be evaluated inside the crate dir (from home it
 # would return `stable`, not the pinned 1.96.1, and the remap prefix would miss the build-std
@@ -69,6 +75,54 @@ repro_cargo_args() {
   REPRO_CARGO_ARGS=(
     --config "target.${REPRO_TARGET}.rustflags=[\"--remap-path-prefix=${reg}=/registry\",\"--remap-path-prefix=${sysroot}=/rust\"]"
   )
+}
+
+# #300 STACK FLOOR — the gate that was missing. `.stack` is placed in the DRAM left after `.bss`,
+# and the linker silently shrinks it rather than failing, so a successful link is NOT evidence of a
+# runnable image: with SEQ_CAP 192 the bard image linked with 2592 B of stack (82304 B without bard)
+# and put `__stack_chk_guard` outside the stack region, where the canary cannot detect the overflow
+# it exists to catch. Refuse to package an image that thin.
+#
+# The floor is DERIVED, not chosen: the T13 bench measured a 54,856 B high-water with the stack-paint
+# build (WiFi burst + crown duty + three stories), and 54,856 x 4/3 = 73,141, rounded up to 72 KiB =
+# 73,728. The 4/3 is a third again on top of the worst path we have actually observed — enough to
+# absorb a deeper interrupt nesting or a future radio change without being so generous that the gate
+# stops biting. Re-measure with stack-paint if either the radio stack or the bard's buffers move; a
+# floor copied forward untested is how the last one ended up at 12,288.
+#
+# ⚠️ The floor bounds the linked REGION, which is all an ELF can show. It cannot see runtime
+# high-water: a struct that lives in a stack-resident `RadioManager` costs real stack and moves this
+# number by almost nothing (#181's LedgerLink = 1,760 B on target, but only −32 B of region). So a
+# PASS here means "the region is not absurdly thin", NOT "the image has stack headroom". Re-derive
+# 4/3 x measured-high-water whenever something grows the deep call paths.
+#
+# #338: extracted from `repro_build_bin` so CI measures with the SAME code the packaging path uses.
+# A CI copy of this arithmetic would be a second definition free to drift from the one that actually
+# gates shipping — which is the exact failure this issue exists to remove.
+# repro_stack_check <elf>
+repro_stack_check() {
+  local elf="$1" stack_floor="${REPRO_STACK_FLOOR:-73728}"
+  local ss se
+  ss=$(readelf -sW "$elf" 2>/dev/null | awk '$8=="_stack_start"{print $2; exit}')
+  se=$(readelf -sW "$elf" 2>/dev/null | awk '$8=="_stack_end"{print $2; exit}')
+  if [ -n "$ss" ] && [ -n "$se" ]; then
+    local stack_bytes=$(( 0x$ss - 0x$se ))
+    if [ "$stack_bytes" -lt "$stack_floor" ]; then
+      echo "FATAL: runtime stack is ${stack_bytes} B, below the ${stack_floor} B floor." >&2
+      echo "       Something grew .bss. Shrink it (nano_llm::SEQ_CAP is the bard's lever) or" >&2
+      echo "       reclaim DRAM elsewhere — do NOT ship this image." >&2
+      return 1
+    fi
+    echo "  stack: ${stack_bytes} B (floor ${stack_floor} B)"
+  else
+    # FAIL CLOSED. This gate exists precisely because "it links" was not evidence of a runnable
+    # image; a gate that waves through an unreadable ELF restores that blind spot exactly, and
+    # the one time it matters is the time something is wrong with the build.
+    echo "FATAL: could not read _stack_start/_stack_end from $elf — refusing to package." >&2
+    echo "       Check that the ELF exists and that readelf is available; do NOT ship an" >&2
+    echo "       image whose stack was never measured." >&2
+    return 1
+  fi
 }
 
 # repro_build_bin <clock_dir> <out_bin> <hash> <build_number> [node_id]
@@ -154,46 +208,12 @@ repro_build_bin() {
     # it SILENTLY, so "it links" says nothing about whether the firmware can run — see the
     # stack-floor gate below. ⚠️ FORKS THE #44 SHA LINEAGE: every image built from this commit
     # forward differs from the pre-bard lineage by definition.
-    cargo build --release --features espnow,cast,io,bard "${REPRO_CARGO_ARGS[@]}"
+    cargo build --release --features "$REPRO_FLEET_FEATURES" "${REPRO_CARGO_ARGS[@]}"
   ) || return 1
   # Honor CARGO_TARGET_DIR (verify_image.sh --twice points each build at an isolated dir);
   # default to the in-tree target/ (ota_publish.sh's path) when unset.
   local tdir="${CARGO_TARGET_DIR:-$clock/target}"
-  # #300 STACK FLOOR — the gate that was missing. `.stack` is placed in the DRAM left after
-  # `.bss`, and the linker silently shrinks it rather than failing, so a successful link is NOT
-  # evidence of a runnable image: with SEQ_CAP 192 the bard image linked with 2592 B of stack
-  # (82304 B without bard) and put `__stack_chk_guard` outside the stack region, where the canary
-  # cannot detect the overflow it exists to catch. Refuse to package an image that thin.
-  #
-  # The floor is DERIVED, not chosen: the T13 bench measured a 54,856 B high-water with the
-  # stack-paint build (WiFi burst + crown duty + three stories), and 54,856 x 4/3 = 73,141,
-  # rounded up to 72 KiB = 73,728. The 4/3 is a third again on top of the worst path we have
-  # actually observed — enough to absorb a deeper interrupt nesting or a future radio change
-  # without being so generous that the gate stops biting. Re-measure with stack-paint if either
-  # the radio stack or the bard's buffers move; a floor copied forward untested is how the last
-  # one ended up at 12,288.
-  local elf="$tdir/${REPRO_TARGET}/release/clock" stack_floor=73728
-  local ss se
-  ss=$(readelf -sW "$elf" 2>/dev/null | awk '$8=="_stack_start"{print $2; exit}')
-  se=$(readelf -sW "$elf" 2>/dev/null | awk '$8=="_stack_end"{print $2; exit}')
-  if [ -n "$ss" ] && [ -n "$se" ]; then
-    local stack_bytes=$(( 0x$ss - 0x$se ))
-    if [ "$stack_bytes" -lt "$stack_floor" ]; then
-      echo "FATAL: runtime stack is ${stack_bytes} B, below the ${stack_floor} B floor." >&2
-      echo "       Something grew .bss. Shrink it (nano_llm::SEQ_CAP is the bard's lever) or" >&2
-      echo "       reclaim DRAM elsewhere — do NOT ship this image." >&2
-      return 1
-    fi
-    echo "  stack: ${stack_bytes} B (floor ${stack_floor} B)"
-  else
-    # FAIL CLOSED. This gate exists precisely because "it links" was not evidence of a runnable
-    # image; a gate that waves through an unreadable ELF restores that blind spot exactly, and
-    # the one time it matters is the time something is wrong with the build.
-    echo "FATAL: could not read _stack_start/_stack_end from $elf — refusing to package." >&2
-    echo "       Check that the ELF exists and that readelf is available; do NOT ship an" >&2
-    echo "       image whose stack was never measured." >&2
-    return 1
-  fi
+  repro_stack_check "$tdir/${REPRO_TARGET}/release/clock" || return 1
   "$espflash" save-image --chip esp32c3 \
     "$tdir/${REPRO_TARGET}/release/clock" "$out" >/dev/null || return 1
 }


### PR DESCRIPTION
Closes #338.

`.github/workflows/` held only `pages.yml`. Nothing built a feature tier, ran clippy, or ran the host suites — the "4-tier gate" cited in `ONBOARDING.md` and `rust-toolchain.toml` was **prose plus whoever remembered**. In one session that cost us three things: `main` sat red on its own `-D warnings` rule unnoticed (fixed in 4c5955f), a new feature (`ledger-provision`) arrived with no matrix to add it to, and two agents independently hand-built baselines to compute a clippy delta.

## Shape

`tools/gate.sh` is the gate. CI calls that same script, so the local instructions and CI are one definition rather than two free to drift. The workflow only supplies a machine.

| arm | covers |
|---|---|
| `cargo check` | default · wifi · espnow · canonical fleet · `ledger-provision` |
| `clippy -D warnings` | canonical tier |
| host suites | every `experiments/*_verify`, found by **glob** — a new verifier is picked up automatically |
| **stack floor** | canonical ELF `.stack` vs 73,728 B, **printed to the PR job summary** |

Tiers naming a feature absent on the branch are **skipped, not failed**, so this works on both sides of the #266 merge.

## Proof it can fail

A gate nobody has watched fail is a gate nobody should trust — this is the third "gate that couldn't fail" found this session, so each arm was broken deliberately first:

| injected breakage | result |
|---|---|
| `needless_range_loop` reintroduced (the exact 4c5955f class) | 🔴 `FAIL clippy canonical` |
| stack floor raised above actual | 🔴 `FAIL stack floor` — `FATAL: runtime stack is 75560 B, below the 80000 B floor.` reaches the job summary |
| host verifier made to assert false | 🔴 `FAIL etx_verify` |
| syntax error in tracked source | 🔴 `GATE RED — 4 failure(s)` |
| all reverted | 🟢 `GATE GREEN` |

One honest note: my first stack-breach attempt injected an **immutable** all-zero `static`, which lands in `.rodata` (flash), not `.bss` (DRAM) — so it moved nothing and the arm looked un-failable. The gate was right and the test was wrong. Recorded because that is the same "suspect the instrument" failure the stack gate itself exists to catch.

## Why `repro_build.sh` changed

- `repro_stack_check()` extracted from `repro_build_bin` so **CI measures with the same code that gates shipping**. A CI copy of that arithmetic would be a second definition free to drift. Behaviour-preserving: verified byte-identical output (75,560 B) by running the pre-refactor script against the same tree.
- `REPRO_FLEET_FEATURES` names the canonical tier once. It previously existed only inside the build line, so CI could have gated a *different* tier than the one that ships and nothing would have said so.

## Two supporting changes

- **`tools/ci_provision.sh`** — a clean checkout has no `secrets.rs`/`board.rs` (git-ignored; public repo), which is precisely *why* no CI job ever built a tier. Non-destructive: an existing file is left alone, so running the gate locally cannot eat real credentials. Forward-compatible with #266 — when the example ships the published all-zero `GROUP_KEY` that #336's assert refuses, it substitutes a random throwaway (verified: 32 valid `u8`s, non-zero, stable across runs).
- **`cfgsched.rs`** — item-scoped `#[allow(dead_code)]` on `ticks_to_cover`/`peek`. Both are genuinely exercised by `cfg_relay_verify` via `#[path]` and dead only in the binary, the same precedent as `net::{ledger,treehead,sth}`. **Prerequisite:** the canonical tier could not go green while `main` still failed its own gate.

## Not covered — stated, not hidden

- `clippy -D` on `default`/`wifi`: pre-existing dead-code findings there (symbols used only by espnow builds). They get `cargo check`, so compile breaks are caught but new warnings are not. Worth a follow-up.
- `mesh-test` (needs a real board's `DEAF_MACS`), espflash `save-image` packaging, and anything needing hardware.
- ⚠️ The stack check bounds the linked **region**, not runtime high-water. #181's `LedgerLink` costs 1,760 B of real stack while moving the region by ~32 B. **A green stack line is not evidence of runtime headroom.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)