### PR TITLE
ci: #343 clippy -D on every tier, not just the canonical one

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -138,11 +138,10 @@ Full toolchain + gotchas: **[`docs/BUILDING.md`](docs/BUILDING.md)**. TL;DR for 
    the prose was wrong without anyone noticing: `main` sat red on its own `-D warnings` rule, and a
    feature was added with no matrix to add it to. Add a tier to `gate.sh`, not to this paragraph.
 
-   **Known gaps** (`gate.sh` states them too): `clippy -D` runs on the canonical tier only —
-   `default`/`wifi` carry pre-existing dead-code findings and get `cargo check` alone; `mesh-test`
-   needs a real board's `DEAF_MACS`; image packaging and anything needing hardware are out of scope.
-   The stack check bounds the linked **region**, *not* runtime high-water — green there is not
-   evidence of headroom.
+   **Known gaps** (`gate.sh` states them too): `mesh-test` needs a real board's `DEAF_MACS`; image
+   packaging and anything needing hardware are out of scope. The stack check bounds the linked
+   **region**, *not* runtime high-water — green there is not evidence of headroom.
+   (`clippy -D` covered only the canonical tier until #343; it now runs on **every** tier.)
 
    The `default` build must also stay behaviourally unaffected (prove via cfg-gating, **not** ELF
    byte-equality — `build.rs` stamps a per-commit git hash, so the default ELF changes every commit

--- a/rust/clock/src/app.rs
+++ b/rust/clock/src/app.rs
@@ -185,6 +185,14 @@ pub trait Plugin {
     /// 224-274 ms measured — two orders of magnitude too long), no sensor reads, no radio, no
     /// flash. `main` calls it at most every `SYNC_REDRAW_MS`, the same cadence the OTA progress
     /// screens have already been hardware-watched at.
+    ///
+    /// `#[allow(dead_code)]`: both call sites are radio-gated — `main.rs:1097` under
+    /// `#[cfg(feature = "espnow")]` and `main.rs:1637` under `#[cfg(feature = "coexist-soak")]`
+    /// (which implies `espnow`) — so a `default` or `wifi` build compiles this and never calls it.
+    /// NOT cfg-gated away: this is a trait method with a default body, so gating it would make the
+    /// `Plugin` contract itself feature-dependent and force the cfg onto every implementor. The
+    /// empty default body inlines to nothing, so the lower tiers pay no bytes for the allow.
+    #[allow(dead_code)]
     fn paint_burst(&mut self, _display: &mut Oled, _now_ms: u64) {}
 }
 
@@ -513,6 +521,10 @@ impl App {
     /// Render-only dispatch for a WiFi-burst yield — see [`Plugin::paint_burst`]. Statically
     /// dispatched exactly like [`Self::update`], so a screen that does not implement it costs
     /// nothing at all (the default body is empty and inlines away).
+    ///
+    /// `#[allow(dead_code)]` for the same reason as the trait method it dispatches to: every caller
+    /// is `espnow`-gated, so `default`/`wifi` builds compile this dispatcher unused.
+    #[allow(dead_code)]
     pub fn paint_burst(&mut self, display: &mut Oled, now_ms: u64) {
         match self {
             App::Menu(s) => Plugin::paint_burst(s, display, now_ms),

--- a/rust/clock/src/net/election.rs
+++ b/rust/clock/src/net/election.rs
@@ -193,6 +193,12 @@ pub fn yield_to_co_channel_owner(
 /// recovery burst and fires RELIABLY — fixing the racy ~2/3 seize where a happy leaf-lock (co_channel
 /// transiently unknown at the boot tick) stopped the bursts that would have seized. A co-channel owner
 /// (`owner_ch == mesh`) or an unknown owner channel (`0`) → lock normally (false). Pure + deterministic.
+/// `#[allow(dead_code)]`: the firmware caller (`net/mode.rs`'s leaf-lock decision) is `espnow`-gated
+/// while this module is `wifi`-gated, so a `wifi`-only build compiles it unused. Deleting it is NOT
+/// an option — `experiments/election_verify` `#[path]`-includes this file and asserts five cases
+/// against this exact function, so it is the tested half of the API, the same shape as
+/// `cfgsched::{ticks_to_cover, peek}`. Item-scoped so the rest of `election` stays under `-D`.
+#[allow(dead_code)]
 pub fn refuse_leaf_lock_off_channel(my_ap_ch: u8, mesh_ch: u8, owner_ch: u8) -> bool {
     mesh_ch != 0 && my_ap_ch == mesh_ch && owner_ch != 0 && owner_ch != mesh_ch
 }

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -1749,8 +1749,16 @@ pub const CFG_KEY_TALE: u8 = b'T';
 /// 20..=500 ms/char on the node (a 0 would peg the reveal loop) and a malformed value is REFUSED
 /// with the previous setting kept — see `bard::delivery::Delivery::parse`. Cached + relayed like
 /// S/L/U/P/Y/T, applied live: the next tick uses it, mid-tale, no reboot.
+/// `#[allow(dead_code)]`: every consumer of this key is `espnow`-gated — the relay/cache paths in
+/// `net::mode` and the `take_cfg_offer` apply in `main.rs` — so a `wifi`-only build compiles the
+/// constant and never reads it. Kept HERE, ungated, so the whole keyed-CFG namespace stays in one
+/// place and a future key cannot silently reuse the letter (`V`); an unused `const` emits no code.
+#[allow(dead_code)]
 pub const CFG_KEY_DELIVERY: u8 = b'V';
 
+/// `#[allow(dead_code)]`: same as [`CFG_KEY_DELIVERY`] — consumed only by `espnow` paths
+/// (`net::mode`'s scan-request relay + `main.rs`'s offer apply). Kept for namespace integrity (`W`).
+#[allow(dead_code)]
 pub const CFG_KEY_SCAN: u8 = b'W';
 /// ~~#100 network-switch CONFIG (key `N`)~~ — **RETIRED by #142.** It used to carry the active
 /// WiFi-slot index (`0`/`1`), applied by writing the NVS net-record and rebooting into the slot.

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -2134,7 +2134,13 @@ pub fn mark_bl_revert(on: bool) {
 ///
 /// `off` is the honest reading of "not promoted": whether the bootloader has rollback disabled or
 /// simply did not set the state, the operational consequence is the same — there is no net.
+/// `#[allow(dead_code)]`: the sole caller is `diag_record` (`net/mode.rs`, the `|blrev=` PROTECTED
+/// field), which is `espnow`-gated — so a `wifi` build compiles this and never calls it. Left on
+/// `cfg(wifi)` rather than narrowed to `espnow`: it reads OTA bootloader state that belongs to the
+/// `wifi` tier's OTA machinery, and narrowing it would put the reader on a tighter gate than the
+/// `BL_REVERT` state it reads, which is the kind of mismatch that rots.
 #[cfg(feature = "wifi")]
+#[allow(dead_code)]
 pub fn bl_revert_token() -> Option<&'static str> {
     unsafe {
         let m = core::ptr::addr_of!(BL_REVERT).read();

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -10,14 +10,11 @@
 #
 # WHAT IT COVERS
 #   1. cargo check --release across the build tiers (default / wifi / espnow / canonical fleet)
-#   2. cargo clippy --release -D warnings on the CANONICAL tier
+#   2. cargo clippy --release -D warnings on EVERY tier (#343 — was canonical-only)
 #   3. the host experiments/*_verify suites
 #   4. the #300 stack floor — the canonical ELF's .stack region vs the 73,728 B floor
 #
 # WHAT IT DOES NOT COVER — read this before trusting a green run:
-#   * clippy -D on `default`/`wifi`: those tiers carry PRE-EXISTING dead-code findings (symbols used
-#     only by espnow builds). They get `cargo check` (compile breaks caught, new warnings NOT). Fixing
-#     them is a separate change; until then this is a known hole, stated rather than hidden.
 #   * `mesh-test`: needs a per-board `DEAF_MACS` that only a real board.rs has.
 #   * espflash `save-image` packaging: not run (no espflash in CI). The stack number does not depend
 #     on it — it is read from the ELF — but image PACKAGING is therefore unproven here.
@@ -93,14 +90,23 @@ if [ "$run_fw" = 1 ]; then
     fi
   done
 
-  step "cargo clippy -D warnings — canonical tier ($REPRO_FLEET_FEATURES)"
-  if (cd "$CLOCK" && cargo clippy --release "${JOBS[@]}" --features "$REPRO_FLEET_FEATURES" -- -D warnings) \
-       >/tmp/gate-clippy.log 2>&1; then
-    ok "clippy canonical"
-  else
-    bad "clippy canonical"
-    grep -E "^(error|warning)" /tmp/gate-clippy.log | grep -v "could not compile" | sort -u | sed 's/^/        /' | head -20
-  fi
+  # `-D warnings` on EVERY tier, not just the canonical one. Until #343 this ran on the canonical
+  # tier alone because `default`/`wifi` carried dead-code findings (symbols whose only callers are
+  # espnow-gated); those now carry item-scoped `#[allow(dead_code)]` with a cited reason, so the
+  # gate can cover what ONBOARDING has claimed all along. A tier that only gets `cargo check` has
+  # its new warnings invisible — which is how the findings accumulated unnoticed in the first place.
+  step "cargo clippy -D warnings — every tier"
+  for tier in "default:" "wifi:wifi" "espnow:espnow" "canonical:$REPRO_FLEET_FEATURES"; do
+    name="${tier%%:*}"; feats="${tier#*:}"
+    args=(--release "${JOBS[@]}"); [ -n "$feats" ] && args+=(--features "$feats")
+    if (cd "$CLOCK" && cargo clippy "${args[@]}" -- -D warnings) >/tmp/gate-clippy-$name.log 2>&1; then
+      ok "clippy $name"
+    else
+      bad "clippy $name"
+      grep -E "^(error|warning)" /tmp/gate-clippy-$name.log | grep -v "could not compile" \
+        | sort -u | sed 's/^/        /' | head -12
+    fi
+  done
 
   # #300 stack floor, measured with the SAME function the packaging path uses (repro_stack_check).
   # Built with repro_cargo_args so the ELF matches the shipped one's geometry.


### PR DESCRIPTION
Closes #343. Closes the hole #341 named in its own "not covered" section.

The gate ran `clippy -D warnings` on the canonical tier only. `default`/`wifi` got `cargo check` — compile breaks caught, **new warnings invisible**. That is precisely how findings accumulated on main unnoticed until #338, so leaving it was leaving the fence with a gap in it.

## Why those tiers were dirty

All five findings are one shape: **live code whose only callers are `espnow`-gated**, so a lower tier compiles it and never calls it. Verified per symbol, not assumed:

| symbol | why dead in default/wifi | fix |
|---|---|---|
| `paint_burst` ×2 (`app.rs`) | callers are `main.rs:1097` `cfg(espnow)` + `main.rs:1637` `cfg(coexist-soak)` | allow — it's a trait method w/ default body; gating would make the `Plugin` contract feature-dependent |
| `CFG_KEY_DELIVERY`/`CFG_KEY_SCAN` (`net/wifi.rs`) | consumed only by `net::mode` + main's espnow apply | allow — keeps the keyed-CFG namespace intact so `V`/`W` can't be silently reused; unused `const` emits no code |
| `refuse_leaf_lock_off_channel` (`net/election.rs`) | caller `mode.rs:5678` is espnow; module is wifi-gated | allow — **`election_verify` `#[path]`-includes it and asserts 5 cases**; deleting it deletes the tested property |
| `bl_revert_token` (`ota.rs`) | sole caller is `diag_record`'s `\|blrev=` (espnow) | allow — left on `cfg(wifi)` so the reader isn't on a tighter gate than the state it reads |

Item-scoped, each citing which caller and which gate. No module-level allows; nothing deleted that a host verifier exercises.

## Proven able to fail — with tier granularity

A tier added to the gate that has never been observed going red isn't gated. Both new arms were broken deliberately, by removing the very allows this PR adds:

| injected | result |
|---|---|
| drop the `bl_revert_token` allow (a wifi-only symbol) | 🔴 **`FAIL clippy wifi` only** — default/espnow/canonical green |
| drop the `paint_burst` allows (present in all tiers) | 🔴 **`FAIL clippy default` AND `wifi`** — espnow/canonical green |
| reverted | 🟢 GATE GREEN, 4/4 clippy tiers |

The granularity is the interesting part: each arm reddens exactly its own tier, so these are four independent gates rather than one repeated four times.

## Stale-doc cleanup

`gate.sh`'s own "WHAT IT DOES NOT COVER" header and `ONBOARDING.md` both still advertised the canonical-only limitation. Both corrected in this PR — a gate that misdescribes its own coverage is the failure mode this whole sequence has been about.

## Measurement note

Findings were measured on a **CI-faithful tree** (provisioning generated from the `.example` files). A developer's local `secrets.rs` may carry `GROUP_KEY` (#190) or `WEATHER_*` (#227) from unmerged branches and produce findings CI will never see — those are deliberately not "fixed" here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)