### PR TITLE
ci: #345 run the gate on every branch push, not just main

### DIFF
--- a/.github/workflows/fw-gate.yml
+++ b/.github/workflows/fw-gate.yml
@@ -13,14 +13,37 @@ name: fw gate
 
 on:
   pull_request:
+  # #345: EVERY branch, not just main. With `branches: [main]` a commit pushed to a feature branch
+  # whose PR had already closed triggered NOTHING — no `pull_request` event (the PR is closed) and
+  # no `push` event (not main) — so it was silently ungated. That is not hypothetical: it happened
+  # to this workflow's own follow-up commit within an hour of it landing (#341 squash-merged while
+  # `ec16fe3` was in flight; the commit sat on a closed branch with zero CI and was only rescued
+  # because the same work had been opened as a second PR).
+  #
+  # `'**'` is branches-only by design — it does NOT match tags. A release tag should not spend
+  # forty minutes re-running a gate that already passed on the commit it points at.
   push:
-    branches: [main]
+    branches: ['**']
   workflow_dispatch:
 
-# A force-push supersedes its own in-flight run; main runs are never cancelled.
+# Keyed on the BRANCH, deliberately, so the `push` and `pull_request` events for the same branch
+# land in ONE group and dedupe instead of double-running: `github.head_ref` is the PR's source
+# branch and is empty for a push, where `github.ref_name` supplies the same name. Keying on
+# `github.ref` (the previous form) could not dedupe them — a PR's ref is `refs/pull/N/merge` and a
+# push's is the branch, so they were always distinct groups.
+#
+# `main` gets its OWN group and NEVER cancels: a branch push cannot reach `fw-gate-main`, and
+# cancel-in-progress is false there, so an in-flight main gate always runs to completion. Over-
+# running is the cheap failure here; a main gate cancelled by unrelated branch activity is not.
+# (Two independent guarantees on purpose — either alone would do.)
+#
+# SECURITY: `github.head_ref` is attacker-controlled (a fork can name a branch anything), so it must
+# never reach a `run:` shell or a checkout `ref:`. Here it is used ONLY as part of a concurrency
+# GROUP NAME — an opaque scheduling label that is never evaluated — which is the form GitHub's own
+# docs recommend. These two lines are the only interpolations in this file; keep it that way.
 concurrency:
-  group: fw-gate-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: fw-gate-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Closes #345.

A commit pushed to a feature branch whose PR had already closed triggered **nothing**: no `pull_request` event (PR closed) and no `push` event (filter was `branches: [main]`). Silently ungated — a hole in the tool built to close holes.

Not hypothetical. It happened to this workflow's own follow-up **within an hour of it landing**: #341 was squash-merged while `ec16fe3` was in flight, and that commit sat on a closed branch with zero CI. It survived only because the same work had been opened as #342. Second squash-merge race of the day; the first cost 175 lines.

## Change

| | before | after |
|---|---|---|
| trigger | `pull_request` + `push: [main]` | `pull_request` + `push: ['**']` (branches only — **not tags**) |
| concurrency key | `github.ref` | `github.head_ref \|\| github.ref_name` (the **branch**) |
| main | own group, never cancels | unchanged — own group, `cancel-in-progress: false` |

Re-keying is what lets `push` and `pull_request` for the same branch **dedupe into one group** instead of double-running. The old key couldn't: a PR's ref is `refs/pull/N/merge`, a push's is the branch — always distinct.

## Proven, not argued

**(a) A branch push with no PR now fires the gate.** This branch demonstrated its own fix: pushed with **zero** PRs open (`state=all` query returned 0), and a run appeared with `event: push`. That is precisely the case that used to produce nothing.

**(b) Concurrency behaves, both directions** — measured with a throwaway probe branch, since "it should be a different group" is a claim, not evidence:

| scenario | expected | observed |
|---|---|---|
| run A in flight on branch 1, push to **branch 2** | A survives (different group) | **A: completed/success** ✅ |
| run B in flight, second push to the **same branch** | B superseded (dedupe works) | **B: completed/cancelled** ✅ |

The second is the one that makes `push` + `pull_request` coexist without double-running; the first is why a branch push can never disturb main. For `main` there are two independent guarantees — a branch push cannot reach `fw-gate-main`, and `cancel-in-progress` is `false` there — so an in-flight main gate always completes. Over-running is the cheap failure; a cancelled main gate is not.

Probe branch deleted afterwards (remote + local, verified gone).

## Security

`github.head_ref` is attacker-controlled (a fork can name a branch anything). It is used **only** as part of a concurrency group name — an opaque scheduling label, never evaluated — which is the form GitHub's own docs recommend. Audited: the two `concurrency` lines are the **only** interpolations in the file, and none appear in a `run:` shell or a checkout `ref:`.

## Cost, stated plainly

Every branch push now runs the gate (~1–2 min). With several agents pushing worktree branches that is real minutes, mitigated by same-branch dedupe. The alternative is the status quo: commits silently ungated at exactly the moment a merge race makes them easiest to lose.

Unrelated but worth recording: main's stack number re-measured after the #339/#343 merges — still **75,560 B**, confirming those changes (comments, item-scoped allows, tooling) moved no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)