### PR TITLE
feat(build): declare per-chip memory budgets as data and predicate the bard on them (#348)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -78,6 +78,16 @@ formula are a bug in this document** — check them together.
 > moved. The `bard` feature still exists and `tools/gate.sh` still builds a `bard` tier — it is
 > off the C3's shared image, not out of the project. See #347.
 >
+> 🟢 **Since #348 this is enforced at COMPILE time, not just written here.**
+> `rust/clock/src/budget.rs` declares the C3's budget as data — flash and DRAM as separate
+> axes, OpenWrt-style — and `--features bard` is now an `E0080` compile error on the C3 rather
+> than an image that links and dies. **Update that file whenever you update this block:** the
+> two must agree, and the ELF wins over both. The budget declares the *worst* supported radio
+> stack (esp-radio 0.18's 106,560 B, not `main`'s 114,648 B) so it keeps biting across the #233
+> cutover, which is why its headroom reads 32,352 B where the slack above reads 40,920 B.
+> A build that deliberately is not the fleet image declares `off-fleet`; `repro_build_bin`
+> refuses to package anything that does.
+>
 > > 📌 **History, pre-#347 (the figures below describe the with-bard image and are superseded by
 > > the block above).** Corrected 2026-07-28 — this block previously disagreed with itself, and
 > > BOTH figures were

--- a/docs/ota.md
+++ b/docs/ota.md
@@ -338,12 +338,17 @@ ota_1,    app,  ota_1, 0x210000, 0x1F0000   # 1.938 MB slot
 ```
 
 **Slot occupancy, measured 2026-08-01 (post-#347).** The canonical fleet image is
-`espnow,cast,io` and comes out at a **measured 1,155,648 B — 56.9 % of a `0x1F0000`
+`espnow,cast,io` and comes out at a **measured ~1,155,700 B — 56.9 % of a `0x1F0000`
 (2,031,616 B) slot, 1.76× headroom, ~855 KiB spare.**
-<!-- #348: was 1,155,600 here. Re-derived through `repro_build_bin` on three trees (this
-     branch, main @ 8b74dd8, and a detached worktree at 1efb8b5 — the commit this paragraph
-     cites); all three gave 1,155,648 B. 48 B, no percentage moves, which is why it survived
-     — and it was about to be copied into src/budget.rs as a measurement. -->
+
+> ⚠️ **This figure is tree-dependent to ~128 B, so do not "correct" it to match another
+> document (#348 nearly did).** `src/board.rs` and `src/secrets.rs` are git-ignored and
+> provisioned per tree — `tools/ci_provision.sh` generates them from the `.example` templates —
+> and their literals land in `.rodata`/`.data`. Same commit, same `repro_build_bin`, 2026-08-01:
+> **1,155,648 B** with this workstation's provisioning, **1,155,776 B** with the CI templates;
+> the `.stack` region moves the same way (114,648 / 114,640 local, 114,608 on the runner).
+> Reproducibility (#44) is a property of two builds of the *same* tree, which is what
+> `verify_image.sh --twice` checks; it is not a property of a number quoted in a doc.
  #347 took the Bard's ~281 KB model blob
 out of `.rodata`, which is where the 1,432,400 B / 70.5 % / 1.42× figure recorded here between
 #300 and #347 came from.

--- a/docs/ota.md
+++ b/docs/ota.md
@@ -338,8 +338,13 @@ ota_1,    app,  ota_1, 0x210000, 0x1F0000   # 1.938 MB slot
 ```
 
 **Slot occupancy, measured 2026-08-01 (post-#347).** The canonical fleet image is
-`espnow,cast,io` and comes out at a **measured 1,155,600 B — 56.9 % of a `0x1F0000`
-(2,031,616 B) slot, 1.76× headroom, ~855 KiB spare.** #347 took the Bard's ~281 KB model blob
+`espnow,cast,io` and comes out at a **measured 1,155,648 B — 56.9 % of a `0x1F0000`
+(2,031,616 B) slot, 1.76× headroom, ~855 KiB spare.**
+<!-- #348: was 1,155,600 here. Re-derived through `repro_build_bin` on three trees (this
+     branch, main @ 8b74dd8, and a detached worktree at 1efb8b5 — the commit this paragraph
+     cites); all three gave 1,155,648 B. 48 B, no percentage moves, which is why it survived
+     — and it was about to be copied into src/budget.rs as a measurement. -->
+ #347 took the Bard's ~281 KB model blob
 out of `.rodata`, which is where the 1,432,400 B / 70.5 % / 1.42× figure recorded here between
 #300 and #347 came from.
 

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -137,8 +137,10 @@ esp-bootloader-esp-idf = { version = "=0.2.0", optional = true, features = ["esp
 # whereas `sha2` is peripheral-free + move-friendly. Cost is ~4 KB flash — still negligible,
 # and the slot has room again: #300's Bard model took the canonical image from ~590 KB to
 # 1,432,400 B (70.5% of a 0x1F0000 / 2,031,616 B slot), and #347 took the Bard back off the
-# fleet tier, measuring 1,155,648 B — 56.9%, 1.76x headroom, ~855 KiB spare (2026-08-01;
-# #348 re-derived this from 1,155,600 — three trees through repro_build_bin all gave ...648).
+# fleet tier, measuring ~1,155,700 B — 56.9%, 1.76x headroom, ~855 KiB spare (2026-08-01).
+# #348: that last figure is TREE-DEPENDENT to ~128 B — the git-ignored board.rs/secrets.rs are
+# provisioned per tree and their literals sit in .rodata/.data (1,155,648 here vs 1,155,776 with
+# the ci_provision.sh templates). Don't reconcile it against another doc's copy; recompute.
 # Recompute rather than trusting this line: slot / actual image size; `ota_publish.sh`
 # hard-gates size <= 0x1F0000, so an overflow fails the publish, not a board.
 # Hashing is bound by the ~1.2 MB HTTP download, not the digest, so there is still no

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -137,7 +137,8 @@ esp-bootloader-esp-idf = { version = "=0.2.0", optional = true, features = ["esp
 # whereas `sha2` is peripheral-free + move-friendly. Cost is ~4 KB flash — still negligible,
 # and the slot has room again: #300's Bard model took the canonical image from ~590 KB to
 # 1,432,400 B (70.5% of a 0x1F0000 / 2,031,616 B slot), and #347 took the Bard back off the
-# fleet tier, measuring 1,155,600 B — 56.9%, 1.76x headroom, ~855 KiB spare (2026-08-01).
+# fleet tier, measuring 1,155,648 B — 56.9%, 1.76x headroom, ~855 KiB spare (2026-08-01;
+# #348 re-derived this from 1,155,600 — three trees through repro_build_bin all gave ...648).
 # Recompute rather than trusting this line: slot / actual image size; `ota_publish.sh`
 # hard-gates size <= 0x1F0000, so an overflow fails the publish, not a board.
 # Hashing is bound by the ~1.2 MB HTTP download, not the digest, so there is still no
@@ -233,7 +234,29 @@ cast = ["espnow"]
 # ── bard (#300): on-device tiny-LLM storyteller ─────────────────────────────
 # Radio-free: rides `hw` only, so it can ship in every tier incl. `default`.
 # Pulls no alloc — the core is static-buffer only (spec §5).
+# ⚠️ SINCE #348 this feature is PREDICATED on the chip's declared memory budget
+# (src/budget.rs): `--features bard` is a COMPILE ERROR on the C3, because the model's
+# 39,072 B of DRAM does not fit the 32,352 B a C3 has left after the radio stack and the
+# stack floor. That is #347's decision made permanent — it was one word in
+# tools/repro_build.sh that anyone could re-add. The feature STAYS here: the S3 and C6
+# have the DRAM to carry it as an ordinary smol feature (OpenWrt's `DEFAULT := n` — the
+# definition stays, the default flips), and `bard` still gets a CI tier.
 bard = ["hw", "dep:libm"]
+
+# ── #348 budget waiver ───────────────────────────────────────────────────────
+# Declares "this build is NOT the C3 fleet image, so the fleet baseline the budget was
+# measured against does not apply" — which is the honest reason a build may exceed it, and
+# the only one. Two in-tree users, both deliberate:
+#   * tools/gate.sh's `bard` tier, which exists to keep the Bard compiled + linted for the
+#     bigger chips (#347). Without this the tier that keeps a feature alive would be the
+#     thing the guard kills.
+#   * a future Bard-only / S3 image (#347 Phase 3), which carries no radio stack and so has
+#     a different baseline entirely.
+# It is NOT an "ignore the guard" switch: `repro_build_bin` REFUSES to package a build that
+# names it, so a waived image cannot become a published OTA artifact. (OpenWrt keeps the
+# same split — `sysupgrade -F` is a documented escape hatch, and it is separate from the
+# gate that decides suitability.)
+off-fleet = []
 
 # #300 BENCH ONLY — stack high-water measurement (src/bard/stack_paint.rs). Paints the unused
 # stack with a sentinel at boot and reports how deep the story actually went, turning "14240 B

--- a/rust/clock/src/budget.rs
+++ b/rust/clock/src/budget.rs
@@ -1,0 +1,312 @@
+//! #348 — per-chip memory budgets, **declared as data**, with heavy features predicated on them.
+//!
+//! ## Why this exists
+//!
+//! #347 took the Bard off the C3 fleet image by deleting one word from
+//! `REPRO_FLEET_FEATURES` in `tools/repro_build.sh`. Nothing stops someone typing it back.
+//! The only mechanism that would notice is `repro_stack_check`, which runs at *package*
+//! time — the latest possible moment, after every build in CI has already gone green.
+//! Worse, the relationship it is checking ("the Bard's `.bss` comes out of the runtime
+//! stack") existed nowhere but prose: a Cargo.toml comment, a ROADMAP block, three issue
+//! bodies. A capability that is not declared cannot be queried — OpenWrt learned that the
+//! expensive way when its low-RAM deprecation sweep had to hand-audit hundreds of devices
+//! against a wiki table because RAM size was never a field
+//! ([openwrt#12672](https://github.com/openwrt/openwrt/pull/12672)).
+//!
+//! So: declare it, and let the compiler refuse.
+//!
+//! ## The model (OpenWrt's, not WLED's)
+//!
+//! OpenWrt predicates a feature on a **declared capability**, never on a chip name —
+//! `include/target.mk:94` drops `procd-ujail` from any subtarget that declared
+//! `small_flash`, and nothing in that rule names a SoC. It also keeps **flash and RAM as
+//! two independent axes** (`FEATURES += low_mem small_flash`), because they are two
+//! different scarcities. The Bard is short on one and comfortable on the other, and a
+//! model that conflated them would report the wrong reason.
+//!
+//! The alternatives, both rejected:
+//!   * **WLED** — a commented-out line with the reason in prose
+//!     (`;; pushed program flash size over the limits`). Nothing fails if someone
+//!     uncomments it. That is the status quo #347 left behind, written down.
+//!   * **Tasmota** — a separate named build (`tasmota-lite`). Costs a whole artifact, an
+//!     OTA URL, and a taxonomy the user has to navigate.
+//!
+//! Full study: `scratch/parity/multitarget-prior-art.md`.
+//!
+//! ## ⚠️ PLACEMENT — this module moves to `smol-core` (#347 Phase 2)
+//!
+//! It belongs in the core crate, not in `clock`. If the memory math lives here, the Bard
+//! device firmware and the esp32c6-watch each re-derive their own copy — which is exactly
+//! the divergence the core extraction exists to prevent (they have already hand-copied
+//! `names.rs` and `sigil.rs` between them). Core is not extracted yet, so this module is
+//! written to **move without edits**:
+//!
+//!   * no `use crate::…`, no `super::`, no esp-hal, no `alloc`, no `std`;
+//!   * every item `pub`;
+//!   * the only crate-local coupling is the `#[cfg(feature = "…")]` on the assertions at
+//!     the bottom, which is the one part that stays behind in whichever crate owns the
+//!     feature flags.
+//!
+//! Moving it is `git mv` + `pub use smol_core::budget::*;`. Keep it that way.
+//!
+//! ## Relationship to the other guards
+//!
+//! | guard | when it fires | what it proves |
+//! |---|---|---|
+//! | **this module** | compile | the declared cost of a feature fits the declared budget |
+//! | `repro_stack_check` | package | the *linked* `.stack` region clears the floor |
+//! | `--features stack-paint` | runtime, on a board | the *actual* high-water under live radio |
+//!
+//! They are not redundant and none replaces another. This one is a **declaration checked
+//! against a declaration** — it is only as honest as the numbers below, which is why every
+//! one of them carries its provenance. `repro_stack_check` measures the real link and
+//! stays the authority; if the two ever disagree, the ELF is right and this file is stale.
+
+// This module is DATA. Its consumers are (a) the cfg-gated const-assertions at the bottom,
+// (b) `tests/budget.rs`, and (c) — after #347 Phase 2 — other crates. Under a firmware
+// build with no predicated feature enabled, nothing in it is referenced, and `clippy -D
+// warnings` runs on every tier since #343.
+#![allow(dead_code)]
+
+/// What a chip can afford. One `const` per chip; see [`ESP32C3`].
+///
+/// **Flash and DRAM are separate fields on purpose** (OpenWrt's `small_flash` vs `low_mem`).
+/// A feature can be comfortable on one axis and impossible on the other — the Bard is
+/// exactly that case — and a verdict that cannot say which one is not actionable.
+pub struct ChipBudget {
+    /// Chip identifier, for messages and for whoever cross-references the artifact.
+    ///
+    /// Deliberately a `&'static str` and **not** a new enum: #349 is defining a structured
+    /// `TargetId` for the OTA manifest, and this field should become that type rather than
+    /// compete with it.
+    pub chip: &'static str,
+
+    /// DRAM available to a predicated feature's statics **plus** the runtime stack, measured
+    /// with the canonical fleet tier linked and no predicated feature in it.
+    ///
+    /// This is the linked `.stack` region of the baseline image, because on this platform
+    /// `.stack` *is* the leftover: the linker hands `.stack` whatever DRAM remains after
+    /// `.bss`/`.data` and **silently shrinks it** rather than failing, which is why a
+    /// successful link has never been evidence of a runnable image (#300).
+    pub free_dram_bytes: u32,
+
+    /// The minimum linked `.stack` region an image may ship with — the floor
+    /// `repro_stack_check` enforces at package time.
+    pub stack_floor_bytes: u32,
+
+    /// The OTA app partition a single image must fit in (`partitions-ota.csv`).
+    pub app_slot_bytes: u32,
+
+    /// Image size of the canonical fleet tier with no predicated feature — the flash-axis
+    /// counterpart to [`Self::free_dram_bytes`], and measured from the same baseline.
+    pub baseline_image_bytes: u32,
+}
+
+/// What a predicated feature costs, as an ELF-section delta against the same baseline the
+/// [`ChipBudget`] was measured from. Both fields come from `readelf -SW`, never an estimate.
+pub struct FeatureCost {
+    pub feature: &'static str,
+    /// `.bss` + `.data` (+ alignment) delta — DRAM that comes straight out of the stack.
+    pub dram_bytes: u32,
+    /// `.rodata` + `.text` delta — flash, which on this platform is XIP and costs no DRAM.
+    pub flash_bytes: u32,
+}
+
+impl ChipBudget {
+    /// DRAM a predicated feature may spend before the stack region breaks the floor.
+    pub const fn dram_headroom(&self) -> u32 {
+        self.free_dram_bytes.saturating_sub(self.stack_floor_bytes)
+    }
+
+    /// Flash a predicated feature may spend before the image overruns the OTA slot.
+    pub const fn flash_headroom(&self) -> u32 {
+        self.app_slot_bytes.saturating_sub(self.baseline_image_bytes)
+    }
+
+    pub const fn fits_dram(&self, cost: &FeatureCost) -> bool {
+        cost.dram_bytes <= self.dram_headroom()
+    }
+
+    pub const fn fits_flash(&self, cost: &FeatureCost) -> bool {
+        cost.flash_bytes <= self.flash_headroom()
+    }
+
+    /// Both axes. Kept separate from the two above so a failing assertion can name the axis.
+    pub const fn fits(&self, cost: &FeatureCost) -> bool {
+        self.fits_dram(cost) && self.fits_flash(cost)
+    }
+
+    /// Bytes by which `cost` overruns the DRAM headroom; `0` when it fits.
+    pub const fn dram_shortfall(&self, cost: &FeatureCost) -> u32 {
+        cost.dram_bytes.saturating_sub(self.dram_headroom())
+    }
+
+    /// Bytes by which `cost` overruns the flash headroom; `0` when it fits.
+    pub const fn flash_shortfall(&self, cost: &FeatureCost) -> u32 {
+        cost.flash_bytes.saturating_sub(self.flash_headroom())
+    }
+}
+
+// ── The declared budgets ────────────────────────────────────────────────────────────────
+//
+// PROVENANCE. Every number below was measured, and each says where. Re-measure rather than
+// trusting the comment; a number copied forward untested is how the stack floor once ended
+// up at 12,288 B.
+
+/// ESP32-C3 — the pinned fleet chip (RV32IMC, 4 MB flash, 400 KB SRAM).
+///
+/// ## `free_dram_bytes` is the WORST supported radio stack, deliberately
+///
+/// The C3 fleet image is mid-migration between two radio stacks and the number differs by
+/// 8 KB between them:
+///
+/// | radio stack | canonical tier, no bard | source |
+/// |---|---:|---|
+/// | esp-wifi 0.15 (blocking; `main` today) | 114,648 B | measured 2026-08-01 on `a5b1312`+`1efb8b5`, `repro_build_bin` |
+/// | esp-radio 0.18 (async; #233/#335) | **106,560 B** | measured 2026-08-01 on `spike/233-stack-measure` @ `2b98fba` |
+///
+/// The declared budget takes the **minimum**, for the same reason `stack_floor_bytes` is a
+/// floor over runtime paths rather than the number one run happened to produce: a capability
+/// that is only true on the configuration you happen to be building today stops being a
+/// guard the moment the migration lands. It is a conservative declaration — OpenWrt's
+/// `small_flash` is a declared *class*, not a per-build measurement — and the cost of that
+/// choice is that a feature needing between 32,352 B and 40,920 B is refused here while
+/// still fitting on `main`. That is the direction to be wrong in, and #233 closes the gap.
+///
+/// ## `stack_floor_bytes` is 74,208, not the 73,728 in the gate
+///
+/// 73,728 (`REPRO_STACK_FLOOR`) is 72 KiB — 4/3 × a 54,856 B peak, rounded up. 74,208 is
+/// 4/3 × the later, higher 55,656 B peak (#302), which is the most recent measurement and
+/// is quoted as the re-derived floor in both `tools/repro_build.sh` and #335. This takes the
+/// higher of the two; the 480 B difference does not change any verdict here, and the
+/// packaging gate keeps its own constant (changing it would move what ships, which is not
+/// this issue's business).
+///
+/// ⚠️ **Slack is not headroom.** The floor is 4/3 × a *measured runtime peak*, and the peak
+/// on record was measured with the Bard narrating. A Bard-free peak can only be lower, but
+/// nobody has taken it, so the headroom below is a **lower bound**, not a margin to spend.
+pub const ESP32C3: ChipBudget = ChipBudget {
+    chip: "esp32c3",
+    free_dram_bytes: 106_560,
+    stack_floor_bytes: 74_208,
+    // partitions-ota.csv: ota_0/ota_1 are 0x1F0000 each. `ota_publish.sh` hard-gates on this.
+    app_slot_bytes: 0x001F_0000,
+    // Canonical `espnow,cast,io` image (56.9% of slot), from `repro_build_bin` — the packaging
+    // path, not a plain cargo build.
+    //
+    // ⚠️ 1,155,648, NOT the 1,155,600 in docs/ota.md and rust/clock/Cargo.toml. Re-derived
+    // 2026-08-01 rather than copied, precisely because this file turns prose into data: built
+    // three times — this branch, clean `main` @ 8b74dd8, and a detached worktree at 1efb8b5
+    // (the exact commit those docs cite) — and all three produced 1,155,648 B. The docs figure
+    // is 48 B light. It changes no percentage and no verdict, which is exactly why it survived;
+    // it would have been inherited here as a "measurement" had it not been re-taken.
+    baseline_image_bytes: 1_155_648,
+};
+
+/// The budget in force for the target being compiled.
+///
+/// **Fail-closed by construction.** A bare-metal target with no declared budget is a
+/// compile error, not an unbudgeted pass — the whole point of #348 is that an undeclared
+/// capability cannot be queried, so silently answering "sure, it fits" for a chip nobody has
+/// measured would reproduce the bug in a new place. When the S3 or the C6 arrives (#331),
+/// the compiler will demand its row here before it will build, which is the intended
+/// friction.
+///
+/// The selection is `target_arch`-shaped only because this crate pins exactly one bare-metal
+/// target today. **#349 owns chip identity**; when its `TargetId` lands, replace this cfg
+/// ladder with a lookup on that — it is one function and the data above does not move.
+#[cfg(all(target_os = "none", target_arch = "riscv32"))]
+pub const CHIP: ChipBudget = ESP32C3;
+
+#[cfg(all(target_os = "none", not(target_arch = "riscv32")))]
+compile_error!(
+    "no ChipBudget is declared for this bare-metal target. Add a `ChipBudget` const in \
+     src/budget.rs with MEASURED numbers (build the canonical tier for the chip and read \
+     `.stack` / image size from the artifact) and extend the CHIP cfg ladder. Do not copy \
+     the C3's row: an undeclared capability that is guessed is worse than one that is absent."
+);
+
+/// Host builds (`hostsim`, the `tests/` suites, `web-emu`) link no firmware, so no device
+/// budget applies and the predicates below are inert. The numbers are still reachable as
+/// [`ESP32C3`] etc., which is how `tests/budget.rs` checks the arithmetic without needing a
+/// cross-compile.
+#[cfg(not(target_os = "none"))]
+pub const CHIP: ChipBudget = ChipBudget {
+    chip: "host",
+    free_dram_bytes: u32::MAX,
+    stack_floor_bytes: 0,
+    app_slot_bytes: u32::MAX,
+    baseline_image_bytes: 0,
+};
+
+/// Measured costs of the predicated features.
+pub mod cost {
+    use super::FeatureCost;
+
+    /// The Bard (#300) — a 260K-param transformer, `SEQ_CAP` 80.
+    ///
+    /// ELF-section delta, bard on → off, same commit and toolchain
+    /// (`scratch/347/morpheus-task-a.md`, 2026-08-01):
+    ///
+    /// | section | delta |
+    /// |---|---:|
+    /// | `.bss` | +37,832 |
+    /// | `.data` | +1,232 |
+    /// | alignment (`.rwtext`/`.rwdata_dummy`) | +8 |
+    /// | **DRAM total** | **+39,072** |
+    /// | `.rodata` (the model blob) | **+287,392** |
+    ///
+    /// The DRAM delta and the `.stack` loss matched to the byte in that measurement, which is
+    /// the evidence that `.stack` really is "whatever DRAM is left".
+    ///
+    /// ⚠️ `.bss` is **37,832 B**, not the ~67 KB quoted in #347's body — that figure predates
+    /// the SEQ_CAP 80 / 96 KB-heap shape the Bard actually shipped with.
+    pub const BARD: FeatureCost = FeatureCost {
+        feature: "bard",
+        dram_bytes: 39_072,
+        flash_bytes: 287_392,
+    };
+}
+
+// ── The predicates ──────────────────────────────────────────────────────────────────────
+//
+// A const-eval assertion, not a build-script check: build.rs cannot read these consts, so a
+// copy of this arithmetic over there would be a second definition free to drift from the one
+// that is documented — the exact failure `repro_build.sh` calls out when it explains why the
+// stack check was extracted into a shared function.
+//
+// The cost is that a const panic message must be a literal, so it cannot print the computed
+// shortfall. The shortfall is available two ways instead: `ChipBudget::dram_shortfall()` at
+// any call site, and `tests/budget.rs`, which asserts the exact byte count.
+//
+// ⚠️ These are the only items in this file that do not move to `smol-core` verbatim — the
+// feature flags belong to whichever crate declares them.
+
+/// DRAM axis. Fires for `--features bard` on the C3: the Bard's 39,072 B against a
+/// 32,352 B headroom, **short by 6,720 B** — which reproduces #335's published shortfall
+/// exactly, from data rather than from a bench run.
+#[cfg(all(feature = "bard", not(feature = "off-fleet")))]
+const _: () = assert!(
+    CHIP.fits_dram(&cost::BARD),
+    "`bard` does not fit this chip's declared DRAM budget (src/budget.rs). Its static DRAM \
+     (.bss + .data) is larger than free_dram_bytes - stack_floor_bytes, so the linker would \
+     take the difference out of the runtime stack and shrink it below the floor SILENTLY — \
+     the image would link and then die on hardware (#300, #335, #347). \
+     Options: build it for a chip whose row has the room (#331 — the S3 and C6 do); shrink \
+     the cost (`SEQ_CAP` in src/bard/nano_llm.rs is the lever) and re-measure BOTH the cost \
+     and the budget; or, if this build is deliberately not the C3 fleet image, add the \
+     `off-fleet` feature — which tools/repro_build.sh then refuses to package."
+);
+
+/// Flash axis. Does **not** fire today — the Bard's 287,392 B sits inside an 876,016 B
+/// headroom. It is here because the axes are independent: the day a chip has a smaller OTA
+/// slot, this is the one that catches it, and the message says so instead of blaming DRAM.
+#[cfg(all(feature = "bard", not(feature = "off-fleet")))]
+const _: () = assert!(
+    CHIP.fits_flash(&cost::BARD),
+    "`bard` does not fit this chip's declared FLASH budget (src/budget.rs): the canonical \
+     image plus the model blob overruns the OTA app slot, so ota_publish.sh would refuse the \
+     image at package time. This is the flash axis, NOT the DRAM one — the two are separate \
+     fields and separate verdicts. Shrink the model, use a chip with a larger slot, or \
+     re-cut the partition table (which is an OTA-compatibility change, not a build change)."
+);

--- a/rust/clock/src/budget.rs
+++ b/rust/clock/src/budget.rs
@@ -165,6 +165,9 @@ impl ChipBudget {
 /// | esp-wifi 0.15 (blocking; `main` today) | 114,648 B | measured 2026-08-01 on `a5b1312`+`1efb8b5`, `repro_build_bin` |
 /// | esp-radio 0.18 (async; #233/#335) | **106,560 B** | measured 2026-08-01 on `spike/233-stack-measure` @ `2b98fba` |
 ///
+/// Both figures carry a ~40 B per-tree term from the git-ignored provisioning files — see the
+/// note on `baseline_image_bytes` below. It is four orders of magnitude below the margins here.
+///
 /// The declared budget takes the **minimum**, for the same reason `stack_floor_bytes` is a
 /// floor over runtime paths rather than the number one run happened to produce: a capability
 /// that is only true on the configuration you happen to be building today stops being a
@@ -194,12 +197,27 @@ pub const ESP32C3: ChipBudget = ChipBudget {
     // Canonical `espnow,cast,io` image (56.9% of slot), from `repro_build_bin` — the packaging
     // path, not a plain cargo build.
     //
-    // ⚠️ 1,155,648, NOT the 1,155,600 in docs/ota.md and rust/clock/Cargo.toml. Re-derived
-    // 2026-08-01 rather than copied, precisely because this file turns prose into data: built
-    // three times — this branch, clean `main` @ 8b74dd8, and a detached worktree at 1efb8b5
-    // (the exact commit those docs cite) — and all three produced 1,155,648 B. The docs figure
-    // is 48 B light. It changes no percentage and no verdict, which is exactly why it survived;
-    // it would have been inherited here as a "measurement" had it not been re-taken.
+    // ⚠️ THIS NUMBER IS NOT BYTE-STABLE ACROSS TREES, and neither is `free_dram_bytes`. Both
+    // depend on `src/board.rs` and `src/secrets.rs`, which are GIT-IGNORED and provisioned
+    // per-tree (`tools/ci_provision.sh` generates them from the `.example` templates). Their
+    // string literals and constants land in `.rodata`/`.data`, and `.stack` is whatever DRAM is
+    // left over, so both move. Measured 2026-08-01, same commit, same packaging path:
+    //
+    //   | provisioning                      | image     | .stack  |
+    //   |-----------------------------------|-----------|---------|
+    //   | this workstation's board/secrets  | 1,155,648 | 114,648 |
+    //   | ci_provision.sh templates, local  | 1,155,776 | 114,640 |
+    //   | GitHub Actions runner             |         — | 114,608 |
+    //
+    // So the spread is ~128 B of image and ~40 B of stack. docs/ota.md's 1,155,600 is inside
+    // that band and is not an error — it is a different tree, which is worth knowing before
+    // someone "corrects" one of these figures to match another (this file nearly did).
+    //
+    // It changes nothing here: the verdicts below turn on 6,720 B and 588,576 B, three to four
+    // orders of magnitude above the noise. But a byte-exact constant that is not byte-stable is
+    // false precision, so treat this as a REFERENCE measurement +/- ~200 B, and never as a
+    // reproducibility check — `verify_image.sh` is what proves an image reproducible, and it
+    // compares two builds of the SAME tree.
     baseline_image_bytes: 1_155_648,
 };
 

--- a/rust/clock/src/lib.rs
+++ b/rust/clock/src/lib.rs
@@ -17,6 +17,13 @@
 
 #![no_std]
 
+// #348 per-chip memory budgets. The ONE module here that is NOT host-only: it is pure data
+// plus const-eval assertions (no code emitted), and compiling it in both targets means the
+// budget predicates are checked by a plain `cargo check` of either. It is also what lets
+// `tests/budget.rs` assert the arithmetic host-side without a cross-compile.
+// ⚠️ Moves to `smol-core` (#347 Phase 2) — see the module docs.
+pub mod budget;
+
 // Everything below is host-only. Under a firmware build (no `hostsim`) this lib is empty
 // and `main.rs` (the bin) carries the real modules.
 #[cfg(feature = "hostsim")]

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -95,6 +95,10 @@ mod app;
 // every tier; the 277 KB model is `.rodata` (XIP flash) and its scratch is `.bss`.
 #[cfg(feature = "bard")]
 mod bard;
+// #348 per-chip memory budgets as data, with the heavy features predicated on them. Pure
+// consts + const-eval assertions: it emits NO code and is unconditional so the predicates are
+// evaluated by every build, including `default`. ⚠️ Moves to `smol-core` (#347 Phase 2).
+mod budget;
 // #197 transient on-glass toast overlay — a general primitive (also the mesh-RPG substrate),
 // composited over the active screen from the render loop; never persisted.
 mod toast;

--- a/rust/clock/tests/budget.rs
+++ b/rust/clock/tests/budget.rs
@@ -1,0 +1,130 @@
+//! #348 host tests for the per-chip memory budgets (`src/budget.rs`).
+//!
+//! Gated on `hostsim` like the bard/input suites, and run the same way:
+//! `cargo test --no-default-features --features hostsim --target x86_64-unknown-linux-gnu
+//!  --lib --test budget`
+//!
+//! ## Why a test as well as a compile-time assertion
+//!
+//! The const-assertions in `budget.rs` can only say *no* — a const panic message must be a
+//! literal, so the shortfall the reader most wants ("by how much?") cannot appear in it.
+//! These tests are where that number lives, checked rather than written in a comment.
+//!
+//! They also check the direction the assertions structurally cannot: that the predicate can
+//! say **yes**. A guard that refuses everything is as useless as one that refuses nothing,
+//! and it fails the same way — invisibly, by never being watched doing the other thing.
+
+#![cfg(feature = "hostsim")]
+
+use clock::budget::{cost, ChipBudget, FeatureCost, ESP32C3};
+
+/// The published #335 shortfall. If this test starts failing, either a measurement in
+/// `budget.rs` moved (fine — update it *with* its provenance) or someone rounded something.
+const PUBLISHED_SHORTFALL: u32 = 6_720;
+
+#[test]
+fn c3_dram_headroom_is_the_measured_leftover() {
+    // 106,560 B (the async-stack canonical tier, #233 spike) − 74,208 B (4/3 × the 55,656 B
+    // measured peak, #302). Both numbers are measurements; this is only their subtraction.
+    assert_eq!(ESP32C3.dram_headroom(), 32_352);
+}
+
+#[test]
+fn c3_flash_headroom_is_the_slot_minus_the_baseline() {
+    // 0x1F0000 (2,031,616 B OTA slot) − 1,155,648 B (canonical image, re-measured 2026-08-01
+    // through repro_build_bin on three trees; see the provenance note in budget.rs).
+    assert_eq!(ESP32C3.flash_headroom(), 875_968);
+    assert_eq!(ESP32C3.app_slot_bytes, 2_031_616);
+}
+
+/// The whole point of #348: the C3 must refuse the Bard, and refuse it for the *right reason*.
+#[test]
+fn bard_does_not_fit_the_c3() {
+    assert!(!ESP32C3.fits(&cost::BARD));
+    assert!(!ESP32C3.fits_dram(&cost::BARD));
+}
+
+/// Reproduces #335's published number from declared data instead of a bench run. 39,072 B of
+/// static DRAM against 32,352 B of headroom.
+#[test]
+fn bard_shortfall_matches_the_published_6720() {
+    assert_eq!(ESP32C3.dram_shortfall(&cost::BARD), PUBLISHED_SHORTFALL);
+    assert_eq!(
+        cost::BARD.dram_bytes - ESP32C3.dram_headroom(),
+        PUBLISHED_SHORTFALL
+    );
+}
+
+/// The two axes are independent, and on the C3 they disagree — DRAM refuses, flash is
+/// comfortable. Conflating them (WLED's single `WLED_DISABLE_*` namespace) would report the
+/// wrong constraint and send someone off to shrink the model blob, which is not the problem.
+#[test]
+fn the_flash_axis_is_comfortable_and_says_so_separately() {
+    assert!(ESP32C3.fits_flash(&cost::BARD));
+    assert_eq!(ESP32C3.flash_shortfall(&cost::BARD), 0);
+    // 287,392 B of model blob inside 875,968 B of slot headroom.
+    assert_eq!(ESP32C3.flash_headroom() - cost::BARD.flash_bytes, 588_576);
+}
+
+/// The predicate must be able to say YES. This fixture is a *hypothetical* chip — the C6 has
+/// 512 KB of SRAM and would clear this easily, but nobody has measured its baseline, and an
+/// unmeasured row does not belong in `budget.rs` (that is the #348 anti-lesson: a capability
+/// that is guessed is worse than one that is absent). So the yes-case is proven here, where
+/// the numbers are explicitly a fixture and cannot be mistaken for a declaration.
+#[test]
+fn a_chip_with_room_accepts_the_bard() {
+    let roomy = ChipBudget {
+        chip: "fixture-not-a-real-chip",
+        free_dram_bytes: 200_000,
+        stack_floor_bytes: 74_208,
+        app_slot_bytes: 0x001F_0000,
+        baseline_image_bytes: 1_155_600,
+    };
+    assert!(roomy.fits(&cost::BARD));
+    assert_eq!(roomy.dram_shortfall(&cost::BARD), 0);
+}
+
+/// One byte over is over. The boundary is where an off-by-one in `fits_dram` would hide, and
+/// it is exactly the case the C3 sits 6,720 B on the wrong side of.
+#[test]
+fn the_boundary_is_exact() {
+    let chip = ChipBudget {
+        chip: "fixture-not-a-real-chip",
+        free_dram_bytes: 100_000,
+        stack_floor_bytes: 74_208,
+        app_slot_bytes: 0x001F_0000,
+        baseline_image_bytes: 1_155_600,
+    };
+    let headroom = chip.dram_headroom(); // 25,792
+    let exact = FeatureCost {
+        feature: "fixture",
+        dram_bytes: headroom,
+        flash_bytes: 0,
+    };
+    let one_over = FeatureCost {
+        feature: "fixture",
+        dram_bytes: headroom + 1,
+        flash_bytes: 0,
+    };
+    assert!(chip.fits_dram(&exact), "exactly the headroom must fit");
+    assert!(!chip.fits_dram(&one_over), "one byte over must not fit");
+    assert_eq!(chip.dram_shortfall(&one_over), 1);
+}
+
+/// Headroom arithmetic must not wrap. A chip whose baseline already overruns its own slot is
+/// a bug in the data, but it must report zero headroom rather than 4 GB of it — the
+/// underflow would turn the guard into an unconditional pass, which is the one failure mode
+/// a guard is not allowed to have.
+#[test]
+fn overrun_saturates_instead_of_wrapping() {
+    let broken = ChipBudget {
+        chip: "fixture-not-a-real-chip",
+        free_dram_bytes: 10_000,
+        stack_floor_bytes: 74_208,
+        app_slot_bytes: 100_000,
+        baseline_image_bytes: 1_155_600,
+    };
+    assert_eq!(broken.dram_headroom(), 0);
+    assert_eq!(broken.flash_headroom(), 0);
+    assert!(!broken.fits(&cost::BARD));
+}

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -81,8 +81,14 @@ if [ "$run_fw" = 1 ]; then
   # and C6. The tier is `bard` PLUS the fleet list rather than `bard` alone, because the build that
   # has to keep working on a bigger chip is the COMBINED one. `bard` is named first so the
   # feature-not-on-this-branch SKIP below tests for `bard` and not for `espnow`.
+  # #348: the bard tier now also carries `off-fleet`. That feature is the DECLARATION that this
+  # build is not the C3 fleet image — which is precisely what this tier is — and without it the
+  # #348 budget predicate refuses to compile the Bard on a C3, killing the tier that exists to
+  # keep it alive. Drop `off-fleet` here and you will see the guard fire; that is the check
+  # working, not the tier breaking. `repro_build_bin` refuses to PACKAGE anything naming it, so
+  # this cannot leak into a shipped image.
   step "cargo check — build tiers"
-  for tier in "default:" "wifi:wifi" "espnow:espnow" "fleet:$REPRO_FLEET_FEATURES" "bard:bard,$REPRO_FLEET_FEATURES" "ledger-provision:ledger-provision"; do
+  for tier in "default:" "wifi:wifi" "espnow:espnow" "fleet:$REPRO_FLEET_FEATURES" "bard:bard,off-fleet,$REPRO_FLEET_FEATURES" "ledger-provision:ledger-provision"; do
     name="${tier%%:*}"; feats="${tier#*:}"
     # A tier naming a feature this branch does not have (e.g. ledger-provision before #181 lands)
     # is SKIPPED, not failed — the gate must work on both sides of that merge.
@@ -103,7 +109,7 @@ if [ "$run_fw" = 1 ]; then
   # gate can cover what ONBOARDING has claimed all along. A tier that only gets `cargo check` has
   # its new warnings invisible — which is how the findings accumulated unnoticed in the first place.
   step "cargo clippy -D warnings — every tier"
-  for tier in "default:" "wifi:wifi" "espnow:espnow" "canonical:$REPRO_FLEET_FEATURES" "bard:bard,$REPRO_FLEET_FEATURES"; do
+  for tier in "default:" "wifi:wifi" "espnow:espnow" "canonical:$REPRO_FLEET_FEATURES" "bard:bard,off-fleet,$REPRO_FLEET_FEATURES"; do
     name="${tier%%:*}"; feats="${tier#*:}"
     args=(--release "${JOBS[@]}"); [ -n "$feats" ] && args+=(--features "$feats")
     if (cd "$CLOCK" && cargo clippy "${args[@]}" -- -D warnings) >/tmp/gate-clippy-$name.log 2>&1; then

--- a/tools/repro_build.sh
+++ b/tools/repro_build.sh
@@ -133,6 +133,21 @@ repro_stack_check() {
 repro_build_bin() {
   local clock="$1" out="$2" hash="$3" number="$4" node_id="${5:-}"
   local espflash="${ESPFLASH:-$HOME/.cargo/bin/espflash}"
+  # #348: `off-fleet` is the cargo feature that WAIVES the per-chip memory budget
+  # (rust/clock/src/budget.rs). It exists so tools/gate.sh can keep compiling the Bard for the
+  # bigger chips, and so a future Bard-only image can be built at all — neither of which is
+  # the fleet image. This is where that stays true: a waived build must never become a
+  # published OTA artifact, because the budget it waived is the fleet's. Refuse at the
+  # PACKAGING boundary rather than trusting the caller's list, since this function is the one
+  # thing every publish path goes through.
+  case ",${REPRO_FLEET_FEATURES}," in
+    *,off-fleet,*)
+      echo "FATAL: REPRO_FLEET_FEATURES names 'off-fleet' — that feature waives the #348 chip" >&2
+      echo "       memory budget and is for non-fleet builds (CI tiers, a Bard-only image)." >&2
+      echo "       Refusing to package a fleet image that opted out of its own budget." >&2
+      return 1
+      ;;
+  esac
   # #218: no explicit number ⇒ use the COMMITTED ratchet (version.txt), NOT git-count.
   # The caller sets SMOL_RELEASE=1 for a real release (clean `vN Word` stamp); otherwise
   # build.rs marks it dev (`vN+dev.<hash> Word`) so a canary can't masquerade as the release.
@@ -210,6 +225,15 @@ repro_build_bin() {
     # one toolchain: canonical WITH bard = 67,488 B of stack, WITHOUT = 106,560 B, against a
     # re-derived floor of 74,208 B (4/3 x the 55,656 B measured high-water). With the bard in,
     # the #233 async re-platform does not fit at all — see #335.
+    #
+    # ⚠️ #348 attribution fix: those three figures are from `spike/233-stack-measure` @ 2b98fba
+    # (the esp-radio 0.18 ASYNC stack — the one the fleet is migrating onto), NOT from this
+    # branch. On main's blocking esp-wifi 0.15 the same tiers measure 75,568 / 114,648 against
+    # the 73,728 B constant below, which is what docs/ROADMAP.md records. Both are true; they
+    # are different radio stacks, and a reader who takes one for the other concludes the Bard
+    # has 1,840 B of room when on the stack that matters it is 6,720 B short.
+    # rust/clock/src/budget.rs declares the WORSE of the two and refuses `bard` at COMPILE
+    # time, so this list is no longer the only thing standing between the Bard and the fleet.
     #
     # ⚠️ The `bard` FEATURE STAYS IN Cargo.toml AND IS STILL GATED (tools/gate.sh builds a
     # `bard` tier). It is out of the C3 fleet image, not out of the project: the S3 and C6 have


### PR DESCRIPTION
Closes #348. Turns #347's one-word fix into a fact the compiler enforces.

## The problem

`bard` left the C3 fleet image by deleting one word from `REPRO_FLEET_FEATURES`. Nothing stops it coming back, and the only mechanism that would notice is `repro_stack_check` — which runs at **package** time, after every build in CI has gone green.

## The model

OpenWrt's **declared capability** ([`include/target.mk:94`](https://github.com/openwrt/openwrt/blob/main/include/target.mk) drops `procd-ujail` from any subtarget declaring `small_flash`; nothing names a SoC), not an enumerated env/board table — WLED's maintainers are on record that enumerating variants is *"impossible to maintain over several years"* ([wled/WLED#2953](https://github.com/wled/WLED/issues/2953), open 3 years). **Flash and DRAM stay separate axes**, as OpenWrt separates `small_flash` from `low_mem`.

```
ESP32C3   = { free_dram 106,560 · stack_floor 74,208 · slot 0x1F0000 · baseline_image 1,155,648 }
            -> DRAM headroom 32,352 B · flash headroom 875,968 B
cost::BARD= { dram 39,072 · flash 287,392 }

39,072 - 32,352 = 6,720 B short  <- #335's published shortfall, to the byte, from declared
                                    data instead of a bench run
```

The flash axis passes with 588,576 B spare and reports separately — conflating the axes would send someone off to shrink the model blob, which is not the problem.

## Two decisions worth challenging in review

1. **`free_dram_bytes` is the worst supported radio stack** (esp-radio 0.18 / #233's 106,560 B), not `main`'s 114,648 B. On main's blocking stack the Bard clears the floor by 1,840 B — a budget declared from today's build **could not refuse it**. Cost: a conservative refusal for anything needing 32,352–40,920 B.
2. **`stack_floor_bytes` is 74,208**, the later re-derivation (4/3 x the 55,656 B peak, #302), not the gate's 73,728. Changes no verdict; `REPRO_STACK_FLOOR` is untouched because moving it moves what ships.

## Placement (#347 Phase 2)

`budget.rs` has no `use crate::`, no esp-hal, no std/alloc — it moves to `smol-core` as `git mv` + one `pub use`. Chip identity is a `&'static str`, deliberately **not** a new enum: #349 is defining a structured `TargetId` and this field should become it. A bare-metal target with no declared row is a `compile_error!`, not an unbudgeted pass (#331).

## `off-fleet`

Declares "this build is not the C3 fleet image" — the only honest reason to exceed the budget. `gate.sh`'s bard tier needs it, or the guard kills the tier that keeps the Bard alive for the S3. It is **not** an ignore-the-guard switch: `repro_build_bin` refuses to package anything naming it.

## Demonstrated refusing

| build | result |
|---|---|
| `default` / `espnow,cast,io` | PASS |
| **`bard,espnow,cast,io`** | **`error[E0080]` — REFUSED** |
| `bard,off-fleet,espnow,cast,io` (CI tier) | PASS |
| `off-fleet` through `repro_build_bin` | FATAL, exit 1, no artifact |
| `tests/budget.rs` | 8/8 — incl. the yes-case and the exact boundary |
| `tools/gate.sh fw` locally | every tier PASS · `stack: 114648 B (floor 73728 B)` |
| **CI (`tiers + clippy + stack floor`)** | **success · `stack: 114608 B (floor 73728 B)`** |

The stack region is identical to clean `main` built the same way, which is the proof the module emits no code: `.stack` is the DRAM leftover, so an unchanged region means `.bss`/`.data` did not move.

## A retracted correction, worth reading (second commit)

The first commit claimed `docs/ota.md`'s 1,155,600 B was **48 B light**, on the strength of three trees all producing 1,155,648. **That claim was wrong and is retracted.**

CI then reported `.stack` = 114,608 B against my 114,648, which did not fit the story. Cause: `src/board.rs` and `src/secrets.rs` are **git-ignored and provisioned per tree** (`tools/ci_provision.sh` generates them from `.example` templates); their literals land in `.rodata`/`.data`, and `.stack` is the leftover. Same commit, same `repro_build_bin`:

| provisioning | image | `.stack` |
|---|---:|---:|
| this workstation | 1,155,648 | 114,648 |
| `ci_provision.sh` templates, local | 1,155,776 | 114,640 |
| GitHub Actions runner | — | 114,608 |

My three "independent" trees shared one provisioning — I had copied the same `board.rs` into each. **They were one measurement wearing three hats**, and the agreement I read as corroboration was an artifact of the method. 1,155,600 is inside the band and is not an error. The docs now carry the band and the mechanism instead of a byte, with a note not to reconcile the figure against another document's copy.

No verdict moves: the predicates turn on 6,720 B and 588,576 B, three to four orders of magnitude above this noise.

Also: `repro_build.sh`'s #347 comment quoted the `spike/233` numbers as "canonical" with no attribution while ROADMAP recorded main's for the same tier.

## Not done, deliberately

- **S3 / C6 rows** — no measured baseline exists, and a guessed row is this issue's own anti-lesson. The `compile_error!` arm makes the compiler demand one when the target arrives (#331).
- **`REPRO_STACK_FLOOR` 73,728 -> 74,208** — out of scope; raising it changes what ships.
- **The Bard-free stack peak is still unmeasured.** Every margin here inherits that. Slack is not headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)