### PR TITLE
feat(ota): make the image self-describe its target and let the device refuse an unsuitable one (#349)

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1058,6 +1058,84 @@ the gateway treats last-window exhaustion as a *confirm*, not a failure.
 LDBG names *why* a `relay-failed` had `otan=0` (a leaf that heard no OTAM = an RX problem, not a
 dead leaf). It surfaces on the retained `smol/<leaf>/ota/relaydiag` topic.
 
+## Image target descriptor — what an image is FOR (#349)
+
+Not a frame: a **16-byte record embedded in the firmware image itself**, so a board can decide
+whether an image it has just downloaded is *for a board like it*. The OTA chain already proves
+the image is **authentic** (ed25519 over `build|size|sha256`) and **intact** (readback SHA-256);
+this is the missing third property, **suitability**. `smol/ota/staged` is retained fleet-wide, so
+every board sees every announcement — with the fleet spanning C3-OLED / C3-SuperMini / C6 / S3
+that stops being theoretical.
+
+Cross-*chip* is already caught by the second-stage bootloader (`esp_image_header_t.chip_id`) —
+but only by boot-looping into rollback. A cross-*tier* image passes every check smol had **and
+boots**.
+
+**Layout** — little-endian, 16 bytes, found by a **linear scan for the magic** (no fixed offset:
+where `.rodata` lands is a linker detail). Source: `rust/clock/src/net/target.rs`.
+
+| off | bytes | field | meaning |
+|---|---|---|---|
+| 0 | 4 | magic | `"SMLT"` (`0x53 0x4D 0x4C 0x54`) |
+| 4 | 1 | desc_version | descriptor FORMAT version (currently **1**) |
+| 5 | 1 | chip | `1`=ESP32-C3 `2`=ESP32-C6 `3`=ESP32-S3; `0`=unknown. Derived by `build.rs` **from the target triple**, so it cannot misreport |
+| 6 | 2 | features | LE capability bitset: `1<<0` wifi · `1<<1` espnow · `1<<2` io · `1<<3` cast · `1<<4` wled · `1<<5` bard · `1<<6` mesh-test · `1<<7` coexist-soak · `1<<8` stack-paint |
+| 8 | 1 | compat | the persistent-state (NVS record) layout this image writes |
+| 9 | 1 | min_from_compat | the **oldest** running `compat` this image will install over |
+| 10 | 2 | reserved | 0 (inside the checksum) |
+| 12 | 4 | checksum | LE FNV-1a/32 over bytes 0..12 |
+
+The checksum is what lets a 4-byte magic be trusted after a scan over ~600 KB of arbitrary
+bytes — a real 1,156,864 B fleet image contains **two** `SMLT` occurrences and only **one** that
+checksums (the other is the scanner's own constant), so scanning resumes past a failed candidate.
+
+**The five refusals** (`net::target::decide`, in order). All are DATA compared against DATA;
+nothing names a board, and a new legitimate cross-flash is a bitset, never a branch:
+
+| reason | token | rule |
+|---|---|---|
+| unreadable | `tgt-descver` | `image.desc_version > 1` — cannot read its fields, so cannot judge it |
+| wrong silicon | `tgt-chip` | `image.chip != running.chip` |
+| state too old | `tgt-compat` | `running.compat < image.min_from_compat` |
+| strands the board | `tgt-featloss` | image drops a feature in `wifi\|espnow` that this board has. **espnow counts**: `run_ota_fetch` is `cfg(espnow)`, so a wifi-only image can never self-update again |
+| bench tier | `tgt-bench` | image carries a `mesh-test`/`coexist-soak`/`stack-paint` bit this board does not itself run |
+| no descriptor | `tgt-absent` | no valid record anywhere in the image — fails **closed** |
+
+**Where it is checked.** In `ImageWriter::finalize` / `LeafImageWriter::finalize`, over the
+**slot readback** that already computes the integrity SHA — one pass, two consumers, so the
+identity judged is provably the identity hashed. Scanning the incoming *stream* instead would
+break on a #267-resumed fetch, which skips a prefix already on flash. `otadata` is untouched at
+that point, so a refusal costs a download and nothing else.
+
+**Where it surfaces.** Self-fetch → retained `smol/<id>/ota/diag` as `at=<token>` (fail-point
+codes `13 + reason`, alongside the existing `assoc`/`stall`/`verify`). Leaf mesh-OTA → the LDBG
+`verdict` byte as `8 + reason` (`8` absent … `13` bench), i.e. `smol/<leaf>/ota/relaydiag`'s
+`V<n>`. Release images are serial-silent, so these are the only account of a refusal.
+
+**For a non-Rust fleet member** (#331 Phase 1 keeps Ember on ESPHome) the emittable form is:
+
+```c
+struct __attribute__((packed)) smol_target_desc_t {
+  uint32_t magic;         // 0x544C4D53  ("SMLT" little-endian)
+  uint8_t  desc_version;  // 1
+  uint8_t  chip;          // 1=C3 2=C6 3=S3
+  uint16_t features;      // bitset above
+  uint8_t  compat;
+  uint8_t  min_from_compat;
+  uint16_t reserved;      // 0
+  uint32_t checksum;      // FNV-1a/32 over the first 12 bytes
+};
+```
+
+**Not in here, on purpose:** the board **variant** (OLED vs SuperMini). That is detected at
+runtime (`crate::headless()`); a variant that is not a build artifact needs no OTA guard, no CI
+job, and no row in a table.
+
+**Not yet done** (device-side refusal landed first): the staged manifest still carries no target
+tuple, so a board refuses *after* downloading rather than before; `smol/ota/staged` is still one
+fleet-wide topic; and there is no publisher-side `--force-target-mismatch` escape hatch. Today's
+escape hatch is a USB flash.
+
 ## MQTT burst — the LAN transport that retires the UDP collector
 
 **What changed (v2 pivot).** v1 shipped a Python **collector** on disks that took

--- a/experiments/target_guard_verify/Cargo.toml
+++ b/experiments/target_guard_verify/Cargo.toml
@@ -1,0 +1,31 @@
+# #349 host-test harness for the PURE image-target guard (net/target.rs) — the structured
+# `TargetId` embedded in every OTA-capable image and the checker a board runs over an incoming
+# one before it commits. Runs OFF-target (std) via `cargo run`; `#[path]`-includes the real
+# net/target.rs (no drift), exactly like sth_verify / flood_verify / ota_http_verify.
+#
+# The point of this harness is NOT that the guard accepts a matching image. WLED ships a guard
+# of the same shape whose minimum-version half CANNOT FIRE (the descriptor is instantiated with
+# a literal `1` where the constant belongs, and the check reads `> 1`) — and a test that only
+# exercises the happy path would have passed on that code too. So every assertion below that
+# matters is a REFUSAL, one per rejection reason, plus a scan over a synthetic ~600 KB image.
+#
+# Discovered automatically by tools/gate.sh's `experiments/*_verify` glob → runs in CI on every
+# branch push. No dependencies: the module under test is pure.
+[package]
+name = "target_guard_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "target_guard_verify"
+path = "src/main.rs"
+# DECLARED, never enabled. net/target.rs cfg-gates its firmware-only half (the `SELF` identity
+# built from `env!("SMOL_CHIP_ID")`) behind `wifi`; naming the feature here satisfies cargo's
+# check-cfg without turning it on, so the host build stays the pure core and the harness compiles
+# warning-clean. Enabling it would need the build.rs env stamp, which off-target has no business
+# having.
+[features]
+wifi = []
+[dependencies]
+[profile.dev]
+opt-level = 0

--- a/experiments/target_guard_verify/src/main.rs
+++ b/experiments/target_guard_verify/src/main.rs
@@ -1,0 +1,301 @@
+//! Host verification of the PURE #349 image-target guard. Includes the real
+//! `net/target.rs` verbatim (`#[path]`, no drift). Run: `cargo run` — panics on failure.
+//!
+//! # Why this file is written the way it is
+//!
+//! smol's OTA chain proves an image is authentic and intact. It proves nothing about
+//! **suitability**, and `smol/ota/staged` is retained fleet-wide, so every board sees every
+//! announcement. #349 closes that with a structured `TargetId` embedded in the image; this
+//! harness is the evidence that the guard built from it can say NO.
+//!
+//! That emphasis is deliberate. WLED ships a guard of exactly this shape whose minimum-version
+//! half is **dead code**: the descriptor is instantiated with a literal `1` where the constant
+//! `WLED_CUSTOM_DESC_VERSION` (`= 2`) belongs, and the check reads `> 1`, so the gate cannot
+//! fire on any image they ship. A test that only proved "a matching image is accepted" would
+//! have passed against that code, unchanged. So the accept case here is ONE assertion, and
+//! every rejection reason gets its own — including `min_from_compat`, the field that is dead in
+//! the prior art.
+//!
+//! The final case runs the real streaming scanner over a synthetic ~600 KB image with the
+//! descriptor buried at an arbitrary offset, fed in chunk sizes that deliberately split the
+//! 16-byte record, because "the scanner finds it when it is 16-byte aligned and alone in the
+//! buffer" is not the thing that has to be true on a board.
+
+#[path = "../../../rust/clock/src/net/target.rs"]
+mod target;
+
+use target::*;
+
+/// A C3 board on the canonical fleet tier (`espnow,cast,io` → wifi|espnow|io|cast), NVS
+/// layout 1. This stands in for `net::target::SELF`, which is cfg-gated to firmware builds.
+fn c3_fleet() -> TargetId {
+    TargetId {
+        desc_version: DESC_VERSION,
+        chip: CHIP_ESP32C3,
+        features: FEAT_WIFI | FEAT_ESPNOW | FEAT_IO | FEAT_CAST,
+        compat: 1,
+        min_from_compat: 0,
+    }
+}
+
+fn check(name: &str, got: Result<(), TargetReject>, want: Result<(), TargetReject>) {
+    assert_eq!(got, want, "{name}: guard returned {got:?}, expected {want:?}");
+    match want {
+        Ok(()) => println!("  ok      {name} — accepted"),
+        Err(r) => println!("  REFUSED {name} — {} ({:?})", r.label(), r),
+    }
+}
+
+/// Build a synthetic image: `len` bytes of plausible-but-arbitrary filler with `desc`
+/// spliced in at `at`. The filler is a cheap LCG rather than zeros so the scanner has to
+/// survive bytes that look like data.
+fn synth_image(len: usize, at: usize, desc: &[u8; DESC_LEN]) -> Vec<u8> {
+    let mut img = Vec::with_capacity(len);
+    let mut x: u32 = 0x1234_5678;
+    for _ in 0..len {
+        x = x.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        img.push((x >> 24) as u8);
+    }
+    img[at..at + DESC_LEN].copy_from_slice(desc);
+    img
+}
+
+/// Feed an image through the real scanner in irregular chunks, so the 16-byte descriptor is
+/// split across `feed()` calls the way a 4 KB flash readback would split it.
+fn scan_chunked(img: &[u8], chunk_sizes: &[usize]) -> DescScan {
+    let mut scan = DescScan::new();
+    let mut off = 0;
+    let mut i = 0;
+    while off < img.len() {
+        let n = chunk_sizes[i % chunk_sizes.len()].min(img.len() - off);
+        scan.feed(&img[off..off + n]);
+        off += n;
+        i += 1;
+    }
+    scan
+}
+
+fn main() {
+    let me = c3_fleet();
+
+    // ---------------------------------------------------------------------------------
+    // 1. Codec round-trip. Everything below is worthless if the bytes do not survive.
+    // ---------------------------------------------------------------------------------
+    println!("codec");
+    let enc = me.encode();
+    assert_eq!(decode(&enc), Some(me), "encode→decode is not the identity");
+    assert_eq!(&enc[0..4], &MAGIC[..], "descriptor does not start with the magic");
+    assert_eq!(enc.len(), DESC_LEN);
+    println!("  ok      round-trip, magic, {DESC_LEN} B");
+
+    // A corrupt checksum must not decode — this is what lets a linear scan over ~600 KB of
+    // arbitrary bytes trust a 4-byte magic hit.
+    let mut torn = enc;
+    torn[12] ^= 0x01;
+    assert_eq!(decode(&torn), None, "a bad checksum still decoded");
+    // ...and so must a flipped payload byte, which invalidates the checksum from the other side.
+    let mut bent = enc;
+    bent[6] ^= 0x08;
+    assert_eq!(decode(&bent), None, "a flipped feature bit still decoded");
+    assert_eq!(decode(&enc[..DESC_LEN - 1]), None, "a truncated record still decoded");
+    println!("  ok      torn / bent / truncated records are refused");
+
+    // ---------------------------------------------------------------------------------
+    // 2. The accept case. Exactly one assertion — see the module doc.
+    // ---------------------------------------------------------------------------------
+    println!("accept");
+    check("same board, same tier", decide(me, me), Ok(()));
+
+    // A LEGITIMATE cross-tier upgrade must pass WITHOUT touching the checker. This is the
+    // WLED `normalizeReleaseName()` lesson: their identity was one opaque string, so
+    // permitting one real cross-upgrade meant hardcoding a suffix strip inside the guard.
+    // Here dropping `bard` and `cast` is just a different bitset, and no code knows about it.
+    let leaner = TargetId { features: FEAT_WIFI | FEAT_ESPNOW | FEAT_IO, ..me };
+    check("same board, fewer optional features", decide(me, leaner), Ok(()));
+    let fatter = TargetId { features: me.features | FEAT_WLED | FEAT_BARD, ..me };
+    check("same board, more optional features", decide(me, fatter), Ok(()));
+
+    // ---------------------------------------------------------------------------------
+    // 3. THE REFUSALS. One per reason. This is the part that matters.
+    // ---------------------------------------------------------------------------------
+    println!("refuse");
+
+    // (a) Wrong silicon. The bootloader would also catch this — by boot-looping into
+    //     rollback. Catching it here costs a download and yields a diagnosis instead.
+    check(
+        "S3 image on a C3 board",
+        decide(me, TargetId { chip: CHIP_ESP32S3, ..me }),
+        Err(TargetReject::Chip),
+    );
+    check(
+        "C6 image on a C3 board",
+        decide(me, TargetId { chip: CHIP_ESP32C6, ..me }),
+        Err(TargetReject::Chip),
+    );
+    // An image claiming no chip at all is not "compatible with everything".
+    check(
+        "image declaring CHIP_UNKNOWN",
+        decide(me, TargetId { chip: CHIP_UNKNOWN, ..me }),
+        Err(TargetReject::Chip),
+    );
+
+    // (b) An image that would take away the way back. `run_ota_fetch` is
+    //     `#[cfg(feature = "espnow")]`, so a wifi-only image CANNOT self-update — installing
+    //     one is a one-way trip to a USB cable, and is refused for the same reason as
+    //     dropping wifi entirely.
+    check(
+        "image without espnow (board could never OTA again)",
+        decide(me, TargetId { features: FEAT_WIFI | FEAT_IO, ..me }),
+        Err(TargetReject::FeatureLoss),
+    );
+    check(
+        "image without wifi at all",
+        decide(me, TargetId { features: FEAT_IO | FEAT_CAST, ..me }),
+        Err(TargetReject::FeatureLoss),
+    );
+
+    // (c) A bench-only tier reaching a fleet board over the retained fleet-wide staged topic.
+    check(
+        "mesh-test image on a fleet board",
+        decide(me, TargetId { features: me.features | FEAT_MESH_TEST, ..me }),
+        Err(TargetReject::FeatureForbidden),
+    );
+    check(
+        "coexist-soak image on a fleet board",
+        decide(me, TargetId { features: me.features | FEAT_COEXIST_SOAK, ..me }),
+        Err(TargetReject::FeatureForbidden),
+    );
+
+    // (d) **The dead-in-WLED gate, firing.** An image that declares it will not install over
+    //     NVS layouts older than 2, meeting a board still on layout 1.
+    check(
+        "image requiring NVS compat >= 2, board on 1",
+        decide(me, TargetId { min_from_compat: 2, ..me }),
+        Err(TargetReject::CompatTooOld),
+    );
+    //     ...and the same image on a board that HAS migrated is fine — a gate that refused
+    //     unconditionally would be no better than one that never fires.
+    let migrated = TargetId { compat: 2, ..me };
+    check(
+        "image requiring NVS compat >= 2, board on 2",
+        decide(migrated, TargetId { min_from_compat: 2, ..migrated }),
+        Ok(()),
+    );
+
+    // (e) A descriptor format from the future. We cannot read its fields, so we cannot judge
+    //     suitability, so we do not install it.
+    check(
+        "descriptor version newer than we understand",
+        decide(me, TargetId { desc_version: DESC_VERSION + 1, ..me }),
+        Err(TargetReject::DescVersion),
+    );
+
+    // ---------------------------------------------------------------------------------
+    // 4. The scanner, over a realistically-sized image, split across chunk boundaries.
+    // ---------------------------------------------------------------------------------
+    println!("scan");
+    const IMG: usize = 600 * 1024;
+
+    // Descriptor at an offset that is aligned to nothing in particular, fed in chunk sizes
+    // that are coprime with 16 so the record is split differently on every pass.
+    for &at in &[64usize, 4096 + 7, 137_213, IMG - DESC_LEN] {
+        let img = synth_image(IMG, at, &enc);
+        let scan = scan_chunked(&img, &[4096, 1, 3, 4095, 17, 7]);
+        assert_eq!(scan.found(), Some(me), "descriptor at offset {at} was not found");
+        check(&format!("found at offset {at}"), scan.verdict(me), Ok(()));
+    }
+
+    // The whole point, end to end: a REAL scan of a REAL image stream that ends in a refusal.
+    let foreign = TargetId { chip: CHIP_ESP32S3, ..me };
+    let img = synth_image(IMG, 90_000, &foreign.encode());
+    let scan = scan_chunked(&img, &[4096, 1, 3, 4095, 17, 7]);
+    assert_eq!(scan.found(), Some(foreign));
+    check("scanned S3 image, judged by a C3 board", scan.verdict(me), Err(TargetReject::Chip));
+
+    // An image that never says what it is for. Every build from #349 carries a descriptor and
+    // the monotonicity gate already blocks older builds, so this is the foreign/hand-rolled
+    // case — and it must fail CLOSED.
+    let mute = synth_image(IMG, 0, &[0u8; DESC_LEN]);
+    let scan = scan_chunked(&mute, &[4096, 1, 3, 4095, 17, 7]);
+    assert_eq!(scan.found(), None, "found a descriptor in an image that has none");
+    check("image with no descriptor", scan.verdict(me), Err(TargetReject::Absent));
+
+    // A magic that appears by accident, with garbage behind it, must not be trusted — and must
+    // not blind the scanner to the REAL descriptor that follows it. (The scanner resumes after
+    // a failed candidate; if it did not, one stray "SMLT" in .rodata would silently disable the
+    // guard on every image — the exact class of quiet failure #349 exists to prevent.)
+    let mut decoy = synth_image(IMG, 200_000, &enc);
+    decoy[150_000..150_004].copy_from_slice(&MAGIC);
+    for i in 0..12 {
+        decoy[150_004 + i] = 0xA5; // plausible bytes, wrong checksum
+    }
+    let scan = scan_chunked(&decoy, &[4096, 1, 3, 4095, 17, 7]);
+    assert_eq!(scan.found(), Some(me), "a decoy magic hid the real descriptor");
+    check("decoy magic before the real descriptor", scan.verdict(me), Ok(()));
+
+    // ---------------------------------------------------------------------------------
+    // 5. The numeric channels (`ota_fail` codes, the leaf's `dbg_verdict` byte) carry the
+    //    reason as an ordinal. Round-trip every reason so a wire code can never be decoded
+    //    as a different refusal than the one that happened.
+    // ---------------------------------------------------------------------------------
+    println!("codes");
+    let all = [
+        TargetReject::Absent,
+        TargetReject::DescVersion,
+        TargetReject::Chip,
+        TargetReject::CompatTooOld,
+        TargetReject::FeatureLoss,
+        TargetReject::FeatureForbidden,
+    ];
+    assert_eq!(all.len() as u8, TargetReject::COUNT, "TargetReject::COUNT is stale");
+    for r in all {
+        assert_eq!(TargetReject::from_code(r.code()), Some(r), "{r:?} code round-trip failed");
+        assert!(r.code() < TargetReject::COUNT, "{r:?} code is outside COUNT");
+        assert!(r.label().len() <= 12, "{r:?} label is too long for the capped diag payload");
+    }
+    assert_eq!(TargetReject::from_code(TargetReject::COUNT), None, "unknown code decoded");
+    println!("  ok      {} reasons round-trip through their ordinals", TargetReject::COUNT);
+
+    // ---------------------------------------------------------------------------------
+    // 6. OPTIONAL: the same scanner over a REAL flashed image.
+    //
+    //    Everything above runs on bytes this file made up. `SMOL_TARGET_VERIFY_BIN=<path>`
+    //    points it at an actual `espflash save-image` artifact instead, which is the only way
+    //    to prove the descriptor SURVIVES the link — `#[used]` guards compiler DCE, not
+    //    `--gc-sections`, and a guard whose descriptor was quietly dropped by the linker
+    //    would look exactly like a guard that works until the day it has to refuse something.
+    //
+    //    Skipped by default so CI stays hermetic (the gate has no espflash).
+    // ---------------------------------------------------------------------------------
+    if let Ok(path) = std::env::var("SMOL_TARGET_VERIFY_BIN") {
+        println!("real image  {path}");
+        let img = std::fs::read(&path).expect("SMOL_TARGET_VERIFY_BIN is not readable");
+        let scan = scan_chunked(&img, &[4096]); // the real flash-readback chunk size
+        let found = scan.found().expect("no valid target descriptor in the built image");
+        println!(
+            "  ok      {} B, descriptor found: chip={} features=0x{:04x} compat={} min_from={}",
+            img.len(),
+            found.chip,
+            found.features,
+            found.compat,
+            found.min_from_compat,
+        );
+        assert_eq!(found.desc_version, DESC_VERSION);
+        assert_ne!(found.chip, CHIP_UNKNOWN, "the built image claims no chip");
+        assert!(found.features & FEAT_WIFI != 0, "an OTA-capable image with no wifi bit");
+        // The board this image is for accepts it; a board on other silicon does not. Same
+        // bytes, same checker, opposite verdicts — the whole issue in two lines.
+        let native = TargetId { compat: found.compat, ..found };
+        check("real image on its own chip", scan.verdict(native), Ok(()));
+        let other = if found.chip == CHIP_ESP32S3 { CHIP_ESP32C3 } else { CHIP_ESP32S3 };
+        check(
+            "real image on other silicon",
+            scan.verdict(TargetId { chip: other, ..native }),
+            Err(TargetReject::Chip),
+        );
+    } else {
+        println!("real image  skipped (set SMOL_TARGET_VERIFY_BIN=<path> to scan a built .bin)");
+    }
+
+    println!("\ntarget_guard_verify: PASS — the guard accepts what it should and REFUSES 9 ways");
+}

--- a/rust/clock/build.rs
+++ b/rust/clock/build.rs
@@ -5,6 +5,10 @@
 //!     name (`net::names::version_name`). Falls back to `"dev"`.
 //!   * `BUILD_NUMBER` — monotonic build count (`git rev-list --count HEAD`) shown
 //!     as `v<N>`. Falls back to `"0"`.
+//!   * `SMOL_CHIP_ID` — (#349) the chip this image is built for, DERIVED from the target
+//!     triple (`riscv32imc`→C3, `riscv32imac`→C6, `xtensa-esp32s3`→S3). Consumed by
+//!     `net::target::SELF_CHIP` and embedded in the image's target descriptor so a board can
+//!     refuse an image built for other silicon. `SMOL_CHIP=<name>` overrides by name.
 //!   * `SMOL_NODE_ID` — (#42) OPTIONAL per-board id override, emitted ONLY when the
 //!     env var is set, so `SMOL_NODE_ID=8 cargo build` builds an id-8 image without
 //!     hand-editing `board.rs` (which reads it via `option_env!`, fallback = its own
@@ -41,6 +45,14 @@ fn main() {
     println!("cargo:rustc-env=BUILD_NUMBER={number}");
     println!("cargo:rustc-env=BUILD_DEV={}", if is_release { "0" } else { "1" });
 
+    // #349: the CHIP this image is built for, DERIVED from the target triple rather than
+    // declared. An image that names its own silicon is only useful if it cannot lie, and the
+    // triple is the one fact a build cannot get wrong. `CARGO_CFG_TARGET_ARCH` is NOT enough —
+    // it reports "riscv32" for both the C3 (imc) and the C6 (imac); `TARGET` carries the ISA
+    // extensions that actually distinguish them.
+    println!("cargo:rustc-env=SMOL_CHIP_ID={}", chip_id());
+    println!("cargo:rerun-if-env-changed=SMOL_CHIP");
+
     // #42: OPTIONAL per-board NODE_ID override. Emitted ONLY when set → a normal build
     // is byte-unchanged; `SMOL_NODE_ID=8 cargo build` overrides board.rs's fallback
     // (read there via `option_env!`). Guards the one-image-to-many id collision.
@@ -59,6 +71,38 @@ fn main() {
     println!("cargo:rerun-if-env-changed=SMOL_BUILD_NUMBER");
     println!("cargo:rerun-if-env-changed=SMOL_RELEASE");
     println!("cargo:rerun-if-env-changed=SMOL_NODE_ID");
+}
+
+/// #349: map the build's target triple to the `net::target::CHIP_*` id embedded in the image
+/// descriptor. `SMOL_CHIP` overrides it by NAME (not by number) for a chip whose triple this
+/// mapping does not yet know — an explicit, greppable act rather than a silent default.
+///
+/// `0` (CHIP_UNKNOWN) is returned when the triple is unrecognised, and `net/target.rs` has a
+/// `const _: () = assert!(SELF_CHIP != CHIP_UNKNOWN)` — so an unmapped chip fails the BUILD
+/// instead of shipping an image that claims to be for nothing in particular. That assert only
+/// exists on `wifi` tiers (the ones that can be OTA'd), so a host/hostsim build is unaffected.
+fn chip_id() -> u8 {
+    if let Ok(name) = std::env::var("SMOL_CHIP") {
+        return match name.trim() {
+            "esp32c3" => 1,
+            "esp32c6" => 2,
+            "esp32s3" => 3,
+            _ => 0,
+        };
+    }
+    let target = std::env::var("TARGET").unwrap_or_default();
+    // riscv32imc = C3; riscv32imac (the A extension) = C6; xtensa-esp32s3 = S3. Ordering
+    // matters: "riscv32imac" contains no "riscv32imc" substring, but match the longer/more
+    // specific arms first anyway so a future triple cannot alias onto the C3.
+    if target.starts_with("xtensa-esp32s3") {
+        3
+    } else if target.starts_with("riscv32imac") {
+        2
+    } else if target.starts_with("riscv32imc") {
+        1
+    } else {
+        0 // host/wasm (hostsim, web-emu) — no descriptor is emitted on those tiers anyway
+    }
 }
 
 /// Prefer the explicit env override (archive/pipeline), else read `path` (relative to the

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -132,6 +132,14 @@ pub mod sth;
 #[cfg(feature = "espnow")]
 pub mod ledger_link;
 
+// #349 image TARGET identity — the structured `TargetId` embedded in every OTA-capable image,
+// and the checker a board runs over an incoming one before it commits. PURE (no HAL), so
+// `experiments/target_guard_verify` `#[path]`-includes this exact file and proves on the host
+// that the guard REFUSES, not merely that it accepts. `wifi`-gated: the tiers that carry no OTA
+// engine also carry no descriptor, so the default build stays byte-free of it.
+#[cfg(feature = "wifi")]
+pub mod target;
+
 // #25 WLED WiZmote-emit (smol as a WLED "linked remote"). `wled = ["espnow"]`, so
 // this is present only in a wled build; the default/wifi/espnow builds are byte-free
 // of it (the module is `#![cfg(feature = "wled")]`). Referenced by `app` (the

--- a/rust/clock/src/net/target.rs
+++ b/rust/clock/src/net/target.rs
@@ -1,0 +1,554 @@
+//! #349 — **image target identity**: what an image is FOR, so a board can refuse one that
+//! isn't for it. PURE (no HAL, no alloc, no `env!` outside the cfg-gated self-identity block)
+//! so `experiments/target_guard_verify` `#[path]`-includes this exact file and proves the
+//! checker on the host — including proving it REFUSES.
+//!
+//! # The gap this closes
+//!
+//! smol's OTA chain proves an image is **authentic** (ed25519 over `build|size|sha256`) and
+//! **intact** (readback SHA-256 over the written slot). It proves nothing about
+//! **suitability**. Cross-*chip* is caught for free — `esp_image_header_t.chip_id` at image
+//! byte 12 is validated by the second-stage bootloader — but that costs a boot-loop to
+//! discover, and a cross-*tier* image passes every check smol has **and boots**. Since
+//! `smol/ota/staged` is retained fleet-wide, every board sees every announcement.
+//!
+//! # Design, and why it is shaped like this
+//!
+//! Prior art (`scratch/parity/multitarget-prior-art.md`): OpenWrt's `fwtool_check_image()` is
+//! **data + one checker** — `supported_devices` is a list, `DEVICE_ALT*` are aliases, and the
+//! checker itself never changes when a board is renamed. WLED put the same idea in the right
+//! PLACE for an ESP — a magic-tagged, hash-validated descriptor embedded in the image, found
+//! by a linear scan of the incoming bytes — but gave it the wrong TYPE: one opaque
+//! `release_name` string. Because the identity was one label, permitting a single legitimate
+//! cross-upgrade required hardcoding a suffix strip *inside the checker*
+//! (`normalizeReleaseName()`). So:
+//!
+//! * **`TargetId` is a structured tuple, never a display string.** Chip, feature bitset, and
+//!   persistent-state compat are independent fields, so the checker reasons about each axis on
+//!   its own and a new legitimate cross-flash is a change to DATA, not to [`decide`].
+//! * **Board VARIANT is deliberately absent.** OLED vs SuperMini is detected at runtime
+//!   (`crate::headless()`), and a variant that is not a build artifact needs no OTA guard, no
+//!   CI job and no row in a table. Keep it that way; do not add a variant field here.
+//! * **It is a WIRE type with a C++-emittable subset** (#331 Phase 1 keeps the stationary Ember
+//!   on ESPHome, so a non-Rust fleet member has to be able to emit this). See [`Desc`] below.
+//!
+//! # The anti-lesson this file is built against
+//!
+//! WLED's minimum-version half of the same guard is **dead code in shipped firmware**: the
+//! descriptor is instantiated with a literal `1` where the constant `WLED_CUSTOM_DESC_VERSION`
+//! (`= 2`) belongs, and the check reads `> 1`, so it cannot fire on any image they ship. The
+//! disabling `FIXME` survived a release boundary.
+//!
+//! Two structural defences here, not a comment:
+//!
+//! 1. [`SELF_DESC`] is `SELF.encode()` — the emitted bytes are *computed from* the same const
+//!    the checker compares against. There is no second literal to drift.
+//! 2. `const _: () = assert!(...)` below round-trips `decode(encode(SELF)) == SELF` at compile
+//!    time, field by field. A literal smuggled into either side fails the BUILD.
+//!
+//! And every refusal branch in [`decide`] is exercised by `experiments/target_guard_verify`,
+//! which asserts the REFUSALS, not just the accept.
+//!
+//! # Wire format — 16 bytes, little-endian, C++-emittable
+//!
+//! ```text
+//! off  size  field            meaning
+//!  0    4    magic            "SMLT" (0x53 0x4D 0x4C 0x54)
+//!  4    1    desc_version     descriptor FORMAT version (this file: 1)
+//!  5    1    chip             CHIP_ESP32C3=1 / C6=2 / S3=3; 0 = unknown
+//!  6    2    features         u16 capability bitset (FEAT_*)
+//!  8    1    compat           persistent-state (NVS) layout version this image writes
+//!  9    1    min_from_compat  the OLDEST running `compat` this image will install OVER
+//! 10    2    reserved         0
+//! 12    4    checksum         FNV-1a/32 over bytes 0..12
+//! ```
+//!
+//! The identical struct in C++ (ESPHome external component, #331 Phase 1):
+//!
+//! ```c
+//! struct __attribute__((packed)) smol_target_desc_t {
+//!   uint32_t magic;            // 0x544C4D53  ("SMLT" little-endian)
+//!   uint8_t  desc_version;     // 1
+//!   uint8_t  chip;             // 1=C3 2=C6 3=S3
+//!   uint16_t features;         // FEAT_* bitset
+//!   uint8_t  compat;
+//!   uint8_t  min_from_compat;
+//!   uint16_t reserved;         // 0
+//!   uint32_t checksum;         // FNV-1a/32 over the first 12 bytes
+//! };
+//! ```
+//!
+//! # Where it is checked
+//!
+//! The descriptor is found by scanning the image bytes as they are **read back out of the
+//! written slot** (`ImageWriter::finalize` / `LeafImageWriter::finalize`), not as they stream
+//! in. That placement is deliberate and load-bearing: a #267-resumed fetch skips a prefix that
+//! is already on flash, so a scan of the *incoming* stream would miss a descriptor in the
+//! skipped bytes and report "absent" for a perfectly good image. Reading the slot back is what
+//! the SHA gate already does, it is burst-count invariant, and it covers the mesh-relay leaf
+//! path with the same code. otadata is still untouched at that point, so a refusal costs a
+//! download and nothing else.
+
+#![allow(dead_code)] // the pure core is also compiled by the host verifier, which uses a subset
+
+/// Descriptor magic. Chosen with **no proper border** (no prefix of "SMLT" is also a suffix),
+/// which is what makes the naive restart in [`DescScan::feed_byte`] an exact match rather than
+/// an approximate one — see the assertion next to it.
+pub const MAGIC: [u8; 4] = *b"SMLT";
+
+/// Total descriptor length in bytes.
+pub const DESC_LEN: usize = 16;
+
+/// Descriptor FORMAT version understood by this firmware. An image declaring a HIGHER one is
+/// refused: we cannot read its fields, therefore we cannot judge suitability, therefore we do
+/// not install it. (Unlike WLED's, this comparison is against a named constant that is also
+/// what gets encoded — see the compile-time round-trip below.)
+pub const DESC_VERSION: u8 = 1;
+
+// --- chip axis -------------------------------------------------------------------------
+// A raw u8, NOT a Rust enum: an unknown chip id must stay unknown and compare unequal to
+// every known one, rather than being lost in a `_ =>` arm at decode time.
+pub const CHIP_UNKNOWN: u8 = 0;
+pub const CHIP_ESP32C3: u8 = 1;
+pub const CHIP_ESP32C6: u8 = 2;
+pub const CHIP_ESP32S3: u8 = 3;
+
+// --- feature axis ----------------------------------------------------------------------
+// One bit per WIRE-VISIBLE capability. A bitset rather than a "tier" label is the direct
+// repair of WLED's opaque `release_name`: the checker can ask "does this image keep the
+// radio path I need?" and "does it carry a bench-only tier?" independently, and neither
+// question needs a table of tier names or a special case per legitimate cross-flash.
+pub const FEAT_WIFI: u16 = 1 << 0;
+pub const FEAT_ESPNOW: u16 = 1 << 1;
+pub const FEAT_IO: u16 = 1 << 2;
+pub const FEAT_CAST: u16 = 1 << 3;
+pub const FEAT_WLED: u16 = 1 << 4;
+pub const FEAT_BARD: u16 = 1 << 5;
+// Bench-only tiers. These perturb a live mesh (mesh-test injects traffic; coexist-soak drives
+// the radio; stack-paint repaints the stack region) and must never land on a fleet board.
+pub const FEAT_MESH_TEST: u16 = 1 << 6;
+pub const FEAT_COEXIST_SOAK: u16 = 1 << 7;
+pub const FEAT_STACK_PAINT: u16 = 1 << 8;
+
+/// The bench-only bits, as one mask. Membership is DATA — adding a bench tier is one line
+/// here, not a branch in [`decide`].
+pub const BENCH_FEATS: u16 = FEAT_MESH_TEST | FEAT_COEXIST_SOAK | FEAT_STACK_PAINT;
+
+/// Features whose LOSS strands the board — after installing an image without these, there is
+/// no radio path left to install another one, and recovery is a USB cable.
+///
+/// `FEAT_ESPNOW` is in here for a non-obvious, verified reason: `run_ota_fetch` is
+/// `#[cfg(feature = "espnow")]` (see `ota.rs` — "the wifi-only build reads announces but never
+/// fetches"). A wifi-only image therefore **cannot self-update at all**. Dropping espnow is a
+/// one-way trip, so it is treated exactly like dropping wifi.
+pub const RECOVERY_CRITICAL: u16 = FEAT_WIFI | FEAT_ESPNOW;
+
+/// A structured image identity. Every field is an independent axis; nothing here is a
+/// display string, and nothing here is a board VARIANT (that stays runtime-detected).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct TargetId {
+    pub desc_version: u8,
+    pub chip: u8,
+    pub features: u16,
+    /// The persistent-state (NVS record) layout this image writes.
+    pub compat: u8,
+    /// The OLDEST running `compat` this image is willing to install over. This is WLED's
+    /// `safe_update_version` — here it is live, encoded from a named constant, and proven to
+    /// fire by `experiments/target_guard_verify`.
+    pub min_from_compat: u8,
+}
+
+/// Why an image was judged unsuitable for THIS board. Terse, stable labels because they ride
+/// the retained `smol/<id>/ota/diag` payload, which is packet-capped.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TargetReject {
+    /// No valid descriptor anywhere in the image. An image that will not say what it is for
+    /// cannot be judged suitable, so it is not installed (OpenWrt refuses metadata-less
+    /// images for the same reason). Every build from #349 onward carries one, and the
+    /// monotonicity gate already blocks older builds, so this fires on foreign or
+    /// hand-rolled images.
+    Absent,
+    /// Descriptor format newer than [`DESC_VERSION`] — unreadable, therefore unjudgeable.
+    DescVersion,
+    /// Built for a different SoC. The bootloader would also catch this, but only by
+    /// boot-looping into rollback; catching it here yields a diagnosis instead.
+    Chip,
+    /// The image will not install over persistent state this old (`running.compat <
+    /// image.min_from_compat`). Escape hatch: USB flash.
+    CompatTooOld,
+    /// The image drops a [`RECOVERY_CRITICAL`] feature this board currently has — installing
+    /// it would leave no way to install anything else.
+    FeatureLoss,
+    /// The image carries a bench-only tier ([`BENCH_FEATS`]) that this board does not itself
+    /// run. Bench images reach bench boards over USB, never over the fleet-wide staged topic.
+    FeatureForbidden,
+}
+
+impl TargetReject {
+    /// Short stable token for the retained diag payload. Kept terse on purpose — the MQTT
+    /// packet is capped and DIAG sheds fields under budget pressure.
+    pub fn label(self) -> &'static str {
+        match self {
+            TargetReject::Absent => "tgt-absent",
+            TargetReject::DescVersion => "tgt-descver",
+            TargetReject::Chip => "tgt-chip",
+            TargetReject::CompatTooOld => "tgt-compat",
+            TargetReject::FeatureLoss => "tgt-featloss",
+            TargetReject::FeatureForbidden => "tgt-bench",
+        }
+    }
+
+    /// Dense 0-based ordinal, so a caller with a NUMERIC diagnostic channel (the leaf's
+    /// `dbg_verdict` byte in the `LDBG` beacon, the `ota_fail` fail-point codes) can carry the
+    /// reason at its own base without a second mapping table to keep in sync.
+    pub fn code(self) -> u8 {
+        match self {
+            TargetReject::Absent => 0,
+            TargetReject::DescVersion => 1,
+            TargetReject::Chip => 2,
+            TargetReject::CompatTooOld => 3,
+            TargetReject::FeatureLoss => 4,
+            TargetReject::FeatureForbidden => 5,
+        }
+    }
+
+    /// Inverse of [`code`](Self::code). `None` for an unknown ordinal (a record written by a
+    /// firmware that knows more rejection reasons than this one does).
+    pub fn from_code(c: u8) -> Option<TargetReject> {
+        Some(match c {
+            0 => TargetReject::Absent,
+            1 => TargetReject::DescVersion,
+            2 => TargetReject::Chip,
+            3 => TargetReject::CompatTooOld,
+            4 => TargetReject::FeatureLoss,
+            5 => TargetReject::FeatureForbidden,
+            _ => return None,
+        })
+    }
+
+    /// Number of distinct reasons — the width a numeric channel must reserve.
+    pub const COUNT: u8 = 6;
+}
+
+/// **The whole checker.** Data in, verdict out — no per-board cases, no string normalisation,
+/// no chip named anywhere in the body. Order is chosen so the verdict names the most
+/// fundamental mismatch first (an S3 image on a C3 is reported as a chip mismatch, not as
+/// whatever feature bits happen to differ).
+///
+/// `running` is this board's own [`TargetId`]; `image` is the one decoded out of the image.
+pub fn decide(running: TargetId, image: TargetId) -> Result<(), TargetReject> {
+    // 1. Can we even read it?
+    if image.desc_version > DESC_VERSION {
+        return Err(TargetReject::DescVersion);
+    }
+    // 2. Same silicon. Exact equality, and CHIP_UNKNOWN (0) matches nothing real.
+    if image.chip != running.chip {
+        return Err(TargetReject::Chip);
+    }
+    // 3. Persistent state old enough to be refused by this image.
+    if running.compat < image.min_from_compat {
+        return Err(TargetReject::CompatTooOld);
+    }
+    // 4. Do not install something that takes away the way back. DERIVED from what this board
+    //    actually has, so a board that never had espnow is not held to it — a fixed required
+    //    mask would strand exactly the boards it was meant to protect.
+    let required = running.features & RECOVERY_CRITICAL;
+    if image.features & required != required {
+        return Err(TargetReject::FeatureLoss);
+    }
+    // 5. Bench tiers. Also DERIVED: a bench board tolerates its own bench bits, a fleet board
+    //    tolerates none. No allowlist to maintain, no branch per tier.
+    let forbidden = BENCH_FEATS & !running.features;
+    if image.features & forbidden != 0 {
+        return Err(TargetReject::FeatureForbidden);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------------------
+// Codec
+// ---------------------------------------------------------------------------------------
+
+/// FNV-1a/32 — const-evaluable so the checksum is computed at COMPILE time for [`SELF_DESC`]
+/// (WLED's constexpr djb2 plays the same role). Its only job is to make a coincidental
+/// 4-byte magic match in unrelated image bytes fail to decode.
+pub const fn fnv1a32(data: &[u8]) -> u32 {
+    let mut h: u32 = 0x811c_9dc5;
+    let mut i = 0;
+    while i < data.len() {
+        h ^= data[i] as u32;
+        h = h.wrapping_mul(0x0100_0193);
+        i += 1;
+    }
+    h
+}
+
+impl TargetId {
+    /// Serialise to the 16-byte wire descriptor. `const fn` so the embedded static is built at
+    /// compile time FROM THE SAME VALUE the checker uses — the structural reason this cannot
+    /// drift the way WLED's literal did.
+    pub const fn encode(&self) -> [u8; DESC_LEN] {
+        let mut d = [0u8; DESC_LEN];
+        d[0] = MAGIC[0];
+        d[1] = MAGIC[1];
+        d[2] = MAGIC[2];
+        d[3] = MAGIC[3];
+        d[4] = self.desc_version;
+        d[5] = self.chip;
+        d[6] = (self.features & 0xff) as u8;
+        d[7] = (self.features >> 8) as u8;
+        d[8] = self.compat;
+        d[9] = self.min_from_compat;
+        // d[10], d[11] reserved = 0 (inside the checksum, so a future use fails closed here).
+        let body = [d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9], d[10], d[11]];
+        let ck = fnv1a32(&body);
+        d[12] = (ck & 0xff) as u8;
+        d[13] = ((ck >> 8) & 0xff) as u8;
+        d[14] = ((ck >> 16) & 0xff) as u8;
+        d[15] = ((ck >> 24) & 0xff) as u8;
+        d
+    }
+}
+
+/// Parse a 16-byte candidate. `None` unless the magic AND the checksum hold — that pair is
+/// what lets a linear scan over ~600 KB of arbitrary image bytes trust what it finds.
+/// Panic-free; never indexes past `DESC_LEN`.
+pub fn decode(rec: &[u8]) -> Option<TargetId> {
+    if rec.len() < DESC_LEN {
+        return None;
+    }
+    if rec[0] != MAGIC[0] || rec[1] != MAGIC[1] || rec[2] != MAGIC[2] || rec[3] != MAGIC[3] {
+        return None;
+    }
+    let want = u32::from_le_bytes([rec[12], rec[13], rec[14], rec[15]]);
+    if want != fnv1a32(&rec[..12]) {
+        return None;
+    }
+    Some(TargetId {
+        desc_version: rec[4],
+        chip: rec[5],
+        features: u16::from_le_bytes([rec[6], rec[7]]),
+        compat: rec[8],
+        min_from_compat: rec[9],
+    })
+}
+
+// ---------------------------------------------------------------------------------------
+// Streaming scanner
+// ---------------------------------------------------------------------------------------
+
+/// Finds the descriptor in an image fed as arbitrarily-split slices, with 20 bytes of state
+/// and one comparison per byte — no fixed offset, because where `.rodata` lands in the image
+/// is a linker detail and depending on it is how a guard quietly stops firing. (WLED scans
+/// linearly for exactly this reason.)
+#[derive(Clone, Copy)]
+pub struct DescScan {
+    buf: [u8; DESC_LEN],
+    /// Bytes of a candidate accumulated so far: `< MAGIC.len()` = still matching the magic.
+    n: usize,
+    found: Option<TargetId>,
+}
+
+impl Default for DescScan {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DescScan {
+    pub const fn new() -> DescScan {
+        DescScan { buf: [0u8; DESC_LEN], n: 0, found: None }
+    }
+
+    /// Feed one image slice. Chunk boundaries are irrelevant — state carries across calls.
+    pub fn feed(&mut self, bytes: &[u8]) {
+        if self.found.is_some() {
+            return;
+        }
+        for &b in bytes {
+            self.feed_byte(b);
+            if self.found.is_some() {
+                return;
+            }
+        }
+    }
+
+    #[inline]
+    fn feed_byte(&mut self, b: u8) {
+        if self.n < MAGIC.len() {
+            // Naive restart is EXACT here only because MAGIC has no proper border (no prefix
+            // of "SMLT" is also a suffix of it); with a bordered magic this would skip real
+            // matches. The assertion below is what keeps that true if MAGIC ever changes.
+            if b == MAGIC[self.n] {
+                self.buf[self.n] = b;
+                self.n += 1;
+            } else if b == MAGIC[0] {
+                self.buf[0] = b;
+                self.n = 1;
+            } else {
+                self.n = 0;
+            }
+            return;
+        }
+        self.buf[self.n] = b;
+        self.n += 1;
+        if self.n == DESC_LEN {
+            // First CHECKSUM-VALID candidate wins; a magic that only matched by accident (the
+            // scanner's own immediate, say) fails here and scanning continues.
+            self.found = decode(&self.buf);
+            self.n = 0;
+        }
+    }
+
+    /// The descriptor found so far, if any.
+    pub fn found(&self) -> Option<TargetId> {
+        self.found
+    }
+
+    /// The verdict for `running`, including the "never said what it was for" case. This is the
+    /// single entry point a caller needs.
+    pub fn verdict(&self, running: TargetId) -> Result<(), TargetReject> {
+        match self.found {
+            Some(image) => decide(running, image),
+            None => Err(TargetReject::Absent),
+        }
+    }
+}
+
+/// MAGIC must stay border-free for the scanner's restart rule to be exact.
+const _: () = {
+    let m = MAGIC;
+    assert!(m[0] != m[3], "MAGIC has a 1-byte border — DescScan restart would skip matches");
+    assert!(!(m[0] == m[2] && m[1] == m[3]), "MAGIC has a 2-byte border");
+    assert!(!(m[0] == m[1] && m[1] == m[2]), "MAGIC has a 3-byte border");
+};
+
+// ---------------------------------------------------------------------------------------
+// This firmware's own identity  (cfg-gated: absent from the host verifier and from tiers
+// that have no OTA engine at all)
+// ---------------------------------------------------------------------------------------
+
+/// The persistent-state (NVS record) layout this firmware writes. Bump when the `nvs`
+/// sector-0 identity record or the CFG record layout changes incompatibly.
+#[cfg(feature = "wifi")]
+pub const NVS_COMPAT: u8 = 1;
+
+/// The oldest running [`NVS_COMPAT`] this image will install over. `0` = "over anything",
+/// which is correct today: no NVS break has shipped. Raising it is a deliberate act that says
+/// "boards older than this must be USB-flashed" — and, unlike WLED's, it is the value that is
+/// actually ENCODED (see the round-trip assertion) and it is proven to fire in
+/// `experiments/target_guard_verify`.
+#[cfg(feature = "wifi")]
+pub const MIN_FROM_COMPAT: u8 = 0;
+
+/// Chip id stamped by `build.rs` from the target triple (riscv32imc → C3, riscv32imac → C6,
+/// xtensa-esp32s3 → S3). Derived rather than declared so a chip de-pin (#331/#348) cannot
+/// produce an image that misreports what it was built for.
+#[cfg(feature = "wifi")]
+pub const SELF_CHIP: u8 = parse_chip(env!("SMOL_CHIP_ID"));
+
+#[cfg(feature = "wifi")]
+const fn parse_chip(s: &str) -> u8 {
+    let b = s.as_bytes();
+    let mut n: u8 = 0;
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] >= b'0' && b[i] <= b'9' {
+            n = n * 10 + (b[i] - b'0');
+        }
+        i += 1;
+    }
+    n
+}
+
+/// This firmware's capability bitset, read off the cargo features that are actually enabled.
+#[cfg(feature = "wifi")]
+const fn self_features() -> u16 {
+    let mut f: u16 = 0;
+    if cfg!(feature = "wifi") {
+        f |= FEAT_WIFI;
+    }
+    if cfg!(feature = "espnow") {
+        f |= FEAT_ESPNOW;
+    }
+    if cfg!(feature = "io") {
+        f |= FEAT_IO;
+    }
+    if cfg!(feature = "cast") {
+        f |= FEAT_CAST;
+    }
+    if cfg!(feature = "wled") {
+        f |= FEAT_WLED;
+    }
+    if cfg!(feature = "bard") {
+        f |= FEAT_BARD;
+    }
+    if cfg!(feature = "mesh-test") {
+        f |= FEAT_MESH_TEST;
+    }
+    if cfg!(feature = "coexist-soak") {
+        f |= FEAT_COEXIST_SOAK;
+    }
+    if cfg!(feature = "stack-paint") {
+        f |= FEAT_STACK_PAINT;
+    }
+    f
+}
+
+/// What THIS image is. Both the embedded descriptor and the checker's "running" side are this
+/// one value.
+#[cfg(feature = "wifi")]
+pub const SELF: TargetId = TargetId {
+    desc_version: DESC_VERSION,
+    chip: SELF_CHIP,
+    features: self_features(),
+    compat: NVS_COMPAT,
+    min_from_compat: MIN_FROM_COMPAT,
+};
+
+/// The descriptor embedded in the image, for OTHER boards to read.
+///
+/// `#[used]` + `#[no_mangle]` keep it through compiler DCE; it is additionally READ at runtime
+/// by [`self_desc_present`], which is what keeps `--gc-sections` from dropping the section.
+/// The bytes are `SELF.encode()` — computed, never transcribed.
+#[cfg(feature = "wifi")]
+#[used]
+#[no_mangle]
+pub static SMOL_TARGET_DESC: [u8; DESC_LEN] = SELF.encode();
+
+/// Reads the embedded descriptor back and confirms it decodes to [`SELF`]. Called once on the
+/// OTA path; its real job is to be a genuine runtime REFERENCE to [`SMOL_TARGET_DESC`] so the
+/// linker cannot garbage-collect the very bytes the guard depends on. Returns `false` only if
+/// the section went missing — in which case peers will report `tgt-absent` for our images and
+/// this board has a build problem, not a fleet problem.
+#[cfg(feature = "wifi")]
+pub fn self_desc_present() -> bool {
+    // Volatile so the read is not const-folded away along with the reference it exists for.
+    let mut raw = [0u8; DESC_LEN];
+    for (i, b) in raw.iter_mut().enumerate() {
+        *b = unsafe { core::ptr::read_volatile(SMOL_TARGET_DESC.as_ptr().add(i)) };
+    }
+    decode(&raw) == Some(SELF)
+}
+
+/// **The WLED anti-lesson, structurally.** Their descriptor is instantiated with a literal `1`
+/// where the constant belongs, and the check reads `> 1`, so the gate cannot fire on any
+/// shipped image. Here the emitted bytes are decoded back at COMPILE time and every field is
+/// compared to the value the checker uses. Smuggling a literal into either side fails the
+/// build rather than silently disabling the guard.
+#[cfg(feature = "wifi")]
+const _: () = {
+    let d = SELF.encode();
+    assert!(d[0] == MAGIC[0] && d[1] == MAGIC[1] && d[2] == MAGIC[2] && d[3] == MAGIC[3]);
+    assert!(d[4] == DESC_VERSION, "encoded desc_version is not DESC_VERSION");
+    assert!(d[5] == SELF_CHIP, "encoded chip is not SELF_CHIP");
+    assert!(d[6] == (self_features() & 0xff) as u8, "encoded features low byte drifted");
+    assert!(d[7] == (self_features() >> 8) as u8, "encoded features high byte drifted");
+    assert!(d[8] == NVS_COMPAT, "encoded compat is not NVS_COMPAT");
+    assert!(d[9] == MIN_FROM_COMPAT, "encoded min_from_compat is not MIN_FROM_COMPAT");
+    // A build must never ship claiming an unknown chip — that would make every peer's chip
+    // check meaningless.
+    assert!(SELF_CHIP != CHIP_UNKNOWN, "build.rs could not determine the chip from the target");
+    // And the OTA-capable tiers must always claim the radio path they actually have.
+    assert!(self_features() & FEAT_WIFI != 0);
+};

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -2502,9 +2502,25 @@ mod ota_fail {
     pub const DEADLINE: u32 = 10; // global OTA_FETCH_BUDGET elapsed mid-download
     pub const VERIFY: u32 = 11; // download completed but the size/SHA-256/ed25519 gate rejected it
     pub const RECYCLE: u32 = 12; // the socket never returned to a connectable state between chunks
+    /// #349: first code of the SUITABILITY band — the image is intact and authentic, and it is
+    /// not for this board. `TARGET_BASE + TargetReject::code()`, so the `at=` label IS the
+    /// reason (`tgt-chip`, `tgt-bench`, …) with no second mapping table to drift.
+    ///
+    /// This band exists because folding a suitability refusal into `VERIFY` would have made the
+    /// two most different OTA failures indistinguishable on the wire: "the bytes are damaged"
+    /// and "the bytes are perfect, but they are someone else's". Release images are
+    /// serial-silent, so an operator's only account of a refusal is this label.
+    pub const TARGET_BASE: u32 = 13;
 
     /// Short, stable label for the retained diag payload (kept terse — the MQTT packet is capped).
     pub fn label(fp: u32) -> &'static str {
+        // #349 suitability band, delegated to the reject type itself so this function can never
+        // disagree with it about what a code means.
+        if fp >= TARGET_BASE {
+            if let Some(r) = crate::net::target::TargetReject::from_code((fp - TARGET_BASE) as u8) {
+                return r.label();
+            }
+        }
         match fp {
             ASSOC => "assoc",
             DHCP => "dhcp",
@@ -5484,6 +5500,19 @@ pub fn run_ota_fetch(
         port,
         path
     );
+    // #349: a genuine runtime READ of the embedded target descriptor. Two jobs, both
+    // load-bearing. (a) It is the reference that stops `--gc-sections` from discarding the very
+    // bytes every peer reads to identify our images — `#[used]` alone guards compiler DCE, not
+    // linker GC. (b) It re-decodes them and compares against `SELF`, so a descriptor that is
+    // present but wrong is announced HERE rather than being discovered by a peer refusing our
+    // build. A gate whose own inputs are never checked is the failure mode this whole issue is
+    // about; this is that check.
+    if !crate::net::target::self_desc_present() {
+        log::error!(
+            "smol #349: this image's OWN target descriptor is missing or does not decode to SELF \
+             — peers will report tgt-absent for builds from this commit (build problem, not a fleet one)"
+        );
+    }
 
     let mut iface = create_interface(device);
     let mut sockets_storage: [SocketStorage; 2] = Default::default();
@@ -5989,9 +6018,12 @@ pub fn run_ota_fetch(
     // `splitn(5)` a require-off flag would only fail-OPEN on a bad 5-field sig, pointless;
     // the "deliver #32 UNSIGNED" rollout is a publish-format choice — a 4-field announce
     // pre-#32 boards parse — not a board flag.)
-    if writer.finalize(announce.size, &announce.sha256)
-        && crate::ota::verify_signature(announce.signed_msg(), announce.sig())
-    {
+    // #349: `finalize` now returns WHICH gate refused — integrity, or suitability (the image is
+    // intact and authentic but built for a different board). Both still leave otadata untouched,
+    // so the good slot boots either way; they are separated only so the retained diag can name
+    // the real problem.
+    let outcome = writer.finalize(announce.size, &announce.sha256);
+    if outcome.is_ok() && crate::ota::verify_signature(announce.signed_msg(), announce.sig()) {
         // #188 follow-up: publish ONE final progress line at `done == total`, so the retained topic
         // describes the most recent OUTCOME rather than the most recent FAILURE.
         //
@@ -6030,6 +6062,25 @@ pub fn run_ota_fetch(
         log::info!("smol OTA: image VERIFIED (SHA-256 + ed25519) — activating the new slot");
         crate::ota::activate(target, announce.build, false); // self-OTA → confirm via DHCP
         false // reached only if the otadata write failed
+    } else if let Err(crate::ota::FinalizeFail::Target(why)) = outcome {
+        // #349: the download completed, the bytes are intact — and the image is not for this
+        // board. `smol/ota/staged` is retained FLEET-WIDE, so every board sees every
+        // announcement; with the fleet spanning C3-OLED / C3-SuperMini / C6 / S3 this is the
+        // ordinary way a board meets an image it must not install, not an exotic one. Reported
+        // at its own `at=tgt-*` code rather than as `verify`, because "someone staged the wrong
+        // image" and "the transfer corrupted" want completely different operator responses.
+        *fail = Some((
+            chunk_n,
+            chunk_n,
+            chunk_retries,
+            stall,
+            ota_fail::TARGET_BASE + why.code() as u32,
+        ));
+        log::error!(
+            "smol #349: image REFUSED — intact and authentic, but not for this board ({}) — discarded (good slot intact)",
+            why.label()
+        );
+        false
     } else {
         // #139-followup: the download COMPLETED but the integrity/authenticity gate rejected it
         // (corrupt/truncated/bad-sig). Record K=N (all chunks fetched) + at=verify so the fleet diag

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -602,19 +602,35 @@ impl ImageWriter {
         true
     }
 
-    /// Flush the tail, then the INTEGRITY GATE: written byte-count == announced size
-    /// AND running SHA-256 == announced hash. `true` ⇒ the whole image landed intact
-    /// and [`activate`] is safe. otadata is still untouched here.
-    pub fn finalize(mut self, expected_size: u32, expected_sha: &[u8; 32]) -> bool {
+    /// Flush the tail, then the two gates that stand between a downloaded image and
+    /// `activate`:
+    ///
+    /// 1. **Integrity** — written byte-count == announced size AND a READBACK SHA-256 of
+    ///    `slot[..size]` == the signed hash.
+    /// 2. **#349 Suitability** — the target descriptor embedded in those same readback bytes
+    ///    says this image is for a board like this one.
+    ///
+    /// `Ok(())` ⇒ the image landed intact AND belongs here, and [`activate`] is safe.
+    /// otadata is untouched throughout, so either failure discards with the good slot active.
+    ///
+    /// The suitability scan rides the integrity readback deliberately: a #267-resumed fetch
+    /// never re-feeds the prefix already on flash, so scanning the incoming STREAM would miss a
+    /// descriptor in the skipped bytes and refuse a good image as `tgt-absent`. Reading the
+    /// slot back is burst-count invariant — it sees exactly the bytes that would boot.
+    pub fn finalize(
+        mut self,
+        expected_size: u32,
+        expected_sha: &[u8; 32],
+    ) -> Result<(), FinalizeFail> {
         use embedded_storage::nor_flash::ReadNorFlash;
         use sha2::Digest;
         if !self.flush_stage() {
             ota_resume_clear();
-            return false;
+            return Err(FinalizeFail::Integrity);
         }
         if self.written != expected_size {
             ota_resume_clear();
-            return false;
+            return Err(FinalizeFail::Integrity);
         }
         // #267/#40: READBACK-SHA over `slot[..size]` — the exact bytes that will boot — instead of a
         // streaming hash. Burst-count invariant, so a fetch resumed across N bursts verifies
@@ -623,6 +639,9 @@ impl ImageWriter {
         // are read legally but not hashed), mirroring `LeafImageWriter::finalize`.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(OTA_READBACK) };
         let mut hasher = sha2::Sha256::new();
+        // #349: one pass, two consumers — the SHA and the target-descriptor scan see the
+        // identical bytes, so the identity we judge is provably the identity we hashed.
+        let mut scan = crate::net::target::DescScan::new();
         let mut off = 0u32;
         let mut read_ok = true;
         while off < expected_size {
@@ -633,11 +652,29 @@ impl ImageWriter {
                 break;
             }
             hasher.update(&buf[..want as usize]);
+            scan.feed(&buf[..want as usize]);
             off += want;
         }
         ota_resume_clear(); // fetch terminal (success OR fail) → a fresh attempt starts from 0
-        read_ok && hasher.finalize().as_slice() == &expected_sha[..]
+        if !read_ok || hasher.finalize().as_slice() != &expected_sha[..] {
+            return Err(FinalizeFail::Integrity);
+        }
+        // Integrity FIRST, suitability second: a corrupt image's "descriptor" is meaningless,
+        // so a mismatch reported here is always a mismatch of an image we know is intact.
+        scan.verdict(crate::net::target::SELF).map_err(FinalizeFail::Target)
     }
+}
+
+/// Why a finished download was not activated. Split so the retained `smol/<id>/ota/diag`
+/// record can say WHICH gate refused: a bad transfer and an image built for someone else are
+/// different operator problems, and before #349 both would have surfaced as `at=verify`.
+#[cfg(feature = "espnow")]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FinalizeFail {
+    /// Size mismatch, flash read error, or SHA-256 mismatch.
+    Integrity,
+    /// #349: intact, authentic — and not for this board.
+    Target(crate::net::target::TargetReject),
 }
 
 // ---------------------------------------------------------------------------
@@ -1320,29 +1357,41 @@ impl LeafImageWriter {
         true
     }
 
-    /// The INTEGRITY GATE: exact size match AND a READBACK SHA-256 of `slot[..size]`
-    /// (the exact bytes that will boot) == the signed sha. `true` ⇒ [`activate`] is
-    /// safe. otadata is still untouched here — a failure discards with the good slot
-    /// active. The caller has ALREADY verified the ed25519 sig over the manifest.
-    pub fn finalize(self, expected_size: u32, expected_sha: &[u8; 32]) -> bool {
+    /// The INTEGRITY GATE (exact size match AND a READBACK SHA-256 of `slot[..size]` — the
+    /// exact bytes that will boot — == the signed sha), plus the #349 SUITABILITY gate over
+    /// those same bytes. `Ok(())` ⇒ [`activate`] is safe. otadata is still untouched here — a
+    /// failure discards with the good slot active. The caller has ALREADY verified the ed25519
+    /// sig over the manifest.
+    ///
+    /// A leaf takes its image from a mesh peer rather than from the staged URL, so it is the
+    /// path MOST able to receive an image intended for someone else: the relaying crown picks
+    /// the recipient. The guard therefore has to live here too, and it is the same guard —
+    /// three consumers implementing three subtly different checks is the failure this type was
+    /// designed to prevent.
+    pub fn finalize(
+        self,
+        expected_size: u32,
+        expected_sha: &[u8; 32],
+    ) -> Result<(), FinalizeFail> {
         use embedded_storage::nor_flash::ReadNorFlash;
         use sha2::Digest;
         if self.written != expected_size {
-            return false;
+            return Err(FinalizeFail::Integrity);
         }
         let mut flash = FlashStorage::new();
         let mut ptbuf = [0u8; PT_SCRATCH];
         let pt = match read_partition_table(&mut flash, &mut ptbuf) {
             Ok(pt) => pt,
-            Err(_) => return false,
+            Err(_) => return Err(FinalizeFail::Integrity),
         };
         let app = match pt.find_partition(PartitionType::App(self.sub)) {
             Ok(Some(p)) => p,
-            _ => return false,
+            _ => return Err(FinalizeFail::Integrity),
         };
         let mut region = app.as_embedded_storage(&mut flash);
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(OTA_READBACK) };
         let mut hasher = sha2::Sha256::new();
+        let mut scan = crate::net::target::DescScan::new();
         let mut off = 0u32;
         while off < expected_size {
             let want = core::cmp::min(buf.len() as u32, expected_size - off);
@@ -1350,12 +1399,16 @@ impl LeafImageWriter {
             // non-word-aligned tail still reads legally — extra bytes are not hashed).
             let read_len = (want.div_ceil(4) * 4) as usize;
             if region.read(off, &mut buf[..read_len]).is_err() {
-                return false;
+                return Err(FinalizeFail::Integrity);
             }
             hasher.update(&buf[..want as usize]);
+            scan.feed(&buf[..want as usize]);
             off += want;
         }
-        hasher.finalize().as_slice() == &expected_sha[..]
+        if hasher.finalize().as_slice() != &expected_sha[..] {
+            return Err(FinalizeFail::Integrity);
+        }
+        scan.verdict(crate::net::target::SELF).map_err(FinalizeFail::Target)
     }
 }
 

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -560,6 +560,17 @@ pub fn stat_build(value: &[u8]) -> Option<u32> {
 
 use esp_bootloader_esp_idf::ota::Slot;
 
+/// #349: first `dbg_verdict` value reserved for a SUITABILITY refusal at finalize. The
+/// `on_meta` verdicts occupy 0-7, so the target-reject band starts here and runs
+/// `LEAF_VERDICT_TARGET_BASE + TargetReject::code()`. Kept as one base + an ordinal rather
+/// than six named constants so adding a rejection reason cannot leave this band stale — the
+/// assertion below is what makes that structural instead of hopeful.
+const LEAF_VERDICT_TARGET_BASE: u8 = 8;
+const _: () = assert!(
+    LEAF_VERDICT_TARGET_BASE as u16 + crate::net::target::TargetReject::COUNT as u16 <= 256,
+    "the #349 target-reject verdict band no longer fits the LDBG dbg_verdict byte"
+);
+
 /// Emit a gap-NAK if a window stays incomplete this long since the last NAK (ms).
 const LEAF_IDLE_NAK_MS: u64 = 500;
 /// Abort the session if NO new chunk arrives for this long (a jam / dead gateway, ms).
@@ -700,7 +711,9 @@ pub struct OtaLeafSession {
     /// `relay-failed` (gateway `rx>0 otan=0`) names WHY the leaf never NAK'd:
     /// `dbg_otam_heard` = OTAMs addressed to us that reached `on_meta`; `dbg_verdict` = the last
     /// `on_meta` outcome (0 never-heard, 1 armed, 2 sig-fail, 3 build≤running, 4 ≤fresh_floor,
-    /// 5 size, 6 writer-open-fail, 7 dedup/live); `dbg_otan_sent` = OTANs this leaf emitted.
+    /// 5 size, 6 writer-open-fail, 7 dedup/live) — or, from [`LEAF_VERDICT_TARGET_BASE`] up, a
+    /// #349 SUITABILITY refusal at finalize (`8 + TargetReject::code()`: 8 absent, 9 descver,
+    /// 10 chip, 11 compat, 12 featloss, 13 bench); `dbg_otan_sent` = OTANs this leaf emitted.
     dbg_otam_heard: u16,
     dbg_verdict: u8,
     dbg_otan_sent: u16,
@@ -1012,7 +1025,22 @@ impl OtaLeafSession {
         match self.writer.take() {
             Some(w) => {
                 let target_slot = w.target(); // capture BEFORE finalize() consumes the writer
-                if w.finalize(size, &sha) {
+                let outcome = w.finalize(size, &sha);
+                // #349: a SUITABILITY refusal is not an integrity failure and must not be
+                // reported as one. It gets its own `dbg_verdict` band (LEAF_VERDICT_TARGET_BASE
+                // + the reason ordinal) so `smol/<leaf>/ota/relaydiag`'s `V<n>` names WHICH
+                // mismatch — a crown relaying the wrong image to a leaf is an operator error
+                // that has to be visible, and release images are serial-silent.
+                if let Err(crate::ota::FinalizeFail::Target(why)) = outcome {
+                    log::error!(
+                        "smol #349: mesh image REFUSED — not for this board ({}) — discarded (good slot intact)",
+                        why.label()
+                    );
+                    self.dbg_verdict = LEAF_VERDICT_TARGET_BASE.saturating_add(why.code());
+                    self.discard();
+                    return LeafAction::Abort;
+                }
+                if outcome.is_ok() {
                     log::info!("smol #40 #157: image VERIFIED — finalize-ack then activate build {}", self.build);
                     self.verify_ok = self.verify_ok.saturating_add(1); // #49: full integrity-verified
                     // Enter the finalize-ack phase; stay `active` so tick() drives ack + activate.


### PR DESCRIPTION
Closes #349 (device-side half). Prior art: `scratch/parity/multitarget-prior-art.md`.

**Rebased onto `319e896` (v346 core).** One conflict, in `net.rs` module declarations, resolved additively (ledger modules + `target`). `ota.rs`/`ota_mesh.rs`/`wifi.rs` had no textual overlap — v346's `ota.rs` change is an additive ledger-key NVS block after `resolve_node_id()` and does not touch `finalize`.

**On the MAC/guard composition question:** there is none, and it is structural rather than lucky. `cf651f3` deliberately *excludes* the OTA family from the group-MAC trailer (`should_group_mac` = `SMOLv1 && !is_ota_family && fits-MTU`), because receivers consume OTAM/OTAD/OTAN before verify-then-strip. So image bytes are never MAC'd and the guard never sees a trailer. And if that exemption were ever broken, the ordering here still fails safe: `finalize` checks **integrity first, suitability second**, so MAC-corrupted bytes surface as `Integrity`, never as a bogus `tgt-absent`.

## The gap

The OTA chain proves an image is **authentic** and **intact**. It proves nothing about **suitability**. Cross-*chip* is caught by the bootloader's `esp_image_header_t.chip_id` — but only by boot-looping into rollback. A cross-*tier* image passes every check and **boots**. `smol/ota/staged` is retained fleet-wide, so every board sees every announcement.

## What landed

**`net/target.rs`** — a 16-byte magic-tagged, checksum-validated descriptor embedded in every OTA-capable image, plus the checker and a streaming scanner. OpenWrt's shape (data + one checker), WLED's placement (in the image, linear scan), and neither of WLED's two mistakes:

- **`TargetId` is a structured tuple, not a label.** WLED's opaque `release_name` forced a hardcoded suffix strip *inside* `shouldAllowOTA()` to permit one legitimate cross-upgrade. Here chip / feature-bitset / compat are independent axes — a legitimate cross-flash is a different bitset and the checker never changes. Board **variant** is deliberately absent: it stays runtime-detected, so it needs no guard, no CI job, no table row.
- **WLED's min-version gate is dead code** (struct hardcodes `desc_version = 1`, check tests `> 1`, FIXME survived a release). Two structural defences: `SMOL_TARGET_DESC` *is* `SELF.encode()` (no second literal to drift), and a `const _: () = assert!` round-trips `decode(encode(SELF))` field-by-field — smuggling a literal in **fails the build**.

`chip` is **derived** by `build.rs` from the target triple, never declared; an unmapped triple fails the build rather than shipping `CHIP_UNKNOWN`.

**The refusal** rides the readback that already computes the integrity SHA — one pass, two consumers, so the identity judged is provably the identity hashed. Scanning the incoming *stream* would break on a #267-resumed fetch (which never re-feeds the on-flash prefix) and refuse good images as `tgt-absent`. `otadata` is untouched, so a refusal costs a download and nothing else.

**Diagnosable on the wire**, at zero packet cost: self-fetch → `smol/<id>/ota/diag` `at=tgt-*`; leaf mesh-OTA → LDBG verdict byte → `relaydiag` `V<n>`. Both delegate to `TargetReject`, so no second mapping table can drift.

## Two carry-forwards worth keeping

1. **`#[used]` does NOT guard against `--gc-sections`.** It stops compiler DCE, not linker GC. The descriptor is retained by a *real runtime read* (`self_desc_present()` on the fetch path), and I confirmed its presence by scanning the built `.bin` rather than trusting the attribute. Anyone embedding a section for an external reader should do the same.
2. **A real image contains TWO `SMLT` magics; only ONE checksums.** The second is the scanner's own constant, compiled in as an immediate. This is why the checksum *and* resuming past a failed candidate are load-bearing rather than defensive — a first-match-wins scanner would work until the day the constant sorted first, then silently stop guarding.

## Demonstration — it REFUSES

`experiments/target_guard_verify` (auto-discovered by `gate.sh`) asserts one refusal per reason, not just the accept — a happy-path-only test would pass against WLED's dead gate unchanged. Includes `min_from_compat` **firing**, the one that is dead in the prior art.

Against a real 1,088,528 B post-rebase fleet image (`SMOL_TARGET_VERIFY_BIN`):

```
real image  /tmp/smol349-rebased.bin
  ok      1088528 B, descriptor found: chip=1 features=0x000f compat=1 min_from=0
  ok      real image on its own chip — accepted
  REFUSED real image on other silicon — tgt-chip (Chip)
```

## Gate (post-rebase)

`tools/gate.sh all` **GREEN** — 6 check tiers, 5 clippy tiers `-D warnings`, stack floor, 15 host suites.

Stack: **114,552 B** (floor 73,728). `main`@`319e896` measured with identical methodology (archive build, same identity env, same `version.txt`): **114,608 B** → **−56 B**.

## Deliberately NOT in this pass

- Staged manifest still carries no target tuple → refusal is post-download, not pre-fetch.
- `smol/ota/staged` is still one fleet-wide topic (issue item 5).
- No publisher-side `--force-target-mismatch` (issue item 6). Escape hatch today is a USB flash.

Keeping the manifest unchanged is also what avoids a rollout cliff: old firmware cannot parse a new-format staged line (`splitn(5)`, sig must be 128-hex), so publishing the tuple before the fleet carries the parser would strand the upgrade path. Ship the reader before the format.

Sibling #348 (`ChipBudget`) is untouched — no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)