### PR TITLE
fix(build): one definition for the C3 stack floor, re-derived to 74,208 (#348)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -64,15 +64,22 @@ formula are a bug in this document** — check them together.
 > **157,472 B** · `.data` **13,588 B** · `.stack` **114,648 B** · esp-wifi heap **96 KiB**.
 >
 > **`tools/repro_build.sh` hard-fails a release build when the stack region drops below
-> 73,728 B** — so there is now **40,920 B of slack** before a new static allocation *breaks the
+> 74,208 B** — so there is now **40,440 B of slack** before a new static allocation *breaks the
 > build*. That is 18× the 2,232 B this block recorded before #347, and it is the whole reason
 > the Embassy re-platform (#233/#335) went from not-fitting to fitting.
 >
 > ⚠️ **Slack is not headroom.** The floor is derived from a *measured runtime peak* (peak × 4/3),
-> and the peak on record — **55,440 B** (#302) — was measured **with the Bard narrating**. A
-> Bard-free peak can only be lower, but nobody has measured it, so the real margin is *at least*
-> this and the floor is *at most* right. Re-run the stack-paint build before spending this slack
-> on anything large.
+> and the highest peak on record — **55,656 B** (#335, id5 under crown duty, 10/10 byte-identical
+> reports, 2026-08-01) — was measured **with the Bard narrating**. A Bard-free peak can only be
+> lower, but nobody has measured it, so the real margin is *at least* this and the floor is *at
+> most* right. Re-run the stack-paint build before spending this slack on anything large.
+>
+> 📌 **The floor moved 73,728 → 74,208 (#348 follow-up), and there is now only one of it.** The old
+> value was 4/3 × T13's 54,856 B — the *lowest* of the four peaks on record — so it was knowably
+> 480 B too low once #335 measured 55,656 on hardware. It also existed twice, as a shell literal
+> in `repro_build.sh` and a Rust const in `budget.rs`, disagreeing. The single definition is now
+> `ESP32C3_STACK_FLOOR_BYTES` in `rust/clock/src/budget.rs`; the shell gate parses it
+> (`repro_stack_floor`) and **fails closed** if it cannot. Change it there, once.
 >
 > The Bard's DRAM (`.bss` +37,832 B, `.data` +1,232 B) and its ~281 KB of `.rodata` are what
 > moved. The `bard` feature still exists and `tools/gate.sh` still builds a `bard` tier — it is

--- a/rust/clock/src/bard/nano_llm.rs
+++ b/rust/clock/src/bard/nano_llm.rs
@@ -61,8 +61,10 @@ pub const MAX_VOCAB: usize = 512;
 /// So ~55 KB of stack is the real requirement, and the 14,240 B that `SEQ_CAP=160` left would
 /// have been overrun by nearly 4×. No cache depth alone fixes that: the DRAM had to come from
 /// the esp-wifi heap as well (128 → 96 KiB, `net::init_heap`, JP's call 2026-07-27 — see the
-/// comment there). Together they buy back ~62 KB of stack against a 73,728 B floor that
-/// `tools/repro_build.sh` now enforces from the measured peak (54,856 × 4/3).
+/// comment there). Together they buy back ~62 KB of stack against the floor that
+/// `tools/repro_build.sh` enforces from the measured peak (peak × 4/3). That floor was 73,728
+/// when this was written and is **74,208** since #348's follow-up re-derived it from #335's
+/// higher 55,656 B peak; it is declared once, as `budget::ESP32C3_STACK_FLOOR_BYTES`.
 ///
 /// The trade JP chose was FLEET-WIDE SHORT STORIES — and #302 then made the length question moot:
 /// with a ring cache a tale runs as long as the reader wants, so 80 buys the model three or four

--- a/rust/clock/src/budget.rs
+++ b/rust/clock/src/budget.rs
@@ -153,6 +153,71 @@ impl ChipBudget {
 // trusting the comment; a number copied forward untested is how the stack floor once ended
 // up at 12,288 B.
 
+/// **The C3 stack floor — ONE definition, two languages.**
+///
+/// The minimum linked `.stack` region an image may ship with. Both consumers read *this*:
+///
+///   * the compile-time budget, via [`ESP32C3`]`.stack_floor_bytes`;
+///   * the packaging gate, because **`tools/repro_build.sh` parses the line below**
+///     (`repro_stack_floor`) instead of carrying its own copy.
+///
+/// Until #348-followup they were two constants — 73,728 in the gate, 74,208 here — for one
+/// concept, and the gate's was the stale one. Two numbers for one quantity is the drift this
+/// project keeps getting bitten by; #338 collapsed the feature list the same way.
+///
+/// ## ⚠️ Contract with the shell parser — do not reformat this declaration
+///
+/// `repro_stack_floor` matches a line beginning `pub const ESP32C3_STACK_FLOOR_BYTES: u32 =`
+/// and reads the integer up to the `;`, stripping `_`. So: keep it on ONE line, keep the
+/// literal a plain decimal, and put any comment on its own line above. The parser **fails
+/// closed** — if it cannot read a number, `repro_stack_check` refuses to measure rather than
+/// falling back to a default, because a gate that silently substitutes its own number for the
+/// one you edited is worse than no gate. (`REPRO_STACK_FLOOR` still overrides, for experiments.)
+///
+/// ## Derivation — 4/3 × the highest peak on record
+///
+/// **74,208 = 4/3 × 55,656 B**, and it is exact, not rounded.
+///
+/// | peak | where | note |
+/// |---:|---|---|
+/// | 54,856 B | T13 bench, #300 (id8) | the origin of the old 73,728 (4/3, rounded up to 72 KiB) |
+/// | 54,960 B | T13 final-geometry, #300 | same bench, marginally higher |
+/// | 55,440 B | #302 (id8), 5 byte-identical reports | endless-narration window; does not creep |
+/// | **55,656 B** | **#335 (id5), crown duty, 10/10 byte-identical** | **highest on record — this one** |
+///
+/// The #335 run (2026-08-01) is the strongest evidence in the set: a different board under
+/// live crown duty, ten byte-identical reports, and both instrument-falsification checks
+/// passed. It came in **+216 B above #302 and +800 B above T13** — the old floor was derived
+/// from the *lowest* of the four and was knowably 480 B too low.
+///
+/// **Re-derive this when the peak moves**, with `--features stack-paint` under live radio;
+/// idle numbers are meaningless. A floor copied forward untested is how the last one ended up
+/// at 12,288 B. And note every peak on record was measured **with the Bard narrating**, so for
+/// a Bard-free image this floor is an upper bound on what is required, not a target.
+pub const ESP32C3_STACK_FLOOR_BYTES: u32 = 74_208;
+
+/// The input to that derivation: the highest stack high-water ever **measured on hardware** for
+/// this chip — #335, 2026-08-01, id5 under crown duty, 10/10 byte-identical reports, both
+/// instrument-falsification checks passed.
+///
+/// It is a const rather than a sentence so the floor can be checked against it (below) instead
+/// of merely described by it. When a stack-paint run measures a higher peak, change **this**
+/// first; the assertion will then tell you the floor is stale rather than leaving you to notice.
+pub const ESP32C3_MEASURED_PEAK_BYTES: u32 = 55_656;
+
+/// The floor must be at least 4/3 of the highest measured peak. `>=` rather than `==` because a
+/// peak that is not divisible by 3 must round **up** — today it is exact (55,656 × 4 / 3 =
+/// 74,208). This is what stops the two constants drifting apart the way the floor drifted from
+/// its own derivation before #348: the old 73,728 was 4/3 × 54,856, and stayed put through two
+/// higher measurements.
+const _: () = assert!(
+    ESP32C3_STACK_FLOOR_BYTES >= ESP32C3_MEASURED_PEAK_BYTES * 4 / 3,
+    "the C3 stack floor is below 4/3 of the highest measured stack peak (src/budget.rs). \
+     Either a higher peak was recorded without re-deriving the floor — raise \
+     ESP32C3_STACK_FLOOR_BYTES to at least peak * 4/3, rounding UP — or the floor was lowered \
+     without a measurement to justify it, which is how it once ended up at 12,288 B."
+);
+
 /// ESP32-C3 — the pinned fleet chip (RV32IMC, 4 MB flash, 400 KB SRAM).
 ///
 /// ## `free_dram_bytes` is the WORST supported radio stack, deliberately
@@ -176,14 +241,7 @@ impl ChipBudget {
 /// choice is that a feature needing between 32,352 B and 40,920 B is refused here while
 /// still fitting on `main`. That is the direction to be wrong in, and #233 closes the gap.
 ///
-/// ## `stack_floor_bytes` is 74,208, not the 73,728 in the gate
-///
-/// 73,728 (`REPRO_STACK_FLOOR`) is 72 KiB — 4/3 × a 54,856 B peak, rounded up. 74,208 is
-/// 4/3 × the later, higher 55,656 B peak (#302), which is the most recent measurement and
-/// is quoted as the re-derived floor in both `tools/repro_build.sh` and #335. This takes the
-/// higher of the two; the 480 B difference does not change any verdict here, and the
-/// packaging gate keeps its own constant (changing it would move what ships, which is not
-/// this issue's business).
+/// ## `stack_floor_bytes` — see [`ESP32C3_STACK_FLOOR_BYTES`], which the shell gate parses
 ///
 /// ⚠️ **Slack is not headroom.** The floor is 4/3 × a *measured runtime peak*, and the peak
 /// on record was measured with the Bard narrating. A Bard-free peak can only be lower, but
@@ -191,7 +249,7 @@ impl ChipBudget {
 pub const ESP32C3: ChipBudget = ChipBudget {
     chip: "esp32c3",
     free_dram_bytes: 106_560,
-    stack_floor_bytes: 74_208,
+    stack_floor_bytes: ESP32C3_STACK_FLOOR_BYTES,
     // partitions-ota.csv: ota_0/ota_1 are 0x1F0000 each. `ota_publish.sh` hard-gates on this.
     app_slot_bytes: 0x001F_0000,
     // Canonical `espnow,cast,io` image (56.9% of slot), from `repro_build_bin` — the packaging

--- a/rust/clock/tests/budget.rs
+++ b/rust/clock/tests/budget.rs
@@ -16,11 +16,38 @@
 
 #![cfg(feature = "hostsim")]
 
-use clock::budget::{cost, ChipBudget, FeatureCost, ESP32C3};
+use clock::budget::{
+    cost, ChipBudget, FeatureCost, ESP32C3, ESP32C3_MEASURED_PEAK_BYTES,
+    ESP32C3_STACK_FLOOR_BYTES,
+};
 
 /// The published #335 shortfall. If this test starts failing, either a measurement in
 /// `budget.rs` moved (fine — update it *with* its provenance) or someone rounded something.
 const PUBLISHED_SHORTFALL: u32 = 6_720;
+
+/// The floor is 4/3 of the highest measured peak, and the budget uses that same constant — the
+/// one `tools/repro_build.sh` parses. Before #348's follow-up there were two floors for one
+/// concept (73,728 in the shell, 74,208 here) and the shell's was derived from the *lowest* of
+/// four recorded peaks. There is now one, and this pins it to its input.
+#[test]
+fn the_floor_is_four_thirds_of_the_highest_measured_peak() {
+    assert_eq!(ESP32C3_MEASURED_PEAK_BYTES, 55_656, "#335, id5, 10/10 reports");
+    assert_eq!(ESP32C3_STACK_FLOOR_BYTES, 74_208);
+    assert_eq!(ESP32C3_STACK_FLOOR_BYTES, ESP32C3_MEASURED_PEAK_BYTES * 4 / 3);
+    // And the chip row must not carry a second, independent copy of it.
+    assert_eq!(ESP32C3.stack_floor_bytes, ESP32C3_STACK_FLOOR_BYTES);
+}
+
+/// The old floor was 4/3 of T13's 54,856 B — the lowest peak on record — and stayed put while
+/// two higher ones were measured. This is the regression that guards the direction of the fix.
+#[test]
+fn the_floor_is_no_longer_the_stale_73728() {
+    assert!(
+        ESP32C3_STACK_FLOOR_BYTES > 73_728,
+        "the floor must not fall back to the T13-derived value once a higher peak is on record"
+    );
+    assert_eq!(ESP32C3_STACK_FLOOR_BYTES - 73_728, 480);
+}
 
 #[test]
 fn c3_dram_headroom_is_the_measured_leftover() {

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -13,7 +13,8 @@
 #      canonical+bard, which is off the fleet image since #347 but still a supported build)
 #   2. cargo clippy --release -D warnings on EVERY tier (#343 — was canonical-only)
 #   3. the host experiments/*_verify suites
-#   4. the #300 stack floor — the canonical ELF's .stack region vs the 73,728 B floor
+#   4. the #300 stack floor — the canonical ELF's .stack region vs the floor declared in
+#      rust/clock/src/budget.rs (#348: one definition, parsed by repro_stack_floor)
 #
 # WHAT IT DOES NOT COVER — read this before trusting a green run:
 #   * `mesh-test`: needs a per-board `DEAF_MACS` that only a real board.rs has.
@@ -123,7 +124,11 @@ if [ "$run_fw" = 1 ]; then
 
   # #300 stack floor, measured with the SAME function the packaging path uses (repro_stack_check).
   # Built with repro_cargo_args so the ELF matches the shipped one's geometry.
-  step "stack floor — canonical ELF vs ${REPRO_STACK_FLOOR:-73728} B"
+  # #348: the title reads the floor from the same single definition repro_stack_check will use —
+  # it was a third hardcoded copy of 73728, which would have gone on announcing the old number
+  # while the gate enforced a new one. "unreadable" here is not a failure; repro_stack_check
+  # fails closed on it a few lines down, with the diagnostic.
+  step "stack floor — canonical ELF vs ${REPRO_STACK_FLOOR:-$(repro_stack_floor || echo unreadable)} B"
   if repro_cargo_args "$CLOCK" 2>/dev/null && \
      (cd "$CLOCK" && cargo build --release "${JOBS[@]}" --features "$REPRO_FLEET_FEATURES" "${REPRO_CARGO_ARGS[@]}") \
        >/tmp/gate-stack.log 2>&1; then

--- a/tools/repro_build.sh
+++ b/tools/repro_build.sh
@@ -83,12 +83,26 @@ repro_cargo_args() {
 # and put `__stack_chk_guard` outside the stack region, where the canary cannot detect the overflow
 # it exists to catch. Refuse to package an image that thin.
 #
-# The floor is DERIVED, not chosen: the T13 bench measured a 54,856 B high-water with the stack-paint
-# build (WiFi burst + crown duty + three stories), and 54,856 x 4/3 = 73,141, rounded up to 72 KiB =
-# 73,728. The 4/3 is a third again on top of the worst path we have actually observed — enough to
-# absorb a deeper interrupt nesting or a future radio change without being so generous that the gate
-# stops biting. Re-measure with stack-paint if either the radio stack or the bard's buffers move; a
-# floor copied forward untested is how the last one ended up at 12,288.
+# The floor is DERIVED, not chosen — and since #348 it is derived in exactly ONE place.
+#
+# It used to be the literal 73,728 here: 4/3 x the T13 bench's 54,856 B high-water, rounded up to
+# 72 KiB. That number was the LOWEST of the four peaks now on record, and #335 measured a higher
+# one on hardware (55,656 B, id5 under crown duty, 10/10 byte-identical reports) — so the gate was
+# knowably 480 B too low, while rust/clock/src/budget.rs already carried the re-derived 74,208.
+# Two constants for one concept, disagreeing. `repro_stack_floor` (below) now PARSES the Rust
+# declaration instead, the way #338 collapsed the fleet feature list to one variable.
+#
+# Direction of the dependency, deliberately: the Rust const is the definition and this script
+# reads it, not the reverse. `budget.rs` is moving to `smol-core` (#347 Phase 2) to be shared by
+# smol, the esp32c6-watch and the Bard device — a tools/ script in THIS repo cannot be the source
+# of truth for a crate three firmwares depend on, and a build.rs that shelled out to read it would
+# not move with the crate.
+#
+# The 4/3 is a third again on top of the worst path we have actually observed — enough to absorb a
+# deeper interrupt nesting or a future radio change without being so generous that the gate stops
+# biting. Re-measure with stack-paint if either the radio stack or the bard's buffers move; a floor
+# copied forward untested is how the last one ended up at 12,288. Full derivation + the table of
+# every peak on record lives on ESP32C3_STACK_FLOOR_BYTES in budget.rs.
 #
 # ⚠️ The floor bounds the linked REGION, which is all an ELF can show. It cannot see runtime
 # high-water: a struct that lives in a stack-resident `RadioManager` costs real stack and moves this
@@ -99,9 +113,40 @@ repro_cargo_args() {
 # #338: extracted from `repro_build_bin` so CI measures with the SAME code the packaging path uses.
 # A CI copy of this arithmetic would be a second definition free to drift from the one that actually
 # gates shipping — which is the exact failure this issue exists to remove.
+# Repo root, resolved from this script's own location so the functions below work from any cwd
+# (gate.sh sources this from $ROOT, ota_publish.sh from the crate dir, agents from anywhere).
+REPRO_ROOT="${REPRO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd)}"
+
+# #348: echo the C3 stack floor by PARSING its single definition in Rust. Returns non-zero and
+# echoes nothing if the declaration cannot be read, so callers can fail closed — see the contract
+# documented on ESP32C3_STACK_FLOOR_BYTES (one line, plain decimal, comments on their own line).
+# The awk takes everything between `=` and `;` and strips spaces/underscores, so a trailing
+# comment on the line cannot be swallowed into the number; the digits-only test is the backstop.
+repro_stack_floor() {
+  local src="${REPRO_BUDGET_RS:-$REPRO_ROOT/rust/clock/src/budget.rs}" v
+  [ -f "$src" ] || return 1
+  v=$(awk '/^pub const ESP32C3_STACK_FLOOR_BYTES: u32 =/ {
+             split($0, a, "="); split(a[2], b, ";"); gsub(/[ _]/, "", b[1]); print b[1]; exit
+           }' "$src" 2>/dev/null)
+  case "$v" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s' "$v"
+}
+
 # repro_stack_check <elf>
 repro_stack_check() {
-  local elf="$1" stack_floor="${REPRO_STACK_FLOOR:-73728}"
+  local elf="$1" stack_floor="${REPRO_STACK_FLOOR:-$(repro_stack_floor)}"
+  # FAIL CLOSED on an unreadable declaration, for the same reason as the unreadable-ELF branch
+  # below: a gate that quietly falls back to a built-in default would measure against a number
+  # nobody edited, which is precisely the drift #348 removed. Better to refuse and be fixed.
+  case "$stack_floor" in
+    ''|*[!0-9]*)
+      echo "FATAL: could not read ESP32C3_STACK_FLOOR_BYTES from ${REPRO_BUDGET_RS:-$REPRO_ROOT/rust/clock/src/budget.rs}" >&2
+      echo "       — refusing to measure the stack against a guessed floor. Check that the" >&2
+      echo "       declaration is one line of plain decimal (see its doc comment), or set" >&2
+      echo "       REPRO_STACK_FLOOR explicitly if you are deliberately overriding it." >&2
+      return 1
+      ;;
+  esac
   local ss se
   ss=$(readelf -sW "$elf" 2>/dev/null | awk '$8=="_stack_start"{print $2; exit}')
   se=$(readelf -sW "$elf" 2>/dev/null | awk '$8=="_stack_end"{print $2; exit}')


### PR DESCRIPTION
Follow-up to #348 (merged as `2d1dab4`). Closes the two-floors problem it exposed.

## The problem

Two constants for one concept, and **the gate's was the stale one**:

| where | value | derived from |
|---|---:|---|
| `tools/repro_build.sh` (the shipping gate) | 73,728 | 4/3 × T13's **54,856 B** — the *lowest* of four recorded peaks |
| `rust/clock/src/budget.rs` (#348) | 74,208 | 4/3 × #335's **55,656 B** |
| `tools/gate.sh` step title | 73,728 | a **third** hardcoded copy |

The shell number stayed put while two higher peaks were measured. #335 settled it on hardware — **id5 under crown duty, 10/10 byte-identical reports, both instrument falsifications passed: 55,656 B**, +216 B over #302's id8 reading and +800 B over T13. So the gate was knowably **480 B too low**.

Every peak on record, for whoever re-derives this next:

| peak | where | note |
|---:|---|---|
| 54,856 B | T13 bench, #300 (id8) | origin of the old 73,728 |
| 54,960 B | T13 final-geometry, #300 | same bench, marginally higher |
| 55,440 B | #302 (id8), 5 byte-identical reports | endless-narration window |
| **55,656 B** | **#335 (id5), crown duty, 10/10** | **highest on record — this one** |

## The fix

`budget::ESP32C3_STACK_FLOOR_BYTES` is the single definition. `repro_stack_floor` **parses** it instead of carrying a copy — the way #338 collapsed the fleet feature list to one variable. `gate.sh`'s title reads the same source.

**Direction of the dependency is deliberate:** the Rust const is the definition and the shell reads it, not the reverse. `budget.rs` moves to `smol-core` (#347 Phase 2) to be shared by smol, the esp32c6-watch and the Bard device — a `tools/` script in this repo cannot be the source of truth for a crate three firmwares depend on, and a `build.rs` that shelled out to read one would not move with the crate.

**The parser fails closed.** If the declaration cannot be read, `repro_stack_check` refuses to measure rather than falling back to a built-in default. A gate that silently substitutes its own number for the one you edited is worse than no gate. `REPRO_STACK_FLOOR` still overrides, for experiments.

**The floor now cites its input rather than describing it:** `ESP32C3_MEASURED_PEAK_BYTES = 55_656`, plus a const-assert that the floor is at least `peak * 4/3` (`>=`, not `==`, because a peak not divisible by 3 must round up). That is the drift that actually happened — a higher peak recorded, the floor left alone — so it is the one worth making unrepresentable.

## Verified, not assumed

| check | result |
|---|---|
| parse | `repro_stack_floor` -> **74208** |
| **tamper (the real test)** | const edited to `999_999` -> shell reports 999999 **and `repro_stack_check` FATALs on the real ELF**. It *follows* the Rust declaration; it does not merely agree with it. |
| fail-closed | unreadable declaration -> FATAL, exit 1, no measurement taken |
| trailing comment | `= 74_208; // 12345` -> `74208`, not `7420812345` |
| **main clears the new floor** | **`stack: 114616 B (floor 74208 B)`** — margin 40,408 B |
| `gate.sh fw` | every tier PASS incl. `bard` + `ledger-provision`; title prints the parsed `74208` |
| host tests | **10/10** (2 new: the derivation, and a regression pinning the floor above 73,728) |
| budget predicates | `bard`+fleet still REFUSED; `off-fleet` tier still compiles |

114,616 rather than the 114,648 in #348 — the −32 B is #181's LedgerLink landing on main, exactly the effect `repro_stack_check`'s own comment documents ("1,760 B on target, but only −32 B of region"), not this change.

Headroom is unchanged at 32,352 B: `budget.rs` already used 74,208, so no verdict moves. This raises the **shipping** gate to match it.

## Still open

The Bard-free stack peak remains unmeasured — every peak in that table was taken with the Bard narrating, so for a no-bard image this floor is an upper bound on what is required, not a target. Re-running stack-paint without `bard` under crown duty is bench work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)