### PR TITLE
feat(ci): derive the (chip, tier) build matrix from one manifest; split builds from ships (#350)

### DIFF
--- a/.github/workflows/fw-gate.yml
+++ b/.github/workflows/fw-gate.yml
@@ -104,4 +104,32 @@ jobs:
             echo "⚠️ This bounds the linked **region**, not runtime high-water. A struct in a"
             echo "stack-resident \`RadioManager\` can cost ~1.8 KB of real stack while moving this"
             echo "number by ~32 B. Green here is not evidence of runtime headroom."
+            echo ""
+            echo "⚠️ It is also **tree-dependent** and must not be compared byte-for-byte against a"
+            echo "number from another tree: \`board.rs\`/\`secrets.rs\` are git-ignored and provisioned"
+            echo "per tree, their literals land in \`.rodata\`/\`.data\`, and \`.stack\` is the leftover."
+            echo "Same commit measures ~114,648 on a dev box and ~114,608 here (#348)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # #350: what this run actually covered, from the manifest rather than from this file.
+      #
+      # NOT a `strategy.matrix` fan-out yet, deliberately. Exactly one chip has `builds = true`
+      # today (`esp-hal` is pinned to `esp32c3` and `.cargo/config.toml` pins the target), so a
+      # fan-out would be one job wearing a matrix costume — and a permanently-red S3 arm would
+      # teach everyone to ignore the gate, which is worse than not having it. The manifest is
+      # already the single declaration; when #331 flips a second chip to `builds = true`, this
+      # step's `include` becomes `strategy.matrix` and nothing else moves. Printing it now keeps
+      # the emitter exercised and makes the coverage claim checkable by a reader.
+      - name: Build matrix → job summary
+        if: always()
+        run: |
+          {
+            echo "### Build matrix (derived from \`tools/build-matrix.toml\`)"
+            echo '```'
+            tools/build_matrix.py check || true
+            echo '```'
+            echo "Jobs this manifest declares:"
+            echo '```json'
+            tools/build_matrix.py ci-matrix | python3 -m json.tool
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -129,10 +129,13 @@ Full toolchain + gotchas: **[`docs/BUILDING.md`](docs/BUILDING.md)**. TL;DR for 
    ignored files, so every board stamps the same clean commit hash.
 2. **Build tiers and the gate: `tools/gate.sh`.** Run it before you push; CI (`.github/workflows/
    fw-gate.yml`) runs the *same script*, so there is nothing here to fall out of step with it.
-   `tools/gate.sh` (or `host` / `fw` for one half) covers: `cargo check` across the tiers — default
-   (always-green) · `wifi` · `espnow` · the canonical fleet tier · any feature it finds in
-   `Cargo.toml` — plus `clippy -D warnings` on **every** tier (#343), the host
-   `experiments/*_verify` suites, and the #300 **stack floor** (printed on every PR).
+   `tools/gate.sh` (or `host` / `fw` for one half) covers: `cargo check` and `clippy -D warnings`
+   across **every tier**, the host `experiments/*_verify` suites, the crate's own `tests/*.rs`
+   suites, and the #300 **stack floor** (printed on every PR).
+
+   **Since #350 the tier and chip lists are DERIVED from `tools/build-matrix.toml`**, which also
+   separates *what CI builds* from *what the release ships* — the S3 is declared and not shipped,
+   OpenWrt's `DEFAULT := n`. Add a tier or a chip **there**, not in `gate.sh`, and not here.
 
    **This list deliberately lives in the script, not here.** Until #338 it lived only in prose, and
    the prose was wrong without anyone noticing: `main` sat red on its own `-D warnings` rule, and a

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -271,7 +271,15 @@ off-fleet = []
 # should be enough" into a measured number. Deliberately NOT in the canonical fleet list in
 # tools/repro_build.sh: it writes the whole free stack at boot, which is a diagnostic cost no
 # shipped image should pay.
-stack-paint = ["bard"]
+#
+# #350: `off-fleet` is part of the feature, not something each call site has to remember. This
+# build is BY DEFINITION not the fleet image — see the paragraph above — so it must carry #348's
+# waiver or the budget predicate refuses to compile it. Without this, `--features stack-paint`
+# fails outright with "`bard` does not fit this chip's declared DRAM budget", which took the
+# bench instrument that MEASURES the high-water the stack floor is derived from and made it
+# unbuildable. Nothing noticed, because no tier compiled it. Declaring the waiver here means the
+# next person to reach for the instrument finds it working.
+stack-paint = ["bard", "off-fleet"]
 
 # COEXIST SOAK (issue #23 PART 1 — the gating experiment, NOT for production).
 # The gateway stays WiFi-associated after boot (no switch to ESP-NOW time-share),

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -113,3 +113,42 @@ features = "bard,off-fleet,${canonical}"
 [tier.ledger-provision]
 # #181/#266. A deliberate USB-touch provisioning build, never shipped.
 features = "ledger-provision"
+
+# ── the three that nothing was compiling ──────────────────────────────────────
+# Found by the `feature coverage` arm below when it was first written: `wled`, `coexist-soak`
+# and `mesh-test` were in Cargo.toml with no tier anywhere, i.e. code paths CI never built —
+# the exact `ledger-provision` case that motivated #338, still live in the file that fixed it.
+# All three compile; they were simply never asked to.
+
+[tier.wled]
+# #26 smol Cast — the display streamed to a WLED matrix as realtime UDP pixels.
+features = "wled,${canonical}"
+
+[tier.coexist-soak]
+# #23/#204 bench soak for the WiFi <-> ESP-NOW co-channel window.
+features = "coexist-soak,${canonical}"
+
+[tier.mesh-test]
+# #13 routed-flood bench harness. It cannot RUN in CI — it needs a per-board `DEAF_MACS` that
+# only a real board.rs has — but it can and must COMPILE. "Cannot run" was silently treated as
+# "cannot build", which is how it stopped being compiled at all.
+features = "mesh-test,${canonical}"
+
+[tier.stack-paint]
+# #300 bench instrument: paints the free stack with a sentinel and reports the true high-water —
+# the measurement the whole stack floor is derived from. It carries `off-fleet` via its own
+# Cargo.toml declaration (#350), because a build that exists to measure is by definition not the
+# fleet image.
+features = "stack-paint,${canonical}"
+
+# ── features with NO tier, declared so the omission is a decision ─────────────
+# The coverage arm requires every feature in Cargo.toml to be either covered by a tier above or
+# listed here with a reason. An undeclared gap is a gate failure — the aspiration that used to
+# live in a gate.sh comment ("any feature not covered below should be added"), made checkable.
+[exempt]
+default  = "the `default` tier IS this feature set"
+hw       = "implied by every firmware tier; a tier for it alone would build nothing new"
+hostsim  = "host-only, and covered by the `cargo test` arm in tools/gate.sh"
+# `off-fleet` deliberately has NO entry here: the bard tier names it, so it is covered, and the
+# checker rejects a feature that is both exempted and covered — an exemption whose reason has
+# quietly stopped applying is worse than none. It caught this exact case when first written.

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -1,0 +1,115 @@
+# build-matrix.toml — #350. The (chip, tier) matrix, declared ONCE as data.
+#
+# ── WHY ───────────────────────────────────────────────────────────────────────
+# #338 made the canonical feature set a single variable so CI could not gate a different
+# tier than the one that ships. That fixed the one-variable case. This is the same lesson
+# generalised to a table, before #331 makes `chips x tiers` unbounded.
+#
+# The failure mode being designed against is not hypothetical. WLED's maintainers hand-
+# enumerated their build environments and are on record that it became "impossible to
+# maintain over several years"; their fix was to DERIVE the CI matrix from the config
+# (`pio project config --json-output | jq ...`) rather than list it. Full study:
+# `scratch/parity/multitarget-prior-art.md`.
+#
+# ── THE TWO RULES THIS FILE ENCODES ───────────────────────────────────────────
+#
+# 1. BUILDS AND SHIPS ARE SEPARATE DECLARATIONS. A target can be defined and compiled
+#    while being deliberately absent from the release — OpenWrt's `DEFAULT := n`
+#    (openwrt#12672), which kept 4/32 devices buildable after they stopped being shipped.
+#    `ships = true` on a chip with `builds = false` is a contradiction and the checker
+#    refuses it: you cannot ship what nothing compiles.
+#
+# 2. ONE AXIS AT A TIME. The matrix is (every buildable chip x the canonical tier) UNION
+#    (the canonical chip x every tier). It is NEVER the cross product. Tasmota crosses its
+#    27 locales only with the single spine variant — 99 binaries a release instead of 270 —
+#    and that discipline is the only reason their matrix is still legible. `emit` refuses
+#    to produce a cross product; `tools/test_build_matrix.sh` proves the refusal.
+#
+# ── WHAT THIS FILE DELIBERATELY DOES NOT CONTAIN ──────────────────────────────
+# No expected image size, and no expected stack region. Both are TREE-DEPENDENT: `board.rs`
+# and `secrets.rs` are git-ignored and provisioned per tree, their literals land in
+# `.rodata`/`.data`, and `.stack` is whatever DRAM is left over — so the same commit
+# measures 114,648 B here, 114,640 B under the CI templates locally, and 114,608 B on a
+# GitHub runner (#348, 3dd35d1). A byte-equality assertion on either would be a gate that
+# is red for everyone except the tree it was written on. The gates that DO apply are
+# inequalities with margin — `.stack >= floor`, `image <= slot` — and they live in
+# `repro_stack_check` / `ota_publish.sh`, which measure the artifact. Keep it that way: this
+# file declares WHAT is built, never HOW BIG it came out.
+#
+# Per-chip MEMORY BUDGETS are not here either — they are `rust/clock/src/budget.rs` (#348),
+# which has to be Rust because its mechanism is a compile-time const-assertion, and which
+# moves to `smol-core` at #347 Phase 2, where a CI build matrix has no business. The chip
+# ROSTER is therefore stated in two places by necessity, so `build_matrix.py check` asserts
+# the two agree in BOTH directions and fails the gate if either grows a chip alone.
+
+[meta]
+# The chip whose all-tiers axis is crossed, and the tier crossed with every chip.
+canonical_chip = "esp32c3"
+canonical_tier = "fleet"
+
+# ── CHIPS ─────────────────────────────────────────────────────────────────────
+# `builds` means CI compiles it and a green run says something about it. It is FALSE for a
+# chip the tree cannot compile today — declaring a job that always fails is worse than
+# declaring none, because a permanently-red arm teaches everyone to ignore the gate.
+# `blocked_on` records why, so the row is a tracked commitment rather than a wish.
+
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+ships  = true
+
+[chip.esp32s3]
+# JP's next fleet target. Not yet compilable from this tree: `esp-hal` is pinned with
+# `features = ["esp32c3"]`, `.cargo/config.toml` pins `build.target`, and xtensa needs the
+# esp Rust fork rather than the pinned upstream toolchain.
+target     = "xtensa-esp32s3-none-elf"
+builds     = false
+ships      = false
+blocked_on = "#331 multi-target; needs the esp fork toolchain and a per-chip esp-hal feature"
+# When #331 lands, flipping `builds` to true is a ONE-WORD data change and the matrix,
+# the CI jobs and the tier coverage all follow. That is the entire point of this file.
+# `ships` stays false after that: OpenWrt's DEFAULT := n. Buildable is not shipped.
+
+[chip.esp32c6]
+# The esp32c6-watch already runs this chip in its own repo (#347 Phase 2's third consumer).
+target     = "riscv32imac-unknown-none-elf"
+builds     = false
+ships      = false
+blocked_on = "#331 multi-target; esp-hal chip feature is pinned to esp32c3 in Cargo.toml"
+
+# ── TIERS ─────────────────────────────────────────────────────────────────────
+# `features` is passed verbatim to `--features` (empty string = default features only).
+# `${canonical}` expands to the canonical tier's feature string so the combined builds
+# cannot drift from it — the #338 rule applied inside this file.
+#
+# `check` and `clippy` default to TRUE. A tier excluded from either needs a written reason
+# in `why`: #343's finding was that a tier which only gets `cargo check` has its new
+# warnings invisible, which is how findings accumulated unnoticed for months.
+
+[tier.default]
+features = ""
+
+[tier.wifi]
+features = "wifi"
+
+[tier.espnow]
+features = "espnow"
+
+[tier.fleet]
+# THE canonical fleet tier. Must equal `REPRO_FLEET_FEATURES` in tools/repro_build.sh, which
+# stays the source of truth for the PACKAGING path — `repro_build.sh` is sourced by
+# `ota_publish.sh`, and putting a TOML parser on the publish path is new failure surface for
+# no gain. `build_matrix.py check` asserts the two strings are identical.
+features = "espnow,cast,io"
+ships    = true
+
+[tier.bard]
+# #347: off the C3 fleet image, still a supported build for chips with room. `off-fleet` is
+# #348's declaration that this is not the fleet image; without it the budget predicate
+# correctly refuses to compile the Bard for a C3. `repro_build_bin` refuses to PACKAGE
+# anything naming `off-fleet`, so this tier cannot leak into a shipped artifact.
+features = "bard,off-fleet,${canonical}"
+
+[tier.ledger-provision]
+# #181/#266. A deliberate USB-touch provisioning build, never shipped.
+features = "ledger-provision"

--- a/tools/build_matrix.py
+++ b/tools/build_matrix.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""#350 — read `tools/build-matrix.toml` and be the ONE place the (chip, tier) matrix exists.
+
+`tools/gate.sh` derives its tier loops from `emit`, CI derives its job matrix from
+`ci-matrix`, and `check` refuses the ways the declaration can drift from the rest of the
+tree. Nothing downstream hand-lists a tier or a chip; that is the whole design.
+
+Why a checker and not just a reader: the roster is necessarily stated twice — here, and as
+`ChipBudget` consts in `rust/clock/src/budget.rs`, which must be Rust because its mechanism
+is a compile-time const-assertion and which moves to `smol-core` at #347 Phase 2. Two
+statements of one fact is exactly what rots. #339 solved the same shape for the DIAG shed
+order by making the agreement a machine-checked fact rather than a convention, and this is
+that move again.
+
+Exit codes:  0 ok · 1 a check failed · 2 the manifest is malformed
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_MANIFEST = HERE / "build-matrix.toml"
+DEFAULT_REPRO = HERE / "repro_build.sh"
+DEFAULT_BUDGET = HERE.parent / "rust" / "clock" / "src" / "budget.rs"
+
+
+# ── loading ───────────────────────────────────────────────────────────────────
+
+
+class Bad(Exception):
+    """Malformed manifest. Distinct from a failed CHECK: one is a broken file, the other is
+    a true statement about a tree that disagrees with itself."""
+
+
+def load(path: Path) -> dict:
+    try:
+        with open(path, "rb") as fh:
+            doc = tomllib.load(fh)
+    except FileNotFoundError:
+        raise Bad(f"no manifest at {path}")
+    except tomllib.TOMLDecodeError as exc:
+        raise Bad(f"{path}: {exc}")
+
+    meta = doc.get("meta") or {}
+    chips = doc.get("chip") or {}
+    tiers = doc.get("tier") or {}
+    if not chips:
+        raise Bad("manifest declares no chips")
+    if not tiers:
+        raise Bad("manifest declares no tiers")
+
+    canon_chip = meta.get("canonical_chip")
+    canon_tier = meta.get("canonical_tier")
+    if canon_chip not in chips:
+        raise Bad(f"meta.canonical_chip {canon_chip!r} is not a declared chip")
+    if canon_tier not in tiers:
+        raise Bad(f"meta.canonical_tier {canon_tier!r} is not a declared tier")
+
+    # `${canonical}` expands to the canonical tier's feature string, so a combined tier
+    # cannot drift from the fleet list it is supposed to extend. Expanded once, here, so
+    # every consumer sees the same resolved string.
+    canon_features = tiers[canon_tier].get("features")
+    if canon_features is None:
+        raise Bad(f"canonical tier {canon_tier!r} declares no `features`")
+    for name, tier in tiers.items():
+        if "features" not in tier:
+            raise Bad(f"tier {name!r} declares no `features`")
+        tier["features"] = tier["features"].replace("${canonical}", canon_features)
+        if "${" in tier["features"]:
+            raise Bad(f"tier {name!r} has an unexpanded placeholder: {tier['features']!r}")
+
+    for name, chip in chips.items():
+        for field in ("target", "builds", "ships"):
+            if field not in chip:
+                raise Bad(f"chip {name!r} declares no `{field}`")
+
+    return {"meta": meta, "chips": chips, "tiers": tiers,
+            "canonical_chip": canon_chip, "canonical_tier": canon_tier}
+
+
+# ── the matrix ────────────────────────────────────────────────────────────────
+
+
+def matrix(doc: dict) -> list[dict]:
+    """(chip, tier) pairs, ONE AXIS AT A TIME.
+
+    every buildable chip x the canonical tier   UNION   the canonical chip x every tier
+
+    Deliberately not the cross product. With 3 chips and 6 tiers that would be 18 jobs to
+    this function's 8, and the ratio is what kills a matrix as chips accumulate — Tasmota
+    ships 99 binaries a release precisely because it refuses to cross its 27-locale axis
+    with its variant axis (27 x 10 would be 270). The refusal is the feature.
+    """
+    ct, cc = doc["canonical_tier"], doc["canonical_chip"]
+    out, seen = [], set()
+    for chip, spec in doc["chips"].items():
+        if spec["builds"]:
+            out.append({"chip": chip, "tier": ct, "target": spec["target"],
+                        "features": doc["tiers"][ct]["features"]})
+            seen.add((chip, ct))
+    for tier, spec in doc["tiers"].items():
+        if (cc, tier) in seen:
+            continue
+        out.append({"chip": cc, "tier": tier, "target": doc["chips"][cc]["target"],
+                    "features": spec["features"]})
+    return out
+
+
+# ── checks ────────────────────────────────────────────────────────────────────
+
+
+def repro_fleet_features(path: Path) -> str:
+    """The canonical tier as the PACKAGING path defines it.
+
+    Read lexically on purpose: `repro_build.sh` must stay a plain sourced library with no
+    parser in it, because `ota_publish.sh` sources it and the publish path is the last
+    place to add new failure surface.
+    """
+    text = path.read_text(encoding="utf-8")
+    m = re.search(r'^REPRO_FLEET_FEATURES="\$\{REPRO_FLEET_FEATURES:-([^}"]*)\}"',
+                  text, re.M)
+    if not m:
+        raise Bad(f"could not read REPRO_FLEET_FEATURES from {path}")
+    return m.group(1)
+
+
+def budget_chips(path: Path) -> set[str]:
+    """Chip ids declared as `ChipBudget` consts.
+
+    FAILS CLOSED. This is a lexical scrape of Rust, which is a thing to be nervous about, so
+    it does not merely collect what it recognises: it counts `ChipBudget {` literals and
+    requires a `chip:` string for each one. A declaration written in a form this does not
+    recognise therefore makes the check RED rather than silently shrinking the roster it is
+    supposed to be comparing — the same discipline `repro_stack_check` uses when it cannot
+    read an ELF. `chip: "host"` is skipped: it is the non-device fallback for host builds,
+    not a fleet target.
+    """
+    text = path.read_text(encoding="utf-8")
+    # `= ChipBudget {` is an INITIALISER. Anchoring on the `=` matters: a bare
+    # `ChipBudget\s*\{` also matches `pub struct ChipBudget {` and `impl ChipBudget {`, which
+    # made the first version of this check report 4 literals against 2 `chip:` fields and go
+    # red on a correct tree. That is the fail-closed behaviour working as designed — it
+    # refused to compare rather than quietly comparing a roster it had miscounted — but the
+    # pattern still had to be right, so: initialisers only.
+    literals = len(re.findall(r"=\s*ChipBudget\s*\{", text))
+    found = re.findall(r'chip:\s*"([A-Za-z0-9_-]+)"', text)
+    if len(found) < literals:
+        raise Bad(
+            f"{path}: found {literals} `ChipBudget {{` literals but only {len(found)} "
+            f"`chip:` fields — refusing to compare a roster I cannot fully read")
+    return {c for c in found if c != "host"}
+
+
+def check(doc: dict, repro: Path, budget: Path) -> list[str]:
+    fails: list[str] = []
+    chips, tiers = doc["chips"], doc["tiers"]
+
+    # 1. ships => builds. You cannot publish what nothing compiles.
+    for name, spec in chips.items():
+        if spec["ships"] and not spec["builds"]:
+            fails.append(f"chip {name}: ships = true but builds = false")
+    for name, spec in tiers.items():
+        if spec.get("ships") and name != doc["canonical_tier"]:
+            # A shipped tier that is not the canonical one means two fleet images exist and
+            # `REPRO_FLEET_FEATURES` no longer names "the" image. That may become true, but
+            # it is a design change, not a config tweak.
+            fails.append(f"tier {name}: ships = true, but only the canonical tier ships")
+
+    # 2. the canonical tier equals what the packaging path builds.
+    try:
+        rff = repro_fleet_features(repro)
+        declared = tiers[doc["canonical_tier"]]["features"]
+        if rff != declared:
+            fails.append(
+                f"canonical tier drift: manifest says {declared!r}, "
+                f"REPRO_FLEET_FEATURES says {rff!r}")
+    except Bad as exc:
+        fails.append(str(exc))
+
+    # 3. the chip roster agrees with the #348 budgets, in BOTH directions.
+    if budget.exists():
+        try:
+            declared_chips = budget_chips(budget)
+            manifest_chips = set(chips)
+            for missing in sorted(manifest_chips - declared_chips):
+                if chips[missing]["builds"]:
+                    fails.append(
+                        f"chip {missing}: builds = true but no ChipBudget in {budget.name} "
+                        f"— a buildable chip with no declared memory budget")
+            for extra in sorted(declared_chips - manifest_chips):
+                fails.append(
+                    f"chip {extra}: has a ChipBudget in {budget.name} but no manifest row")
+        except Bad as exc:
+            fails.append(str(exc))
+
+    # 4. the emitted matrix is not a cross product.
+    n = len(matrix(doc))
+    buildable = sum(1 for c in chips.values() if c["builds"])
+    if buildable and n > buildable + len(tiers):
+        fails.append(f"matrix emitted {n} jobs; one-axis-at-a-time allows at most "
+                     f"{buildable + len(tiers)} — this is a cross product")
+    return fails
+
+
+# ── cli ───────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("command", choices=("emit", "chips", "ci-matrix", "check"))
+    ap.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    ap.add_argument("--repro", type=Path, default=DEFAULT_REPRO)
+    ap.add_argument("--budget", type=Path, default=DEFAULT_BUDGET)
+    ap.add_argument("--for", dest="phase", choices=("check", "clippy"), default="check",
+                    help="emit: which gate phase's tier list to produce")
+    ap.add_argument("--builds", action="store_true", help="chips: only buildable ones")
+    args = ap.parse_args()
+
+    try:
+        doc = load(args.manifest)
+    except Bad as exc:
+        print(f"build-matrix: MALFORMED — {exc}", file=sys.stderr)
+        return 2
+
+    if args.command == "emit":
+        # `name<TAB>features`, one per line, for the gate's tier loops. Tab-separated so an
+        # empty feature string (the `default` tier) survives the round trip — a colon-joined
+        # form cannot express "no features" distinguishably from a missing field.
+        for name, spec in doc["tiers"].items():
+            if spec.get(args.phase, True):
+                print(f"{name}\t{spec['features']}")
+        return 0
+
+    if args.command == "chips":
+        for name, spec in doc["chips"].items():
+            if not args.builds or spec["builds"]:
+                print(name)
+        return 0
+
+    if args.command == "ci-matrix":
+        print(json.dumps({"include": matrix(doc)}, separators=(",", ":")))
+        return 0
+
+    fails = check(doc, args.repro, args.budget)
+    jobs = matrix(doc)
+    builds = [c for c, s in doc["chips"].items() if s["builds"]]
+    ships = [c for c, s in doc["chips"].items() if s["ships"]]
+    print(f"  build matrix: {len(jobs)} jobs · chips builds={','.join(builds) or '-'} "
+          f"ships={','.join(ships) or '-'} · {len(doc['tiers'])} tiers")
+    if fails:
+        for f in fails:
+            print(f"  FAIL {f}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/build_matrix.py
+++ b/tools/build_matrix.py
@@ -28,6 +28,7 @@ HERE = Path(__file__).resolve().parent
 DEFAULT_MANIFEST = HERE / "build-matrix.toml"
 DEFAULT_REPRO = HERE / "repro_build.sh"
 DEFAULT_BUDGET = HERE.parent / "rust" / "clock" / "src" / "budget.rs"
+DEFAULT_CARGO = HERE.parent / "rust" / "clock" / "Cargo.toml"
 
 
 # ── loading ───────────────────────────────────────────────────────────────────
@@ -81,6 +82,7 @@ def load(path: Path) -> dict:
                 raise Bad(f"chip {name!r} declares no `{field}`")
 
     return {"meta": meta, "chips": chips, "tiers": tiers,
+            "exempt": doc.get("exempt") or {},
             "canonical_chip": canon_chip, "canonical_tier": canon_tier}
 
 
@@ -157,6 +159,16 @@ def budget_chips(path: Path) -> set[str]:
     return {c for c in found if c != "host"}
 
 
+def cargo_features(path: Path) -> set[str]:
+    """Feature names from `[features]`. Parsed as TOML, not scraped — Cargo.toml IS TOML, so
+    there is no excuse for a regex here (unlike budget.rs, which is Rust and has one)."""
+    try:
+        with open(path, "rb") as fh:
+            return set((tomllib.load(fh).get("features") or {}))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise Bad(f"{path}: cannot read [features] — {exc}")
+
+
 def check(doc: dict, repro: Path, budget: Path) -> list[str]:
     fails: list[str] = []
     chips, tiers = doc["chips"], doc["tiers"]
@@ -199,7 +211,30 @@ def check(doc: dict, repro: Path, budget: Path) -> list[str]:
         except Bad as exc:
             fails.append(str(exc))
 
-    # 4. the emitted matrix is not a cross product.
+    # 4. every cargo feature is covered by a tier, or exempted with a reason.
+    #
+    # `tools/gate.sh` carried this as an aspiration in a comment — "any feature listed in
+    # Cargo.toml's [features] that is not covered below should be added" — and prose cannot
+    # be tested, so it wasn't: `wled`, `coexist-soak` and `mesh-test` were all in Cargo.toml
+    # with no tier, and `stack-paint` had stopped compiling entirely without anyone noticing.
+    # An omission is fine; an UNDECLARED omission is not.
+    cargo_toml = doc.get("_cargo_toml")
+    if cargo_toml and cargo_toml.exists():
+        feats = cargo_features(cargo_toml)
+        covered = {f for spec in tiers.values()
+                   for f in spec["features"].split(",") if f}
+        exempt = set(doc.get("exempt") or {})
+        for gap in sorted(feats - covered - exempt):
+            fails.append(
+                f"feature {gap!r} is in Cargo.toml but no tier builds it and it is not in "
+                f"[exempt] — a code path nothing compiles (#338)")
+        for stale in sorted(exempt & covered):
+            fails.append(f"feature {stale!r} is both exempted and covered by a tier — "
+                         f"drop the [exempt] entry so the reason cannot go stale")
+        for ghost in sorted(exempt - feats):
+            fails.append(f"[exempt] names {ghost!r}, which is not a feature in Cargo.toml")
+
+    # 5. the emitted matrix is not a cross product.
     n = len(matrix(doc))
     buildable = sum(1 for c in chips.values() if c["builds"])
     if buildable and n > buildable + len(tiers):
@@ -217,6 +252,7 @@ def main() -> int:
     ap.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     ap.add_argument("--repro", type=Path, default=DEFAULT_REPRO)
     ap.add_argument("--budget", type=Path, default=DEFAULT_BUDGET)
+    ap.add_argument("--cargo", type=Path, default=DEFAULT_CARGO)
     ap.add_argument("--for", dest="phase", choices=("check", "clippy"), default="check",
                     help="emit: which gate phase's tier list to produce")
     ap.add_argument("--builds", action="store_true", help="chips: only buildable ones")
@@ -247,6 +283,7 @@ def main() -> int:
         print(json.dumps({"include": matrix(doc)}, separators=(",", ":")))
         return 0
 
+    doc["_cargo_toml"] = args.cargo
     fails = check(doc, args.repro, args.budget)
     jobs = matrix(doc)
     builds = [c for c, s in doc["chips"].items() if s["builds"]]

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -9,15 +9,25 @@
 # ONBOARDING.md points AT this file rather than restating the commands, so the two cannot drift.
 #
 # WHAT IT COVERS
-#   1. cargo check --release across the build tiers (default / wifi / espnow / canonical fleet /
-#      canonical+bard, which is off the fleet image since #347 but still a supported build)
-#   2. cargo clippy --release -D warnings on EVERY tier (#343 — was canonical-only)
+#   0. #350 the build-matrix declarations — the canonical tier matches REPRO_FLEET_FEATURES, every
+#      buildable chip has a #348 ChipBudget (and vice versa), nothing ships that nothing builds,
+#      and the matrix is one-axis-at-a-time rather than a cross product
+#   1. cargo check --release across the build tiers — DERIVED from tools/build-matrix.toml, not
+#      listed here (#350). Adding a chip or a tier is a data change in one file.
+#   2. cargo clippy --release -D warnings on EVERY tier (#343 — was canonical-only), from the
+#      same manifest, so the two lists cannot disagree the way they had already started to
 #   3. the host experiments/*_verify suites
 #   4. the #300 stack floor — the canonical ELF's .stack region vs the floor declared in
-#      rust/clock/src/budget.rs (#348: one definition, parsed by repro_stack_floor)
+#      rust/clock/src/budget.rs (#348: one definition, parsed by repro_stack_floor). The number
+#      is deliberately NOT repeated in this file, in build-matrix.toml, or anywhere else.
+#   5. the crate's own tests/*.rs suites via cargo test (#350) — bard / budget / input. Nothing
+#      ran these before: 57 tests, including the Bard's bit-for-bit golden, that no gate executed
+#   6. tools/test_build_matrix.sh — proof that (0)'s arms can actually fail
 #
 # WHAT IT DOES NOT COVER — read this before trusting a green run:
-#   * `mesh-test`: needs a per-board `DEAF_MACS` that only a real board.rs has.
+#   * `mesh-test`: cannot RUN — it needs a per-board `DEAF_MACS` that only a real board.rs has.
+#     It does now COMPILE, as a tier (#350). "Cannot run" had been silently widened to "cannot
+#     build", which is how it went uncompiled for months.
 #   * espflash `save-image` packaging: not run (no espflash in CI). The stack number does not depend
 #     on it — it is read from the ELF — but image PACKAGING is therefore unproven here.
 #   * Anything requiring hardware: OTA, radio, election, the stack-paint HIGH-WATER measurement.
@@ -72,6 +82,19 @@ if [ "$run_fw" = 1 ]; then
     printf '%s\n' "$out"; bad "shed order"
   fi
 
+  # #350: cheap and before any compile, because everything below DERIVES from this manifest —
+  # a gate that builds the wrong tier list confidently is worse than one that refuses to start.
+  # The arms: the canonical tier matches REPRO_FLEET_FEATURES (the packaging path's own
+  # definition); every buildable chip has a #348 ChipBudget and every ChipBudget has a chip row;
+  # nothing ships that nothing builds; the emitted matrix is one-axis-at-a-time, not a cross
+  # product. `tools/test_build_matrix.sh` (host half) proves each of those can fail.
+  step "build matrix declarations (#350)"
+  if out=$("$ROOT/tools/build_matrix.py" check 2>&1); then
+    printf '%s\n' "$out"; ok "build matrix"
+  else
+    printf '%s\n' "$out"; bad "build matrix"
+  fi
+
   # The tiers. `default` is the always-green baseline; `wifi`/`espnow` are the documented rungs;
   # the canonical fleet tier is what actually ships. A feature added to Cargo.toml and NOT added
   # here is a code path nothing compiles — the `ledger-provision` case that motivated this issue.
@@ -88,9 +111,12 @@ if [ "$run_fw" = 1 ]; then
   # keep it alive. Drop `off-fleet` here and you will see the guard fire; that is the check
   # working, not the tier breaking. `repro_build_bin` refuses to PACKAGE anything naming it, so
   # this cannot leak into a shipped image.
+  # #350: the tier list is DERIVED from tools/build-matrix.toml, not written here. It used to
+  # be a literal in this loop and a second literal in the clippy loop below, and the two had
+  # already drifted — `ledger-provision` was in one and not the other, so that tier compiled
+  # but was never linted. One declaration, two consumers, no third place to forget.
   step "cargo check — build tiers"
-  for tier in "default:" "wifi:wifi" "espnow:espnow" "fleet:$REPRO_FLEET_FEATURES" "bard:bard,off-fleet,$REPRO_FLEET_FEATURES" "ledger-provision:ledger-provision"; do
-    name="${tier%%:*}"; feats="${tier#*:}"
+  while IFS=$'\t' read -r name feats; do
     # A tier naming a feature this branch does not have (e.g. ledger-provision before #181 lands)
     # is SKIPPED, not failed — the gate must work on both sides of that merge.
     if [ -n "$feats" ] && ! grep -qE "^${feats%%,*} *=" "$CLOCK/Cargo.toml"; then
@@ -102,16 +128,23 @@ if [ "$run_fw" = 1 ]; then
     else
       bad "check $name"; tail -15 /tmp/gate-$name.log | sed 's/^/        /'
     fi
-  done
+  done < <("$ROOT/tools/build_matrix.py" emit --for check)
 
   # `-D warnings` on EVERY tier, not just the canonical one. Until #343 this ran on the canonical
   # tier alone because `default`/`wifi` carried dead-code findings (symbols whose only callers are
   # espnow-gated); those now carry item-scoped `#[allow(dead_code)]` with a cited reason, so the
   # gate can cover what ONBOARDING has claimed all along. A tier that only gets `cargo check` has
   # its new warnings invisible — which is how the findings accumulated unnoticed in the first place.
+  # #350: derived from the same manifest as the check loop, so "every tier" is now literally
+  # true instead of "every tier someone remembered to add here". The fleet tier is named
+  # `fleet` in both loops now — it was `canonical` here and `fleet` above, which is why the
+  # two lists could disagree without looking like they did. Log path moves with the name:
+  # /tmp/gate-clippy-fleet.log, was /tmp/gate-clippy-canonical.log.
   step "cargo clippy -D warnings — every tier"
-  for tier in "default:" "wifi:wifi" "espnow:espnow" "canonical:$REPRO_FLEET_FEATURES" "bard:bard,off-fleet,$REPRO_FLEET_FEATURES"; do
-    name="${tier%%:*}"; feats="${tier#*:}"
+  while IFS=$'\t' read -r name feats; do
+    if [ -n "$feats" ] && ! grep -qE "^${feats%%,*} *=" "$CLOCK/Cargo.toml"; then
+      printf '   \033[33mSKIP\033[0m %-16s (feature not in Cargo.toml on this branch)\n' "$name"; continue
+    fi
     args=(--release "${JOBS[@]}"); [ -n "$feats" ] && args+=(--features "$feats")
     if (cd "$CLOCK" && cargo clippy "${args[@]}" -- -D warnings) >/tmp/gate-clippy-$name.log 2>&1; then
       ok "clippy $name"
@@ -120,7 +153,7 @@ if [ "$run_fw" = 1 ]; then
       grep -E "^(error|warning)" /tmp/gate-clippy-$name.log | grep -v "could not compile" \
         | sort -u | sed 's/^/        /' | head -12
     fi
-  done
+  done < <("$ROOT/tools/build_matrix.py" emit --for clippy)
 
   # #300 stack floor, measured with the SAME function the packaging path uses (repro_stack_check).
   # Built with repro_cargo_args so the ELF matches the shipped one's geometry.
@@ -164,6 +197,43 @@ if [ "$run_host" = 1 ]; then
       bad "$n"; tail -10 /tmp/gate-$n.log | sed 's/^/        /'
     fi
   done
+
+  # #350: the crate's OWN test suites — `rust/clock/tests/*.rs`. Found while wiring the matrix:
+  # NOTHING in tools/ or .github/ ran `cargo test`, so `tests/bard.rs` (the Bard's bit-for-bit
+  # golden against an independent reference), `tests/input.rs`, and #348's brand-new
+  # `tests/budget.rs` were three suites no gate executed. #348's PR reported "8/8 host tests"
+  # from a manual run — which is exactly how a suite stops being evidence.
+  #
+  # `--no-default-features` is LOAD-BEARING, not tidiness: the default features pull the
+  # bare-metal stack, and `portable-atomic`'s `unsafe-assume-single-core` then leaks into the
+  # HOST build and hard-errors ("not supported yet on this architecture"). Drop the flag and
+  # this arm fails on a healthy tree.
+  #
+  # Discovered by GLOB for the same reason the loop above is: a list would stop covering what
+  # is added after it.
+  step "crate host test suites (cargo test)"
+  HOST_TRIPLE="${SMOL_HOST_TRIPLE:-$(rustc -vV | sed -n 's/^host: //p')}"
+  for t in "$ROOT/$CLOCK"/tests/*.rs; do
+    [ -f "$t" ] || continue
+    n=$(basename "$t" .rs)
+    if (cd "$ROOT/$CLOCK" && cargo test --no-default-features --features hostsim \
+          --target "$HOST_TRIPLE" --test "$n" "${JOBS[@]}") >/tmp/gate-test-$n.log 2>&1; then
+      # Print the count rather than a bare PASS: "8 passed" is checkable, "ok" is not, and a
+      # suite that silently starts running ZERO tests still says ok.
+      ok "test $n — $(grep -Eo '[0-9]+ passed' /tmp/gate-test-$n.log | tail -1)"
+    else
+      bad "test $n"; tail -12 /tmp/gate-test-$n.log | sed 's/^/        /'
+    fi
+  done
+
+  # #350: prove the matrix checker's arms can fail. Pure text, no cargo — see the file header
+  # for why a green-only demonstration is not evidence.
+  step "build-matrix checker regression suite (#350)"
+  if out=$("$ROOT/tools/test_build_matrix.sh" 2>&1); then
+    printf '%s\n' "$out" | tail -2; ok "test_build_matrix"
+  else
+    printf '%s\n' "$out" | sed 's/^/        /'; bad "test_build_matrix"
+  fi
 fi
 
 step "summary"

--- a/tools/test_build_matrix.sh
+++ b/tools/test_build_matrix.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# test_build_matrix.sh — #350. Prove `tools/build_matrix.py check` can FAIL, one arm at a time.
+#
+# ── WHY THIS EXISTS AND NOT JUST A GREEN RUN ──────────────────────────────────
+# A gate demonstrated only in its passing state is the #335 failure: both Embassy branches
+# produced "all tiers green" evidence from a configuration that contained no stack-floor
+# gate at all, and nothing about a green run said so. The same trap applies here — every
+# cross-check in `build_matrix.py` would report success on a tree where it had been
+# silently disabled, and the day it matters is the day someone adds a chip.
+#
+# So each case below is a manifest crafted to violate exactly one rule, and the suite
+# asserts BOTH that the checker fails AND that it fails with the right finding — a check
+# that goes red for the wrong reason is a check that will be "fixed" by deleting it.
+#
+# No cargo, no network, no hardware: this is a python script reading text files.
+#
+# Case format — directives in the fixture's own comments, so a case is one file:
+#   # EXPECT: <substring>          the failure text that must appear (exit 1)
+#   # EXPECT-MALFORMED: <substring> the manifest is broken, not merely wrong (exit 2)
+#   # EXPECT-OK                    must pass
+#   # EXPECT-JOBS: <n>             the emitted matrix must have exactly n jobs
+#   # BUDGET: <file>               use this budget fixture instead of _budget_ok.rs
+#
+# Exit 0 all cases behaved; 1 otherwise.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CASES="$HERE/test_build_matrix_cases"
+BM="$HERE/build_matrix.py"
+REPRO="$CASES/_repro_ok.sh"
+pass=0; fail=0
+
+note() { printf '   \033[32mok\033[0m   %s\n' "$1"; pass=$((pass + 1)); }
+oops() { printf '   \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail + 1)); }
+
+for case_file in "$CASES"/*.toml; do
+  name="$(basename "$case_file" .toml)"
+  budget="$CASES/$(sed -n 's/^# BUDGET: *//p' "$case_file" | head -1)"
+  [ -f "$budget" ] || budget="$CASES/_budget_ok.rs"
+
+  want_fail="$(sed -n 's/^# EXPECT: *//p' "$case_file" | head -1)"
+  want_bad="$(sed -n 's/^# EXPECT-MALFORMED: *//p' "$case_file" | head -1)"
+  want_jobs="$(sed -n 's/^# EXPECT-JOBS: *//p' "$case_file" | head -1)"
+  # A directive must be on its OWN line — these patterns are anchored at `^# `. The first
+  # version of this suite had `# EXPECT-OK, EXPECT-JOBS: 8` on one line and the job-count
+  # assertion silently never ran, which is the same silent-skip class of bug the whole file
+  # exists to prevent. So: a case with no recognised directive is an ERROR, never a pass.
+  if [ -z "$want_fail$want_bad$want_jobs" ] && ! grep -q '^# EXPECT-OK$' "$case_file"; then
+    oops "$name: no recognised EXPECT directive (typo? directive not on its own line?)"
+    continue
+  fi
+
+  out="$("$BM" check --manifest "$case_file" --repro "$REPRO" --budget "$budget" 2>&1)"
+  rc=$?
+
+  if [ -n "$want_bad" ]; then
+    if [ "$rc" != 2 ]; then
+      oops "$name: expected exit 2 (malformed), got $rc"
+    elif ! printf '%s' "$out" | grep -qF -- "$want_bad"; then
+      oops "$name: exit 2 but not for '$want_bad' — got: $(printf '%s' "$out" | head -1)"
+    else
+      note "$name — malformed, correctly refused"
+    fi
+  elif [ -n "$want_fail" ]; then
+    # rc 2 here would mean the fixture is broken rather than violating the rule it targets,
+    # which would make the case pass for the wrong reason — the one outcome worse than a
+    # missing test. Insist on exit 1.
+    if [ "$rc" != 1 ]; then
+      oops "$name: expected exit 1 (check failed), got $rc — fixture may be malformed"
+    elif ! printf '%s' "$out" | grep -qF -- "$want_fail"; then
+      oops "$name: failed, but not with '$want_fail' — got: $(printf '%s' "$out" | tail -2 | head -1)"
+    else
+      note "$name — caught: $want_fail"
+    fi
+  else
+    if [ "$rc" != 0 ]; then
+      oops "$name: expected pass, got $rc — $(printf '%s' "$out" | tail -1)"
+      continue
+    fi
+    note "$name — passes"
+  fi
+
+  if [ -n "$want_jobs" ]; then
+    got=$("$BM" ci-matrix --manifest "$case_file" | python3 -c \
+      'import json,sys; print(len(json.load(sys.stdin)["include"]))')
+    if [ "$got" != "$want_jobs" ]; then
+      oops "$name: expected $want_jobs jobs, got $got — the axes are being crossed"
+    else
+      note "$name — $got jobs (one axis at a time; the cross product would be more)"
+    fi
+  fi
+done
+
+printf '\n   %d ok, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tools/test_build_matrix.sh
+++ b/tools/test_build_matrix.sh
@@ -20,6 +20,7 @@
 #   # EXPECT-OK                    must pass
 #   # EXPECT-JOBS: <n>             the emitted matrix must have exactly n jobs
 #   # BUDGET: <file>               use this budget fixture instead of _budget_ok.rs
+#   # CARGO: <file>                use this Cargo.toml fixture instead of _cargo_empty.toml
 #
 # Exit 0 all cases behaved; 1 otherwise.
 set -uo pipefail
@@ -35,8 +36,15 @@ oops() { printf '   \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail + 1)); }
 
 for case_file in "$CASES"/*.toml; do
   name="$(basename "$case_file" .toml)"
+  # `_`-prefixed files are SHARED FIXTURES (a stub Cargo.toml, a stub budget.rs), not cases.
+  # They live here rather than in a subdirectory so a case and the thing it points at are
+  # visible together; the prefix is what keeps them out of the case glob.
+  case "$name" in _*) continue ;; esac
+
   budget="$CASES/$(sed -n 's/^# BUDGET: *//p' "$case_file" | head -1)"
   [ -f "$budget" ] || budget="$CASES/_budget_ok.rs"
+  cargo="$CASES/$(sed -n 's/^# CARGO: *//p' "$case_file" | head -1)"
+  [ -f "$cargo" ] || cargo="$CASES/_cargo_empty.toml"
 
   want_fail="$(sed -n 's/^# EXPECT: *//p' "$case_file" | head -1)"
   want_bad="$(sed -n 's/^# EXPECT-MALFORMED: *//p' "$case_file" | head -1)"
@@ -50,7 +58,7 @@ for case_file in "$CASES"/*.toml; do
     continue
   fi
 
-  out="$("$BM" check --manifest "$case_file" --repro "$REPRO" --budget "$budget" 2>&1)"
+  out="$("$BM" check --manifest "$case_file" --repro "$REPRO" --budget "$budget" --cargo "$cargo" 2>&1)"
   rc=$?
 
   if [ -n "$want_bad" ]; then

--- a/tools/test_build_matrix_cases/_budget_ok.rs
+++ b/tools/test_build_matrix_cases/_budget_ok.rs
@@ -1,0 +1,4 @@
+pub struct ChipBudget { pub chip: &'static str }
+impl ChipBudget { pub const fn x() {} }
+pub const ESP32C3: ChipBudget = ChipBudget { chip: "esp32c3" };
+pub const CHIP: ChipBudget = ChipBudget { chip: "host" };

--- a/tools/test_build_matrix_cases/_budget_three.rs
+++ b/tools/test_build_matrix_cases/_budget_three.rs
@@ -1,0 +1,4 @@
+pub const ESP32C3: ChipBudget = ChipBudget { chip: "esp32c3" };
+pub const ESP32S3: ChipBudget = ChipBudget { chip: "esp32s3" };
+pub const ESP32C6: ChipBudget = ChipBudget { chip: "esp32c6" };
+pub const CHIP: ChipBudget = ChipBudget { chip: "host" };

--- a/tools/test_build_matrix_cases/_budget_unreadable.rs
+++ b/tools/test_build_matrix_cases/_budget_unreadable.rs
@@ -1,0 +1,4 @@
+// A ChipBudget written in a form the scraper does not recognise: the `chip:` field is
+// built rather than a literal. The check must go RED, not silently see a smaller roster.
+pub const ESP32C3: ChipBudget = ChipBudget { chip: "esp32c3" };
+pub const MYSTERY: ChipBudget = ChipBudget { chip: CHIP_NAME_CONST };

--- a/tools/test_build_matrix_cases/_cargo_empty.toml
+++ b/tools/test_build_matrix_cases/_cargo_empty.toml
@@ -1,0 +1,5 @@
+# Cargo fixture with no features, so the #350 feature-coverage arm is inert for cases that
+# target a different arm. Cases that exercise coverage name _cargo_ok.toml via `# CARGO:`.
+[package]
+name = "fixture"
+[features]

--- a/tools/test_build_matrix_cases/_cargo_ok.toml
+++ b/tools/test_build_matrix_cases/_cargo_ok.toml
@@ -1,0 +1,10 @@
+[package]
+name = "fixture"
+[features]
+default = []
+hw = []
+wifi = []
+espnow = []
+cast = []
+io = []
+wled = []

--- a/tools/test_build_matrix_cases/_repro_ok.sh
+++ b/tools/test_build_matrix_cases/_repro_ok.sh
@@ -1,0 +1,1 @@
+REPRO_FLEET_FEATURES="${REPRO_FLEET_FEATURES:-espnow,cast,io}"

--- a/tools/test_build_matrix_cases/budget_orphan.toml
+++ b/tools/test_build_matrix_cases/budget_orphan.toml
@@ -1,0 +1,11 @@
+# BUDGET: _budget_three.rs
+# EXPECT: but no manifest row
+[meta]
+canonical_chip = "esp32c3"
+canonical_tier = "fleet"
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+ships = true
+[tier.fleet]
+features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/budget_unreadable.toml
+++ b/tools/test_build_matrix_cases/budget_unreadable.toml
@@ -1,0 +1,11 @@
+# BUDGET: _budget_unreadable.rs
+# EXPECT: refusing to compare
+[meta]
+canonical_chip = "esp32c3"
+canonical_tier = "fleet"
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+ships = true
+[tier.fleet]
+features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/canonical_tier_drift.toml
+++ b/tools/test_build_matrix_cases/canonical_tier_drift.toml
@@ -1,0 +1,10 @@
+# EXPECT: canonical tier drift
+[meta]
+canonical_chip = "esp32c3"
+canonical_tier = "fleet"
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+ships = true
+[tier.fleet]
+features = "espnow,cast,io,bard"

--- a/tools/test_build_matrix_cases/chip_without_budget.toml
+++ b/tools/test_build_matrix_cases/chip_without_budget.toml
@@ -1,0 +1,14 @@
+# EXPECT: no ChipBudget
+[meta]
+canonical_chip = "esp32c3"
+canonical_tier = "fleet"
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+ships = true
+[chip.esp32s3]
+target = "xtensa-esp32s3-none-elf"
+builds = true
+ships = false
+[tier.fleet]
+features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/feature_without_tier.toml
+++ b/tools/test_build_matrix_cases/feature_without_tier.toml
@@ -1,0 +1,15 @@
+# CARGO: _cargo_ok.toml
+# EXPECT: a code path nothing compiles
+[meta]
+canonical_chip = "esp32c3"
+canonical_tier = "fleet"
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+ships = true
+[tier.fleet]
+features = "espnow,cast,io"
+[exempt]
+default = "the default tier is this feature set"
+hw = "implied by every firmware tier"
+wifi = "covered transitively"

--- a/tools/test_build_matrix_cases/missing_canonical_chip.toml
+++ b/tools/test_build_matrix_cases/missing_canonical_chip.toml
@@ -1,0 +1,10 @@
+# EXPECT-MALFORMED: is not a declared chip
+[meta]
+canonical_chip = "esp32s3"
+canonical_tier = "fleet"
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+ships = true
+[tier.fleet]
+features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/second_shipped_tier.toml
+++ b/tools/test_build_matrix_cases/second_shipped_tier.toml
@@ -1,0 +1,14 @@
+# EXPECT: only the canonical tier ships
+[meta]
+canonical_chip = "esp32c3"
+canonical_tier = "fleet"
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+ships = true
+[tier.fleet]
+features = "espnow,cast,io"
+ships = true
+[tier.bard]
+features = "bard,off-fleet,${canonical}"
+ships = true

--- a/tools/test_build_matrix_cases/ships_without_builds.toml
+++ b/tools/test_build_matrix_cases/ships_without_builds.toml
@@ -1,0 +1,14 @@
+# EXPECT: ships = true but builds = false
+[meta]
+canonical_chip = "esp32c3"
+canonical_tier = "fleet"
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+ships = true
+[chip.esp32s3]
+target = "xtensa-esp32s3-none-elf"
+builds = false
+ships = true
+[tier.fleet]
+features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/stale_exemption.toml
+++ b/tools/test_build_matrix_cases/stale_exemption.toml
@@ -1,0 +1,18 @@
+# CARGO: _cargo_ok.toml
+# EXPECT: both exempted and covered
+[meta]
+canonical_chip = "esp32c3"
+canonical_tier = "fleet"
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+ships = true
+[tier.fleet]
+features = "espnow,cast,io"
+[tier.wled]
+features = "wled,${canonical}"
+[exempt]
+default = "the default tier is this feature set"
+hw = "implied"
+wifi = "covered transitively"
+wled = "STALE: a tier covers this now"

--- a/tools/test_build_matrix_cases/three_chips_one_axis.toml
+++ b/tools/test_build_matrix_cases/three_chips_one_axis.toml
@@ -1,0 +1,33 @@
+# EXPECT-OK
+# EXPECT-JOBS: 8
+# BUDGET: _budget_three.rs
+# Three buildable chips x six tiers would be 18 jobs if the axes were crossed. One axis at
+# a time gives 3 (chips x canonical tier) + 5 (canonical chip x the other tiers) = 8. If
+# someone rewrites matrix() to cross-multiply, THIS is the case that goes red.
+[meta]
+canonical_chip = "esp32c3"
+canonical_tier = "fleet"
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+ships = true
+[chip.esp32s3]
+target = "xtensa-esp32s3-none-elf"
+builds = true
+ships = false
+[chip.esp32c6]
+target = "riscv32imac-unknown-none-elf"
+builds = true
+ships = false
+[tier.default]
+features = ""
+[tier.wifi]
+features = "wifi"
+[tier.espnow]
+features = "espnow"
+[tier.fleet]
+features = "espnow,cast,io"
+[tier.bard]
+features = "bard,off-fleet,${canonical}"
+[tier.ledger-provision]
+features = "ledger-provision"

--- a/tools/test_build_matrix_cases/unexpanded_placeholder.toml
+++ b/tools/test_build_matrix_cases/unexpanded_placeholder.toml
@@ -1,0 +1,12 @@
+# EXPECT-MALFORMED: unexpanded placeholder
+[meta]
+canonical_chip = "esp32c3"
+canonical_tier = "fleet"
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+ships = true
+[tier.fleet]
+features = "espnow,cast,io"
+[tier.oops]
+features = "bard,${cannonical}"


### PR DESCRIPTION
Closes #350. Stacked on #348 + #349, now rebased onto main (both landed).

## What

`tools/build-matrix.toml` is the one declaration of the (chip, tier) matrix. `tools/gate.sh`'s two tier loops derive from it; CI puts it in the job summary.

Per #350 and the prior-art study:

- **`builds` and `ships` are separate declarations.** S3 and C6 are declared and not buildable yet (`esp-hal` is pinned to `esp32c3`), each with `blocked_on`. S3 stays `ships = false` after #331 — OpenWrt's `DEFAULT := n`.
- **One axis at a time.** Every buildable chip × the canonical tier, UNION the canonical chip × every tier. Never the cross product: with 3 chips and 6 tiers that is 8 jobs, not 18, and a fixture asserts the 8.
- **`ships ⇒ builds`.** You cannot publish what nothing compiles.

**Deliberately not in the manifest: any expected image size or stack region.** Both are tree-dependent (#348 `3dd35d1`) — the same commit measures `.stack` 114,648 on a dev box, 114,640 under CI templates locally, 114,608 on a runner. A byte-equality would be red for every tree but the one it was written on. The gates that apply are inequalities against the artifact and stay in `repro_stack_check` / `ota_publish.sh`.

## Why a checker and not just a reader

The chip roster is necessarily stated twice — here, and as `ChipBudget` consts in `budget.rs`, which must be Rust (its mechanism is a compile-time const-assertion) and which moves to `smol-core` at #347 Phase 2, where a CI matrix has no business. So `check` asserts the two agree **in both directions**. Same move #339 made for the shed order.

Reading `budget.rs` is a lexical scrape and **fails closed** — it counts `= ChipBudget {` initialisers and requires a `chip:` for each, so an unrecognised declaration goes red rather than silently shrinking the roster being compared.

## The drift it found immediately

- `ledger-provision` was in the check list and **not** the clippy list — that tier compiled but was never linted. #343's finding, recurring in the file that fixed it.
- The fleet tier was named `fleet` in one loop and `canonical` in the other, which is why the disagreement did not look like one.
- **`wled`, `coexist-soak`, `mesh-test` had no tier at all** — three code paths CI never compiled.
- **`stack-paint` did not compile.** #348 predicates `bard` on the DRAM budget, and `stack-paint = ["bard"]` without `off-fleet` fails the const assertion. The instrument that measures the high-water the 73,728 B floor is *derived from* was unbuildable, and nothing noticed because no tier built it. Fixed at the declaration: `stack-paint = ["bard", "off-fleet"]`.
- **Nothing ran `cargo test`.** `rust/clock/tests/{bard,budget,input}.rs` — 57 tests including the Bard's bit-for-bit golden against an independent reference — were executed by no gate.

## Proof the arms can fail

`tools/test_build_matrix.sh`, 12 cases, asserting both the exit code and the specific finding — a check that goes red for the wrong reason gets "fixed" by deletion. Verified with a **negative control**: sabotage one arm and the suite reports 11 ok / 1 failed. A green-only demonstration is the #335 trap.

## Verified

```
10 check tiers PASS · 10 clippy tiers PASS      (were 6 and 5)
stack: 114552 B (floor 73728 B)                  PASS
15 host verifiers · bard 41 / budget 8 / input 8 · 12/12 matrix cases
GATE GREEN
```

CI is not a `strategy.matrix` fan-out yet, deliberately: exactly one chip is buildable today, so a fan-out would be one job in a matrix costume, and a permanently-red S3 arm teaches everyone to ignore the gate. When #331 flips a chip to `builds = true`, `include` becomes `strategy.matrix` and nothing else moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)