### PR TITLE
feat(ota): carry the target in the signed manifest + route staged announces per chip (#349 items 1 & 5)

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1131,10 +1131,69 @@ struct __attribute__((packed)) smol_target_desc_t {
 runtime (`crate::headless()`); a variant that is not a build artifact needs no OTA guard, no CI
 job, and no row in a table.
 
-**Not yet done** (device-side refusal landed first): the staged manifest still carries no target
-tuple, so a board refuses *after* downloading rather than before; `smol/ota/staged` is still one
-fleet-wide topic; and there is no publisher-side `--force-target-mismatch` escape hatch. Today's
-escape hatch is a USB flash.
+### The signed manifest carries the target too (`OTA2|`)
+
+The descriptor above says what an image is *after* you have downloaded it. The staged announce now
+says the same thing *before*, so an unsuitable image costs nothing instead of ~1.1 MB.
+
+| generation | staged payload | signed M |
+|---|---|---|
+| #32 legacy | `OTA\|build\|size\|sha256\|sig\|url` | `build\|size\|sha256` |
+| #349 | `OTA2\|build\|size\|sha256\|**target**\|sig\|url` | `build\|size\|sha256\|**target**` |
+
+`target` is the **same 16 bytes as the embedded descriptor**, lowercase hex (32 chars) — not a
+second, tidier encoding. `ota_publish.sh` *extracts* it from the binary it just built rather than
+recomputing it from build flags, so the manifest and the image cannot disagree by construction.
+Worst-case M is **119 B** (two 10-digit `u32`s), against `SIGNED_MSG_MAX = 128`; `ota_mesh.rs` now
+carries real `const` asserts that `OTAM`/`ODEL` still fit the 250 B ESP-NOW MTU, a bound that until
+now lived only in a prose comment.
+
+The target sits **inside** M, before the signature field, for two reasons: M stays a contiguous
+prefix of the payload (so it can be rebuilt from exact wire bytes with no re-serialization), and an
+unauthenticated target could be stripped or rewritten by anyone with broker write access — a
+suitability check on unsigned data is theatre.
+
+Versioning is **by prefix, never by field shape**. `strip_prefix("OTA|")` cannot match `"OTA2|"`,
+so pre-#349 firmware ignores a new line *cleanly* rather than mis-slicing it into a bogus fetch.
+That property is asserted in `experiments/target_guard_verify`, not assumed.
+
+Refusals here are the same `TargetReject` tokens, surfaced as `Reject::Target(..)`. A legacy line
+states no target and is therefore **never refused pre-fetch** — `None` means "this staging did not
+say", not "suitable for anyone".
+
+### Per-chip staged topic
+
+`smol/ota/staged/<chip>` (e.g. `smol/ota/staged/esp32c3`), alongside the fleet-wide
+`smol/ota/staged`. One retained line arming every board was fine while the fleet was one chip; with
+C3/C6/S3 it is a correctness bug independent of any device-side guard.
+
+**Chip only, not chip+tier.** A "tier" here is a feature *bitset*, not a name; putting it in a topic
+segment would mint a new topic whenever a feature moves and make each board's subscription brittle
+— the per-env explosion WLED's maintainers say did not scale. Chip is small, closed and stable, and
+it is the axis where a wrong image is worst. Every finer distinction rides the signed target tuple
+and is re-checked against the image's own descriptor.
+
+### Migration — which step needs what
+
+This is the part to get right, because only one step can strand a board. **A merged `main` is not a
+rolled fleet**: boards run whatever was last installed, so the reader only exists in the field after
+boards carry it.
+
+| step | precondition | why |
+|---|---|---|
+| 1. firmware parses **both** generations, subscribes both topics | **merged main** | purely additive; a board that never sees an `OTA2\|` line behaves exactly as before |
+| 2. publisher **dual-stages** (legacy line unchanged + `OTA2\|` per-chip) | **merged main** | old firmware keeps reading the legacy topic it always read; new firmware prefers the per-chip line. Nothing is taken away, so nothing can be stranded |
+| 3. retire the fleet-wide `smol/ota/staged` line | **a ROLLED fleet** | the moment it stops being published, any board that cannot parse `OTA2\|` stops seeing updates — silently, since its symptom is simply never updating |
+
+Step 3 has a second, less obvious dependency: a crown relays the **signed M verbatim** to leaves
+over `OTAM`, so once a crown installs from an `OTA2` line it relays a 119 B M that a pre-#349 leaf
+rejects (`m_len > SIGNED_MSG_MAX`). Leaf mesh-OTA to un-upgraded leaves therefore also depends on
+the legacy path. Both reasons point the same way: **keep dual-staging until every board reports a
+build that carries the `OTA2` parser.**
+
+**Still not done:** no publisher-side `--force-target-mismatch` escape hatch (issue item 6) and no
+device-side override. Today's escape hatch is a USB flash — which is also the honest one, since a
+board that refuses an image is not reachable by the mechanism you would use to override it.
 
 ## MQTT burst — the LAN transport that retires the UDP collector
 

--- a/experiments/target_guard_verify/src/main.rs
+++ b/experiments/target_guard_verify/src/main.rs
@@ -38,6 +38,22 @@ fn c3_fleet() -> TargetId {
     }
 }
 
+/// The legacy (pre-#349) firmware's announce entry point, transcribed exactly: `ota.rs` did
+/// `s.strip_prefix("OTA|")?` and nothing else before splitting fields.
+fn legacy_prefix(s: &str) -> Option<&str> {
+    s.strip_prefix("OTA|")
+}
+
+/// The #349 firmware's dispatch: versioned by PREFIX, never by guessing at field shapes.
+/// Returns `(has_target, rest_after_prefix)`.
+fn new_prefix(s: &str) -> Option<(bool, &str)> {
+    if let Some(r) = s.strip_prefix("OTA2|") {
+        Some((true, r))
+    } else {
+        s.strip_prefix("OTA|").map(|r| (false, r))
+    }
+}
+
 fn check(name: &str, got: Result<(), TargetReject>, want: Result<(), TargetReject>) {
     assert_eq!(got, want, "{name}: guard returned {got:?}, expected {want:?}");
     match want {
@@ -257,7 +273,97 @@ fn main() {
     println!("  ok      {} reasons round-trip through their ordinals", TargetReject::COUNT);
 
     // ---------------------------------------------------------------------------------
-    // 6. OPTIONAL: the same scanner over a REAL flashed image.
+    // 6. The MANIFEST — both generations. This is the stranding-risk surface: if the new
+    //    parser stopped accepting the legacy form, every board that has not yet been rolled
+    //    would silently stop seeing updates, and the only symptom would be a fleet that
+    //    quietly stays on an old build. So the legacy form is asserted, not assumed.
+    // ---------------------------------------------------------------------------------
+    println!("manifest");
+    let sha_hex = "a".repeat(64);
+    let tgt_hex = core::str::from_utf8(&encode_hex(&me)).unwrap().to_string();
+
+    // #32 legacy M — target None, and that must NOT read as "suitable for anyone".
+    let legacy = parse_manifest_str(&format!("905|1156864|{sha_hex}")).expect("legacy M rejected");
+    assert_eq!(legacy.build, 905);
+    assert_eq!(legacy.size, 1_156_864);
+    assert_eq!(legacy.target, None, "legacy M must yield NO target, not a permissive one");
+    println!("  ok      legacy `build|size|sha` still parses, target=None");
+
+    // #349 M — target present and equal to what we encoded.
+    let v2 = parse_manifest_str(&format!("905|1156864|{sha_hex}|{tgt_hex}")).expect("OTA2 M rejected");
+    assert_eq!(v2.target, Some(me), "OTA2 M did not round-trip the target");
+    assert_eq!((v2.build, v2.size), (905, 1_156_864));
+    println!("  ok      OTA2 `build|size|sha|target` parses, target round-trips");
+
+    // Hex codec edges. A corrupted target must fail the WHOLE manifest, never degrade to None.
+    assert_eq!(decode_hex(&tgt_hex[..30]), None, "short target hex decoded");
+    assert_eq!(decode_hex(&format!("{}zz", &tgt_hex[..30])), None, "non-hex target decoded");
+    let mut bad = tgt_hex.clone();
+    bad.replace_range(12..13, if &bad[12..13] == "0" { "1" } else { "0" });
+    assert_eq!(decode_hex(&bad), None, "checksum-broken target hex decoded");
+    assert_eq!(
+        parse_manifest_str(&format!("905|1156864|{sha_hex}|{bad}")),
+        None,
+        "a manifest with a CORRUPT target parsed anyway — it must fail closed, not fall back to None",
+    );
+    println!("  ok      corrupt target hex fails the whole manifest (never degrades to None)");
+
+    // Trailing-junk / short-field fail-closed.
+    assert_eq!(parse_manifest_str(&format!("905|1156864|{}", &sha_hex[..62])), None);
+    assert_eq!(parse_manifest_str(&format!("905|1156864|{sha_hex}|{tgt_hex}|extra")), None);
+    assert_eq!(parse_manifest_str("905|notanumber|"), None);
+    println!("  ok      short sha / 5th field / bad integer all fail closed");
+
+    // M must fit the signed-message buffer the firmware allocates. Worst case is two 10-digit
+    // u32s; if this ever exceeds SIGNED_MSG_MAX the OTAM frame silently truncates.
+    let worst = format!("{}|{}|{}|{}", u32::MAX, u32::MAX, sha_hex, tgt_hex);
+    assert!(parse_manifest_str(&worst).is_some(), "worst-case M does not parse");
+    println!("  ok      worst-case M is {} B (firmware SIGNED_MSG_MAX must be >= this)", worst.len());
+    assert!(worst.len() <= 128, "worst-case M ({} B) exceeds SIGNED_MSG_MAX=128", worst.len());
+
+    // ---------------------------------------------------------------------------------
+    // 6b. THE NO-STRANDING CLAIM, as a test.
+    //
+    //     The entire migration rests on one sentence: "firmware older than #349 ignores an
+    //     `OTA2|` line cleanly instead of mis-parsing it." That is a claim about
+    //     `str::strip_prefix("OTA|")`, and asserting it in a comment is how it would silently
+    //     stop being true. So here is the legacy parser's first step, verbatim, run against
+    //     both lines. If this ever fails, publishing OTA2 would strand every un-rolled board —
+    //     the exact failure this whole design is sequenced to avoid.
+    // ---------------------------------------------------------------------------------
+    println!("no-stranding");
+    let url = "http://10.0.0.1:8087/ota/smol-905.bin";
+    let sig_hex = "b".repeat(128);
+    let legacy_line = format!("OTA|905|1156864|{sha_hex}|{sig_hex}|{url}");
+    let v2_line = format!("OTA2|905|1156864|{sha_hex}|{tgt_hex}|{sig_hex}|{url}");
+
+    // The legacy firmware's ONLY entry point into announce parsing.
+    assert!(legacy_prefix(&legacy_line).is_some(), "legacy fw stopped accepting its own format");
+    assert!(
+        legacy_prefix(&v2_line).is_none(),
+        "PRE-#349 FIRMWARE WOULD MIS-PARSE AN OTA2 LINE — publishing it would strand the fleet",
+    );
+    println!("  ok      pre-#349 fw accepts `OTA|`, cleanly REJECTS `OTA2|` (no mis-slice)");
+
+    // And the new firmware's dispatch accepts both — which is what makes dual-publish work.
+    assert_eq!(new_prefix(&legacy_line).map(|(t, _)| t), Some(false));
+    assert_eq!(new_prefix(&v2_line).map(|(t, _)| t), Some(true));
+    println!("  ok      #349 fw accepts BOTH, and tells them apart by prefix (not by shape)");
+
+    // The OTA2 line's signed prefix must be exactly the M we sign — reconstructed from the
+    // wire bytes, since that is how the firmware rebuilds it before verifying.
+    let (_, rest) = new_prefix(&v2_line).unwrap();
+    let m_expect = format!("905|1156864|{sha_hex}|{tgt_hex}");
+    assert!(rest.starts_with(&m_expect), "M is not a contiguous prefix of the OTA2 payload");
+    assert_eq!(
+        parse_manifest_str(&rest[..m_expect.len()]).and_then(|m| m.target),
+        Some(me),
+        "the signed prefix of the wire line does not parse back to the target",
+    );
+    println!("  ok      M is a contiguous prefix of the wire line and re-parses to the target");
+
+    // ---------------------------------------------------------------------------------
+    // 7. OPTIONAL: the same scanner over a REAL flashed image.
     //
     //    Everything above runs on bytes this file made up. `SMOL_TARGET_VERIFY_BIN=<path>`
     //    points it at an actual `espflash save-image` artifact instead, which is the only way

--- a/rust/clock/src/net/target.rs
+++ b/rust/clock/src/net/target.rs
@@ -113,6 +113,21 @@ pub const CHIP_ESP32C3: u8 = 1;
 pub const CHIP_ESP32C6: u8 = 2;
 pub const CHIP_ESP32S3: u8 = 3;
 
+/// The chip's operator-facing name — the same spelling `budget.rs` and `build.rs` use, and the
+/// segment a per-chip MQTT topic is built from (`smol/ota/staged/esp32c3`).
+///
+/// One table, because these names are now load-bearing in three places (topic routing, the
+/// `SMOL_CHIP` build override, and #348's `ChipBudget.chip`). #348 says outright that **#349
+/// owns chip identity**; this is that owner.
+pub fn chip_name(chip: u8) -> &'static str {
+    match chip {
+        CHIP_ESP32C3 => "esp32c3",
+        CHIP_ESP32C6 => "esp32c6",
+        CHIP_ESP32S3 => "esp32s3",
+        _ => "unknown",
+    }
+}
+
 // --- feature axis ----------------------------------------------------------------------
 // One bit per WIRE-VISIBLE capability. A bitset rather than a "tier" label is the direct
 // repair of WLED's opaque `release_name`: the checker can ask "does this image keep the
@@ -331,6 +346,117 @@ pub fn decode(rec: &[u8]) -> Option<TargetId> {
         compat: rec[8],
         min_from_compat: rec[9],
     })
+}
+
+// ---------------------------------------------------------------------------------------
+// Hex form — the SAME 16 bytes, for the signed OTA manifest
+// ---------------------------------------------------------------------------------------
+
+/// Hex length of a descriptor carried as a manifest field.
+pub const DESC_HEX_LEN: usize = DESC_LEN * 2;
+
+/// Serialise a [`TargetId`] as the lowercase-hex form used in the `OTA2|` manifest.
+///
+/// **This is deliberately the identical 16 bytes as the embedded descriptor, magic and all** —
+/// not a second, tidier encoding of the same facts. One encoding means the publisher can lift
+/// the record verbatim out of the image it just built and paste it into the manifest, which
+/// makes "the manifest says one thing and the image says another" structurally impossible
+/// rather than merely unlikely. (WLED derives its artifact FILENAME from the same define that
+/// makes the embedded string, for exactly this reason; the 4 magic bytes are the small price.)
+pub fn encode_hex(t: &TargetId) -> [u8; DESC_HEX_LEN] {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let raw = t.encode();
+    let mut out = [0u8; DESC_HEX_LEN];
+    let mut i = 0;
+    while i < DESC_LEN {
+        out[i * 2] = HEX[(raw[i] >> 4) as usize];
+        out[i * 2 + 1] = HEX[(raw[i] & 0x0f) as usize];
+        i += 1;
+    }
+    out
+}
+
+/// Parse the hex manifest field back into a [`TargetId`]. `None` on wrong length, a non-hex
+/// character, a bad magic, or a bad checksum — the same fail-closed rules as [`decode`], so a
+/// mangled manifest field can never be read as a permissive target.
+pub fn decode_hex(s: &str) -> Option<TargetId> {
+    let b = s.as_bytes();
+    if b.len() != DESC_HEX_LEN {
+        return None;
+    }
+    let mut raw = [0u8; DESC_LEN];
+    let mut i = 0;
+    while i < DESC_LEN {
+        raw[i] = (hexval(b[i * 2])? << 4) | hexval(b[i * 2 + 1])?;
+        i += 1;
+    }
+    decode(&raw)
+}
+
+fn hexval(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------------------
+// The signed manifest M — the string the ed25519 signature covers
+// ---------------------------------------------------------------------------------------
+
+/// The fields of a signed OTA manifest M, in either generation:
+///
+/// * `build|size|sha256hex`             — #32 legacy, `target: None`
+/// * `build|size|sha256hex|targethex`   — #349
+///
+/// This lives HERE, in the pure module, rather than beside the flash writer, for one reason:
+/// **M is the exact string the signature covers, and it is also the compatibility boundary that
+/// decides whether an un-upgraded fleet gets stranded.** That is not something to leave provable
+/// only on hardware. `experiments/target_guard_verify` exercises both generations, including the
+/// legacy form a pre-#349 publisher emits, so "old lines still parse" is a test rather than a
+/// belief. `ota.rs` wraps this; there is one definition.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Manifest {
+    pub build: u32,
+    pub size: u32,
+    pub sha256: [u8; 32],
+    pub target: Option<TargetId>,
+}
+
+/// Parse M. Fail-closed on anything malformed.
+///
+/// Strictness that does the work: `splitn(4)` folds any 5th field into the target slot, where
+/// [`decode_hex`]'s exact-length + magic + checksum checks reject it; on the 3-field form the
+/// exact-64 sha check rejects a trailing tail the same way. A present-but-unparseable target
+/// fails the WHOLE manifest rather than degrading to `None` — a corrupted target must never be
+/// read as a permissive one.
+pub fn parse_manifest_str(m: &str) -> Option<Manifest> {
+    let mut it = m.splitn(4, '|');
+    let build: u32 = it.next()?.parse().ok()?;
+    let size: u32 = it.next()?.parse().ok()?;
+    let sha256 = parse_sha256_hex(it.next()?)?;
+    let target = match it.next() {
+        Some(t) => Some(decode_hex(t)?),
+        None => None,
+    };
+    Some(Manifest { build, size, sha256, target })
+}
+
+/// Exactly 64 lowercase/uppercase hex chars → 32 bytes. `None` on any other length.
+fn parse_sha256_hex(hex: &str) -> Option<[u8; 32]> {
+    let b = hex.as_bytes();
+    if b.len() != 64 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    let mut i = 0;
+    while i < 32 {
+        out[i] = (hexval(b[i * 2])? << 4) | hexval(b[i * 2 + 1])?;
+        i += 1;
+    }
+    Some(out)
 }
 
 // ---------------------------------------------------------------------------------------

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -299,6 +299,31 @@ impl MeshElect {
 #[cfg(feature = "wifi")]
 const OTA_STAGED_TOPIC: &[u8] = b"smol/ota/staged";
 
+/// #349: the PER-CHIP staged topic, `smol/ota/staged/<chip>` (e.g. `smol/ota/staged/esp32c3`),
+/// built at runtime from this board's own [`crate::net::target::SELF`].
+///
+/// The fleet-wide topic above arms EVERY board with ONE retained line. That was fine while the
+/// fleet was one chip; with C3 / C6 / S3 it is a correctness bug independent of any device-side
+/// guard — an S3 staging would arm every C3 in the fleet, each of which then downloads ~1.1 MB
+/// before refusing it. Routing by chip means the wrong image never reaches the board at all.
+///
+/// **Chip only, not chip+tier**, deliberately. #349 proposed `<chip>/<tier>`, but a "tier" here
+/// is a feature BITSET, not a name — putting it in a topic segment would mint a new topic every
+/// time a feature moves and make each board's subscription brittle in exactly the way WLED's
+/// per-env explosion was. Chip is a small, closed, stable set, and it is the axis where a wrong
+/// image is worst (the bootloader catches it by boot-looping into rollback). Every finer
+/// distinction is already carried by the signed target tuple and re-checked against the image's
+/// own descriptor, so the topic does not need to encode it.
+///
+/// The legacy fleet-wide topic is still subscribed, and both feed the same parse+gate. That
+/// overlap is the migration: see `docs/protocol.md` for which step needs a ROLLED fleet.
+#[cfg(feature = "wifi")]
+fn ota_staged_chip_topic() -> MqttScratch {
+    let mut t = MqttScratch::new();
+    let _ = write!(t, "smol/ota/staged/{}", crate::net::target::chip_name(crate::net::target::SELF.chip));
+    t
+}
+
 /// A retained owner whose `seq` has not advanced for this long is presumed DEAD and
 /// may be taken over. The owner re-publishes `MC` (seq++) every gateway flush (~30 s),
 /// so 3 missed refreshes with a frozen seq is a safe "owner gone" threshold. Consumed
@@ -2690,6 +2715,11 @@ fn mqtt_session(
     // #33 Model-A per-board OTA install command topic (native HA Update button → INSTALL).
     let mut cmd_topic = MqttScratch::new();
     let _ = write!(cmd_topic, "smol/{}/ota/install", node_id);
+
+    // #349: this board's per-chip staged topic. Built once per session, beside the other
+    // scratch topics, and used for BOTH the subscribe and the receive-side exact compare — one
+    // construction site, so the filter we ask for and the topic we match cannot diverge.
+    let staged_chip_topic = ota_staged_chip_topic();
     // #26 cast: this board's retained cast-enable topic (payload ON/OFF). feature=cast.
     #[cfg(feature = "cast")]
     let mut cast_topic = MqttScratch::new();
@@ -2799,6 +2829,14 @@ fn mqtt_session(
     // latest_version source + fetch target. No per-id announce-act topic exists (dropped
     // — the #32 closure): staging only advertises "update available"; it never fetches.
     if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 4, OTA_STAGED_TOPIC) {
+        let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
+    }
+    // #349: ALSO subscribe this board's PER-CHIP staged topic (pid 30 — the first free id; ids
+    // 1-29 are taken, and two in-flight SUBSCRIBEs sharing one is an MQTT-3.1.1 violation).
+    // Placed here, well above the batt/grid/mc trio, because the drain's break-gate keys on
+    // those three retained topics: a subscribe emitted after them can have its retained payload
+    // land past the gate and be silently dropped (the #100 drain-order defect, HW-observed).
+    if let Some(n) = crate::net::mqtt::encode_subscribe(&mut pkt, 30, staged_chip_topic.as_bytes()) {
         let _ = tcp_send(iface, device, sockets, tcp_handle, &pkt[..n], deadline, tick);
     }
     // #21 node-manager: subscribe this board's retained default-screen config (pid 6).
@@ -3478,12 +3516,18 @@ fn mqtt_session(
                                 w.uptime
                             ),
                         }
-                    } else if topic == OTA_STAGED_TOPIC {
+                    } else if topic == OTA_STAGED_TOPIC || topic == staged_chip_topic.as_bytes() {
                         // #33 Model-A: parse + GATE the retained STAGED line (monotonicity +
                         // host allowlist + size). A gate-passing staged build becomes the
                         // latest_version + fetch TARGET (ota_offer) — but it does NOT fetch;
                         // the fetch is AND-gated on this board's own `install` command below.
                         // Stale/foreign/oversize → ignored (up-to-date; no offer).
+                        //
+                        // #349: the fleet-wide and per-chip topics feed the SAME parse+gate on
+                        // purpose. Whichever arrives, the monotonicity gate decides — so during
+                        // the migration a board may see both a legacy `OTA|` line and an
+                        // `OTA2|` line for the same build, and simply takes whichever is newer
+                        // than what it runs. Nothing needs to know which topic it came from.
                         match crate::ota::parse_announce(payload) {
                             Some(a) => {
                                 // #40: PERSIST the RAW announce (pre-gate) for a possible leaf

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -83,8 +83,19 @@ pub const CHUNK: usize = 4096;
 /// Max announce URL length kept in an owned [`Announce`] (bounded, no alloc).
 pub const URL_MAX: usize = 160;
 
-/// #32: max bytes of the signed manifest M = `"build|size|sha256hex"` (≤10+1+10+1+64 = 86).
-pub const SIGNED_MSG_MAX: usize = 96;
+/// Max bytes of the signed manifest M.
+///
+/// * #32 legacy (`OTA|`):  `"build|size|sha256hex"`              ≤ 10+1+10+1+64        =  86
+/// * #349 (`OTA2|`):       `"build|size|sha256hex|targethex"`    ≤ 10+1+10+1+64+1+32   = 119
+///
+/// 128 leaves headroom over the 119 worst case (both integers are `u32`, so 10 decimal digits
+/// each is the true ceiling even though a real `size` is capped at `MAX_IMAGE_SIZE` = 7 digits).
+///
+/// **Raising this grows two ESP-NOW frames**, and until #349 the only thing keeping them under
+/// the 250 B MTU was a prose comment ("= 184 B — < the 250 B ESP-NOW MTU"). `ota_mesh.rs` now
+/// carries a real `const _: () = assert!` on `OTAM_FRAME_MAX`/`ODEL_FRAME_MAX`, so the next
+/// person who extends the manifest gets a build error instead of a truncated frame.
+pub const SIGNED_MSG_MAX: usize = 128;
 
 /// Partition-table read scratch (an ESP-IDF table is ≤ 0xC00 bytes). Stack-only,
 /// used transiently by the flash helpers.
@@ -160,6 +171,12 @@ pub struct Announce {
     // Read by the fetch (espnow) integrity gate; parsed but unused in a wifi-only build.
     #[allow(dead_code)]
     pub sha256: [u8; 32],
+    /// #349: the target this image declares, when the announce is an `OTA2|` line. `None` for a
+    /// legacy `OTA|` line, which means "this staging did not say" — NOT "suitable for anyone".
+    /// A `None` here therefore never refuses anything; it just leaves the post-download
+    /// descriptor check as the only guard, exactly as before #349's follow-up. That asymmetry
+    /// is what lets the new publisher and the old fleet coexist.
+    pub target: Option<crate::net::target::TargetId>,
     // #32: the 64-byte Ed25519 signature over M, and the exact signed manifest bytes.
     // Parsed (written) in every build; READ only by the espnow verify-before-activate →
     // unused in a wifi-only build.
@@ -204,17 +221,14 @@ impl Announce {
         if m.is_empty() || m.len() > SIGNED_MSG_MAX {
             return None;
         }
-        let s = core::str::from_utf8(m).ok()?;
-        let mut it = s.splitn(3, '|');
-        let build: u32 = it.next()?.parse().ok()?;
-        let size: u32 = it.next()?.parse().ok()?;
-        let sha256 = parse_hex_n::<32>(it.next()?)?;
+        let (build, size, sha256, target) = split_manifest(m)?;
         let mut signed_msg = [0u8; SIGNED_MSG_MAX];
         signed_msg[..m.len()].copy_from_slice(m);
         Some(Announce {
             build,
             size,
             sha256,
+            target,
             sig: *sig,
             signed_msg,
             signed_len: m.len(),
@@ -224,31 +238,64 @@ impl Announce {
     }
 }
 
-/// Parse `OTA|build|size|sha256hex|sighex|url` (#32: `sighex` = 128-hex Ed25519 sig; url
-/// last so it may contain no `|`). ASCII, decimal build/size. Panic-free — `None` on ANY
-/// malformed field. An OLD unsigned 5-field-less announce (`OTA|build|size|sha|url`) fails
-/// closed: its `url` lands in the `sig` slot and fails the 128-hex parse.
+/// Parse a retained staged announce. **Two formats are accepted, distinguished by PREFIX** —
+/// never by guessing at field shapes:
+///
+/// * `OTA|build|size|sha256hex|sighex|url`                  — #32 legacy, no target
+/// * `OTA2|build|size|sha256hex|targethex|sighex|url`       — #349, target in the SIGNED part
+///
+/// In both, `url` is last so it may contain no `|`, and `sighex` is the 128-hex Ed25519 sig.
+/// M (the signed bytes) stays a CONTIGUOUS PREFIX of the payload in both, which is what lets it
+/// be rebuilt from the exact wire bytes with no re-serialization — hence `targethex` sits
+/// before `sighex` rather than after it. **The target is inside M on purpose:** a target field
+/// outside the signature could be stripped or rewritten by anyone with broker write access, and
+/// a suitability check on unauthenticated data is theatre.
+///
+/// Panic-free — `None` on ANY malformed field. Version by prefix means an older firmware, whose
+/// `strip_prefix("OTA|")` cannot match `"OTA2|"`, ignores a new-format line CLEANLY instead of
+/// mis-slicing it into a bogus fetch.
 pub fn parse_announce(payload: &[u8]) -> Option<Announce> {
     let s = core::str::from_utf8(payload).ok()?;
-    let rest = s.strip_prefix("OTA|")?;
+    // Try the versioned prefix FIRST: "OTA|" is not a prefix of "OTA2|", so the order is only
+    // about clarity, not correctness.
+    if let Some(rest) = s.strip_prefix("OTA2|") {
+        parse_fields(rest, true)
+    } else {
+        parse_fields(s.strip_prefix("OTA|")?, false)
+    }
+}
+
+/// Shared field walk for both announce generations. `has_target` selects whether a `targethex`
+/// field sits between the sha and the sig — and therefore whether it is inside M.
+fn parse_fields(rest: &str, has_target: bool) -> Option<Announce> {
     // Keep the field &strs so M can be rebuilt from their EXACT wire bytes (no re-serialize).
-    let mut it = rest.splitn(5, '|');
+    let mut it = rest.splitn(if has_target { 6 } else { 5 }, '|');
     let build_s = it.next()?;
     let size_s = it.next()?;
     let sha_s = it.next()?;
+    let target_s = if has_target { Some(it.next()?) } else { None };
     let sig_s = it.next()?;
     let url = it.next()?;
     let build: u32 = build_s.parse().ok()?;
     let size: u32 = size_s.parse().ok()?;
     let sha256 = parse_hex_n::<32>(sha_s)?;
     let sig = parse_hex_n::<64>(sig_s)?;
+    // A present-but-unparseable target fails the WHOLE announce rather than degrading to
+    // "no target stated". Silently dropping to the legacy path would turn a corrupted target
+    // into a permissive one — the failure direction this feature exists to prevent.
+    let target = match target_s {
+        Some(t) => Some(crate::net::target::decode_hex(t)?),
+        None => None,
+    };
     if url.is_empty() || url.len() > URL_MAX || !url.is_ascii() {
         return None;
     }
-    // #32: M = the EXACT wire bytes "build|size|sha256hex" (fields 1-3 + their two '|'),
-    // reconstructed from the field lengths so it is byte-identical to what the host signed
-    // (no decimal/hex re-serialization). M is a prefix of `rest`, so the slice is in-bounds.
-    let m_len = build_s.len() + 1 + size_s.len() + 1 + sha_s.len();
+    // M = the EXACT wire bytes of the signed prefix (fields 1-3, plus `targethex` on `OTA2|`)
+    // with their separators, byte-identical to what the host signed.
+    let mut m_len = build_s.len() + 1 + size_s.len() + 1 + sha_s.len();
+    if let Some(t) = target_s {
+        m_len += 1 + t.len();
+    }
     if m_len > SIGNED_MSG_MAX {
         return None;
     }
@@ -260,6 +307,7 @@ pub fn parse_announce(payload: &[u8]) -> Option<Announce> {
         build,
         size,
         sha256,
+        target,
         sig,
         signed_msg,
         signed_len: m_len,
@@ -359,6 +407,13 @@ pub enum Reject {
     BadSize,
     /// URL did not parse.
     BadUrl,
+    /// #349: the announce STATED a target and it is not this board's. Refused before a socket
+    /// opens, so an unsuitable image costs nothing at all rather than a whole download.
+    ///
+    /// Only reachable from an `OTA2|` line. A legacy `OTA|` line states no target and is never
+    /// refused here — the post-download descriptor check remains its guard. That asymmetry is
+    /// deliberate: it is what lets a new publisher and an un-rolled fleet coexist.
+    Target(crate::net::target::TargetReject),
 }
 
 /// Gate an announce in spec order (§3 Stage C-2): monotonicity → host allowlist →
@@ -374,6 +429,18 @@ pub fn gate(a: &Announce) -> Result<(), Reject> {
     }
     if a.size == 0 || a.size > MAX_IMAGE_SIZE {
         return Err(Reject::BadSize);
+    }
+    // #349 pre-fetch suitability. Cheap, and it runs on data the signature COVERS — the target
+    // sits inside M, so this refusal is exactly as trustworthy as the build/size/sha gate.
+    //
+    // NOTE this is an OPTIMIZATION, not the guard. It saves a ~1.1 MB download when the staging
+    // says up front that the image is not ours. The authoritative check remains the descriptor
+    // read out of the written slot at finalize, because that one judges the bytes that will
+    // actually boot rather than what an announce claimed about them.
+    if let Some(t) = a.target {
+        if let Err(why) = crate::net::target::decide(crate::net::target::SELF, t) {
+            return Err(Reject::Target(why));
+        }
     }
     Ok(())
 }
@@ -1217,16 +1284,32 @@ pub fn boot_confirm(self_test_passed: bool) {
 /// caller MUST have already verified the ed25519 signature over these bytes (§3, the
 /// verify-BEFORE-trust order) before acting on the result.
 #[cfg(feature = "espnow")]
-pub fn parse_manifest(m: &[u8]) -> Option<(u32, u32, [u8; 32])> {
+pub fn parse_manifest(m: &[u8]) -> Option<(u32, u32, [u8; 32], Option<crate::net::target::TargetId>)> {
+    split_manifest(m)
+}
+
+/// The ONE parser for the signed manifest M, in both generations:
+///
+/// * `build|size|sha256hex`             — #32 legacy, target `None`
+/// * `build|size|sha256hex|targethex`   — #349
+///
+/// Shared by `Announce::from_signed`, [`parse_manifest`] and the staged-line walk, because M is
+/// the string the SIGNATURE covers: three parsers that disagreed about its shape would be three
+/// chances to verify a signature over one interpretation and act on another.
+///
+/// The field walk itself lives in the PURE `net::target` module (`parse_manifest_str`), because
+/// M is both the signed string and the legacy-compatibility boundary — the thing that decides
+/// whether an un-upgraded fleet is stranded — and that deserves host tests, not hardware.
+/// This is the `&[u8]` → tuple adapter over it, and the single definition every caller shares:
+/// three parsers that disagreed about M's shape would be three chances to verify a signature
+/// over one interpretation and act on another.
+#[cfg(feature = "espnow")]
+fn split_manifest(
+    m: &[u8],
+) -> Option<(u32, u32, [u8; 32], Option<crate::net::target::TargetId>)> {
     let s = core::str::from_utf8(m).ok()?;
-    let mut it = s.splitn(3, '|');
-    let build: u32 = it.next()?.parse().ok()?;
-    let size: u32 = it.next()?.parse().ok()?;
-    let sha256 = parse_hex_n::<32>(it.next()?)?;
-    // The final field must be EXACTLY the 64-hex sha with nothing trailing (splitn(3)
-    // would otherwise fold a `build|size|sha|junk` tail into field 3 — parse_hex_n's
-    // strict length check rejects that, so a trailing field fails closed).
-    Some((build, size, sha256))
+    let p = crate::net::target::parse_manifest_str(s)?;
+    Some((p.build, p.size, p.sha256, p.target))
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -99,6 +99,23 @@ pub const ODEL_FRAME_MAX: usize = 12 + 3 + 4 + 2 + 2 + 1 + ota::SIGNED_MSG_MAX +
 /// #237 max `ODON` frame: 12 + 3 (target) + 4 (build) + 2 (session) + 1 (result) = 22 B.
 pub const ODON_FRAME_MAX: usize = 12 + 3 + 4 + 2 + 1;
 
+/// #349: the two frames that carry the signed manifest must fit one ESP-NOW datagram. This was
+/// only ever asserted in PROSE above ("= 184 B — < the 250 B ESP-NOW MTU") — true when written,
+/// and nothing would have caught it becoming false. Extending M for the #349 target tuple
+/// (`SIGNED_MSG_MAX` 96 → 128) is exactly the change that would have broken it silently: an
+/// over-MTU OTAM does not fail loudly, it fails as a leaf that never arms.
+///
+/// The OTA family is EXEMPT from the #190 group-MAC trailer (`should_group_mac`), and ODEL/ODON
+/// go out via `send_arb_raw`, so neither budget needs `MAC_TRAILER_LEN` headroom.
+const _: () = assert!(
+    OTAM_FRAME_MAX <= crate::net::wire::ESP_NOW_MTU,
+    "OTAM no longer fits one ESP-NOW datagram — shrink SIGNED_MSG_MAX or split the frame"
+);
+const _: () = assert!(
+    ODEL_FRAME_MAX <= crate::net::wire::ESP_NOW_MTU,
+    "ODEL no longer fits one ESP-NOW datagram — shrink SIGNED_MSG_MAX or split the frame"
+);
+
 // ---------------------------------------------------------------------------
 // Parsed frames (borrow the RX buffer; used immediately in `service()`)
 // ---------------------------------------------------------------------------
@@ -847,10 +864,29 @@ impl OtaLeafSession {
             self.verify_fail = self.verify_fail.saturating_add(1); // #49: the #32 refuse-line proof
             return LeafAction::None;
         }
-        // (2) Only now is M trustworthy → parse build/size/sha.
-        let Some((build, size, sha256)) = crate::ota::parse_manifest(m) else {
+        // (2) Only now is M trustworthy → parse build/size/sha (+ the #349 target, when the
+        // crown staged from an `OTA2|` line).
+        let Some((build, size, sha256, target)) = crate::ota::parse_manifest(m) else {
             return LeafAction::None;
         };
+        // (2b) #349 PRE-FLASH suitability. This is the biggest win of putting the target in the
+        // SIGNED manifest: a leaf's image arrives chunk-by-chunk over ESP-NOW, so without this
+        // it would spend a whole mesh transfer — minutes of airtime that makes the mesh deaf —
+        // only to refuse at finalize. Here it declines the session outright.
+        //
+        // Trustworthy because the signature was verified in (1) and the target lives inside M.
+        // `None` (a legacy crown relaying a legacy manifest) refuses NOTHING: the finalize
+        // descriptor check still stands behind it.
+        if let Some(t) = target {
+            if let Err(why) = crate::net::target::decide(crate::net::target::SELF, t) {
+                log::warn!(
+                    "smol #349: OTAM declined — image is not for this board ({}) — no session, no flash",
+                    why.label()
+                );
+                self.dbg_verdict = LEAF_VERDICT_TARGET_BASE.saturating_add(why.code());
+                return LeafAction::None;
+            }
+        }
         // (3) FRESHNESS + size gate (design §3C). Monotonicity ∧ floor ∧ slot bound.
         if build <= crate::ota::BUILD_NUMBER {
             log::info!("smol #40: OTAM build {} <= running {} — rejected", build, crate::ota::BUILD_NUMBER);

--- a/tools/ota_publish.sh
+++ b/tools/ota_publish.sh
@@ -285,6 +285,60 @@ SIZE="$(stat -c%s "$BIN")"
 SHA="$(sha256sum "$BIN" | cut -d' ' -f1)"
 [ "$SIZE" -le "$SLOT_MAX" ] || die "image $SIZE B > slot $SLOT_MAX B (0x1F0000) — WILL NOT FIT, aborting"
 
+# ---- #349: read the TARGET DESCRIPTOR out of the image we are about to publish ----------
+# The descriptor is a 16-byte record (magic "SMLT" + fields + FNV-1a/32 checksum) that the
+# firmware embeds in itself; see rust/clock/src/net/target.rs and docs/protocol.md.
+#
+# It is EXTRACTED FROM THE BINARY, never recomputed from the build flags. That is the whole
+# point: the manifest's target and the image's target are then the same 16 bytes by
+# construction, so they cannot disagree. Deriving it a second way here would be exactly WLED's
+# bug — their descriptor is instantiated with a literal where the constant belongs, and the two
+# silently drifted apart.
+#
+# A real image contains TWO "SMLT" occurrences and only ONE that checksums (the other is the
+# firmware's own scanner constant), so the checksum is what selects the record — matching the
+# device-side scanner byte for byte.
+read_target_desc() { # <bin> → "<hexdesc> <chipname>" on stdout, non-zero if absent/ambiguous
+  python3 - "$1" <<'PY'
+import re, sys
+CHIPS = {1: "esp32c3", 2: "esp32c6", 3: "esp32s3"}
+data = open(sys.argv[1], "rb").read()
+def fnv(b):
+    h = 0x811c9dc5
+    for x in b:
+        h ^= x
+        h = (h * 0x01000193) & 0xFFFFFFFF
+    return h
+found = []
+for m in re.finditer(re.escape(b"SMLT"), data):
+    rec = data[m.start():m.start() + 16]
+    if len(rec) == 16 and int.from_bytes(rec[12:16], "little") == fnv(rec[:12]):
+        found.append(rec)
+uniq = {r.hex() for r in found}
+if not uniq:
+    sys.stderr.write("no valid #349 target descriptor in the image\n"); sys.exit(1)
+if len(uniq) > 1:
+    sys.stderr.write("MULTIPLE conflicting target descriptors in the image: %s\n" % sorted(uniq)); sys.exit(1)
+rec = found[0]
+chip = CHIPS.get(rec[5])
+if chip is None:
+    sys.stderr.write("image declares unknown chip id %d\n" % rec[5]); sys.exit(1)
+print("%s %s" % (rec.hex(), chip))
+PY
+}
+if _desc_out="$(read_target_desc "$BIN")"; then
+  TARGET_HEX="${_desc_out%% *}"; TARGET_CHIP="${_desc_out##* }"
+  echo "target  ${TARGET_CHIP}  desc ${TARGET_HEX}"
+else
+  # Pre-#349 image (or --bin of an old artifact): stage LEGACY-ONLY. Refusing here would block
+  # staging a rollback build, and the device-side descriptor check already fails such an image
+  # closed if it ever reaches a board that expects one.
+  TARGET_HEX=""; TARGET_CHIP=""
+  echo "WARNING: #349 — no target descriptor in this image; staging the LEGACY line only." >&2
+  echo "         Boards route by chip on smol/ota/staged/<chip>; this build will only be seen" >&2
+  echo "         on the fleet-wide smol/ota/staged topic." >&2
+fi
+
 # ---- host on the LAN image server (VLAN11, same subnet as boards) ------------
 # Resolve the remote dir absolutely — scp's SFTP protocol does NOT expand remote $HOME.
 [ -n "$OTA_REMOTE_DIR" ] || OTA_REMOTE_DIR="$(ssh "$OTA_HOST_SSH" 'printf %s "$HOME/smol-ota/ota"')"
@@ -304,19 +358,51 @@ _msgf="$(mktemp)"; _keyf="$(mktemp -p /dev/shm 2>/dev/null || mktemp)"
 # EXIT trap here would otherwise silently drop the one mqtt_cfg installed and leave the
 # credential dir behind on every stage.
 trap 'shred -u "$_msgf" "$_keyf" 2>/dev/null; _mqtt_cfg_cleanup' EXIT INT TERM
-printf '%s' "${BUILD}|${SIZE}|${SHA}" > "$_msgf"
 bw get notes "$SMOL_OTA_SIGNING_KEY_ITEM" > "$_keyf" 2>/dev/null \
   || { shred -u "$_msgf" "$_keyf" 2>/dev/null; die "bw: couldn't read signing key '$SMOL_OTA_SIGNING_KEY_ITEM' (locked?)"; }
-SIG="$(openssl pkeyutl -sign -rawin -inkey "$_keyf" -in "$_msgf" | xxd -p -c 64)"
+# #349: the key is now used for up to TWO signatures (legacy M and OTA2 M), so it stays in
+# /dev/shm across both and is shredded once, immediately after. The trap above still covers an
+# interrupt in that (slightly longer, still sub-second) window.
+sign_msg() { # <message> → 128-hex ed25519 signature on stdout; dies on any failure
+  local _m="$1" _s
+  printf '%s' "$_m" > "$_msgf"   # printf, NOT echo: M is exact wire bytes, no trailing newline
+  _s="$(openssl pkeyutl -sign -rawin -inkey "$_keyf" -in "$_msgf" | xxd -p -c 64)"
+  case "$_s" in *[!0-9a-f]*|"") die "ed25519 signing failed (empty/non-hex sig — openssl >=3.0 + valid key?)";; esac
+  [ "${#_s}" -eq 128 ] || die "ed25519 sig wrong length ${#_s} (want 128 hex)"
+  printf '%s' "$_s"
+}
+SIG="$(sign_msg "${BUILD}|${SIZE}|${SHA}")"
+# #349 OTA2 M puts the target INSIDE the signed bytes — an unauthenticated target field could be
+# stripped or rewritten by anyone with broker write access, and a suitability check on
+# unauthenticated data is theatre.
+SIG2=""
+[ -n "$TARGET_HEX" ] && SIG2="$(sign_msg "${BUILD}|${SIZE}|${SHA}|${TARGET_HEX}")"
 shred -u "$_msgf" "$_keyf" 2>/dev/null
-case "$SIG" in *[!0-9a-f]*|"") die "ed25519 signing failed (empty/non-hex sig — openssl >=3.0 + valid key?)";; esac
-[ "${#SIG}" -eq 128 ] || die "ed25519 sig wrong length ${#SIG} (want 128 hex)"
 
 # 6-field SIGNED announce (was 4-field unsigned): url stays LAST (may contain no '|').
 LINE="OTA|${BUILD}|${SIZE}|${SHA}|${SIG}|${URL}"
 
-# ---- publish: stage the retained line (arms every board's native Update) -----
+# ---- publish: DUAL-STAGE (#349) ---------------------------------------------
+# The legacy fleet-wide line is published UNCHANGED, and it is what makes this a safe
+# migration rather than a flag day:
+#
+#   * Firmware older than #349 only knows `smol/ota/staged` and only parses `OTA|` — it keeps
+#     working, untouched. (It cannot parse `OTA2|` at all: its `strip_prefix("OTA|")` fails on
+#     "OTA2|", so it ignores the new line cleanly rather than mis-slicing it.)
+#   * Firmware with #349 subscribes BOTH topics and prefers whichever build is newer, so it
+#     picks up the per-chip line automatically.
+#
+# Retiring `smol/ota/staged` is therefore the ONE step that needs a ROLLED fleet — not a merged
+# main. Do not remove it here until every board reports a build carrying the OTA2 parser.
 pub_retained "smol/ota/staged" "$LINE"
 echo "staged  smol/ota/staged  <-  build $BUILD ($HASH) ${SIZE}B sha ${SHA:0:12}… sig ${SIG:0:12}… @ $URL"
-echo "done. Every board's native HA Update entity now shows build $BUILD as available."
+if [ -n "$TARGET_HEX" ]; then
+  LINE2="OTA2|${BUILD}|${SIZE}|${SHA}|${TARGET_HEX}|${SIG2}|${URL}"
+  pub_retained "smol/ota/staged/${TARGET_CHIP}" "$LINE2"
+  echo "staged  smol/ota/staged/${TARGET_CHIP}  <-  OTA2 build $BUILD target ${TARGET_HEX}"
+  echo "done. ${TARGET_CHIP} boards see build $BUILD on their per-chip topic; every board still"
+  echo "      sees it fleet-wide. Boards on other silicon will not be armed by the per-chip line."
+else
+  echo "done. Every board's native HA Update entity now shows build $BUILD as available."
+fi
 echo "      Install per-node from HA (the Update entity's Install button) or: ota_publish.sh install <id>"


### PR DESCRIPTION
Follow-up to #349 / PR #354 (`f80cba9`). Completes issue items 1 and 5: the target tuple in the signed manifest, and the per-target staged topic.

## The sequencing question, answered plainly

You asked me to say which precondition each step gates on. **A merged `main` is not a rolled fleet** — and there is a wrinkle worth stating: `f80cba9` shipped the *descriptor* reader, not a *manifest* reader. `parse_announce` on merged main is still strictly 6-field. So the fleet does not yet carry anything that can read a new-format line, and step 1 below is itself firmware that has to be rolled before step 3 is safe.

| step | precondition | why |
|---|---|---|
| 1. firmware parses **both** generations, subscribes both topics | **merged main** | purely additive; a board that never meets an `OTA2\|` line behaves exactly as before |
| 2. publisher **dual-stages** (legacy unchanged + `OTA2\|` per-chip) | **merged main** | nothing is taken away, so nothing can be stranded |
| 3. retire the fleet-wide `smol/ota/staged` line | **a ROLLED fleet** | the moment it stops being published, any board that cannot parse `OTA2\|` silently stops seeing updates |

**This PR does steps 1 and 2 only.** Step 3 is deliberately not done and is documented as needing the fleet, not the merge.

Step 3 has a second dependency I did not expect and want on record: a crown relays the **signed M verbatim** over `OTAM`, so once a crown installs from an `OTA2` line it relays a 119 B M that a pre-#349 leaf rejects (`m_len > SIGNED_MSG_MAX`). Leaf mesh-OTA to un-upgraded leaves therefore also depends on the legacy path. Both reasons point the same way.

## What landed

**`OTA2|build|size|sha256|target|sig|url`**, signing `build|size|sha256|target`.

- `target` is the **same 16 bytes as the embedded descriptor**, hex — not a second encoding. `ota_publish.sh` *extracts* it from the binary it just built rather than recomputing it from build flags, so manifest and image cannot disagree by construction. Verified: the publisher's extractor and the firmware's own scanner return the identical 16 bytes from a real image (`534d4c5401010f0001000000193934d5`, esp32c3).
- Target sits **inside M**, before the sig field: M stays a contiguous prefix (rebuildable from exact wire bytes), and an unauthenticated target could be stripped by anyone with broker write access — a suitability check on unsigned data is theatre.
- **Versioned by prefix, never by field shape.**

**Two new refusal points**, both *before* any cost: `gate()` (pre-fetch, before a socket opens) and `on_meta()` (the leaf declines the OTAM session, so a mesh transfer that would end in refusal never starts — that one saves minutes of airtime that makes the whole mesh deaf).

A legacy target-less line is **never refused** — `None` means "did not say", not "suitable for anyone", and the finalize descriptor check still stands behind it. That asymmetry is what lets a new publisher and an un-rolled fleet coexist.

**`smol/ota/staged/<chip>`** beside the fleet-wide topic, pid 30, subscribed above the batt/grid/mc trio (a later subscribe can have its retained payload land past the drain's break-gate — the #100 defect).

**Chip only, not chip+tier** as the issue proposed. A "tier" here is a feature *bitset*, not a name; putting it in a topic segment mints a new topic whenever a feature moves — the per-env explosion WLED's maintainers said in writing did not scale. Chip is small, closed, stable, and the axis where a wrong image is worst. Flag if you disagree; it's the one place I went off-spec.

## Things I found on the way

- **`OTAM`/`ODEL` fitting the 250 B ESP-NOW MTU was asserted only in a prose comment.** Extending M (`SIGNED_MSG_MAX` 96 → 128) is exactly the change that would have broken it silently — an over-MTU OTAM doesn't fail loudly, it fails as a leaf that never arms. Added real `const` asserts.
- **M's parser was three parsers.** `parse_announce`, `from_signed` and `parse_manifest` each walked the signed string separately — three chances to verify a signature over one interpretation and act on another. Now one definition, in the pure module.
- **#348 says "#349 owns chip identity"**; `chip_name()` is that owner. Converging `budget.rs`'s `chip: &'static str` onto it is a small follow-up I have not done.

## Demonstration

`target_guard_verify` now proves the **no-stranding claim** instead of stating it — the legacy parser's `strip_prefix("OTA|")` is transcribed verbatim and asserted to REJECT an `OTA2|` line, because that one sentence is what the whole migration rests on:

```
manifest
  ok      legacy `build|size|sha` still parses, target=None
  ok      OTA2 `build|size|sha|target` parses, target round-trips
  ok      corrupt target hex fails the whole manifest (never degrades to None)
  ok      worst-case M is 119 B (firmware SIGNED_MSG_MAX must be >= this)
no-stranding
  ok      pre-#349 fw accepts `OTA|`, cleanly REJECTS `OTA2|` (no mis-slice)
  ok      #349 fw accepts BOTH, and tells them apart by prefix (not by shape)
  ok      M is a contiguous prefix of the wire line and re-parses to the target
```

## Gate

`tools/gate.sh all` **GREEN** — 6 check tiers, 5 clippy tiers `-D warnings`, stack floor, 15 host suites.

Stack **114,560 B** (floor 73,728). `main`@`f80cba9` measured identically (archive build, same identity env): **114,552 B** → **+8 B of region**, i.e. it grew slightly.

Honest caveat, since the region is a *linked bound* and not runtime high-water: `Announce` grew ~40 B (`signed_msg` +32, plus the target Option) and lives in two `Option<Announce>` slots, so the real runtime delta is tens of bytes. Only the stack-paint rig measures high-water.

🤖 Generated with [Claude Code](https://claude.com/claude-code)