### PR TITLE
chore(233): esp-hal 1.1 / esp-radio 0.18 matched-set upgrade — superloop preserved, executor OFF

### DIFF
--- a/rust/clock/.cargo/config.toml
+++ b/rust/clock/.cargo/config.toml
@@ -56,19 +56,14 @@ protocol = "sparse"
 # 72 KiB heap would OOM. Keys/ranges verified against esp-wifi 0.15's generated config table; each
 # static RX buffer ≈ 1.6 KB, allocated at esp_wifi::init from the (now-grown) esp-alloc heap.
 # HW-GATE-HELD: throughput/stability win only provable on the deaf-list/fetch rig (pairs with #143).
-[env]
-# ALL-CHANNEL SCAN (association-layer fix, 2026-07-20): esp-wifi's default WIFI_FAST_SCAN stops at
-# the FIRST matching-SSID AP it hears, which made nodes associate to a WEAK ch1 AP (2c:56:dc @ -83)
-# over the STRONG ch6 office AP (a62bb0 @ -66) → off-channel → OTA-deaf (the #204/#217 root cause).
-# `1` = WIFI_ALL_CHANNEL_SCAN: scan every channel, then associate to the STRONGEST AP. This is the
-# prerequisite for the best-gateway election — the election's co_channel / ap_rssi inputs are only
-# meaningful once a board reliably associates to the right (strong, ch6) AP first.
-ESP_WIFI_CONFIG_SCAN_METHOD = "1"
-# 10→16: more 802.11 RX headroom (IDF throughput profile uses 16–25). +~9.6 KB permanent at init.
-ESP_WIFI_CONFIG_STATIC_RX_BUF_NUM = "16"
-# 32→40: on-demand ceiling; must be ≥ static_rx_buf_num. Freed as the TCP stack drains each frame.
-ESP_WIFI_CONFIG_DYNAMIC_RX_BUF_NUM = "40"
-# 5→8: deeper RX frame queue to ride short bursts without drop.
-ESP_WIFI_CONFIG_RX_QUEUE_SIZE = "8"
-# 6→12: bigger Block-Ack RX window for AMPDU throughput. MUST stay ≤ static_rx_buf_num (16). iperf 9–12.
-ESP_WIFI_CONFIG_RX_BA_WIN = "12"
+#
+# #233: esp-radio 0.18 moved ALL of these RX knobs (and the scan method) out of build-env
+# into the runtime `ControllerConfig` — static_rx 16 / dynamic_rx 40 / rx_queue 8 /
+# rx_ba_win 12 and WIFI_ALL_CHANNEL_SCAN are applied in net::radio_controller_config()
+# (threaded into wifi::new). esp-config HARD-ERRORS on unknown ESP_RADIO_CONFIG_* env keys,
+# and RX_QUEUE_SIZE / SCAN_METHOD are no longer among them, so there is no [env] block.
+#
+# ALL-CHANNEL SCAN (association-layer fix, 2026-07-20) — carried forward as a RUNTIME knob:
+# the default WIFI_FAST_SCAN stops at the FIRST matching-SSID AP it hears, which made nodes
+# associate to a WEAK ch1 AP over the STRONG ch6 office AP → off-channel → OTA-deaf (the
+# #204/#217 root cause). It is the prerequisite for the best-gateway election.

--- a/rust/clock/Cargo.lock
+++ b/rust/clock/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c583acf993cf4245c4acb0a2cc2ab1f9cc097de73411bb6d3647ff6af2b1013d"
 
 [[package]]
-name = "anyhow"
-version = "1.0.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,15 +19,6 @@ name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
-
-[[package]]
-name = "basic-toml"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitfield"
@@ -66,6 +51,15 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -105,6 +99,7 @@ name = "clock"
 version = "0.1.0"
 dependencies = [
  "ed25519-compact",
+ "embassy-futures",
  "embedded-graphics",
  "embedded-storage",
  "esp-alloc",
@@ -112,9 +107,10 @@ dependencies = [
  "esp-bootloader-esp-idf",
  "esp-hal",
  "esp-println",
+ "esp-radio",
+ "esp-rtos",
  "esp-storage",
- "esp-wifi",
- "esp-wifi-sys",
+ "esp-wifi-sys-esp32c3",
  "libm",
  "log",
  "nb 1.1.0",
@@ -123,6 +119,12 @@ dependencies = [
  "smoltcp",
  "ssd1306",
 ]
+
+[[package]]
+name = "const-default"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "cpufeatures"
@@ -274,6 +276,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
+ "block-buffer 0.10.4",
  "crypto-common 0.1.7",
 ]
 
@@ -283,7 +286,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.1",
  "crypto-common 0.2.2",
 ]
 
@@ -317,12 +320,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "docsplay"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8547ea80db62c5bb9d7796fcce5e6e07d1136bdc1a02269095061e806758fab4"
+dependencies = [
+ "docsplay-macros",
+]
+
+[[package]]
+name = "docsplay-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11772ed3eb3db124d826f3abeadf5a791a557f62c19b123e3f07288158a71fdd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
- "litrs 1.0.0",
+ "litrs",
 ]
 
 [[package]]
@@ -333,31 +356,13 @@ checksum = "5c24599140dc39d7a81e4476e7573d41bbc18e07c803900298e522a5fbcfbfb6"
 
 [[package]]
 name = "embassy-embedded-hal"
-version = "0.3.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c62a3bf127e03832fb97d8b01a058775e617653bc89e2a12c256485a7fb54c1"
-dependencies = [
- "embassy-embedded-hal 0.4.0",
- "embassy-futures",
- "embassy-sync 0.6.2",
- "embassy-time",
- "embedded-hal 0.2.7",
- "embedded-hal 1.0.0",
- "embedded-hal-async",
- "embedded-storage",
- "embedded-storage-async",
- "nb 1.1.0",
-]
-
-[[package]]
-name = "embassy-embedded-hal"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1611b7a7ab5d1fbed84c338df26d56fd9bded58006ebb029075112ed2c5e039"
+checksum = "b0641612053b2f34fc250bb63f6630ae75de46e02ade7f457268447081d709ce"
 dependencies = [
  "embassy-futures",
  "embassy-hal-internal",
- "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -374,9 +379,9 @@ checksum = "dc2d050bdc5c21e0862a89256ed8029ae6c290a93aecefc73084b3002cdebb01"
 
 [[package]]
 name = "embassy-hal-internal"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95285007a91b619dc9f26ea8f55452aa6c60f7115a4edc05085cd2bd3127cd7a"
+checksum = "7f10ce10a4dfdf6402d8e9bd63128986b96a736b1a0a6680547ed2ac55d55dba"
 dependencies = [
  "num-traits",
 ]
@@ -395,10 +400,10 @@ checksum = "8d2c8cdff05a7a51ba0087489ea44b0b1d97a296ca6b1d6d1a33ea7423d34049"
 dependencies = [
  "cfg-if",
  "critical-section",
- "embedded-io-async",
+ "embedded-io-async 0.6.1",
  "futures-sink",
  "futures-util",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -409,35 +414,24 @@ checksum = "73974a3edbd0bd286759b3d483540f0ebef705919a5f56f4fc7709066f71689b"
 dependencies = [
  "cfg-if",
  "critical-section",
- "embedded-io-async",
+ "embedded-io-async 0.6.1",
  "futures-core",
  "futures-sink",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
-name = "embassy-time"
-version = "0.4.0"
+name = "embassy-sync"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f820157f198ada183ad62e0a66f554c610cdcd1a9f27d4b316358103ced7a1f8"
+checksum = "7bbd85cf5a5ae56bdf26f618364af642d1d0a4e245cdd75cd9aabda382f65a81"
 dependencies = [
  "cfg-if",
  "critical-section",
- "document-features",
- "embassy-time-driver",
- "embedded-hal 0.2.7",
- "embedded-hal 1.0.0",
- "embedded-hal-async",
- "futures-util",
-]
-
-[[package]]
-name = "embassy-time-driver"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
-dependencies = [
- "document-features",
+ "embedded-io-async 0.7.0",
+ "futures-core",
+ "futures-sink",
+ "heapless 0.9.3",
 ]
 
 [[package]]
@@ -504,12 +498,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
 name = "embedded-io-async"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
- "embedded-io",
+ "embedded-io 0.6.1",
+]
+
+[[package]]
+name = "embedded-io-async"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
+dependencies = [
+ "embedded-io 0.7.1",
 ]
 
 [[package]]
@@ -556,40 +565,48 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "esp-alloc"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e95f1de57ce5a6600368f3d3c931b0dfe00501661e96f5ab83bc5cdee031784"
+checksum = "46ced060d4085858283df950b80a4da2348e1707d7d07b1e966308582dae79f5"
 dependencies = [
  "allocator-api2",
  "cfg-if",
- "critical-section",
  "document-features",
  "enumset",
+ "esp-config",
+ "esp-sync",
  "linked_list_allocator",
+ "rlsf",
 ]
 
 [[package]]
 name = "esp-backtrace"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f270a29a3c4e492399b13e157b10151a7616cba69c4d554076ea93ed1bd2916"
+checksum = "37950e24b2dfd98f1581102d1798281d4d9547af881e6bffc2c2b534c026ec8f"
 dependencies = [
  "cfg-if",
+ "document-features",
  "esp-config",
+ "esp-metadata-generated",
  "esp-println",
- "heapless",
+ "heapless 0.9.3",
+ "riscv",
+ "xtensa-lx",
 ]
 
 [[package]]
 name = "esp-bootloader-esp-idf"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a093dbdc64b0288baacc214c2e8c2f3f13ecbf979c36ee2f63797ecf22538f1"
+checksum = "35ffc117c3a9859835d89d0e90f5ee9886ce2264a71a849a7a22ab5308f6653c"
 dependencies = [
  "cfg-if",
  "document-features",
  "embedded-storage",
  "esp-config",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
  "esp-rom-sys",
  "jiff",
  "strum",
@@ -597,22 +614,22 @@ dependencies = [
 
 [[package]]
 name = "esp-config"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd4a8db4b72794637a25944bc8d361c3cc271d4f03987ce8741312b6b61529c"
+checksum = "4d9b92fd9cfb0b4f8f1b6219b9763269a335571e307b014903b8201619374b80"
 dependencies = [
  "document-features",
- "esp-metadata-generated 0.1.0",
- "evalexpr",
+ "esp-metadata-generated",
  "serde",
  "serde_yaml",
+ "somni-expr",
 ]
 
 [[package]]
 name = "esp-hal"
-version = "1.0.0-rc.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3887eda2917deef3d99e7a5c324f9190714e99055361ad36890dffd0a995b49"
+checksum = "2bfcf2a0842903717f4663f6a08512c32b0f6b2d7fb7db3c8a6895d2e6d49f72"
 dependencies = [
  "bitfield",
  "bitflags 2.13.1",
@@ -622,36 +639,40 @@ dependencies = [
  "delegate",
  "digest 0.10.7",
  "document-features",
- "embassy-embedded-hal 0.3.2",
+ "embassy-embedded-hal",
  "embassy-futures",
- "embassy-sync 0.6.2",
+ "embassy-sync 0.8.0",
  "embedded-can",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "embedded-io",
- "embedded-io-async",
+ "embedded-io 0.6.1",
+ "embedded-io 0.7.1",
+ "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
  "enumset",
  "esp-config",
  "esp-hal-procmacros",
- "esp-metadata-generated 0.1.0",
+ "esp-metadata-generated",
  "esp-riscv-rt",
  "esp-rom-sys",
+ "esp-sync",
  "esp32",
  "esp32c2",
- "esp32c3 0.30.0",
+ "esp32c3",
  "esp32c6",
  "esp32h2",
  "esp32s2",
  "esp32s3",
  "fugit",
  "instability",
+ "log",
  "nb 1.1.0",
  "paste",
  "portable-atomic",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "rand_core 0.9.5",
  "riscv",
- "serde",
  "strum",
  "ufmt-write",
  "xtensa-lx",
@@ -660,41 +681,16 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-procmacros"
-version = "0.19.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbece384edaf0d1eabfa45afa96d910634d4158638ef983b2d419a8dec832246"
+checksum = "6aebfabb2c21bec45e575e4f6cb6bb7aa8e1b33e7ac45b5dffa0f9d33ff59105"
 dependencies = [
  "document-features",
- "litrs 0.4.2",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
  "termcolor",
-]
-
-[[package]]
-name = "esp-metadata"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fbc1d166be84c0750f121e95c8989ddebd7e7bdd86af3594a6cfb34f039650"
-dependencies = [
- "anyhow",
- "basic-toml",
- "indexmap",
- "proc-macro2",
- "quote",
- "serde",
- "strum",
-]
-
-[[package]]
-name = "esp-metadata-generated"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d36b8c8a752bdebec67fd02a15ebb1432feea345553749bca7ce2393cc795"
-dependencies = [
- "esp-metadata",
 ]
 
 [[package]]
@@ -704,27 +700,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42c2ee95b945a4780796e4359e72c033aed3b45073880e8029458f538532db8a"
 
 [[package]]
-name = "esp-println"
-version = "0.15.0"
+name = "esp-phy"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7e3ab41e96093d7fd307e93bfc88bd646a8ff23036ebf809e116b18869f719"
+checksum = "e7c0a29815cd105ae1a02f3d0c6e7aafda9504a41effae17fac4c3f827719228"
 dependencies = [
- "critical-section",
+ "cfg-if",
  "document-features",
- "esp-metadata-generated 0.1.0",
+ "embassy-sync 0.8.0",
+ "esp-config",
+ "esp-hal",
+ "esp-metadata-generated",
+ "esp-sync",
+ "esp-wifi-sys-esp32c3",
+ "esp32c3",
+ "log",
+]
+
+[[package]]
+name = "esp-println"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42dee1e9ac7c3539bf6464db1707b0edd7557168f98278cf3c84fe70e63c6ce6"
+dependencies = [
+ "document-features",
+ "esp-metadata-generated",
+ "esp-sync",
  "log",
  "portable-atomic",
 ]
 
 [[package]]
-name = "esp-riscv-rt"
-version = "0.12.0"
+name = "esp-radio"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a00370dfcb0ccc01c6b2540076379c6efd6890a27f584de217c38e3239e19d5"
+checksum = "23fbff98b06a96b6ce3791ecec5c668524052a068e23aacd23afe17ddba844ce"
+dependencies = [
+ "allocator-api2",
+ "cfg-if",
+ "docsplay",
+ "document-features",
+ "embassy-net-driver",
+ "embassy-sync 0.8.0",
+ "embedded-io 0.6.1",
+ "embedded-io 0.7.1",
+ "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
+ "enumset",
+ "esp-alloc",
+ "esp-config",
+ "esp-hal",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
+ "esp-phy",
+ "esp-radio-rtos-driver",
+ "esp-sync",
+ "esp-wifi-sys-esp32",
+ "esp-wifi-sys-esp32c2",
+ "esp-wifi-sys-esp32c3",
+ "esp-wifi-sys-esp32c6",
+ "esp-wifi-sys-esp32h2",
+ "esp-wifi-sys-esp32s2",
+ "esp-wifi-sys-esp32s3",
+ "esp32c3",
+ "heapless 0.9.3",
+ "instability",
+ "log",
+ "num-derive",
+ "num-traits",
+ "portable-atomic",
+ "portable_atomic_enum",
+]
+
+[[package]]
+name = "esp-radio-rtos-driver"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd75cd9073a90ffaa53db0bf17df7dc14164f2407a6ff36c725d2d1f78ff494"
+dependencies = [
+ "cfg-if",
+ "esp-sync",
+ "portable-atomic",
+]
+
+[[package]]
+name = "esp-riscv-rt"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a814ae91452de56a5e74f69aebfee40579511756837d3774a56fd24cf0ab79"
 dependencies = [
  "document-features",
  "riscv",
- "riscv-rt-macros",
+ "riscv-rt",
 ]
 
 [[package]]
@@ -735,85 +802,143 @@ checksum = "eae852ccb08971155023d1371c96d5490cbc26860f06aee2d629ef73f1a890c3"
 dependencies = [
  "cfg-if",
  "document-features",
- "esp-metadata-generated 0.4.0",
- "esp32c3 0.32.2",
+ "esp-metadata-generated",
+ "esp32c3",
+]
+
+[[package]]
+name = "esp-rtos"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551f90766e1527edaa0c91e8d559e9e2a60397b545e93357ac61fb31845e5712"
+dependencies = [
+ "allocator-api2",
+ "cfg-if",
+ "document-features",
+ "embassy-sync 0.8.0",
+ "esp-alloc",
+ "esp-config",
+ "esp-hal",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
+ "esp-radio-rtos-driver",
+ "esp-rom-sys",
+ "esp-sync",
+ "log",
+ "portable-atomic",
+ "riscv",
+ "xtensa-lx",
 ]
 
 [[package]]
 name = "esp-storage"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f276ad8a3bdc6b47cd92a3e91013f2e42dce9b3fc5023392063387a1ce2ed69a"
+checksum = "4cf2b3f00c9f94b27c62a4f5296b19470c3a083c687c8146e554a459f9bee596"
 dependencies = [
- "critical-section",
  "document-features",
  "embedded-storage",
- "esp-rom-sys",
-]
-
-[[package]]
-name = "esp-wifi"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84908f2e95cb99a200cf448abafc416576338be590778a15d9224eee237f3210"
-dependencies = [
- "allocator-api2",
- "cfg-if",
- "critical-section",
- "document-features",
- "embassy-net-driver",
- "embedded-io",
- "embedded-io-async",
- "enumset",
- "esp-alloc",
- "esp-config",
  "esp-hal",
- "esp-metadata-generated 0.1.0",
- "esp-wifi-sys",
- "num-derive",
- "num-traits",
- "portable-atomic",
- "portable_atomic_enum",
- "rand_core 0.9.5",
- "smoltcp",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
+ "esp-rom-sys",
+ "esp-sync",
 ]
 
 [[package]]
-name = "esp-wifi-sys"
-version = "0.7.1"
+name = "esp-sync"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b5438361891c431970194a733415006fb3d00b6eb70b3dcb66fd58f04d9b39"
+checksum = "b4736bfbbb9e3f6353344e14fc61b6d18d3b877c3286914cf8c0a037be0ed224"
 dependencies = [
- "anyhow",
+ "cfg-if",
+ "document-features",
+ "embassy-sync 0.6.2",
+ "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
+ "esp-metadata-generated",
+ "riscv",
+ "xtensa-lx",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2556f38f5292d9735d4e156e276815fc001c9a0a2be0544a575c5fb867129d24"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32c2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4b3eb3435dae84de611d4384639e61eed862818223e93fa70c525cb6a70127f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32c3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b290846b53db9a3965866964260220b67f2c41cc2dbc0b377e7136239fe168a7"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32c6"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57649401fc2f906a16e2268de88693724a125adcd0eba89b594a157affcee2d5"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32h2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf1be2e311f4b4e75b5507c6b007ffc3fcb8c6cb57f83cc6a9569ecdcf58484"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32s2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a9a7f1bc51e7026c3012cda4f11d8799e5e0c0bb3be85797462219def6c26e"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32s3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8321f44b57d8112cbd8607cc83b85783b9195289acb45532728e3e229e7786"
+dependencies = [
+ "log",
 ]
 
 [[package]]
 name = "esp32"
-version = "0.38.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7680f79e3a4770e59c2dc25b17dcd852921ee57ffae9a4c4806c9ca5001d54d"
+checksum = "5726e07689249d1a2cb7c492077bc424837fb68a64f7eb5d46569325352e9428"
 dependencies = [
- "critical-section",
  "vcell",
 ]
 
 [[package]]
 name = "esp32c2"
-version = "0.27.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da1bcf86fca83543e0e95561cba27bbcc6b6e7adc5428f49187f5868bc0c3ed2"
+checksum = "5ef0b623533bbaa37e348c18b6b41cfd5b47c3cb64a4b9e44f0295941d62aa2e"
 dependencies = [
- "critical-section",
- "vcell",
-]
-
-[[package]]
-name = "esp32c3"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2c5a33d4377f974cbe8cadf8307f04f2c39755704cb09e81852c63ee4ac7b8"
-dependencies = [
- "critical-section",
  "vcell",
 ]
 
@@ -828,49 +953,39 @@ dependencies = [
 
 [[package]]
 name = "esp32c6"
-version = "0.21.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca8fc81b7164df58b5e04aaac9e987459312e51903cca807317990293973a6e"
+checksum = "c58f34ff2633968c12125efc7f4f8f101078d5d34c7cb60eab82268db20986f9"
 dependencies = [
- "critical-section",
  "vcell",
 ]
 
 [[package]]
 name = "esp32h2"
-version = "0.17.0"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80171d08c17d8c63b53334c60ca654786a7593481531d19b639c4e5c76d276de"
+checksum = "c5bab026020ed4606ce113b6fde598dbc48f7eefcc46e9469ece77cc2b1aa4be"
 dependencies = [
- "critical-section",
  "vcell",
 ]
 
 [[package]]
 name = "esp32s2"
-version = "0.29.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c90d347480fca91f4be3e94b576af9c6c7987795c58dc3c5a7c108b6b3966dc"
+checksum = "d0ad6f21cdf6ec7b06b7f7e0fbe51f0d975fd6a5fa67c3f8a5a910d3981af531"
 dependencies = [
- "critical-section",
  "vcell",
 ]
 
 [[package]]
 name = "esp32s3"
-version = "0.33.0"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3769c56222c4548833f236c7009f1f8b3f2387af26366f6bd1cea456666a49d"
+checksum = "8b4b8c4e4d9f187553ecdb7173edec7b2deb2beea106eedefecdb1654b8ee25a"
 dependencies = [
- "critical-section",
  "vcell",
 ]
-
-[[package]]
-name = "evalexpr"
-version = "12.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae893d2d5e908b78f151ed89de3bfc272cdf6d368c7ed866942f98e24dea208a"
 
 [[package]]
 name = "float-cmp"
@@ -967,6 +1082,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,8 +1120,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1080,15 +1203,6 @@ name = "linked_list_allocator"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b23ac50abb8261cb38c6e2a7192d3302e0836dac1628f6a93b82b4fad185897"
-
-[[package]]
-name = "litrs"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
-dependencies = [
- "proc-macro2",
-]
 
 [[package]]
 name = "litrs"
@@ -1279,12 +1393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r0"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7a31eed1591dcbc95d92ad7161908e72f4677f8fabf2a32ca49b4237cbf211"
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,10 +1405,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
-name = "riscv"
-version = "0.12.1"
+name = "rand_core"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea8ff73d3720bdd0a97925f0bf79ad2744b6da8ff36be3840c48ac81191d7a7"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "riscv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05cfa3f7b30c84536a9025150d44d26b8e1cc20ddf436448d74cd9591eefb25"
 dependencies = [
  "critical-section",
  "embedded-hal 1.0.0",
@@ -1311,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "riscv-macros"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f265be5d634272320a7de94cea15c22a3bfdd4eb42eb43edc528415f066a1f25"
+checksum = "7d323d13972c1b104aa036bc692cd08b822c8bbf23d79a27c526095856499799"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1327,14 +1441,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
 
 [[package]]
-name = "riscv-rt-macros"
-version = "0.4.0"
+name = "riscv-rt"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc71814687c45ba4cd1e47a54e03a2dbc62ca3667098fbae9cc6b423956758fa"
+checksum = "3d07b9f3a0eff773fc4df11f44ada4fa302e529bff4b7fe7e6a4b98a65ce9174"
+dependencies = [
+ "riscv",
+ "riscv-pac",
+ "riscv-rt-macros",
+ "riscv-target-parser",
+]
+
+[[package]]
+name = "riscv-rt-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def519ddeeb5e43c2b4fc3952c27b3a86782fc05192f322b2309125cd85b1fc3"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "riscv-target-parser"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1376b15f3ff160e9b1e8ea564ce427f2f6fcf77528cc0a8bf405cb476f9cea7"
+
+[[package]]
+name = "rlsf"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07393724337be2ee43a9d86164df4505746874a3fa65913374bc6d6a92314362"
+dependencies = [
+ "cfg-if",
+ "const-default",
+ "libc",
+ "rustversion",
 ]
 
 [[package]]
@@ -1409,16 +1553,31 @@ version = "0.1.0"
 
 [[package]]
 name = "smoltcp"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
+checksum = "5f73d40463bba65efc9adc6370b56df76d563cc46e2482bba58351b4afb7535e"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
- "heapless",
+ "heapless 0.9.3",
  "managed",
 ]
+
+[[package]]
+name = "somni-expr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed9b7648d5e8b2df6c5e49940c54bcdd2b4dd71eafc6e8f1c714eb4581b0f53"
+dependencies = [
+ "somni-parser",
+]
+
+[[package]]
+name = "somni-parser"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0f368519fc6c85fc1afdb769fb5a51123f6158013e143656e25a3485a0d401c"
 
 [[package]]
 name = "ssd1306"
@@ -1642,30 +1801,29 @@ dependencies = [
 
 [[package]]
 name = "xtensa-lx"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a564fffeb3cd773a524e8d8a5c66ca5e9739ea7450e36a3e6a54dd31f1e652f"
+checksum = "e012d667b0aa6d2592ace8ef145a98bff3e76cca7a644f4181ecd7a916ed289b"
 dependencies = [
  "critical-section",
 ]
 
 [[package]]
 name = "xtensa-lx-rt"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520a8fb0121eb6868f4f5ff383e262dc863f9042496724e01673a98a9b7e6c2b"
+checksum = "409a9b4629d429e995cde4dfbd9fe562ccae66f7624514e200733fc5d0ea8905"
 dependencies = [
  "document-features",
- "r0",
  "xtensa-lx",
  "xtensa-lx-rt-proc-macros",
 ]
 
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a56a616147f5947ceb673790dd618d77b30e26e677f4a896df049d73059438"
+checksum = "96fb42cd29c42f8744c74276e9f5bee7b06685bbe5b88df891516d72cb320450"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -62,19 +62,19 @@ sigil-names = { path = "../sigil-names", default-features = false }
 # `unstable` is required for I2C/SPI/RNG and is also a hard requirement of
 # esp-wifi. `esp32c3` selects the chip. `rt` + `exception-handler` come from
 # the default features (runtime + fault handler).
-esp-hal = { version = "=1.0.0-rc.0", features = ["esp32c3", "unstable"], optional = true }
+esp-hal = { version = "1.1", features = ["esp32c3", "unstable"], optional = true }
 # NOTE: esp-hal's default features already install the exception handler, so
 # esp-backtrace only provides the panic handler + backtrace printing here.
 # Enabling esp-backtrace's `exception-handler` too causes a duplicate
 # `ExceptionHandler` symbol and an LTO bitcode-load failure at link time.
-esp-backtrace = { version = "=0.17.0", features = ["esp32c3", "panic-handler", "println"], optional = true }
+esp-backtrace = { version = "0.19", features = ["esp32c3", "panic-handler", "println"], optional = true }
 # Force the USB Serial/JTAG backend explicitly. This board's console is the
 # native USB Serial/JTAG link (/dev/ttyACM0); esp-println's default `auto`
 # backend only routes to USB-JTAG when it detects host SOF packets at the
 # instant it writes, which proved unreliable during the busy WiFi burst and
 # left app logs going to the (unwired) UART0. `jtag-serial` pins the output to
 # USB-JTAG so boot/WiFi/NTP/ESP-NOW logs always appear on /dev/ttyACM0.
-esp-println = { version = "=0.15.0", default-features = false, optional = true, features = [
+esp-println = { version = "0.17", default-features = false, optional = true, features = [
     "esp32c3",
     "log-04",
     "jtag-serial",
@@ -98,22 +98,39 @@ libm = { version = "0.2", optional = true, default-features = false }
 ssd1306 = { version = "=0.10.0", optional = true }
 embedded-graphics = "=0.8.2"
 
-# --- WiFi / NTP (Phase 2, feature = "wifi") ------------------------------
-# esp-alloc pinned to 0.8.x to satisfy esp-wifi 0.15.1's `^0.8.0` requirement.
-esp-alloc = { version = "=0.8.0", optional = true }
-esp-wifi-sys = { version = "=0.7.1", optional = true, default-features = false }
-esp-wifi = { version = "=0.15.0", optional = true, default-features = false, features = [
+# --- WiFi / NTP + radio (Phase 2, feature = "wifi") ----------------------
+esp-alloc = { version = "0.10", optional = true }
+# #233: the preemption scheduler that backs esp-radio's `esp_radio_preempt_*` os-adapter
+# hooks. In the old stack this was esp-wifi's in-crate `builtin-scheduler`; in the 0.18
+# stack it moved OUT to esp-rtos. We enable ONLY its `esp-radio` + `esp-alloc` drivers
+# (NOT `embassy`) — smol stays a blocking superloop, and `esp_rtos::start()` turns main()
+# into the scheduler's pinned main task, so the existing blocking code runs as-is.
+esp-rtos = { version = "0.3", optional = true, features = [
+    "esp32c3",
+    "esp-radio",
+    "esp-alloc",
+    "log-04",
+] }
+# esp-wifi RENAMED → esp-radio in 0.18. `unstable` unlocks the raw rx/tx tokens
+# (our smoltcp shim) + the `esp_now` interface. `default-features = false` drops
+# esp-radio's default `esp-alloc` so we re-add it explicitly.
+esp-radio = { version = "0.18", optional = true, default-features = false, features = [
     "esp32c3",
     "wifi",
     "esp-alloc",
-    "smoltcp",
-    # esp-wifi needs a preemption scheduler backing its `esp_wifi_preempt_*`
-    # os-adapter hooks. `builtin-scheduler` is normally in esp-wifi's default
-    # feature set, but we set `default-features = false`, so we must re-add it
-    # explicitly (otherwise: `undefined symbol: esp_wifi_preempt_*` at link).
-    "builtin-scheduler",
+    "unstable",
+    "log-04",
 ] }
-smoltcp = { version = "=0.12.0", optional = true, default-features = false, features = [
+# #141 TX-power clamp + AP-info readback use raw esp-idf bindings. esp-radio's
+# `sys` module is pub(crate), so we depend on the per-chip bindings crate directly
+# and alias it to `esp_wifi_sys` — net.rs keeps `esp_wifi_sys::include::…` verbatim.
+esp-wifi-sys = { package = "esp-wifi-sys-esp32c3", version = "0.2", optional = true, default-features = false }
+# #233: esp-radio 0.18 made connect/disconnect/scan ASYNC-only (no blocking variants).
+# smol is a synchronous superloop, so we drive those futures to completion with
+# embassy-futures' busy-loop `block_on` (no executor needed; the esp-rtos scheduler
+# preempts the busy loop to run the radio task that posts the completion events).
+embassy-futures = { version = "0.1", optional = true }
+smoltcp = { version = "0.13", optional = true, default-features = false, features = [
     "medium-ethernet",
     "proto-ipv4",
     "proto-dhcpv4",
@@ -129,8 +146,8 @@ smoltcp = { version = "=0.12.0", optional = true, default-features = false, feat
 # rom.rs references an unresolved `esp_rom_sys` (md5/crc pulled by the chip
 # feature). esp-storage gives XIP-safe flash writes (FlashStorage auto-detects
 # 4 MB); esp-bootloader-esp-idf gives the otadata slot/state API + esp_app_desc!.
-esp-storage = { version = "=0.7.0", optional = true, features = ["esp32c3"] }
-esp-bootloader-esp-idf = { version = "=0.2.0", optional = true, features = ["esp32c3"] }
+esp-storage = { version = "0.9", optional = true, features = ["esp32c3"] }
+esp-bootloader-esp-idf = { version = "0.5", optional = true, features = ["esp32c3"] }
 # Software SHA-256 for the OTA image integrity gate. Chosen over the HW `esp_hal::sha`
 # peripheral deliberately: the HW path needs the SHA peripheral threaded through boot
 # into the OTA burst + a self-referential `ShaDigest` (borrows the `Sha` beside it),
@@ -200,9 +217,11 @@ io = ["espnow"]
 wifi = [
     "hw", # #152: every firmware tier carries the bare-metal crates (byte-identical to before)
     "dep:esp-alloc",
-    "dep:esp-wifi",
+    "dep:esp-rtos",
+    "dep:esp-radio",
     "dep:esp-wifi-sys",
     "dep:smoltcp",
+    "dep:embassy-futures",
     "dep:esp-storage",
     "dep:esp-bootloader-esp-idf",
     "dep:sha2",
@@ -212,7 +231,13 @@ wifi = [
 
 # Phase 3: ESP-NOW peer messaging + WiFi<->ESP-NOW switching.
 # Builds on `wifi` (shares the radio init path) and turns on esp-wifi/esp-now.
-espnow = ["wifi", "esp-wifi/esp-now", "dep:ed25519-compact"]
+# NOTE (#233): we deliberately do NOT enable esp-radio's `coex` feature. `coex` is the
+# cross-radio (WiFi+BLE) coexistence arbiter and esp-radio's build script HARD-ERRORS if
+# `coex` is set without `ble`. smol's WiFi<->ESP-NOW coexistence (#40/#23) is SAME-RADIO
+# channel management (both live in the WiFi domain), not cross-radio arbitration — the old
+# esp-wifi 0.15 build never enabled coex either. Pulling BLE in would also wedge the C3 in
+# ROM (btdm init busy-wait — see the "native BLE refuted on C3" finding). So: esp-now only.
+espnow = ["wifi", "esp-radio/esp-now", "dep:ed25519-compact"]
 
 # #181/#184 mesh-ledger key PROVISIONING (a JP-supervised USB-touch build, NOT for the fleet OTA
 # image). Enables the one-shot NVS seeding of the ed25519 signing key from a build-time

--- a/rust/clock/src/about.rs
+++ b/rust/clock/src/about.rs
@@ -44,7 +44,12 @@ impl About {
     /// boot), so the entry stamp is reserved, not needed.
     pub fn new(_now_ms: u64) -> Self {
         Self {
-            mac: esp_hal::efuse::Efuse::read_base_mac_address(),
+            // #233: esp-hal 1.1 replaced `Efuse::read_base_mac_address() -> [u8;6]` with the
+            // free fn `efuse::base_mac_address() -> MacAddress` (newtype; `.as_bytes()` → &[u8;6]).
+            mac: esp_hal::efuse::base_mac_address()
+                .as_bytes()
+                .try_into()
+                .unwrap_or([0u8; 6]),
             last_s: None,
         }
     }

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -777,7 +777,7 @@ fn main() -> ! {
         net::try_time_sync(
             net::WifiPeripherals {
                 timg0: peripherals.TIMG0,
-                rng: peripherals.RNG,
+                sw_int: peripherals.SW_INTERRUPT,
                 wifi: peripherals.WIFI,
             },
             &mut batt_cache,
@@ -831,7 +831,7 @@ fn main() -> ! {
         net::mode::start(
             net::WifiPeripherals {
                 timg0: peripherals.TIMG0,
-                rng: peripherals.RNG,
+                sw_int: peripherals.SW_INTERRUPT,
                 wifi: peripherals.WIFI,
             },
             // This unit's short id (see NODE_ID) — embedded in HELLO/ACK/BEACON/TIME

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -9,6 +9,13 @@
 #[cfg(feature = "wifi")]
 mod wifi;
 
+// #233: smoltcp `phy::Device` shim over esp-radio 0.18's raw rx/tx tokens (esp-radio
+// dropped esp-wifi's `smoltcp` feature). Transitional — deleted when #198 lands embassy-net.
+#[cfg(feature = "wifi")]
+mod radio_dev;
+#[cfg(feature = "wifi")]
+pub use radio_dev::SmolWifiDevice;
+
 /// #141: clamp the radio's max TX power. Cheap C3-supermini boards distort their own TX at
 /// full power (worse on marginal USB supplies) — the AP receives corrupted auth/ACK frames
 /// (the "auth expired at strong signal" / silent-hostapd / mid-transfer-stall class). Units
@@ -271,6 +278,20 @@ pub(crate) use wifi::NTP_RESYNC_AGE_S;
 #[cfg(feature = "wifi")]
 pub fn init_heap() {
     esp_alloc::heap_allocator!(size: 96 * 1024);
+}
+
+/// #233/#140: the esp-radio 0.18 controller config. In the old esp-wifi 0.15 stack the
+/// RX-buffer counts were compile-time `ESP_WIFI_CONFIG_*` env knobs (.cargo/config.toml);
+/// in 0.18 they are runtime `ControllerConfig` fields threaded into `wifi::new`. The
+/// #140 tuning (static_rx 16 / dynamic_rx 40 / rx_queue 8 / rx_ba_win 12) is re-applied here.
+/// Shared by both radio-init paths (`wifi::try_time_sync` and `mode::RadioManager::new`).
+#[cfg(feature = "wifi")]
+pub(crate) fn radio_controller_config() -> esp_radio::wifi::ControllerConfig {
+    esp_radio::wifi::ControllerConfig::default()
+        .with_static_rx_buf_num(16)
+        .with_dynamic_rx_buf_num(40)
+        .with_rx_queue_size(8)
+        .with_rx_ba_win(12)
 }
 
 /// Phase-1 (default) placeholder used when no radio features are enabled: the

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -43,18 +43,19 @@
 extern crate alloc;
 
 use esp_hal::{
+    interrupt::software::SoftwareInterruptControl,
     rng::Rng,
     time::Instant,
     timer::timg::TimerGroup,
 };
-use esp_wifi::{
+use embassy_futures::block_on;
+use esp_radio::{
     esp_now::{EspNow, EspNowWifiInterface, PeerInfo, BROADCAST_ADDRESS},
-    wifi::{WifiController, WifiMode},
-    EspWifiController,
+    wifi::{scan::ScanConfig, sta::StationConfig, Config, WifiController},
 };
 
 use crate::led::LedState;
-use crate::net::WifiPeripherals;
+use crate::net::{SmolWifiDevice, WifiPeripherals};
 // #13: the relay-family wire codec + ASCII field helpers live in the PURE, host-testable
 // `net::wire` module (extracted from here, byte-identical). Glob-imported so every call site
 // below (encode_relay, parse_relay[2], *relayack*, encode_dl, write_u5/u10, parse_id/u5/u10,
@@ -388,12 +389,12 @@ const SCAN_SSID_MAX: usize = 12;
 /// stripped (they're free-form → keep the record parseable); BSSIDs are truncated to 3 octets
 /// (PUBLIC-repo topic — a full BSSID is a privacy leak). `|none` when the scan found nothing.
 /// Panic-free (heap `String`); the caller bounds it to `RELAY_VALUE_MAX` at broadcast/publish.
-fn format_scan_record(aps: &[esp_wifi::wifi::AccessPointInfo]) -> alloc::string::String {
+fn format_scan_record(aps: &[esp_radio::wifi::ap::AccessPointInfo]) -> alloc::string::String {
     use core::fmt::Write;
     let mut s = alloc::string::String::from("SCAN");
     for ap in aps.iter().take(SCAN_MAX_APS) {
         let mut ssid = alloc::string::String::new();
-        for c in ap.ssid.chars().take(SCAN_SSID_MAX) {
+        for c in ap.ssid.as_str().chars().take(SCAN_SSID_MAX) {
             ssid.push(if c == '|' || c == ',' { '_' } else { c });
         }
         let b = ap.bssid;
@@ -1994,7 +1995,7 @@ pub struct RadioManager {
     /// and is available again for periodic relay flushes (`flush_telemetry`). The
     /// smoltcp stack is built/dropped inside each burst, so between bursts this is
     /// just an idle handle that doesn't contend with ESP-NOW on ch6.
-    sta: Option<esp_wifi::wifi::WifiDevice<'static>>,
+    sta: Option<SmolWifiDevice>,
     /// Kept for the SNTP ephemeral-port seed during the burst.
     rng: Rng,
     mode: Mode,
@@ -2279,17 +2280,24 @@ impl RadioManager {
         super::init_heap();
 
         let timg0 = TimerGroup::new(p.timg0);
-        let rng = Rng::new(p.rng);
-        // esp-wifi's `init` takes the RNG by value; `Rng` is a `Copy` handle
-        // (not the entropy itself), so we keep our own copy for the SNTP
-        // ephemeral-port seed while also handing one to `init`.
-        let ctrl: EspWifiController<'static> = esp_wifi::init(timg0.timer0, rng).ok()?;
-        let ctrl: &'static EspWifiController<'static> =
-            alloc::boxed::Box::leak(alloc::boxed::Box::new(ctrl));
-
-        let (mut controller, interfaces) = esp_wifi::wifi::new(ctrl, p.wifi).ok()?;
-        controller.set_mode(WifiMode::Sta).ok()?;
-        controller.start().ok()?;
+        let sw = SoftwareInterruptControl::new(p.sw_int);
+        // #233: start the esp-rtos scheduler that backs esp-radio's os-adapter BEFORE
+        // wifi::new (NON-embassy: start() pins THIS context as the main task and returns).
+        esp_rtos::start(timg0.timer0, sw.software_interrupt0);
+        // `Rng` is a `Copy` handle (not entropy itself); kept for the SNTP ephemeral-port seed.
+        let rng = Rng::new();
+        // 0.18: WIFI is 'static → wifi::new returns an owned 'static controller + interfaces
+        // (no EspWifiController Box::leak). STA mode derives from the Config::Station set in
+        // associate(); the old explicit set_mode(WifiMode::Sta) is gone in 0.18.
+        let (mut controller, interfaces) =
+            esp_radio::wifi::new(p.wifi, super::radio_controller_config()).ok()?;
+        // #233: esp-radio 0.18 has no controller.start(); `set_config` is what STARTS the
+        // WiFi driver. ESP-NOW rides the STA interface and needs the driver started even on a
+        // leaf that never associates, so start it here in STA mode with an empty config.
+        // associate() later re-configs with real creds + connect_async().
+        controller
+            .set_config(&Config::Station(StationConfig::default()))
+            .ok()?;
         // #139: assert PowerSaveMode::None at RADIO INIT — the esp-wifi/IDF default is
         // WIFI_PS_MIN_MODEM (the STA sleeps between DTIMs; the AP then buffers UNICAST at DTIM and
         // drops it on marginal links → the re-ARP-after-reply / forwarded-NTP-never-arrives /
@@ -2297,21 +2305,22 @@ impl RadioManager {
         // (which resets ps to the default), and the post-is_connected() sites stay belt-and-
         // suspenders. Shared by every espnow association (NTP/MQTT/OTA/re-election). See nebula
         // finding 2 (scratch/smol-ha-batt/nebula-c3-wifi-research.md).
-        let _ = controller.set_power_saving(esp_wifi::config::PowerSaveMode::None);
+        let _ = controller.set_power_saving(esp_radio::wifi::PowerSaveMode::None);
         crate::net::assert_max_tx_power(); // #141: 8.5 dBm clamp, right after driver start
 
         // #68/#76 SELF-MAC: capture our STA MAC (ESP-NOW rides the STA interface) so service()
         // can DROP frames from our own address. The esp-wifi RX queue can deliver our own
         // broadcasts back to us; with no self-filter the gateway rosters ITSELF (constant-RSSI,
         // age-0, flags-3 self-entry — roster anomaly #1) and wastes an eviction-immune slot.
-        let self_mac = interfaces.sta.mac_address();
+        let self_mac = interfaces.station.mac_address();
 
         Some(Self {
             controller,
             self_mac,
             esp_now: interfaces.esp_now,
             // Keep the STA device alive for the NTP burst; dropped afterward.
-            sta: Some(interfaces.sta),
+            // #233: wrapped in the smoltcp phy::Device shim (net::radio_dev).
+            sta: Some(SmolWifiDevice::new(interfaces.station)),
             rng,
             mode: Mode::WifiSta,
             id,
@@ -2791,7 +2800,7 @@ impl RadioManager {
             Mode::EspNow => {
                 // TIME-SHARE: relinquish the AP association so nothing else
                 // steers the channel, then pin the fixed ESP-NOW channel.
-                let _ = self.controller.disconnect();
+                let _ = block_on(self.controller.disconnect_async());
                 // Keep the MAC/PHY powered (do NOT stop the controller) so the
                 // esp_now handle stays valid; just retune the channel.
                 self.esp_now
@@ -2806,14 +2815,14 @@ impl RadioManager {
                 // COEXIST: come back to the AP. Re-associating retunes the PHY
                 // to the AP's channel automatically; ESP-NOW then coexists on
                 // that channel. (Caller must have valid credentials set.)
-                let _ = self.controller.connect();
+                let _ = block_on(self.controller.connect_async());
                 // #139: connect() resets power-save to the WIFI_PS_MIN_MODEM default, so the
                 // association/auth handshake that follows would otherwise run under modem-sleep
                 // (unicast-deaf window). Re-assert None NOW — before the handshake completes — not
                 // only after the downstream is_connected() gates (MQTT flush / OTA fetch).
                 let _ = self
                     .controller
-                    .set_power_saving(esp_wifi::config::PowerSaveMode::None);
+                    .set_power_saving(esp_radio::wifi::PowerSaveMode::None);
                 crate::net::assert_max_tx_power(); // #141
                 log::info!("smol: radio -> WiFi STA (coexist)");
             }
@@ -3151,7 +3160,14 @@ impl RadioManager {
         // scan_n = scan_with_config_sync_max(Default, N): a synchronous full-band scan capped at N
         // results. We cap generously then keep the strongest few, so a busy band still yields the
         // most-relevant APs.
-        let record = match self.controller.scan_n(16) {
+        let record = match block_on(
+            self.controller
+                // #233 REGRESSION FIX: esp-radio 0.18's scan_async(ScanConfig::default()) has
+                // max=None and returns EVERY AP in range as a heap Vec — the old esp-wifi
+                // scan_n(16) capped at 16. In a dense RF environment the unbounded Vec is an
+                // OOM-panic risk (alloc failure = rst=panic); .with_max(16) restores the bound.
+                .scan_async(&ScanConfig::default().with_max(16)),
+        ) {
             Ok(mut aps) => {
                 // Strongest RSSI first (descending → Reverse of the ascending key).
                 aps.sort_by_key(|a| core::cmp::Reverse(a.signal_strength));
@@ -3200,7 +3216,14 @@ impl RadioManager {
         };
         // Full scan (needs co-channel AND off-channel visibility so `select_crown_ap` can decide
         // co-channel vs the strand fallback in ONE pass). Filter to our SSID; feed the pure selector.
-        let decision = match self.controller.scan_n(16) {
+        let decision = match block_on(
+            self.controller
+                // #233 REGRESSION FIX: esp-radio 0.18's scan_async(ScanConfig::default()) has
+                // max=None and returns EVERY AP in range as a heap Vec — the old esp-wifi
+                // scan_n(16) capped at 16. In a dense RF environment the unbounded Vec is an
+                // OOM-panic risk (alloc failure = rst=panic); .with_max(16) restores the bound.
+                .scan_async(&ScanConfig::default().with_max(16)),
+        ) {
             Ok(aps) => {
                 let mut views: alloc::vec::Vec<ApView> = alloc::vec::Vec::new();
                 for a in aps.iter() {
@@ -3236,19 +3259,21 @@ impl RadioManager {
             | CrownApDecision::OffChannelFallback { bssid, ch } => (Some(bssid), Some(ch)),
             CrownApDecision::NoAp => (None, None),
         };
-        let _ = self.controller.disconnect();
-        let _ = self
-            .controller
-            .set_configuration(&esp_wifi::wifi::Configuration::Client(
-                esp_wifi::wifi::ClientConfiguration {
-                    ssid: net.ssid.into(),
-                    password: net.pass.into(),
-                    bssid,
-                    channel: chan,
-                    ..Default::default()
-                },
-            ));
-        let _ = self.controller.connect();
+        let _ = block_on(self.controller.disconnect_async());
+        // #233: StationConfig has private fields — build via BuilderLite setters. 0.18's
+        // with_bssid/with_channel take the INNER value (wrapping in Some), so only call them
+        // when we actually have a bssid / channel; otherwise leave the defaults (None).
+        let mut sta_cfg = StationConfig::default()
+            .with_ssid(net.ssid)
+            .with_password(net.pass.into());
+        if let Some(b) = bssid {
+            sta_cfg = sta_cfg.with_bssid(b);
+        }
+        if let Some(c) = chan {
+            sta_cfg = sta_cfg.with_channel(c);
+        }
+        let _ = self.controller.set_config(&Config::Station(sta_cfg));
+        let _ = block_on(self.controller.connect_async());
         // Track the resulting channel so `off-channel` (!= ESP_NOW_FIXED_CHANNEL) is detectable
         // pre-fetch without a live controller query (0 = NoAp → still off-channel → retry next arm).
         self.my_ap_channel = match decision {
@@ -4683,7 +4708,7 @@ impl RadioManager {
         use crate::ota_mesh::{
             self as om, LeafOtaOutcome, CHUNK_PAYLOAD, WINDOW_BYTES, WINDOW_CHUNKS,
         };
-        use esp_bootloader_esp_idf::ota::Slot;
+        use esp_bootloader_esp_idf::partitions::AppPartitionSubType as Slot;
         // #237: a GATEWAY-fetch serve needs the crown role (it does the WiFi fetch); a HOLDER
         // active-slot serve is authorized by the crown's ODEL (term/session + serve-time
         // readback-sha verified by the caller), so it does NOT require is_gateway.
@@ -4714,10 +4739,10 @@ impl RadioManager {
             let _ = self.switch(Mode::EspNow); // ch6 (the flush left us in WifiSta)
             let mut s = 0u16;
             while s < 40 {
-                if !matches!(self.controller.is_connected(), Ok(true)) {
+                if !self.controller.is_connected() {
                     break;
                 }
-                let _ = self.controller.disconnect();
+                let _ = block_on(self.controller.disconnect_async());
                 s = s.saturating_add(1);
                 if tick() {
                     return LeafOtaOutcome::Aborted;
@@ -4726,7 +4751,7 @@ impl RadioManager {
             let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
             if !self.esp_now.peer_exists(&BROADCAST_ADDRESS) {
                 let _ = self.esp_now.add_peer(PeerInfo {
-                    interface: EspNowWifiInterface::Sta,
+                    interface: EspNowWifiInterface::Station,
                     peer_address: BROADCAST_ADDRESS,
                     lmk: None,
                     channel: None,
@@ -4828,7 +4853,7 @@ impl RadioManager {
         // below proves whether the send now succeeds.
         if !self.esp_now.peer_exists(&BROADCAST_ADDRESS) {
             let _ = self.esp_now.add_peer(PeerInfo {
-                interface: EspNowWifiInterface::Sta,
+                interface: EspNowWifiInterface::Station,
                 peer_address: BROADCAST_ADDRESS,
                 lmk: None,
                 channel: None,
@@ -4844,10 +4869,10 @@ impl RadioManager {
         // the STA held on — settle>0 confirms this WAS the off-channel egress.
         let mut settle: u16 = 0;
         while settle < 40 {
-            if !matches!(self.controller.is_connected(), Ok(true)) {
+            if !self.controller.is_connected() {
                 break;
             }
-            let _ = self.controller.disconnect();
+            let _ = block_on(self.controller.disconnect_async());
             settle = settle.saturating_add(1);
             if tick() {
                 return LeafOtaOutcome::Aborted;
@@ -6575,7 +6600,7 @@ impl RadioManager {
             }
         }
         let _ = self.esp_now.add_peer(PeerInfo {
-            interface: EspNowWifiInterface::Sta,
+            interface: EspNowWifiInterface::Station,
             peer_address: mac,
             lmk: None,
             channel: None,

--- a/rust/clock/src/net/radio_dev.rs
+++ b/rust/clock/src/net/radio_dev.rs
@@ -1,0 +1,85 @@
+//! smoltcp `phy::Device` shim over esp-radio 0.18's raw WiFi rx/tx tokens.
+//!
+//! #233 TRANSITIONAL. esp-radio 0.18 dropped the `smoltcp` feature that esp-wifi
+//! 0.15 shipped: its STA `Interface` now implements only `embassy_net_driver::Driver`.
+//! smol drives a *raw* smoltcp `Interface`/`SocketSet` from its synchronous superloop
+//! (see `net::wifi` / `net::mode`), so we re-expose the device's raw `receive()` /
+//! `transmit()` tokens through smoltcp's `phy::Device` trait. This is exactly the
+//! adapter esp-wifi used to provide internally; when smol moves to embassy-net
+//! (#198) this whole module is deleted.
+
+use esp_radio::wifi::{Interface, WifiRxToken, WifiTxToken};
+use smoltcp::phy::{self, DeviceCapabilities, Medium};
+use smoltcp::time::Instant;
+
+/// Standard Ethernet frame MTU. esp-radio's internal `MTU` const is `pub(crate)`,
+/// so we mirror the 1514 the old esp-wifi `WifiDevice` reported for the same silicon.
+const WIFI_MTU: usize = 1514;
+
+/// Newtype wrapping esp-radio's (Copy) STA `Interface` handle so we can implement
+/// smoltcp's `phy::Device` on it. The real rx/tx state lives in esp-radio's global
+/// packet queues; this handle is just a lightweight token source.
+pub struct SmolWifiDevice(Interface<'static>);
+
+impl SmolWifiDevice {
+    /// Wrap the STA interface returned by `esp_radio::wifi::new(..).1.station`.
+    pub fn new(iface: Interface<'static>) -> Self {
+        Self(iface)
+    }
+
+    /// STA MAC — used to seed the smoltcp `Interface`'s hardware address.
+    pub fn mac_address(&self) -> [u8; 6] {
+        self.0.mac_address()
+    }
+}
+
+/// smoltcp RX token wrapping esp-radio's raw `WifiRxToken`.
+pub struct RxToken(WifiRxToken);
+/// smoltcp TX token wrapping esp-radio's raw `WifiTxToken`.
+pub struct TxToken(WifiTxToken);
+
+impl phy::RxToken for RxToken {
+    fn consume<R, F>(self, f: F) -> R
+    where
+        F: FnOnce(&[u8]) -> R,
+    {
+        // esp-radio hands the callback a `&mut [u8]`; smoltcp's RxToken wants `&[u8]`
+        // (a `&mut` coerces to `&` at the call site).
+        self.0.consume_token(|buf| f(buf))
+    }
+}
+
+impl phy::TxToken for TxToken {
+    fn consume<R, F>(self, len: usize, f: F) -> R
+    where
+        F: FnOnce(&mut [u8]) -> R,
+    {
+        self.0.consume_token(len, f)
+    }
+}
+
+impl phy::Device for SmolWifiDevice {
+    type RxToken<'a>
+        = RxToken
+    where
+        Self: 'a;
+    type TxToken<'a>
+        = TxToken
+    where
+        Self: 'a;
+
+    fn receive(&mut self, _now: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+        self.0.receive().map(|(rx, tx)| (RxToken(rx), TxToken(tx)))
+    }
+
+    fn transmit(&mut self, _now: Instant) -> Option<Self::TxToken<'_>> {
+        self.0.transmit().map(TxToken)
+    }
+
+    fn capabilities(&self) -> DeviceCapabilities {
+        let mut caps = DeviceCapabilities::default();
+        caps.max_transmission_unit = WIFI_MTU;
+        caps.medium = Medium::Ethernet;
+        caps
+    }
+}

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -29,15 +29,18 @@ extern crate alloc;
 use core::net::Ipv4Addr;
 
 use esp_hal::{
-    peripherals::{RNG, TIMG0, WIFI},
+    interrupt::software::SoftwareInterruptControl,
+    peripherals::{SW_INTERRUPT, TIMG0, WIFI},
     rng::Rng,
     time::{Duration, Instant},
     timer::timg::TimerGroup,
 };
-use esp_wifi::{
-    wifi::{ClientConfiguration, Configuration},
-    EspWifiController,
-};
+use esp_radio::wifi::{sta::StationConfig, Config};
+
+use crate::net::SmolWifiDevice;
+// #233: esp-radio 0.18's connect/disconnect are async-only; drive them to completion
+// synchronously (the esp-rtos scheduler preempts the busy loop to run the radio task).
+use embassy_futures::block_on;
 use smoltcp::{
     iface::{Interface, SocketSet, SocketStorage},
     socket::{dhcpv4, tcp, udp},
@@ -437,7 +440,10 @@ pub(crate) const RELAY_FLUSH_BUDGET: Duration = Duration::from_secs(15); // read
 
 pub struct WifiPeripherals {
     pub timg0: TIMG0<'static>,
-    pub rng: RNG<'static>,
+    // #233: esp-radio 0.18's scheduler (esp-rtos) needs SW_INTERRUPT.software_interrupt0
+    // for context switches. The RNG peripheral is no longer threaded in — esp-hal 1.1's
+    // `Rng::new()` is arg-less and esp-radio pulls entropy internally.
+    pub sw_int: SW_INTERRUPT<'static>,
     pub wifi: WIFI<'static>,
 }
 
@@ -450,7 +456,7 @@ fn smoltcp_now() -> smoltcp::time::Instant {
 
 /// Build a smoltcp `Interface` bound to the WiFi STA device (verbatim from the
 /// esp-wifi `wifi_dhcp` example's `create_interface`).
-fn create_interface(device: &mut esp_wifi::wifi::WifiDevice) -> Interface {
+fn create_interface(device: &mut SmolWifiDevice) -> Interface {
     Interface::new(
         smoltcp::iface::Config::new(HardwareAddress::Ethernet(EthernetAddress::from_bytes(
             &device.mac_address(),
@@ -473,19 +479,20 @@ pub fn try_time_sync(
 ) -> Option<u32> {
     super::init_heap();
 
-    // --- Radio init ------------------------------------------------------
+    // --- Radio init (#233: esp-radio 0.18 + esp-rtos scheduler) ----------
     let timg0 = TimerGroup::new(p.timg0);
-    // `Rng` is a `Copy` handle; keep our own copy for the SNTP port seed.
-    let rng = Rng::new(p.rng);
-    let esp_wifi_ctrl: EspWifiController<'static> =
-        esp_wifi::init(timg0.timer0, rng).ok()?;
-    // Leak the controller so its borrow lives 'static for the rest of the
-    // burst; the device is dropped when we return, which stops WiFi cleanly.
-    let esp_wifi_ctrl: &'static EspWifiController<'static> =
-        alloc::boxed::Box::leak(alloc::boxed::Box::new(esp_wifi_ctrl));
-
-    let (mut controller, interfaces) = esp_wifi::wifi::new(esp_wifi_ctrl, p.wifi).ok()?;
-    let mut device = interfaces.sta;
+    let sw = SoftwareInterruptControl::new(p.sw_int);
+    // esp-radio's os-adapter needs the esp-rtos scheduler running BEFORE wifi::new.
+    // NON-embassy: start() converts THIS context into the pinned main task and returns,
+    // so the blocking superloop below runs unchanged while the radio task preempts in.
+    esp_rtos::start(timg0.timer0, sw.software_interrupt0);
+    // `Rng` is a `Copy` handle; keep our own copy for the SNTP source-port seed.
+    let rng = Rng::new();
+    // In 0.18 the WIFI peripheral is 'static, so wifi::new returns an owned 'static
+    // controller + interfaces — no more EspWifiController Box::leak.
+    let (mut controller, interfaces) =
+        esp_radio::wifi::new(p.wifi, super::radio_controller_config()).ok()?;
+    let mut device = SmolWifiDevice::new(interfaces.station);
 
     // Phase-2 (wifi-only) build has no status LED, so the tick is a no-op.
     // wifi-only build has no relay/gateway role, so the reached-DHCP flag is unused.
@@ -643,7 +650,7 @@ impl NtpMachine {
     /// Build the hoisted smoltcp stack (DHCP + UDP/SNTP + TCP/MQTT sockets over the
     /// module `static mut` buffers) and start in `Assoc`. `sntp_src_port` is the
     /// caller's RNG-seeded ephemeral port for the SNTP request.
-    fn new(device: &mut esp_wifi::wifi::WifiDevice, sntp_src_port: u16) -> Self {
+    fn new(device: &mut SmolWifiDevice, sntp_src_port: u16) -> Self {
         let iface = create_interface(device);
 
         // SAFETY: F2 precedent — boot-only, single-caller, main-thread, never re-entered
@@ -706,8 +713,8 @@ impl NtpMachine {
     /// `BURST_POLL_BUDGET` of continuous progress.
     fn poll(
         &mut self,
-        controller: &mut esp_wifi::wifi::WifiController<'static>,
-        device: &mut esp_wifi::wifi::WifiDevice<'static>,
+        controller: &mut esp_radio::wifi::WifiController<'static>,
+        device: &mut SmolWifiDevice,
     ) -> NtpPoll {
         let poll_start = Instant::now();
         loop {
@@ -732,14 +739,14 @@ impl NtpMachine {
     /// reconfigure, not pumpable — design §2) runs once per attempt; then we poll
     /// `is_connected()`. Returns whether the phase advanced this step (`false` = still
     /// waiting → yield).
-    fn step_assoc(&mut self, controller: &mut esp_wifi::wifi::WifiController<'static>) -> bool {
+    fn step_assoc(&mut self, controller: &mut esp_radio::wifi::WifiController<'static>) -> bool {
         let net = &crate::secrets::WIFI_NETWORK;
         // #192: an ALREADY-associated caller (the periodic NTP re-sync burst on a coexist
         // gateway) skips the disconnect/reconfigure/connect FFI — issuing it would TEAR a live
         // coexist association (mesh-deaf + re-election churn) for no reason. Go straight to DHCP.
         // Boot is NOT yet connected here, so the boot burst still runs the full setup below →
         // boot behaviour is byte-identical.
-        if !self.assoc_configured && matches!(controller.is_connected(), Ok(true)) {
+        if !self.assoc_configured && controller.is_connected() {
             self.assoc_configured = true;
             self.deadline = Instant::now() + SYNC_BUDGET; // shared DHCP+SNTP budget
             self.phase = NtpPhase::Dhcp;
@@ -747,19 +754,23 @@ impl NtpMachine {
         }
         if !self.assoc_configured {
             // Drop any prior association before reconfiguring (harmless if not connected).
-            let _ = controller.disconnect();
+            let _ = block_on(controller.disconnect_async());
+            // #233: esp-radio 0.18's StationConfig has private fields — build via BuilderLite.
+            #[allow(unused_mut)]
+            let mut sta_cfg = StationConfig::default()
+                .with_ssid(net.ssid)
+                .with_password(net.pass.into());
+            // COEXIST SOAK (#23 PART 1): pin association to ch1. (0.18 with_channel takes u8,
+            // wrapping it in Some internally.)
+            #[cfg(feature = "coexist-soak")]
+            {
+                sta_cfg = sta_cfg.with_channel(1);
+            }
             let ok = controller
-                .set_configuration(&Configuration::Client(ClientConfiguration {
-                    ssid: net.ssid.into(),
-                    password: net.pass.into(),
-                    // COEXIST SOAK (#23 PART 1): pin association to ch1.
-                    #[cfg(feature = "coexist-soak")]
-                    channel: Some(1),
-                    ..Default::default()
-                }))
+                // #233: set_config STARTS the controller in 0.18 (no separate start()).
+                .set_config(&Config::Station(sta_cfg))
                 .is_ok()
-                && (matches!(controller.is_started(), Ok(true)) || controller.start().is_ok())
-                && controller.connect().is_ok();
+                && block_on(controller.connect_async()).is_ok();
             if !ok {
                 return self.assoc_attempt_failed();
             }
@@ -767,7 +778,7 @@ impl NtpMachine {
             self.deadline = Instant::now() + SYNC_BUDGET; // per-attempt assoc budget
             return true;
         }
-        if matches!(controller.is_connected(), Ok(true)) {
+        if controller.is_connected() {
             log::info!("smol #142: associated to '{}'", net.ssid);
             // Shared DHCP+SNTP budget starts now (mirrors the pre-#89 `deadline` set at
             // the top of the DHCP loop).
@@ -799,7 +810,7 @@ impl NtpMachine {
 
     /// DHCP step: one `iface.poll()`, apply a lease if it arrived. On a lease, set the
     /// gateway qualifier (N3c: `run_ntp_burst` returns `ReachedDhcp`) and advance to SNTP.
-    fn step_dhcp(&mut self, device: &mut esp_wifi::wifi::WifiDevice<'static>) -> bool {
+    fn step_dhcp(&mut self, device: &mut SmolWifiDevice) -> bool {
         let changed = matches!(
             self.iface.poll(smoltcp_now(), device, &mut self.sockets),
             smoltcp::iface::PollResult::SocketStateChanged
@@ -828,7 +839,7 @@ impl NtpMachine {
     /// SNTP step: bind once, send the NTPv4 request once the socket can send, parse a
     /// reply into Unix seconds. Deadline → `Done(None)` (DHCP already succeeded → MQTT
     /// tail still runs, just no time this burst).
-    fn step_sntp(&mut self, device: &mut esp_wifi::wifi::WifiDevice<'static>) -> bool {
+    fn step_sntp(&mut self, device: &mut SmolWifiDevice) -> bool {
         let changed = matches!(
             self.iface.poll(smoltcp_now(), device, &mut self.sockets),
             smoltcp::iface::PollResult::SocketStateChanged
@@ -977,9 +988,9 @@ pub(crate) const NTP_RESYNC_AGE_S: u32 = 3600;
 /// flush/burst is ever in flight in the single-threaded main loop), so the borrows never overlap.
 #[cfg(feature = "espnow")]
 pub fn run_ntp_resync(
-    controller: &mut esp_wifi::wifi::WifiController<'static>,
-    device: &mut esp_wifi::wifi::WifiDevice<'static>,
-    mut rng: Rng,
+    controller: &mut esp_radio::wifi::WifiController<'static>,
+    device: &mut SmolWifiDevice,
+    rng: Rng,
     tick: &mut dyn FnMut() -> bool,
 ) -> Option<u32> {
     let sntp_src_port = 49152 + (rng.random() % 16384) as u16;
@@ -1013,9 +1024,9 @@ pub fn run_ntp_resync(
 /// of the firmware's style and keeping the dependency set on crates.io.
 #[allow(clippy::too_many_arguments)] // +grid (issue #16) tips this to 8 params
 pub fn run_ntp_burst(
-    controller: &mut esp_wifi::wifi::WifiController<'static>,
-    device: &mut esp_wifi::wifi::WifiDevice<'static>,
-    mut rng: Rng,
+    controller: &mut esp_radio::wifi::WifiController<'static>,
+    device: &mut SmolWifiDevice,
+    rng: Rng,
     tick: &mut dyn FnMut() -> bool,
     // #89 Stage 1: painted on each prologue yield (assoc/DHCP/SNTP stall) so the boot
     // screen shows a LIVE clock through the sync window. UI-agnostic here — the display
@@ -2433,7 +2444,7 @@ impl RelayCache {
 #[cfg(feature = "wifi")]
 fn tcp_send(
     iface: &mut Interface,
-    device: &mut esp_wifi::wifi::WifiDevice,
+    device: &mut SmolWifiDevice,
     sockets: &mut SocketSet,
     handle: smoltcp::iface::SocketHandle,
     data: &[u8],
@@ -2576,7 +2587,7 @@ pub(crate) fn ota_fail_is_bulk_deaf(w: u32) -> bool {
 #[allow(clippy::too_many_arguments)]
 fn mqtt_session(
     iface: &mut Interface,
-    device: &mut esp_wifi::wifi::WifiDevice,
+    device: &mut SmolWifiDevice,
     sockets: &mut SocketSet,
     tcp_handle: smoltcp::iface::SocketHandle,
     node_id: u8,
@@ -4902,9 +4913,9 @@ fn mqtt_session(
 #[cfg(feature = "espnow")]
 #[allow(clippy::too_many_arguments)] // +grid (issue #16) tips this to 8 params
 pub fn run_mqtt_burst(
-    controller: &mut esp_wifi::wifi::WifiController<'static>,
-    device: &mut esp_wifi::wifi::WifiDevice<'static>,
-    mut rng: Rng,
+    controller: &mut esp_radio::wifi::WifiController<'static>,
+    device: &mut SmolWifiDevice,
+    rng: Rng,
     node_id: u8,
     messages: &[(u8, &[u8])],
     batt: &mut crate::batt::BattCache,
@@ -5046,12 +5057,12 @@ pub fn run_mqtt_burst(
     // one full RECONNECT_EVERY window before the first retry.
     const RECONNECT_EVERY: Duration = Duration::from_millis(2000);
     let mut next_reconnect = Instant::now() + RECONNECT_EVERY;
-    while !matches!(controller.is_connected(), Ok(true)) {
+    while !controller.is_connected() {
         if tick() {
             return false; // #20 abort during flush re-association
         }
         if Instant::now() > next_reconnect {
-            let _ = controller.connect();
+            let _ = block_on(controller.connect_async());
             next_reconnect = Instant::now() + RECONNECT_EVERY;
         }
         if Instant::now() > deadline {
@@ -5065,7 +5076,7 @@ pub fn run_mqtt_burst(
     // resets the IDF ps state, and here the unicast that matters is the whole TCP /
     // MQTT stream (the old UDP path only needed the ARP reply). Same reasoning,
     // same placement (must be AFTER the reconnect). Tradeoff: higher idle draw.
-    let _ = controller.set_power_saving(esp_wifi::config::PowerSaveMode::None);
+    let _ = controller.set_power_saving(esp_radio::wifi::PowerSaveMode::None);
     crate::net::assert_max_tx_power(); // #141
 
     // #64: capture the WiFi-uplink RSSI HERE — the STA is confirmed connected (the loop
@@ -5213,7 +5224,7 @@ const CAST_FRAME_INTERVAL: Duration = Duration::from_millis(100);
 #[cfg(feature = "cast")]
 fn cast_stream(
     iface: &mut Interface,
-    device: &mut esp_wifi::wifi::WifiDevice<'static>,
+    device: &mut SmolWifiDevice,
     sockets: &mut SocketSet,
     cast_handle: smoltcp::iface::SocketHandle,
     src_port: u16,
@@ -5338,7 +5349,7 @@ fn parse_ipv4(host: &str) -> Option<smoltcp::wire::Ipv4Address> {
 #[allow(clippy::too_many_arguments)]
 fn publish_ota_progress(
     iface: &mut Interface,
-    device: &mut esp_wifi::wifi::WifiDevice,
+    device: &mut SmolWifiDevice,
     sockets: &mut SocketSet,
     tcp_handle: smoltcp::iface::SocketHandle,
     src_port: u16,
@@ -5457,9 +5468,9 @@ fn publish_ota_progress(
 #[cfg(feature = "espnow")]
 #[allow(clippy::too_many_arguments)] // +fail diag (#139-followup) tips this to 8 params
 pub fn run_ota_fetch(
-    controller: &mut esp_wifi::wifi::WifiController<'static>,
-    device: &mut esp_wifi::wifi::WifiDevice<'static>,
-    mut rng: Rng,
+    controller: &mut esp_radio::wifi::WifiController<'static>,
+    device: &mut SmolWifiDevice,
+    rng: Rng,
     announce: &crate::ota::Announce,
     tick: &mut dyn FnMut() -> bool,
     // #40 relay-mode: when true, stage+verify the image to the inactive slot but do NOT
@@ -5467,7 +5478,7 @@ pub fn run_ota_fetch(
     // it to a leaf (no gateway reboot). Self-OTA passes `false` + `&mut None` → the fetch
     // body is byte-identical, only the terminal action differs (activate-reboot vs return).
     relay_mode: bool,
-    staged_slot: &mut Option<esp_bootloader_esp_idf::ota::Slot>,
+    staged_slot: &mut Option<esp_bootloader_esp_idf::partitions::AppPartitionSubType>,
     // #139-followup observability: on a genuine self-fetch FAILURE (not a user abort), set to
     // `(chunk_k, chunk_n, retries, stalls)` — how far the download got + the transfer-trouble
     // counters. The self-OTA caller (`run_ota_update`) formats + publishes it retained to
@@ -5545,7 +5556,7 @@ pub fn run_ota_fetch(
     let deadline = Instant::now() + OTA_FETCH_BUDGET;
 
     // The caller's switch(WifiSta) already issued connect(); wait for association.
-    while !matches!(controller.is_connected(), Ok(true)) {
+    while !controller.is_connected() {
         if tick() {
             return false;
         }
@@ -5555,7 +5566,7 @@ pub fn run_ota_fetch(
             return false;
         }
     }
-    let _ = controller.set_power_saving(esp_wifi::config::PowerSaveMode::None);
+    let _ = controller.set_power_saving(esp_radio::wifi::PowerSaveMode::None);
     crate::net::assert_max_tx_power(); // #141
 
     // Fresh DHCP lease (interface just rebuilt).

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -35,7 +35,7 @@ use esp_hal::{
     time::{Duration, Instant},
     timer::timg::TimerGroup,
 };
-use esp_radio::wifi::{sta::StationConfig, Config};
+use esp_radio::wifi::{sta::{ScanMethod, StationConfig}, Config};
 
 use crate::net::SmolWifiDevice;
 // #233: esp-radio 0.18's connect/disconnect are async-only; drive them to completion
@@ -759,7 +759,15 @@ impl NtpMachine {
             #[allow(unused_mut)]
             let mut sta_cfg = StationConfig::default()
                 .with_ssid(net.ssid)
-                .with_password(net.pass.into());
+                .with_password(net.pass.into())
+                // #337/#233: carry the 2026-07-20 ALL-CHANNEL SCAN fix forward. It used to be the
+                // build-env knob ESP_WIFI_CONFIG_SCAN_METHOD=1, which esp-radio 0.18 deleted; the
+                // 0.18 equivalent is this runtime StationConfig field, and its default is
+                // `Fast` — i.e. the exact WIFI_FAST_SCAN behaviour that was the #204/#217 root
+                // cause (stop at the FIRST matching-SSID AP → associate to a WEAK ch1 AP over the
+                // STRONG ch6 one → off-channel → OTA-deaf). Scan every channel, then take the
+                // strongest. Prerequisite for the best-gateway election's co_channel/ap_rssi inputs.
+                .with_scan_method(ScanMethod::AllChannels);
             // COEXIST SOAK (#23 PART 1): pin association to ch1. (0.18 with_channel takes u8,
             // wrapping it in Some internally.)
             #[cfg(feature = "coexist-soak")]

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -903,7 +903,9 @@ fn encode_ledger_key(seed: &[u8; 32]) -> [u8; LEDGER_KEY_REC_LEN] {
 #[cfg(feature = "espnow")]
 fn read_ledger_key_nvs() -> Option<[u8; 32]> {
     use embedded_storage::nor_flash::ReadNorFlash;
-    let mut flash = FlashStorage::new();
+    // #233: esp-storage 0.9 — handle comes from the shared `flash()` steal helper. Sequential
+    // and dropped on return; `resolve_ledger_key` runs once at boot, never during an OTA.
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let pt = read_partition_table(&mut flash, &mut buf).ok()?;
     let nvs = pt
@@ -922,7 +924,9 @@ fn read_ledger_key_nvs() -> Option<[u8; 32]> {
 #[cfg(feature = "ledger-provision")]
 fn provision_ledger_key_nvs(seed: &[u8; 32]) -> bool {
     use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
-    let mut flash = FlashStorage::new();
+    // #233: esp-storage 0.9 — see `flash()`. Runs only on a `ledger-provision` build at boot,
+    // strictly after the read above has dropped its handle: never two live at once.
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
         return false;
@@ -931,7 +935,7 @@ fn provision_ledger_key_nvs(seed: &[u8; 32]) -> bool {
         return false;
     };
     let mut region = nvs.as_embedded_storage(&mut flash);
-    let sector = <FlashStorage as NorFlash>::ERASE_SIZE as u32;
+    let sector = <FlashStorage<'_> as NorFlash>::ERASE_SIZE as u32;
     // Refuse unless the WHOLE target sector is erased — never overwrite an existing key.
     let mut chunk = [0u8; 64];
     let mut off = LEDGER_KEY_OFFSET;

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -26,14 +26,53 @@
 //! is defence-in-depth, not authentication. Do NOT let any code imply sha256 == trust.
 
 use esp_bootloader_esp_idf::ota::{Ota, OtaImageState};
-use esp_bootloader_esp_idf::partitions::{read_partition_table, DataPartitionSubType, PartitionType};
+// #233: esp-bootloader 0.5 made the `Slot` enum PRIVATE. The public currency is now
+// `AppPartitionSubType` (the APP partition you name), so smol's OTA engine uses that
+// throughout: Slot0↔Ota0, Slot1↔Ota1, blank-otadata↔Factory (what current_app_partition()
+// returns on a blank/uninitialised record — smol has no factory partition, so the ROM boots
+// ota_0 and the true inactive target is Ota1).
+use esp_bootloader_esp_idf::partitions::{
+    read_partition_table, AppPartitionSubType, DataPartitionSubType, PartitionType,
+};
 use esp_storage::FlashStorage;
-// Named only by the download/activation path (the wifi-only build reads announces but
-// never fetches, so these would be unused imports there).
-#[cfg(feature = "espnow")]
-use esp_bootloader_esp_idf::ota::Slot;
-#[cfg(feature = "espnow")]
-use esp_bootloader_esp_idf::partitions::AppPartitionSubType;
+
+/// #233: esp-storage 0.9's `FlashStorage::new` CONSUMES the FLASH peripheral. Its
+/// "Panics if called more than once" doc is the *compile-time move contract* on the
+/// esp-hal peripheral singleton, NOT a runtime check — two independent source-reads
+/// (#247's flashstorage-steal-verdict) confirmed there is NO once-guard anywhere in
+/// esp-storage 0.9 (the lone `.unwrap()` is capacity-detect), and esp-hal 1.1.1's
+/// `FLASH::steal()` fabricates the zero-state token unconditionally. So a freshly-stolen
+/// per-op handle reproduces the exact semantics of the old 0.7 throwaway
+/// `flash()` — each call just re-reads the constant flash-size header. This
+/// avoids threading the FLASH peripheral through the whole radio stack
+/// (main → mode → RadioManager → run_ota_fetch) and dodges a `&mut FlashStorage` borrow
+/// held across the streaming write.
+///
+/// ⚠️ HUMAN-AUDITED INVARIANT (steal() moves the exclusivity guarantee from the compiler
+/// to us — the risk class is a torn write from a concurrent flash user overlapping an
+/// in-flight OTA op):
+/// - Callers must NEVER hold two `FlashStorage` instances live-and-in-use at once.
+/// - ALL flash access stays on the main loop: OTA is strictly serial (one
+///   `ImageWriter`/`LeafImageWriter` at a time; the otadata/identity helpers run before
+///   begin / after finalize, never concurrently), and no ISR touches flash.
+///
+/// This holds STRUCTURALLY in the non-embassy superloop. #198 (embassy-net migration):
+/// re-evaluate this deliberately — once flash users can interleave at await points, move
+/// to a single owned instance (StaticCell/once-init here in `ota::`) instead of per-op
+/// steal. Do not carry this helper into an async world unexamined.
+fn flash() -> FlashStorage<'static> {
+    FlashStorage::new(unsafe { esp_hal::peripherals::FLASH::steal() })
+}
+
+/// The OTHER app partition — the inactive slot to write / roll back to. Replaces the old
+/// `Slot::next()` (now private in 0.5). Blank otadata reports `Factory`; smol has no factory
+/// partition (ROM boots ota_0), so `Factory`/`Ota0` ⇒ the inactive target is `Ota1`.
+fn other_app(cur: AppPartitionSubType) -> AppPartitionSubType {
+    match cur {
+        AppPartitionSubType::Ota1 => AppPartitionSubType::Ota0,
+        _ => AppPartitionSubType::Ota1, // Ota0 | Factory(blank) | anything else
+    }
+}
 
 /// This firmware's monotonic build number (git `rev-list --count`), embedded by
 /// `build.rs` as `BUILD_NUMBER` and parsed at compile time. The MONOTONICITY gate
@@ -421,8 +460,8 @@ static mut OTA_RESUME: OtaResumeState = OtaResumeState { saved: None };
 
 /// Target-slot discriminator for the resume key (`0` = Slot0, `1` = Slot1).
 #[cfg(feature = "espnow")]
-fn slot_key(s: Slot) -> u8 {
-    if s == Slot::Slot1 {
+fn slot_key(s: AppPartitionSubType) -> u8 {
+    if s == AppPartitionSubType::Ota1 {
         1
     } else {
         0
@@ -432,7 +471,7 @@ fn slot_key(s: Slot) -> u8 {
 /// The resume offset for a fresh fetch of `(build, sha)` into `slot` — `0` if none matches (a fresh
 /// fetch from byte 0). Delegates the match to the pure `net::ota_resume::resume_offset`.
 #[cfg(feature = "espnow")]
-fn ota_resume_lookup(build: u32, sha: &[u8; 32], slot: Slot, size: u32) -> u32 {
+fn ota_resume_lookup(build: u32, sha: &[u8; 32], slot: AppPartitionSubType, size: u32) -> u32 {
     let want = crate::net::ota_resume::ResumeKey {
         build,
         sha_key: crate::net::ota_resume::sha_key16(sha),
@@ -460,7 +499,9 @@ pub fn ota_resume_clear() {
 
 #[cfg(feature = "espnow")]
 pub struct ImageWriter {
-    flash: FlashStorage,
+    // #233: esp-storage 0.9 FlashStorage is lifetime'd; the writer owns a 'static handle
+    // (from the stolen FLASH peripheral via `flash()`), held for the whole streaming write.
+    flash: FlashStorage<'static>,
     /// Absolute flash offset of the target slot.
     base: u32,
     /// Target slot capacity (write bound).
@@ -481,7 +522,7 @@ pub struct ImageWriter {
     /// #267: identifies the staged image + slot this fetch belongs to, so each sector flush can
     /// persist the resume cursor keyed to it (a re-stage / slot flip then can't resume onto it).
     resume_key: crate::net::ota_resume::ResumeKey,
-    target: Slot,
+    target: AppPartitionSubType,
 }
 
 #[cfg(feature = "espnow")]
@@ -490,14 +531,12 @@ impl ImageWriter {
     /// `None` on any partition/flash error (e.g. a board without the OTA table).
     pub fn begin(build: u32, expected_sha: &[u8; 32]) -> Option<ImageWriter> {
         let target = inactive_slot()?;
-        let sub = if target == Slot::Slot1 {
-            AppPartitionSubType::Ota1
-        } else {
-            AppPartitionSubType::Ota0
-        };
+        // #233: `target` is already the AppPartitionSubType to write (inactive_slot → other_app,
+        // always Ota0/Ota1), so the write-target partition IS the target.
+        let sub = target;
         // Fresh flash + scratch: only `find_partition` is used here (it borrows the
         // parsed table, NOT the flash), so `flash` stays free to move into the writer.
-        let mut flash = FlashStorage::new();
+        let mut flash = flash();
         let mut buf = [0u8; PT_SCRATCH];
         let (base, size) = {
             let pt = read_partition_table(&mut flash, &mut buf).ok()?;
@@ -534,7 +573,7 @@ impl ImageWriter {
     }
 
     /// The slot this writer targets (needed by [`activate`] after a good finalize).
-    pub fn target(&self) -> Slot {
+    pub fn target(&self) -> AppPartitionSubType {
         self.target
     }
 
@@ -577,7 +616,7 @@ impl ImageWriter {
             return true;
         }
         let erase_to = self.base + self.flushed + len as u32;
-        let sector = <FlashStorage as NorFlash>::ERASE_SIZE as u32;
+        let sector = <FlashStorage<'_> as NorFlash>::ERASE_SIZE as u32;
         while self.erased_upto < erase_to {
             let s = self.erased_upto;
             if self.flash.erase(s, s + sector).is_err() {
@@ -585,7 +624,7 @@ impl ImageWriter {
             }
             self.erased_upto = self.erased_upto.saturating_add(sector);
         }
-        let ws = <FlashStorage as NorFlash>::WRITE_SIZE;
+        let ws = <FlashStorage<'_> as NorFlash>::WRITE_SIZE;
         let padded = len.div_ceil(ws) * ws;
         for b in self.stage[len..padded].iter_mut() {
             *b = 0xFF;
@@ -741,7 +780,7 @@ fn encode_identity(id: u8) -> [u8; IDENT_REC_LEN] {
 #[cfg(feature = "wifi")]
 fn read_identity_nvs() -> Option<u8> {
     use embedded_storage::nor_flash::ReadNorFlash;
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let pt = read_partition_table(&mut flash, &mut buf).ok()?;
     let nvs = pt
@@ -759,7 +798,7 @@ fn read_identity_nvs() -> Option<u8> {
 #[cfg(feature = "wifi")]
 fn seed_identity_nvs(id: u8) {
     use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
         return;
@@ -771,7 +810,7 @@ fn seed_identity_nvs(id: u8) {
     // Refuse to write unless the WHOLE first sector is erased (all 0xFF) — guards any
     // (unexpected) real NVS content from being erased. An erase-flashed board's nvs is
     // uniformly 0xFF, so a genuinely-fresh board always seeds.
-    let sector = <FlashStorage as NorFlash>::ERASE_SIZE as u32;
+    let sector = <FlashStorage<'_> as NorFlash>::ERASE_SIZE as u32;
     let mut chunk = [0u8; 64];
     let mut off = 0u32;
     while off < sector {
@@ -955,42 +994,35 @@ pub fn resolve_ledger_key() -> Option<[u8; 32]> {
 /// Read `otadata` → the INACTIVE slot (the write target). Self-contained flash borrow
 /// (its own `FlashStorage`, dropped on return), so it never pins flash for callers.
 #[cfg(feature = "espnow")]
-fn inactive_slot() -> Option<Slot> {
-    let mut flash = FlashStorage::new();
+fn inactive_slot() -> Option<AppPartitionSubType> {
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let pt = read_partition_table(&mut flash, &mut buf).ok()?;
     let od = pt
         .find_partition(PartitionType::Data(DataPartitionSubType::Ota))
         .ok()??;
-    let mut region = od.as_embedded_storage(&mut flash);
-    let mut ota = Ota::new(&mut region).ok()?;
-    // #226 SELF-OVERWRITE FIX: on a BLANK/uninitialized otadata, `current_slot()` returns
-    // `Slot::None`, and `Slot::None.next()` folds to `Slot::Slot0` (esp-bootloader 0.2.0
-    // ota.rs:64) — i.e. the RUNNING slot, so an OTA would overwrite the LIVE image (a boot-
-    // critical self-overwrite / brick class). A blank otadata always ROM-falls-back to ota_0
-    // (there is no factory partition in partitions-ota.csv), so the running slot is provably
-    // ota_0 and the true inactive write-target is ota_1. Explicit match instead of the blind
-    // `.next()`. Validated against JP's ESP32-C6 watch (esp-bootloader 0.5), which avoids this
-    // exact bug the same way — the `.next()` footgun SURVIVES into 0.5 (current_slot() still
-    // returns None on blank), so the crate bump does NOT auto-fix it; the explicit mapping does
-    // (watch study: scratch/watch-backport/226-comment.md, task #49).
+    let region = od.as_embedded_storage(&mut flash);
+    let mut ota = Ota::new(region, 2).ok()?;
+    // #226/#233 SELF-OVERWRITE FIX: on a BLANK/uninitialised otadata, current_app_partition()
+    // returns `Factory` (esp-bootloader 0.5). smol has NO factory partition (partitions-ota.csv),
+    // so the ROM boots ota_0 — the running slot is provably ota_0 and the true inactive
+    // write-target is ota_1. `other_app` encodes exactly that (Factory|Ota0 => Ota1, Ota1 => Ota0),
+    // replacing the old blind `Slot::next()` — now PRIVATE in 0.5 — which folded a blank record to
+    // ota_0 (the LIVE image → a self-overwrite/brick class). The 0.5 rename made the footgun
+    // structurally unwritable from app code; `other_app` keeps the explicit, audited mapping.
+    // Validated against JP's ESP32-C6 watch (same Factory=>Ota1 mapping).
     //
-    // No first-boot otadata write is needed (supersedes the original init sketch): a boot-time
-    // flash write to boot-critical partition state would be an unnecessary risk, and `activate()`
-    // already makes otadata valid (set_current_slot + New) on the first real OTA. So the blank
-    // state self-heals on the first successful update, with zero boot-path flash mutation.
-    let target = match ota.current_slot().ok()? {
-        Slot::None => Slot::Slot1,
-        other => other.next(),
-    };
-    Some(target)
+    // No first-boot otadata write is needed: a boot-time flash write to boot-critical partition
+    // state would be an unnecessary risk, and `activate()` already makes otadata valid
+    // (set_current_app_partition + New) on the first real OTA.
+    Some(other_app(ota.current_app_partition().ok()?))
 }
 
 /// Point `otadata` at the freshly-written `target` slot + arm the state machine
 /// (`New`), then REBOOT into it. Call ONLY after [`ImageWriter::finalize`] returned
 /// true. If the otadata write fails, we do NOT reboot — the good slot stays active.
 #[cfg(feature = "espnow")]
-pub fn activate(target: Slot, new_build: u32, is_leaf_ota: bool) {
+pub fn activate(target: AppPartitionSubType, new_build: u32, is_leaf_ota: bool) {
     if set_slot_new(target).is_some() {
         // #40: tag the marker with the NEW image's build# + OTA type. `boot_confirm` self-tests
         // IFF the running build matches (bug #5 — a USB flash of a different build won't match a
@@ -1009,16 +1041,16 @@ pub fn activate(target: Slot, new_build: u32, is_leaf_ota: bool) {
 }
 
 #[cfg(feature = "espnow")]
-fn set_slot_new(target: Slot) -> Option<()> {
-    let mut flash = FlashStorage::new();
+fn set_slot_new(target: AppPartitionSubType) -> Option<()> {
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let pt = read_partition_table(&mut flash, &mut buf).ok()?;
     let od = pt
         .find_partition(PartitionType::Data(DataPartitionSubType::Ota))
         .ok()??;
-    let mut region = od.as_embedded_storage(&mut flash);
-    let mut ota = Ota::new(&mut region).ok()?;
-    ota.set_current_slot(target).ok()?;
+    let region = od.as_embedded_storage(&mut flash);
+    let mut ota = Ota::new(region, 2).ok()?;
+    ota.set_current_app_partition(target).ok()?;
     ota.set_current_ota_state(OtaImageState::New).ok()?;
     Some(())
 }
@@ -1045,7 +1077,7 @@ fn set_slot_new(target: Slot) -> Option<()> {
 /// BEFORE the #40 unconfirmed-boot block. Boot-critical partition write → HW-canary gated.
 #[cfg(feature = "espnow")]
 pub fn init_otadata_if_blank() {
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
         return;
@@ -1053,16 +1085,16 @@ pub fn init_otadata_if_blank() {
     let Ok(Some(od)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Ota)) else {
         return; // no otadata partition (non-OTA board) → nothing to init
     };
-    let mut region = od.as_embedded_storage(&mut flash);
-    let Ok(mut ota) = Ota::new(&mut region) else {
+    let region = od.as_embedded_storage(&mut flash);
+    let Ok(mut ota) = Ota::new(region, 2) else {
         return;
     };
     // Only touch a genuinely BLANK otadata — never perturb a provisioned record.
-    if !matches!(ota.current_slot(), Ok(Slot::None)) {
+    if !matches!(ota.current_app_partition(), Ok(AppPartitionSubType::Factory)) {
         return;
     }
     // Blank ⟹ ROM booted ota_0 ⟹ formalize Slot0 as the valid boot selection.
-    if ota.set_current_slot(Slot::Slot0).is_err()
+    if ota.set_current_app_partition(AppPartitionSubType::Ota0).is_err()
         || ota.set_current_ota_state(OtaImageState::Valid).is_err()
     {
         log::error!(
@@ -1071,8 +1103,10 @@ pub fn init_otadata_if_blank() {
         return;
     }
     // Verify-after-write (boot-critical): confirm the record now resolves to Slot0.
-    match ota.current_slot() {
-        Ok(Slot::Slot0) => log::info!("smol #226: otadata first-boot init — blank → Slot0/Valid"),
+    match ota.current_app_partition() {
+        Ok(AppPartitionSubType::Ota0) => {
+            log::info!("smol #226: otadata first-boot init — blank → Slot0/Valid")
+        }
         other => log::error!(
             "smol #226: otadata init verify FAILED (got {other:?}) — inactive_slot net still protects OTA"
         ),
@@ -1087,16 +1121,14 @@ pub fn init_otadata_if_blank() {
 /// (don't roll back into the unknown). `wifi`-scoped so `boot_confirm` (also `wifi`) can call
 /// it; the types resolve from the `esp-bootloader-esp-idf` dep present in every radio build.
 #[cfg(feature = "wifi")]
-fn slot_has_valid_image(slot: esp_bootloader_esp_idf::ota::Slot) -> bool {
+fn slot_has_valid_image(slot: AppPartitionSubType) -> bool {
     use embedded_storage::nor_flash::ReadNorFlash;
-    use esp_bootloader_esp_idf::ota::Slot;
-    use esp_bootloader_esp_idf::partitions::AppPartitionSubType;
+    // #233: brick-safe guard — only ota_0/ota_1 are valid rollback targets on smol's table.
     let sub = match slot {
-        Slot::Slot0 => AppPartitionSubType::Ota0,
-        Slot::Slot1 => AppPartitionSubType::Ota1,
-        _ => return false, // >2-slot table we don't use — refuse (brick-safe)
+        AppPartitionSubType::Ota0 | AppPartitionSubType::Ota1 => slot,
+        _ => return false, // factory/test/>2-slot — refuse (brick-safe)
     };
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
         return false;
@@ -1127,7 +1159,7 @@ fn slot_has_valid_image(slot: esp_bootloader_esp_idf::ota::Slot) -> bool {
 /// `Valid` (so we don't loop), and reset — the app-side net that works even with the
 /// bootloader's auto-revert OFF.
 pub fn boot_confirm(self_test_passed: bool) {
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let pt = match read_partition_table(&mut flash, &mut buf) {
         Ok(pt) => pt,
@@ -1137,8 +1169,8 @@ pub fn boot_confirm(self_test_passed: bool) {
         Ok(Some(p)) => p,
         _ => return, // no otadata (non-OTA board) → nothing to confirm
     };
-    let mut region = od.as_embedded_storage(&mut flash);
-    let mut ota = match Ota::new(&mut region) {
+    let region = od.as_embedded_storage(&mut flash);
+    let mut ota = match Ota::new(region, 2) {
         Ok(o) => o,
         Err(_) => return,
     };
@@ -1182,12 +1214,12 @@ pub fn boot_confirm(self_test_passed: bool) {
         // current image (mark Valid, keep running). A USB-flashed image is operator-intended
         // and a mesh-OTA image was ed25519+sha verified before activate, so accepting it is
         // safe; bricking is not.
-        let target = ota.current_slot().ok().map(|c| c.next());
+        let target = ota.current_app_partition().ok().map(other_app);
         let can_rollback = target.map(slot_has_valid_image).unwrap_or(false);
         clear_ota_activated(); // fate decided either way
         if can_rollback {
             if let Some(t) = target {
-                let _ = ota.set_current_slot(t);
+                let _ = ota.set_current_app_partition(t);
             }
             let _ = ota.set_current_ota_state(OtaImageState::Valid);
             mark_ota_outcome(true); // #70: DIAG ota=rolled-back — set BEFORE reset; the good-slot
@@ -1268,7 +1300,7 @@ pub struct LeafImageWriter {
     /// Partition-relative address erased through (sector granularity, monotonic).
     erased_upto: u32,
     /// The slot [`activate`] targets after a good finalize.
-    target: Slot,
+    target: AppPartitionSubType,
 }
 
 #[cfg(feature = "espnow")]
@@ -1276,12 +1308,9 @@ impl LeafImageWriter {
     /// Open a writer for the inactive slot. `None` on any partition/flash error.
     pub fn begin() -> Option<LeafImageWriter> {
         let target = inactive_slot()?;
-        let sub = if target == Slot::Slot1 {
-            AppPartitionSubType::Ota1
-        } else {
-            AppPartitionSubType::Ota0
-        };
-        let mut flash = FlashStorage::new();
+        // #233: `target` is already the AppPartitionSubType to write.
+        let sub = target;
+        let mut flash = flash();
         let mut buf = [0u8; PT_SCRATCH];
         let part_len = {
             let pt = read_partition_table(&mut flash, &mut buf).ok()?;
@@ -1292,7 +1321,7 @@ impl LeafImageWriter {
     }
 
     /// The slot this writer targets (passed to [`activate`] after a good finalize).
-    pub fn target(&self) -> Slot {
+    pub fn target(&self) -> AppPartitionSubType {
         self.target
     }
 
@@ -1314,7 +1343,7 @@ impl LeafImageWriter {
         }
         // Re-derive the partition-scoped region from locals (table + flash borrowed
         // together for the region's lifetime; dropped at end of this call).
-        let mut flash = FlashStorage::new();
+        let mut flash = flash();
         let mut ptbuf = [0u8; PT_SCRATCH];
         let pt = match read_partition_table(&mut flash, &mut ptbuf) {
             Ok(pt) => pt,
@@ -1326,8 +1355,8 @@ impl LeafImageWriter {
         };
         let mut region = app.as_embedded_storage(&mut flash);
 
-        let word = <FlashStorage as NorFlash>::WRITE_SIZE as u32; // 4
-        let sector = <FlashStorage as NorFlash>::ERASE_SIZE as u32; // 4096
+        let word = <FlashStorage<'_> as NorFlash>::WRITE_SIZE as u32; // 4
+        let sector = <FlashStorage<'_> as NorFlash>::ERASE_SIZE as u32; // 4096
         let padded = real.div_ceil(word) * word;
         let write_end = self.written + padded;
         // Erase-ahead (sector granularity). Monotonic — never re-erases written bytes.
@@ -1378,7 +1407,7 @@ impl LeafImageWriter {
         if self.written != expected_size {
             return Err(FinalizeFail::Integrity);
         }
-        let mut flash = FlashStorage::new();
+        let mut flash = flash();
         let mut ptbuf = [0u8; PT_SCRATCH];
         let pt = match read_partition_table(&mut flash, &mut ptbuf) {
             Ok(pt) => pt,
@@ -1429,13 +1458,10 @@ pub struct SlotReader {
 #[cfg(feature = "espnow")]
 impl SlotReader {
     /// Open a reader for `slot` (the gateway's just-staged inactive slot). `None` on error.
-    pub fn open(slot: Slot) -> Option<SlotReader> {
-        let sub = if slot == Slot::Slot1 {
-            AppPartitionSubType::Ota1
-        } else {
-            AppPartitionSubType::Ota0
-        };
-        let mut flash = FlashStorage::new();
+    pub fn open(slot: AppPartitionSubType) -> Option<SlotReader> {
+        // #233: `slot` is already the AppPartitionSubType to read.
+        let sub = slot;
+        let mut flash = flash();
         let mut buf = [0u8; PT_SCRATCH];
         let part_len = {
             let pt = read_partition_table(&mut flash, &mut buf).ok()?;
@@ -1453,7 +1479,7 @@ impl SlotReader {
         if off.saturating_add(out.len() as u32) > self.part_len {
             return false;
         }
-        let mut flash = FlashStorage::new();
+        let mut flash = flash();
         let mut ptbuf = [0u8; PT_SCRATCH];
         let pt = match read_partition_table(&mut flash, &mut ptbuf) {
             Ok(pt) => pt,
@@ -1476,17 +1502,18 @@ impl SlotReader {
 /// ⇒ `Slot0` — the same mapping as #226's inactive_slot fix. `None` on any partition/flash error.
 #[cfg(feature = "espnow")]
 #[allow(dead_code)] // #237: wired by the crown/holder serve arbiter (later slice-1 increment)
-pub fn active_slot() -> Option<Slot> {
-    let mut flash = FlashStorage::new();
+pub fn active_slot() -> Option<AppPartitionSubType> {
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let pt = read_partition_table(&mut flash, &mut buf).ok()?;
     let od = pt
         .find_partition(PartitionType::Data(DataPartitionSubType::Ota))
         .ok()??;
-    let mut region = od.as_embedded_storage(&mut flash);
-    let mut ota = Ota::new(&mut region).ok()?;
-    Some(match ota.current_slot().ok()? {
-        Slot::None => Slot::Slot0, // blank ⇒ ROM booted ota_0 (mirrors inactive_slot, #226)
+    let region = od.as_embedded_storage(&mut flash);
+    let mut ota = Ota::new(region, 2).ok()?;
+    Some(match ota.current_app_partition().ok()? {
+        // blank ⇒ ROM booted ota_0 (mirrors inactive_slot, #226/#233)
+        AppPartitionSubType::Factory => AppPartitionSubType::Ota0,
         s => s,
     })
 }
@@ -1598,7 +1625,7 @@ fn crc32(data: &[u8]) -> u32 {
 #[cfg(feature = "espnow")]
 fn floor_cell_read(rel: u32) -> Option<u32> {
     use embedded_storage::nor_flash::ReadNorFlash;
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut ptbuf = [0u8; PT_SCRATCH];
     let pt = read_partition_table(&mut flash, &mut ptbuf).ok()?;
     let nvs = pt
@@ -1650,7 +1677,7 @@ pub fn fresh_floor_bump(build: u32) {
     let crc = crc32(&rec[0..8]);
     rec[8..12].copy_from_slice(&crc.to_le_bytes());
 
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut ptbuf = [0u8; PT_SCRATCH];
     let pt = match read_partition_table(&mut flash, &mut ptbuf) {
         Ok(pt) => pt,
@@ -1683,7 +1710,7 @@ pub fn fresh_floor_bump(build: u32) {
 /// `[magic, count]` in persistent RTC-fast RAM. `#[ram(rtc_fast, persistent)]` keeps it
 /// across a `software_reset`; it is uninitialized at power-on (magic detects that).
 #[cfg(feature = "espnow")]
-#[esp_hal::ram(rtc_fast, persistent)]
+#[esp_hal::ram(unstable(rtc_fast, persistent))]
 static mut OTA_BOOT_GUARD: [u32; 2] = [0u32; 2];
 
 #[cfg(feature = "espnow")]
@@ -1716,7 +1743,7 @@ const BOOT_GUARD_MAGIC: u32 = 0x736D_6C4B; // "smlK"
 /// rolled back by the leaf hear-a-frame path (the 113↔114 oscillation), and its role is
 /// ambiguous at that boot anyway.
 #[cfg(feature = "wifi")]
-#[esp_hal::ram(rtc_fast, persistent)]
+#[esp_hal::ram(unstable(rtc_fast, persistent))]
 static mut OTA_ACTIVATE_GUARD: [u32; 3] = [0u32; 3];
 
 #[cfg(feature = "wifi")]
@@ -1805,7 +1832,7 @@ pub fn unconfirmed_boot_reset() {
 /// we can't read otadata on simply skips the OTA bookkeeping).
 #[cfg(feature = "espnow")]
 pub fn otadata_unconfirmed() -> bool {
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
         return false;
@@ -1813,8 +1840,8 @@ pub fn otadata_unconfirmed() -> bool {
     let Ok(Some(od)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Ota)) else {
         return false;
     };
-    let mut region = od.as_embedded_storage(&mut flash);
-    let Ok(mut ota) = Ota::new(&mut region) else {
+    let region = od.as_embedded_storage(&mut flash);
+    let Ok(mut ota) = Ota::new(region, 2) else {
         return false;
     };
     matches!(
@@ -1858,7 +1885,7 @@ const BOOTCOUNT_RECORD_LEN: usize = 12;
 #[cfg(feature = "espnow")]
 fn bootcount_cell_read(rel: u32) -> Option<u32> {
     use embedded_storage::nor_flash::ReadNorFlash;
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut ptbuf = [0u8; PT_SCRATCH];
     let pt = read_partition_table(&mut flash, &mut ptbuf).ok()?;
     let nvs = pt
@@ -1902,7 +1929,7 @@ pub fn boot_count_bump() -> u32 {
     rec[4..8].copy_from_slice(&next.to_le_bytes());
     let crc = crc32(&rec[0..8]);
     rec[8..12].copy_from_slice(&crc.to_le_bytes());
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut ptbuf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut ptbuf) else {
         return next;
@@ -1924,7 +1951,7 @@ pub fn boot_count_bump() -> u32 {
 /// next boot can tell a panic-reset (`rr=panic`) from a clean `rr=sw`. Survives the reset AND
 /// a USB reflash; a true power cycle clears it (a power-cycled board reports `por`, correct).
 #[cfg(feature = "wifi")]
-#[esp_hal::ram(rtc_fast, persistent)]
+#[esp_hal::ram(unstable(rtc_fast, persistent))]
 static mut PANIC_MARK: [u32; 1] = [0u32; 1];
 
 #[cfg(feature = "wifi")]
@@ -2145,7 +2172,7 @@ fn encode_net_cfg(c: NetCfg) -> [u8; NET_REC_LEN] {
 #[cfg(feature = "wifi")]
 pub fn read_net_cfg() -> Option<NetCfg> {
     use embedded_storage::nor_flash::ReadNorFlash;
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let pt = read_partition_table(&mut flash, &mut buf).ok()?;
     let nvs = pt
@@ -2168,7 +2195,7 @@ pub fn read_net_cfg() -> Option<NetCfg> {
 #[cfg(feature = "espnow")]
 pub fn write_net_cfg(c: NetCfg) {
     use embedded_storage::nor_flash::NorFlash;
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
         return;
@@ -2183,7 +2210,7 @@ pub fn write_net_cfg(c: NetCfg) {
     // never persisted. Erase+write RAW at absolute addresses instead — same 4 KB, same
     // segregation (identity/floor/boot-count live in sectors 0-4, untouched).
     let base = nvs.offset(); // absolute flash address of the nvs partition
-    let sector = <FlashStorage as NorFlash>::ERASE_SIZE as u32; // 4096
+    let sector = <FlashStorage<'_> as NorFlash>::ERASE_SIZE as u32; // 4096
     if flash.erase(base + NET_REC_OFF, base + NET_REC_OFF + sector).is_err() {
         return;
     }
@@ -2251,7 +2278,7 @@ pub fn parse_ota_host_override(s: &str) -> Option<[u8; 4]> {
 /// error. A silent rollback flips this vs the pushed slot — the headline #70 signal.
 #[cfg(feature = "espnow")]
 pub fn boot_slot() -> u8 {
-    let mut flash = FlashStorage::new();
+    let mut flash = flash();
     let mut buf = [0u8; PT_SCRATCH];
     let Ok(pt) = read_partition_table(&mut flash, &mut buf) else {
         return 255;
@@ -2259,13 +2286,13 @@ pub fn boot_slot() -> u8 {
     let Ok(Some(od)) = pt.find_partition(PartitionType::Data(DataPartitionSubType::Ota)) else {
         return 255;
     };
-    let mut region = od.as_embedded_storage(&mut flash);
-    let Ok(mut ota) = Ota::new(&mut region) else {
+    let region = od.as_embedded_storage(&mut flash);
+    let Ok(mut ota) = Ota::new(region, 2) else {
         return 255;
     };
-    match ota.current_slot() {
-        Ok(Slot::Slot0) => 0,
-        Ok(Slot::Slot1) => 1,
+    match ota.current_app_partition() {
+        Ok(AppPartitionSubType::Ota0) => 0,
+        Ok(AppPartitionSubType::Ota1) => 1,
         _ => 255,
     }
 }
@@ -2278,7 +2305,7 @@ pub fn boot_slot() -> u8 {
 /// good-slot boot reports `rolled-back`; a power cycle clears it → `none`, correct). Magic-gated
 /// so uninitialised RTC RAM reads as `none`, never a false outcome.
 #[cfg(feature = "wifi")]
-#[esp_hal::ram(rtc_fast, persistent)]
+#[esp_hal::ram(unstable(rtc_fast, persistent))]
 static mut OTA_OUTCOME: [u32; 3] = [0u32; 3]; // [magic, 1=confirmed / 2=rolled-back, build]
 
 #[cfg(feature = "wifi")]
@@ -2306,7 +2333,7 @@ const OTA_OUTCOME_MAGIC: u32 = 0x736D_6C4F; // "smlO"
 /// the field simply disappears until the next OTA re-measures it, which is honest: a bootloader can
 /// only change by being reflashed.
 #[cfg(feature = "wifi")]
-#[esp_hal::ram(rtc_fast, persistent)]
+#[esp_hal::ram(unstable(rtc_fast, persistent))]
 static mut BL_REVERT: [u32; 3] = [0u32; 3]; // [magic, 1=on / 2=off, build]
 
 #[cfg(feature = "wifi")]

--- a/rust/clock/src/ota_mesh.rs
+++ b/rust/clock/src/ota_mesh.rs
@@ -558,7 +558,7 @@ pub fn stat_build(value: &[u8]) -> Option<u32> {
 // with otadata untouched (the good slot boots; a hard brick ⇒ USB recovery, §4).
 // ===========================================================================
 
-use esp_bootloader_esp_idf::ota::Slot;
+use esp_bootloader_esp_idf::partitions::AppPartitionSubType as Slot;
 
 /// #349: first `dbg_verdict` value reserved for a SUITABILITY refusal at finalize. The
 /// `on_meta` verdicts occupy 0-7, so the target-reject band starts here and runs


### PR DESCRIPTION
Closes #233. Step 2 of the #335 epic: **the dependency wave alone**, on the synchronous superloop — PR #247's approach, rebased onto current `main`. **No Embassy phases** (#335's later work); `embassy-executor` does not appear in the lockfile at all.

## The number

**Stack region 106,472 B against the 74,208 B floor — a 1.43× margin.**

The blocker is gone. #335 recorded 67,488 B vs the floor (short 6,720) *with the Bard*; a5b1312 took the Bard out of the canonical fleet image, and this is the measured result on the 0.18 stack.

Stable across bases and machines:

| base | stack | note |
|---|---|---|
| `be0bdf8` local | 106,464 B | first rebase |
| `be0bdf8` CI, cold runner | 106,464 B | byte-identical to local |
| `dde5256` local | **106,472 B** | +8 B from main's 4 newer commits |

(#347 predicted 106,560 B.)

## Resolved matched set (from `Cargo.lock`, not the manifest)

| crate | was | now |
|---|---|---|
| esp-hal | 1.0.0-rc.0 | **1.1.1** |
| esp-wifi → **esp-radio** | 0.15.0 | **0.18.0** |
| esp-hal-embassy → **esp-rtos** | 0.9.0 | **0.3.0** |
| esp-storage | 0.7.0 | **0.9.0** |
| esp-bootloader-esp-idf | 0.2.0 | **0.5.0** |
| esp-alloc | 0.8.0 | **0.10.0** |
| esp-backtrace / esp-println | 0.17 / 0.15 | **0.19 / 0.17** |

`esp-rtos` is enabled with `esp-radio` + `esp-alloc` only — **not** `embassy`. `fn main() -> !` keeps its `loop {}`.

## What actually had to be reconciled

**Both rebases applied with zero textual conflicts. That is the finding, not the good news.**

#181's ledger-key NVS helpers landed on `main` after the spike forked, written against esp-storage 0.7's `FlashStorage::new()`. Under 0.9 that constructor consumes the FLASH peripheral — textually clean, semantically dead. Caught here only because the arity changed; the same class would have been **silent** had the signature merely widened. Converted to the spike's `flash()` steal idiom.

Audited rather than assumed: `flash()` carries a human-audited invariant (never two live `FlashStorage`, since `steal()` moves exclusivity off the compiler). `resolve_ledger_key` runs once at boot with strictly sequential handles and no OTA in flight — documented at both sites.

Verified surviving the `Slot` → `AppPartitionSubType` translation: the **#226 blank-otadata footgun** (blank ⇒ active `Ota0`, inactive `Ota1`), and both #247 harvest items — `radio_dev.rs` and the `scan_async` `.with_max(16)` bound at both call sites (0.18's default is an unbounded heap `Vec` = OOM risk). A 4th commit retires the now-dead `Slot` vocabulary from #226's docs, where the code was right but the prose still named a private type.

## Rebased twice

`main` advanced (`be0bdf8` → `dde5256`) while this PR was open, landing #349, #314, #359 and #350 across `ota.rs` (+135), `wifi.rs` (+46), `ota_mesh.rs` (+40). Rebased again and re-gated rather than trusting `mergeable=MERGEABLE` — verified by grep that main's new code touches flash zero times, so no recurrence of the class above.

## Gate — `GATE GREEN`, 42 PASS / 0 FAIL, exit 0

#350's manifest-derived matrix widened coverage since the first run:

- `cargo check` + `cargo clippy -D warnings` across every tier — default, wifi, espnow, fleet, bard, ledger-provision, **wled, coexist-soak, mesh-test, stack-paint**
- stack floor: **106,472 B vs 74,208 B**
- 15 host verifier suites — including `target_guard_verify` (#349) and `ledger_verify` / `mac_verify` (#190/#181), i.e. main's newest work passes on the 0.18 stack
- crate host test suites

## Not covered by this PR — read before merging

CI is a **build** gate. esp-radio's scheduler/os-adapter change is precisely the class that fails only on hardware, and **nothing here has run on a board**. The stack figure is a *linked region*, not a runtime high-water — per #300 an ELF cannot show the latter.

Per #233's own gate clause this needs a **bench canary + a dual-slot OTA-roll regression** before any fleet roll. ⚠️ Note this branch's `git rev-list --count` is **below** main's (the rebase dropped a merge commit), so `ota_publish.sh`'s ratchet is what prevents a build-number regression — **do not `--build N` override on this branch.** Full cutover proposal on #335; a fleet roll is JP's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)