### PR TITLE
ci(#351): the BYTE-FREE claims, measured instead of asserted

### DIFF
--- a/.github/workflows/fw-gate.yml
+++ b/.github/workflows/fw-gate.yml
@@ -168,7 +168,9 @@ jobs:
             tools/check_exclusions.py claims || true
             echo '```'
             echo "Derived from the \`#[cfg(feature = …)]\` on each \`mod\`, walked from"
-            echo "\`src/main.rs\`. Gate a module and it is covered; there is no list to update."
+            echo "\`src/main.rs\`, and cross-checked both ways against \`[tier_exclusive]\` in"
+            echo "\`tools/build-matrix.toml\` — so REMOVING a gate fails the gate instead of"
+            echo "quietly removing the claim along with it."
             echo ""
             echo "⚠️ This proves no **executable** bytes from an excluded module survived, via the"
             echo "DWARF line table (which attributes inlined code back to its source file). A"

--- a/.github/workflows/fw-gate.yml
+++ b/.github/workflows/fw-gate.yml
@@ -133,3 +133,45 @@ jobs:
             tools/build_matrix.py ci-matrix | python3 -m json.tool
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # #351 — the BYTE-FREE claims, checked instead of asserted.
+  #
+  # A SEPARATE JOB, not another step in `firmware`, for one measured reason: this arm LINKS every
+  # tier (the check/clippy loops only compile), which on a dev box is ~70s x 10 on top of a
+  # `firmware` job already budgeted at 45 minutes. Bolting it on would have made the timeout the
+  # thing that fails, and a gate that times out gets deleted. The two jobs share no state — a
+  # different target dir and a different profile (`CARGO_PROFILE_RELEASE_DEBUG`) — so running them
+  # in parallel costs wall-clock nothing.
+  exclusions:
+    name: tier exclusions (#351)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust/clock
+          key: excl                      # its own cache: a different profile, so different artifacts
+      # Same assertion as the `firmware` job, for the same reason — and it matters more here,
+      # because without readelf this gate has no instrument at all.
+      - name: Assert readelf present
+        run: readelf --version >/dev/null
+
+      - run: tools/gate.sh excl
+
+      - name: Exclusions → job summary
+        if: always()
+        run: |
+          {
+            echo "### Tier exclusions — the BYTE-FREE claims"
+            echo '```'
+            tools/check_exclusions.py claims || true
+            echo '```'
+            echo "Derived from the \`#[cfg(feature = …)]\` on each \`mod\`, walked from"
+            echo "\`src/main.rs\`. Gate a module and it is covered; there is no list to update."
+            echo ""
+            echo "⚠️ This proves no **executable** bytes from an excluded module survived, via the"
+            echo "DWARF line table (which attributes inlined code back to its source file). A"
+            echo "consts-only module emits no line rows and is invisible — those are declared in"
+            echo "\`tools/build-matrix.toml\`'s \`[unobservable]\` with a reason."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -149,6 +149,14 @@ Full toolchain + gotchas: **[`docs/BUILDING.md`](docs/BUILDING.md)**. TL;DR for 
    The `default` build must also stay behaviourally unaffected (prove via cfg-gating, **not** ELF
    byte-equality — `build.rs` stamps a per-commit git hash, so the default ELF changes every commit
    by design).
+
+   **Since #351 the "BYTE-FREE" claims are checked, not asserted.** `tools/check_exclusions.py`
+   links every tier and reads the DWARF line table to ask which source files actually contributed
+   code; a module the tier's features exclude must contribute none. The claims are **derived from
+   the `#[cfg(feature = …)]` on each `mod`**, walked from `src/main.rs` — so you gate a module and
+   the gate covers it, with no list to update. Two things to know: it proves no *executable* bytes
+   (a consts-only module is invisible — declare it in `build-matrix.toml`'s `[unobservable]` with a
+   reason), and a module no tier ever builds is reported **UNPROVEN**, not passing.
 3. **Version identity:** `build.rs` embeds `BUILD_HASH` + `BUILD_NUMBER` →
    `names.rs::version_name()`, a forge-realm sigil name. The number is the OTA monotonicity gate;
    the name is the boot-splash reveal. Two things to get right:

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -153,10 +153,15 @@ Full toolchain + gotchas: **[`docs/BUILDING.md`](docs/BUILDING.md)**. TL;DR for 
    **Since #351 the "BYTE-FREE" claims are checked, not asserted.** `tools/check_exclusions.py`
    links every tier and reads the DWARF line table to ask which source files actually contributed
    code; a module the tier's features exclude must contribute none. The claims are **derived from
-   the `#[cfg(feature = …)]` on each `mod`**, walked from `src/main.rs` — so you gate a module and
-   the gate covers it, with no list to update. Two things to know: it proves no *executable* bytes
-   (a consts-only module is invisible — declare it in `build-matrix.toml`'s `[unobservable]` with a
-   reason), and a module no tier ever builds is reported **UNPROVEN**, not passing.
+   the `#[cfg(feature = …)]` on each `mod`**, walked from `src/main.rs`. Three things to know:
+
+   * **Ungating a module is a manifest change.** `build-matrix.toml`'s `[tier_exclusive]` lists
+     the commitment, and the source is checked against it both ways. This exists because deleting
+     a `#[cfg]` deletes the derived claim with it — the binary check went green on a real planted
+     leak until this arm was added. Regenerate with `tools/check_exclusions.py claims --toml`.
+   * It proves no *executable* bytes. A consts-only module emits no line rows — declare it in
+     `[unobservable]` with a reason.
+   * A module no tier ever builds is reported **UNPROVEN**, not passing.
 3. **Version identity:** `build.rs` embeds `BUILD_HASH` + `BUILD_NUMBER` →
    `names.rs::version_name()`, a forge-realm sigil name. The number is the OTA monotonicity gate;
    the name is the boot-splash reveal. Two things to get right:

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -202,7 +202,9 @@ hostsim = ["dep:libm"]
 # Compiles the digital-`Flex` driver menu into ONE image; a runtime pin-map relayed
 # over the #56 keyed-CFG `G` channel selects which driver binds each free GPIO at
 # boot — no recompile. Default-OFF so the default/wifi/espnow builds stay BYTE-FREE
-# of it (#44): `src/io.rs` is `#![cfg(feature = "io")]` and every hook is cfg-gated.
+# of it (#44): `src/io.rs` is gated at its `mod io;` declaration (main.rs) and every hook
+# is cfg-gated. (This line said `src/io.rs` carries `#![cfg(feature = "io")]`; it does not —
+# same effect, wrong citation, corrected while #351 made the CLAIM checkable.)
 # Implies `espnow`: the pin-map's transport (the CfgTracker relay + `take_cfg_offer`
 # apply) lives in the ESP-NOW radio manager, and the fleet runs espnow end-to-end.
 # v1 = digital in/out only (the provably-feasible `Flex` case); ADC/PWM/WS2812-RMT
@@ -248,8 +250,12 @@ ledger-provision = ["espnow"]
 # #25 WLED WiZmote-emit: smol impersonates a WLED "linked remote" (13-B WiZmote
 # ESP-NOW broadcast). Needs the ESP-NOW broadcast path + RadioManager, so it builds
 # on `espnow`. Nothing new links — pure encode + the existing `esp_now.send`. The
-# default build is BYTE-FREE of it (symbol-absence provable; net/wled.rs is
-# `#![cfg(feature = "wled")]` and every hook is `#[cfg(feature = "wled")]`).
+# default build is BYTE-FREE of it (net/wled.rs is `#![cfg(feature = "wled")]` and every
+# hook is `#[cfg(feature = "wled")]`). Since #351 that is CHECKED, not asserted:
+# `tools/check_exclusions.py` links each tier and reads its DWARF line table, and the
+# default tier contributes no row from net/wled.rs. "Symbol-absence provable" was the old
+# wording and was the weaker claim — under fat LTO an inlined module leaves no symbol while
+# its bytes are very much there, which is why the line table is the instrument.
 wled = ["espnow"]
 
 # #26 smol Cast: mirror the gateway's OLED image onto a network WLED matrix as
@@ -259,9 +265,14 @@ wled = ["espnow"]
 # stream, both of which only the espnow build has (a wifi-only board only associates
 # once at boot). Pure-additive: NO new crate links — a DrawTarget tee mirrors the
 # framebuffer, a pure packer encodes DNRGB, and the existing flush association carries
-# it. The default / wifi / espnow / wled builds are BYTE-FREE of it (`net::cast*` is
+# it. The default / wifi / espnow builds are BYTE-FREE of it (`net::cast*` is
 # `#[cfg(feature = "cast")]` and every hook is cfg-gated; the `Oled` type only swaps to
-# the tee under this flag).
+# the tee under this flag) — checked per tier by #351's `tools/check_exclusions.py`.
+# NOTE: this line used to include `wled` in that list. It no longer can: since #350 the
+# `wled` TIER is `wled,${canonical}` and the canonical fleet features include `cast`, so a
+# wled build DOES carry the cast code. The claim was about a hypothetical `--features wled`
+# alone; the exclusion checker judges the tiers that are actually built, and would have
+# called this false. Narrowed rather than waived.
 cast = ["espnow"]
 
 # ── bard (#300): on-device tiny-LLM storyteller ─────────────────────────────

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -157,8 +157,11 @@ pub mod wled;
 // #26 smol Cast: stream the gateway's OLED image to a network WLED matrix as
 // realtime UDP pixels. `cast = ["wifi"]`. `cast` is the PURE packer + shadow
 // framebuffer (host-testable, no HAL deps); `cast_oled` is the DrawTarget tee that
-// feeds it (needs ssd1306). Absent from every non-cast build → the default / wifi /
-// espnow / wled profiles are byte-free of it.
+// feeds it (needs ssd1306). Absent from every non-cast build → the default / wifi / espnow
+// tiers are byte-free of it, and #351's tools/check_exclusions.py proves that per tier from
+// the DWARF line table rather than leaving it as this sentence. (The `wled` TIER is NOT on
+// that list: since #350 it is `wled,${canonical}`, and the canonical fleet features include
+// `cast`. The old wording named a feature combination nothing builds.)
 #[cfg(feature = "cast")]
 pub mod cast;
 #[cfg(feature = "cast")]

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -169,3 +169,69 @@ hostsim  = "host-only, and covered by the `cargo test` arm in tools/gate.sh"
 consts only (WIFI_NETWORK / MQTT_* / WLED_CAST_*) — 0 fn / 0 impl in both secrets.rs and \
 secrets.rs.example, so it emits .rodata and no line rows. It is also git-ignored and \
 provisioned per tree, so its contents are not a property of the commit at all."""
+
+# ── the tier-exclusion COMMITMENT (#351) ──────────────────────────────────────────────────
+# Which modules smol commits to keeping out of the tiers that do not enable them. The source
+# already says this in each `#[cfg(feature = …)]`, and stating it twice is normally the thing
+# that rots — so why here.
+#
+# Because it was MEASURED to be necessary. The realistic regression is not "someone references
+# an excluded module": that does not compile, the module is not there. It is "someone drops the
+# `#[cfg]` so their new call site compiles, and leaves the BYTE-FREE comment above it". Doing
+# exactly that to `pub mod target;` put src/net/target.rs into the default tier — 11 crate files
+# to 12 — and the ELF check reported **0 leaked**, because the claim it would have violated was
+# derived from the very `#[cfg]` the regression deleted. A gate that can be silenced by editing
+# its subject is not a gate.
+#
+# So: declared here, checked against the source in BOTH directions (same move #350 makes for the
+# chip roster vs budget.rs). Removing a gate now fails the gate until the line below is deleted
+# too — which puts the decision in the diff, where a reviewer sees it. Adding a gated module
+# without an entry fails as well, so the table cannot quietly stop covering what is added later.
+# The value is the gate CONJUNCTION, so changing a gate is caught, not only removing one.
+#
+# Regenerate with: tools/check_exclusions.py claims --toml
+[tier_exclusive]
+"src/bard/delivery.rs" = "bard"
+"src/bard/mod.rs" = "bard"
+"src/bard/nano_llm.rs" = "bard"
+"src/bard/persona.rs" = "bard"
+"src/bard/stack_paint.rs" = "bard+stack-paint"
+"src/bard/textflow.rs" = "bard"
+"src/bard/tokenizer.rs" = "bard"
+"src/batt.rs" = "wifi"
+"src/bench.rs" = "espnow"
+"src/custom.rs" = "espnow"
+"src/familiar/mod.rs" = "espnow"
+"src/finder.rs" = "espnow"
+"src/grid.rs" = "wifi"
+"src/hunt.rs" = "espnow"
+"src/io.rs" = "io"
+"src/led.rs" = "espnow"
+"src/mesh_snake/mod.rs" = "espnow"
+"src/mesh_snake/snake_core.rs" = "espnow"
+"src/net/cast.rs" = "cast"
+"src/net/cast_oled.rs" = "cast"
+"src/net/cfgsched.rs" = "espnow"
+"src/net/coexist.rs" = "espnow"
+"src/net/election.rs" = "wifi"
+"src/net/etx.rs" = "espnow"
+"src/net/flood.rs" = "espnow"
+"src/net/http.rs" = "espnow"
+"src/net/ledger.rs" = "espnow"
+"src/net/ledger_link.rs" = "espnow"
+"src/net/mode.rs" = "espnow"
+"src/net/mqtt.rs" = "wifi"
+"src/net/ota_resume.rs" = "espnow"
+"src/net/radio_dev.rs" = "wifi"
+"src/net/sth.rs" = "espnow"
+"src/net/target.rs" = "wifi"
+"src/net/treehead.rs" = "espnow"
+"src/net/wifi.rs" = "wifi"
+"src/net/wire.rs" = "espnow"
+"src/net/wled.rs" = "wled"
+"src/ota.rs" = "wifi"
+"src/ota_mesh.rs" = "espnow"
+"src/ota_screen.rs" = "espnow"
+"src/rssi.rs" = "espnow"
+"src/secrets.rs" = "wifi"
+"src/watch.rs" = "espnow"

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -152,3 +152,20 @@ hostsim  = "host-only, and covered by the `cargo test` arm in tools/gate.sh"
 # `off-fleet` deliberately has NO entry here: the bard tier names it, so it is covered, and the
 # checker rejects a feature that is both exempted and covered — an exemption whose reason has
 # quietly stopped applying is worse than none. It caught this exact case when first written.
+
+# ── modules #351's exclusion check cannot SEE, declared so the blind spot is a decision ───────
+# `tools/check_exclusions.py` proves a module contributed no code to a tier that excludes it, by
+# asking the tier's DWARF line table which source files its instructions came from. A module of
+# pure `const`/`static` items emits no instructions, therefore no line-table rows, therefore
+# nothing to find — and an absence check that cannot detect presence proves nothing at all. So
+# the checker REFUSES to pass a claim it never observed anywhere, and an honest blind spot has to
+# be written down here with its reason.
+#
+# Same discipline as [exempt] above, including the stale case: a module listed here that IS
+# observed fails the gate, because a reason that has quietly stopped applying reads as a
+# considered decision and is worse than no entry.
+[unobservable]
+"src/secrets.rs" = """\
+consts only (WIFI_NETWORK / MQTT_* / WLED_CAST_*) — 0 fn / 0 impl in both secrets.rs and \
+secrets.rs.example, so it emits .rodata and no line rows. It is also git-ignored and \
+provisioned per tree, so its contents are not a property of the commit at all."""

--- a/tools/check_exclusions.py
+++ b/tools/check_exclusions.py
@@ -46,6 +46,20 @@ it. Not hypothetical: the default tier's file set omits `budget.rs` and `board.r
 exactly this reason. The `--require-observed` rule below is what keeps that limitation
 from silently widening into "the instrument sees nothing and says PASS".
 
+── THE ARM THE BINARY CANNOT PROVIDE ────────────────────────────────────────
+Planting a real leak exposed a hole in the above, and it is the hole that matters most. The
+realistic regression is not "someone references an excluded module" — that does not compile,
+the module is not there. It is "someone drops the `#[cfg]` so their new call site compiles,
+and leaves the BYTE-FREE comment". MEASURED: doing that to `pub mod target;` put
+src/net/target.rs into the default tier (11 crate files → 12) and this checker reported
+**0 leaked** — the claim it would have violated was derived from the very `#[cfg]` that was
+deleted. A gate that can be silenced by editing its subject is not a gate.
+
+So the commitment is ALSO declared as data, in build-matrix.toml's `[tier_exclusive]`, and
+the source is checked against it in both directions (removed gate / added gate / changed
+gate). Removing a gate now fails until the declaration is deleted too, which puts the
+decision in the diff where a reviewer sees it.
+
 ── THE ANTI-VACUITY RULE ────────────────────────────────────────────────────
 An absence check is worthless unless the instrument can be shown to detect presence. So
 across a whole run, EVERY claim must be OBSERVED at least once: some checked tier must
@@ -346,6 +360,55 @@ def violations(claim: Claim, present: set[str]) -> list[str]:
     return sorted(f for f in present if f == str(claim.path) or f.startswith(sub))
 
 
+def load_declared(manifest: Path) -> dict[str, str]:
+    """`[tier_exclusive]` — the modules smol COMMITS to keeping out of lower tiers.
+
+    ── WHY A SECOND STATEMENT OF A FACT THE SOURCE ALREADY CARRIES ───────────────
+    Found by planting a real leak, which is the only way it could have been found. The
+    realistic regression is not "someone references an excluded module" — that does not
+    compile, because the module is not there. It is "someone drops the `#[cfg]` so their new
+    call site compiles, and leaves the BYTE-FREE comment above it untouched". MEASURED: doing
+    exactly that to `pub mod target;` put `src/net/target.rs` into the default tier (11 crate
+    files → 12) and the checker said **0 leaked** — because the claim it would have violated
+    was derived from the very `#[cfg]` the regression deleted. The expectation evaporated with
+    the gate. A gate that can be silenced by editing its subject is not a gate.
+
+    So the commitment is declared HERE and the source is checked AGAINST it, in both
+    directions — the #350 move for the chip roster (`build-matrix.toml` vs `budget.rs`),
+    applied to the thing that turned out to need it. Ungating a module now has to be written
+    down, where a reviewer sees it in the diff, instead of being a deletion nobody notices.
+
+    Values are the gate conjunction (`"bard+stack-paint"`), so CHANGING a gate is caught too,
+    not just removing one. Regenerate with `tools/check_exclusions.py claims --toml`.
+    """
+    if not manifest.exists():
+        return {}
+    with open(manifest, "rb") as fh:
+        return dict(tomllib.load(fh).get("tier_exclusive") or {})
+
+
+def declaration_fails(claims: list[Claim], declared: dict[str, str]) -> list[str]:
+    fails = []
+    derived = {str(c.path): "+".join(sorted(c.gates)) for c in claims}
+    for path, gates in sorted(declared.items()):
+        if path not in derived:
+            fails.append(
+                f"DECLARATION: {path} is declared tier-exclusive ({gates}) but is NOT "
+                f"cfg-gated in the source any more — it now compiles into EVERY tier. If "
+                f"that is intended, delete the [tier_exclusive] line in the same commit and "
+                f"fix the comment that still calls the lower tiers byte-free of it.")
+        elif derived[path] != gates:
+            fails.append(
+                f"DECLARATION: {path} is declared to require {gates}, but the source gates "
+                f"it on {derived[path]} — one of the two moved.")
+    for path, gates in sorted(derived.items()):
+        if path not in declared:
+            fails.append(
+                f"DECLARATION: {path} is cfg-gated on {gates} but has no [tier_exclusive] "
+                f"entry — add it so removing the gate later cannot go unnoticed.")
+    return fails
+
+
 def load_unobservable(manifest: Path) -> dict[str, str]:
     """Modules the instrument provably cannot see, each with a written reason.
 
@@ -368,6 +431,8 @@ def main() -> int:
     ap.add_argument("--elf", action="append", default=[], metavar="TIER=FEATURES=PATH",
                     help="check: one built tier. Repeatable — pass them ALL in one call so "
                          "the anti-vacuity rule can see the whole run. `files`: a bare path.")
+    ap.add_argument("--toml", action="store_true",
+                    help="claims: emit the [tier_exclusive] block for build-matrix.toml")
     ap.add_argument("--fileset", action="append", default=[], metavar="TIER=FEATURES=PATH",
                     help="check: a tier whose file set is a saved newline list instead of an "
                          "ELF (what `files` prints). Lets tools/test_check_exclusions.sh "
@@ -383,6 +448,13 @@ def main() -> int:
         return 2
 
     if args.command == "claims":
+        if args.toml:
+            # Regenerator for build-matrix.toml's [tier_exclusive]. Printed, never written in
+            # place: the whole value of that table is that a human sees the change in a diff.
+            print("[tier_exclusive]")
+            for c in sorted(claims, key=lambda c: str(c.path)):
+                print(f'"{c.path}" = "{"+".join(sorted(c.gates))}"')
+            return 0
         print(f"  {len(claims)} cfg-gated modules derived from src/main.rs:")
         for c in sorted(claims, key=lambda c: str(c.path)):
             print(f"    {str(c.path):32} requires {'+'.join(sorted(c.gates))}")
@@ -407,9 +479,27 @@ def main() -> int:
         return 2
     try:
         unobs = load_unobservable(args.manifest)
+        declared = load_declared(args.manifest)
     except Exception as exc:                                  # noqa: BLE001 — reported below
         print(f"exclusions: {args.manifest}: {exc}", file=sys.stderr)
         return 2
+
+    # FIRST, and before a single ELF is read: does the source still make the commitments the
+    # manifest says it makes? This is the arm that catches the regression the ELF arm cannot —
+    # a deleted `#[cfg]` deletes the claim, so there is nothing left for the binary to violate.
+    #
+    # Returns IMMEDIATELY on a mismatch rather than folding into the ELF verdict. Once the
+    # derived claim set and the declared one disagree, the ELF arm is checking a different
+    # question than the one that was committed to, and printing its cheerful per-tier
+    # "0 leaked" underneath would be the most misleading output this tool could produce.
+    if declared:
+        dfails = declaration_fails(claims, declared)
+        if dfails:
+            print(f"  declaration: {len(declared)} declared vs {len(claims)} derived — "
+                  f"{len(dfails)} disagreement(s); NOT reading any ELF")
+            for f in dfails:
+                print(f"  FAIL {f}", file=sys.stderr)
+            return 1
 
     fails: list[str] = []
     observed: set[str] = set()
@@ -470,7 +560,8 @@ def main() -> int:
             fails.append(f"[unobservable] names {p}, which is not a cfg-gated module")
 
     print(f"  {checked} tiers · {len(claims)} claims · {len(observed)} observed"
-          + (f" · {len(unobs)} declared unobservable" if unobs else ""))
+          + (f" · {len(unobs)} declared unobservable" if unobs else "")
+          + (f" · {len(declared)} declared tier-exclusive, source agrees" if declared else ""))
     if fails:
         for f in fails:
             print(f"  FAIL {f}", file=sys.stderr)

--- a/tools/check_exclusions.py
+++ b/tools/check_exclusions.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""#351 — turn the BYTE-FREE tier claims into a machine-checked fact.
+
+── WHAT WAS WRONG ────────────────────────────────────────────────────────────
+The source asserts, repeatedly and with confidence, that a lower build tier contains
+none of a higher tier's code:
+
+    rust/clock/Cargo.toml   "the default build is BYTE-FREE of it (symbol-absence provable)"
+    rust/clock/src/net.rs   "the default/wifi/espnow builds are byte-free of it"
+    rust/clock/src/main.rs  "so the default/wifi/espnow builds are BYTE-FREE of it (#44)"
+
+NOTHING verified any of them. They were aspirations in comments — the same species as
+gate.sh's "any feature not covered below should be added", which on 2026-08-01 turned out
+to be false for three features at once (#350). A claim that no instrument can refute is
+not a guarantee; it is a habit.
+
+── WHY DWARF, AND WHY NOT WHAT THE PRIOR ART SAYS ───────────────────────────
+WLED gates the same property and documents the trap: under LTO the LINKER MAP CANNOT
+attribute code to modules, so their script uses `readelf --debug-dump=info` and asserts
+each selected module contributed a compilation unit
+(scratch/parity/multitarget-prior-art.md).
+
+That instrument does not transfer unchanged, and the difference matters:
+
+  * WLED is C++ — one CU per .cpp, so "module" and "CU" coincide.
+  * smol's firmware is ONE Rust crate built with `codegen-units = 1` + `lto = "fat"`.
+    MEASURED: the linked ELF has exactly ONE CU whose `DW_AT_comp_dir` is the crate
+    (`src/main.rs/@/clock.<hash>-cgu.0`). A per-CU assertion would therefore be TRUE for
+    every module in every tier, forever — a gate that cannot fail, which is the failure
+    this whole issue is about.
+
+The unit that DOES survive is one level down: the CU's **line-table file set**. Every
+instruction the linker kept has a line-table row naming the source file it came from, and
+that attribution SURVIVES INLINING — verified on this tree, where addresses inside
+ssd1306 carry rows pointing at display-interface-i2c. So: build the tier, read the clock
+CU's line table, and assert the excluded module contributed no row.
+
+── WHAT IT PROVES, AND WHAT IT DOES NOT ─────────────────────────────────────
+PROVES: no *executable code* from the excluded file survived into the tier's binary,
+inlined or otherwise. That is what every one of the claims above is actually about — they
+are claims about hooks, encoders and drivers.
+
+DOES NOT PROVE: that the file contributed no *data*. A module consisting only of `const`
+/ `static` items lands in `.rodata` with no line-table rows, and this check would not see
+it. Not hypothetical: the default tier's file set omits `budget.rs` and `board.rs` for
+exactly this reason. The `--require-observed` rule below is what keeps that limitation
+from silently widening into "the instrument sees nothing and says PASS".
+
+── THE ANTI-VACUITY RULE ────────────────────────────────────────────────────
+An absence check is worthless unless the instrument can be shown to detect presence. So
+across a whole run, EVERY claim must be OBSERVED at least once: some checked tier must
+enable the module's gate AND find its file in that tier's line table. A module nothing can
+see is reported as UNPROVEN, not as passing. That is the difference between this and the
+comments it replaces.
+
+Exit codes:  0 ok · 1 a claim failed or is unproven · 2 the tree could not be read
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_CRATE = HERE.parent / "rust" / "clock"
+DEFAULT_MANIFEST = HERE / "build-matrix.toml"
+
+
+class Bad(Exception):
+    """The tree could not be read well enough to judge it. Distinct from a FAILED claim:
+    one means the instrument is broken, the other means the code is."""
+
+
+# ── the feature graph ─────────────────────────────────────────────────────────
+
+
+def feature_graph(cargo_toml: Path) -> dict[str, list[str]]:
+    try:
+        with open(cargo_toml, "rb") as fh:
+            feats = tomllib.load(fh).get("features") or {}
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise Bad(f"{cargo_toml}: cannot read [features] — {exc}")
+    if not feats:
+        raise Bad(f"{cargo_toml}: no [features] table")
+    return {k: list(v) for k, v in feats.items()}
+
+
+def resolve(features_csv: str, graph: dict[str, list[str]]) -> set[str]:
+    """The features a tier actually builds with.
+
+    `default` is included because the gate's cargo invocations do NOT pass
+    `--no-default-features` — a resolver that forgot that would compute a smaller feature
+    set than the compiler saw, and every extra module in the binary would look like a
+    violation. Entries naming a dependency (`dep:esp-hal`) or another crate's feature
+    (`esp-wifi/esp-now`) are not OUR features and are dropped: they cannot gate a `#[cfg]`
+    in this crate.
+    """
+    todo = ["default"] + [f.strip() for f in features_csv.split(",") if f.strip()]
+    out: set[str] = set()
+    while todo:
+        f = todo.pop()
+        if f in out or f not in graph:
+            continue
+        out.add(f)
+        todo.extend(graph[f])
+    return out
+
+
+# ── the claims, read out of the source ────────────────────────────────────────
+
+MOD_DECL = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;")
+ATTR = re.compile(r"^\s*#!?\[(.*)\]\s*$")
+CFG_FEATURE = re.compile(r'^cfg\(feature\s*=\s*"([A-Za-z0-9_.-]+)"\)$')
+PATH_ATTR = re.compile(r'^path\s*=\s*"([^"]+)"$')
+INNER_CFG = re.compile(r'^\s*#!\[cfg\(feature\s*=\s*"([A-Za-z0-9_.-]+)"\)\]\s*$')
+
+
+class Claim:
+    """One module and the feature conjunction that must hold for it to exist."""
+
+    def __init__(self, path: Path, gates: frozenset[str], sites: tuple[str, ...]):
+        self.path = path          # relative to the crate root, e.g. src/net/wled.rs
+        self.gates = gates        # {"cast"} — ALL must be on, or the file must be absent
+        self.sites = sites        # where the gates are written, for the failure message
+
+    def __repr__(self) -> str:  # pragma: no cover — diagnostics only
+        return f"Claim({self.path}, {sorted(self.gates)})"
+
+
+def _attrs_above(lines: list[str], i: int) -> list[str]:
+    """The attributes attached to the item on line `i`.
+
+    Walks back over the contiguous run of attributes, comments and blank lines. Comments are
+    skipped rather than terminating the walk because this codebase puts a paragraph of
+    rationale between the `#[cfg]` and the `mod` it gates — which is the house style and
+    must not make the gate blind.
+    """
+    out, j = [], i - 1
+    while j >= 0:
+        line = lines[j]
+        if not line.strip() or line.lstrip().startswith("//"):
+            j -= 1
+            continue
+        m = ATTR.match(line)
+        if not m:
+            break
+        out.append(m.group(1).strip())
+        j -= 1
+    return out
+
+
+def _resolve_mod_file(crate: Path, parent_rel: Path, name: str, path_attr: str | None) -> Path:
+    """Where `mod name;` in `parent_rel` reads from. FAILS CLOSED on a miss."""
+    base = parent_rel.parent if parent_rel.name in ("main.rs", "lib.rs", "mod.rs") \
+        else parent_rel.parent / parent_rel.stem
+    cands = [base / path_attr] if path_attr else [base / f"{name}.rs", base / name / "mod.rs"]
+    for c in cands:
+        if (crate / c).is_file():
+            return c
+    raise Bad(f"{parent_rel}: `mod {name};` resolves to none of "
+              f"{', '.join(str(c) for c in cands)} — refusing to judge a module I cannot find")
+
+
+def collect_claims(crate: Path, root_rel: Path = Path("src/main.rs")) -> list[Claim]:
+    """Walk the FIRMWARE crate root transitively and record every cfg-gated module.
+
+    Rooted at `src/main.rs`, not at a glob over `src/`, for two reasons. It is the binary
+    the tiers build — `src/lib.rs` is the #152 hostsim library, a different compilation with
+    a different feature set, and folding its `hostsim` gates in here would produce claims no
+    firmware tier can ever observe. And a transitive walk cannot silently include a file the
+    build has stopped referencing, which a glob would.
+
+    Gates COMPOSE: a module inside a `#[cfg(feature = "espnow")]` module is present only if
+    both features are on, so a child inherits its parents' conjunction.
+    """
+    claims: list[Claim] = []
+    seen: set[Path] = set()
+    stack: list[tuple[Path, frozenset[str], tuple[str, ...]]] = [(root_rel, frozenset(), ())]
+
+    while stack:
+        rel, gates, sites = stack.pop()
+        if rel in seen:
+            continue
+        seen.add(rel)
+        try:
+            lines = (crate / rel).read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            raise Bad(f"cannot read {rel}: {exc}")
+
+        # A file may gate ITSELF from the inside — `net/wled.rs` and `net/cast_oled.rs` both
+        # carry `#![cfg(feature = "…")]`. That is the form the Cargo.toml comments cite, so
+        # it is read as a first-class claim rather than assumed redundant with the `mod`.
+        for line in lines[:80]:
+            m = INNER_CFG.match(line)
+            if m and m.group(1) not in gates:
+                gates = gates | {m.group(1)}
+                sites = sites + (f"{rel}: #![cfg(feature = \"{m.group(1)}\")]",)
+
+        if gates:
+            claims.append(Claim(rel, frozenset(gates), sites))
+
+        for i, line in enumerate(lines):
+            m = MOD_DECL.match(line)
+            if not m:
+                continue
+            name = m.group(1)
+            child_gates, child_sites, path_attr = set(gates), list(sites), None
+            for attr in _attrs_above(lines, i):
+                mp = PATH_ATTR.match(attr)
+                if mp:
+                    path_attr = mp.group(1)
+                    continue
+                if not attr.startswith("cfg"):
+                    continue
+                mc = CFG_FEATURE.match(attr)
+                if mc:
+                    child_gates.add(mc.group(1))
+                    child_sites.append(f"{rel}:{i + 1}: #[{attr}]")
+                elif "feature" in attr:
+                    # `any(...)` / `not(...)` / `all(...)` over features. Guessing at the
+                    # truth condition is how a checker starts quietly passing; refuse.
+                    raise Bad(f"{rel}:{i + 1}: `mod {name};` is gated by a compound cfg "
+                              f"`#[{attr}]` this checker does not model — teach it or "
+                              f"simplify the gate, but do not let it guess")
+            stack.append((_resolve_mod_file(crate, rel, name, path_attr),
+                          frozenset(child_gates), tuple(child_sites)))
+    return claims
+
+
+# ── the instrument: what the ELF says it is made of ───────────────────────────
+
+
+def _readelf(elf: Path, what: str, extra: tuple[str, ...] = ()) -> str:
+    try:
+        r = subprocess.run(["readelf", f"--debug-dump={what}", *extra, str(elf)],
+                           capture_output=True, text=True)
+    except FileNotFoundError:
+        raise Bad("readelf not found — binutils is required (the #300 stack floor gate "
+                  "already depends on it, so this adds no new tool)")
+    if r.returncode != 0:
+        raise Bad(f"readelf --debug-dump={what} {elf}: {r.stderr.strip()[:200]}")
+    return r.stdout
+
+
+def _line_programs(elf: Path) -> dict[int, tuple[dict[int, str], list[tuple[int, str]]]]:
+    progs, off, dirs, files, mode = {}, None, {}, [], None
+    for line in _readelf(elf, "rawline").splitlines():
+        m = re.match(r"\s*Offset:\s+(?:0x)?([0-9a-fA-F]+)\s*$", line)
+        if m:
+            if off is not None:
+                progs[off] = (dirs, files)
+            off, dirs, files, mode = int(m.group(1), 16), {}, [], None
+            continue
+        if "The Directory Table" in line:
+            mode = "d"
+            continue
+        if "The File Name Table" in line:
+            mode = "f"
+            continue
+        if "Line Number Statements" in line:
+            mode = None
+            continue
+        if mode == "d":
+            m = re.match(r"\s*(\d+)\t(.*)$", line)
+            if m:
+                dirs[int(m.group(1))] = m.group(2).strip()
+        elif mode == "f":
+            m = re.match(r"\s*(\d+)\t(\d+)\t\S+\t\S+\t(.*)$", line)
+            if m:
+                files.append((int(m.group(2)), m.group(3).strip()))
+    if off is not None:
+        progs[off] = (dirs, files)
+    return progs
+
+
+def elf_crate_files(elf: Path, crate: Path) -> set[str]:
+    """Crate-relative source files the ELF's line table attributes code to.
+
+    FAILS CLOSED three ways, because each corresponds to a way this could go quietly
+    vacuous: no DWARF at all (the release profile ships `debug = false`, so an ELF built
+    without `CARGO_PROFILE_RELEASE_DEBUG` has NOTHING to read and every absence check would
+    pass); no CU belonging to this crate; or a CU whose file set does not contain the crate
+    root, which would mean the join between CU and line program went wrong.
+    """
+    crate = crate.resolve()
+    info = _readelf(elf, "info", ("--dwarf-depth=1",))
+    if not info.strip():
+        raise Bad(f"{elf}: no DWARF. The release profile does not set `debug`, so this ELF "
+                  f"must be built with CARGO_PROFILE_RELEASE_DEBUG=line-tables-only")
+    progs = _line_programs(elf)
+
+    cus, cur = [], {}
+    for line in info.splitlines():
+        if "Compilation Unit @ offset" in line:
+            if cur:
+                cus.append(cur)
+            cur = {}
+        m = re.search(r"DW_AT_(comp_dir)\s*:\s*(.*)$", line)
+        if m:
+            v = m.group(2).strip()
+            if v.startswith("("):           # "(indirect string, offset: 0x…): <value>"
+                v = v.rsplit("): ", 1)[-1]
+            cur["comp_dir"] = v.strip()
+        m = re.search(r"DW_AT_stmt_list\s*:\s*(?:0x)?([0-9a-fA-F]+)", line)
+        if m:
+            cur["stmt_list"] = int(m.group(1), 16)
+    if cur:
+        cus.append(cur)
+
+    mine = [c for c in cus if c.get("comp_dir") == str(crate)]
+    if not mine:
+        raise Bad(f"{elf}: no compilation unit has DW_AT_comp_dir = {crate} — cannot tell "
+                  f"which code is this crate's")
+
+    found: set[str] = set()
+    for cu in mine:
+        dirs, files = progs.get(cu.get("stmt_list", -1), ({}, []))
+        for di, name in files:
+            d = dirs.get(di, "")
+            p = Path(d) / name if d else Path(name)
+            if not p.is_absolute():
+                p = crate / p
+            try:
+                found.add(str(Path(p).resolve().relative_to(crate)))
+            except (ValueError, OSError):
+                continue                     # another crate inlined into ours; not our claim
+    if "src/main.rs" not in found:
+        raise Bad(f"{elf}: the crate CU's line table does not mention src/main.rs — the "
+                  f"instrument is reading the wrong thing, so its silence proves nothing")
+    return found
+
+
+# ── the check ─────────────────────────────────────────────────────────────────
+
+
+def violations(claim: Claim, present: set[str]) -> list[str]:
+    """Files attributed to an EXCLUDED module. A directory module drags its whole subtree,
+    so `src/bard.rs` being excluded excludes `src/bard/*` too — checking only the named file
+    would miss the common case of the submodule that got linked."""
+    sub = str(claim.path.parent / claim.path.stem) + "/" \
+        if claim.path.name != "mod.rs" else str(claim.path.parent) + "/"
+    return sorted(f for f in present if f == str(claim.path) or f.startswith(sub))
+
+
+def load_unobservable(manifest: Path) -> dict[str, str]:
+    """Modules the instrument provably cannot see, each with a written reason.
+
+    Same discipline as #350's `[exempt]`: an omission is fine, an UNDECLARED omission is
+    not — and an entry that has stopped applying is worse than none, so a declared-
+    unobservable module that IS observed fails the gate.
+    """
+    if not manifest.exists():
+        return {}
+    with open(manifest, "rb") as fh:
+        return dict(tomllib.load(fh).get("unobservable") or {})
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("command", choices=("claims", "files", "check"))
+    ap.add_argument("--crate", type=Path, default=DEFAULT_CRATE)
+    ap.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    ap.add_argument("--elf", action="append", default=[], metavar="TIER=FEATURES=PATH",
+                    help="check: one built tier. Repeatable — pass them ALL in one call so "
+                         "the anti-vacuity rule can see the whole run. `files`: a bare path.")
+    ap.add_argument("--fileset", action="append", default=[], metavar="TIER=FEATURES=PATH",
+                    help="check: a tier whose file set is a saved newline list instead of an "
+                         "ELF (what `files` prints). Lets tools/test_check_exclusions.sh "
+                         "prove every arm can fail without a cross toolchain — the ELF "
+                         "reader has its own arms in that suite.")
+    args = ap.parse_args()
+
+    try:
+        graph = feature_graph(args.crate / "Cargo.toml")
+        claims = collect_claims(args.crate)
+    except Bad as exc:
+        print(f"exclusions: CANNOT READ THE TREE — {exc}", file=sys.stderr)
+        return 2
+
+    if args.command == "claims":
+        print(f"  {len(claims)} cfg-gated modules derived from src/main.rs:")
+        for c in sorted(claims, key=lambda c: str(c.path)):
+            print(f"    {str(c.path):32} requires {'+'.join(sorted(c.gates))}")
+        return 0
+
+    if args.command == "files":
+        if len(args.elf) != 1:
+            print("exclusions: `files` takes exactly one --elf PATH", file=sys.stderr)
+            return 2
+        try:
+            for f in sorted(elf_crate_files(Path(args.elf[0]), args.crate)):
+                print(f)
+        except Bad as exc:
+            print(f"exclusions: {exc}", file=sys.stderr)
+            return 2
+        return 0
+
+    # ── check ────────────────────────────────────────────────────────────────
+    if not args.elf and not args.fileset:
+        print("exclusions: check needs at least one --elf/--fileset TIER=FEATURES=PATH",
+              file=sys.stderr)
+        return 2
+    try:
+        unobs = load_unobservable(args.manifest)
+    except Exception as exc:                                  # noqa: BLE001 — reported below
+        print(f"exclusions: {args.manifest}: {exc}", file=sys.stderr)
+        return 2
+
+    fails: list[str] = []
+    observed: set[str] = set()
+    checked = 0
+
+    for kind, spec in [("elf", s) for s in args.elf] + [("set", s) for s in args.fileset]:
+        try:
+            tier, feats, path = spec.split("=", 2)
+        except ValueError:
+            print(f"exclusions: --{kind} wants TIER=FEATURES=PATH, got {spec!r}",
+                  file=sys.stderr)
+            return 2
+        try:
+            if kind == "elf":
+                present = elf_crate_files(Path(path), args.crate)
+            else:
+                present = {l.strip() for l in Path(path).read_text().splitlines() if l.strip()}
+                if "src/main.rs" not in present:
+                    raise Bad(f"{path}: file set omits src/main.rs — same refusal the ELF "
+                              f"reader makes, for the same reason")
+        except (Bad, OSError) as exc:
+            print(f"exclusions: {exc}", file=sys.stderr)
+            return 2
+        on = resolve(feats, graph)
+        checked += 1
+        excluded = leaked = 0
+        for c in claims:
+            if c.gates <= on:
+                if str(c.path) in present:
+                    observed.add(str(c.path))
+                continue
+            excluded += 1
+            bad = violations(c, present)
+            if bad:
+                leaked += 1
+                missing = "+".join(sorted(c.gates - on))
+                fails.append(
+                    f"tier {tier}: {', '.join(bad)} contributed code, but {missing} is OFF\n"
+                    f"        the claim: {'; '.join(c.sites) or c.path}")
+        print(f"  {tier:16} {len(present):3} crate files · {excluded:2} modules "
+              f"claimed absent · {leaked} leaked")
+
+    # Anti-vacuity: a claim nothing ever saw is UNPROVEN, not passing.
+    for c in claims:
+        p = str(c.path)
+        if p in observed or p in unobs:
+            continue
+        fails.append(
+            f"UNPROVEN: {p} was never observed in any checked tier that enables "
+            f"{'+'.join(sorted(c.gates))}, so its absence elsewhere proves nothing. Either a "
+            f"tier that builds it is missing from the run, or it contributes no executable "
+            f"code — declare it in [unobservable] with the reason if the latter.")
+    for p, why in unobs.items():
+        if p in observed:
+            fails.append(f"[unobservable] names {p}, but it WAS observed — drop the entry "
+                         f"({why!r}) rather than let a stale reason stand")
+        elif not any(str(c.path) == p for c in claims):
+            fails.append(f"[unobservable] names {p}, which is not a cfg-gated module")
+
+    print(f"  {checked} tiers · {len(claims)} claims · {len(observed)} observed"
+          + (f" · {len(unobs)} declared unobservable" if unobs else ""))
+    if fails:
+        for f in fails:
+            print(f"  FAIL {f}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Bad as exc:
+        print(f"exclusions: CANNOT READ THE TREE — {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -23,6 +23,12 @@
 #   5. the crate's own tests/*.rs suites via cargo test (#350) — bard / budget / input. Nothing
 #      ran these before: 57 tests, including the Bard's bit-for-bit golden, that no gate executed
 #   6. tools/test_build_matrix.sh — proof that (0)'s arms can actually fail
+#   7. #351 the BYTE-FREE tier claims — each tier is LINKED and its DWARF line table is asked
+#      which source files contributed code, so "the default build is BYTE-FREE of it" is a
+#      measurement instead of a comment. Claims are derived from the `#[cfg(feature = …)]` on
+#      each `mod`, walked from src/main.rs; no second list.
+#   8. tools/test_check_exclusions.sh — proof that (7)'s arms can actually fail, including the
+#      vacuous-green one (an ELF with no DWARF has an empty file set and every absence "holds")
 #
 # WHAT IT DOES NOT COVER — read this before trusting a green run:
 #   * `mesh-test`: cannot RUN — it needs a per-board `DEAF_MACS` that only a real board.rs has.
@@ -34,11 +40,21 @@
 #     ⚠️ The stack check bounds the linked REGION, not runtime high-water. A struct living in a
 #     stack-resident RadioManager can cost ~1.8 KB of real stack and move the region by ~32 B. A
 #     green stack line is NOT evidence of runtime headroom (see repro_stack_check's comment).
+#   * #351 proves no CODE from an excluded module survived. A module of pure `const`/`static`
+#     items lands in .rodata with no line-table rows and is invisible to it — `src/secrets.rs`
+#     is exactly that, and is declared in build-matrix.toml's [unobservable] for the reason.
+#     "BYTE-FREE" is therefore verified for executable bytes, not literally every byte.
 #
 # Usage:  tools/gate.sh              # everything
 #         tools/gate.sh host         # host suites only (no riscv toolchain needed)
 #         tools/gate.sh fw           # tiers + clippy + stack only
+#         tools/gate.sh excl         # #351 tier exclusions only
 # Env:    CARGO_TARGET_DIR honoured; SMOL_GATE_JOBS caps cargo parallelism.
+#
+# `excl` is its own mode because it is the only arm that LINKS every tier, and measured on a
+# katana-class box that is ~70s x 10 tiers on top of everything else. It shares no state with
+# `fw` — different target dir, different profile — so CI runs the two as parallel jobs rather
+# than pushing one job past its timeout. A human running `tools/gate.sh` still gets all of it.
 set -uo pipefail
 
 cd "$(dirname "$0")/.."
@@ -46,12 +62,13 @@ ROOT="$PWD"
 CLOCK="rust/clock"
 WHAT="${1:-all}"
 FAILED=()
-run_fw=1; run_host=1
+run_fw=1; run_host=1; run_excl=1
 case "$WHAT" in
-  host) run_fw=0 ;;
-  fw)   run_host=0 ;;
+  host) run_fw=0; run_excl=0 ;;
+  fw)   run_host=0; run_excl=0 ;;
+  excl) run_host=0; run_fw=0 ;;
   all)  ;;
-  *) echo "usage: tools/gate.sh [all|host|fw]" >&2; exit 2 ;;
+  *) echo "usage: tools/gate.sh [all|host|fw|excl]" >&2; exit 2 ;;
 esac
 
 # shellcheck source=/dev/null
@@ -68,10 +85,14 @@ step() { printf '\n\033[1m── %s\033[0m\n' "$1"; }
 ok()   { printf '   \033[32mPASS\033[0m %s\n' "$1"; }
 bad()  { printf '   \033[31mFAIL\033[0m %s\n' "$1"; FAILED+=("$1"); }
 
-if [ "$run_fw" = 1 ]; then
+# Both firmware halves need `board.rs`/`secrets.rs`, so this runs for either — `excl` on its
+# own in CI would otherwise fail on the missing files rather than on anything it measures.
+if [ "$run_fw" = 1 ] || [ "$run_excl" = 1 ]; then
   step "provisioning (git-ignored; existing files untouched)"
   "$ROOT/tools/ci_provision.sh" "$CLOCK" || { echo "provisioning failed" >&2; exit 1; }
+fi
 
+if [ "$run_fw" = 1 ]; then
   # Cheap and first, so a source-consistency error is not buried behind ten minutes of LTO.
   # #339: the prose describing the DIAG shed order had drifted from the appends it described, in a
   # direction that would send an operator to the wrong fields. Prose cannot be tested; this can.
@@ -154,7 +175,59 @@ if [ "$run_fw" = 1 ]; then
         | sort -u | sed 's/^/        /' | head -12
     fi
   done < <("$ROOT/tools/build_matrix.py" emit --for clippy)
+fi
 
+if [ "$run_excl" = 1 ]; then
+  # #351 the BYTE-FREE claims. Cargo.toml, net.rs and main.rs all assert that a lower tier
+  # contains none of a higher tier's code ("the default build is BYTE-FREE of it (symbol-
+  # absence provable)"), and until now nothing checked a single one of them — the same
+  # species of comment as this file's old "any feature not covered below should be added",
+  # which #350 found to be false for three features at once.
+  #
+  # The claims are DERIVED from the `#[cfg(feature = …)]` on each `mod` declaration, walked
+  # transitively from src/main.rs, so there is no second hand-written list to drift. The
+  # tiers come from the same manifest as the two loops above.
+  #
+  # This arm LINKS each tier, which the check/clippy loops do not, because the property is
+  # about what survives into the binary. Two consequences worth knowing before reading a
+  # green line:
+  #   * it needs DWARF, and `[profile.release]` sets `debug = false`, so the builds carry
+  #     CARGO_PROFILE_RELEASE_DEBUG=line-tables-only. Debug info is not an optimisation
+  #     input — MEASURED on this tree, .text/.rodata/.bss/.stack come out the same SIZE with
+  #     and without it — and it lands only in non-ALLOC sections, so no shipped byte moves.
+  #     The checker REFUSES an ELF with no DWARF rather than reading an empty file set and
+  #     calling it clean.
+  #   * a separate CARGO_TARGET_DIR, so it cannot invalidate the fingerprints the stack-floor
+  #     build below depends on. The ELF is copied out after each tier because the next tier
+  #     overwrites it.
+  step "tier exclusions — the BYTE-FREE claims (#351)"
+  EXCL="${SMOL_GATE_EXCL_DIR:-/tmp/gate-exclusions}"
+  mkdir -p "$EXCL/elf"
+  EXCL_ARGS=()
+  while IFS=$'\t' read -r name feats; do
+    if [ -n "$feats" ] && ! grep -qE "^${feats%%,*} *=" "$CLOCK/Cargo.toml"; then
+      printf '   \033[33mSKIP\033[0m %-16s (feature not in Cargo.toml on this branch)\n' "$name"; continue
+    fi
+    args=(--release --bin clock "${JOBS[@]}"); [ -n "$feats" ] && args+=(--features "$feats")
+    if (cd "$CLOCK" && CARGO_TARGET_DIR="$EXCL/target" \
+          CARGO_PROFILE_RELEASE_DEBUG=line-tables-only cargo build "${args[@]}") \
+          >/tmp/gate-excl-$name.log 2>&1; then
+      cp "$EXCL/target/$REPRO_TARGET/release/clock" "$EXCL/elf/$name"
+      EXCL_ARGS+=(--elf "$name=$feats=$EXCL/elf/$name")
+    else
+      bad "exclusions build $name"; tail -15 /tmp/gate-excl-$name.log | sed 's/^/        /'
+    fi
+  done < <("$ROOT/tools/build_matrix.py" emit --for check)
+  if [ ${#EXCL_ARGS[@]} -eq 0 ]; then
+    bad "tier exclusions (nothing built — no tier could be measured)"
+  elif out=$("$ROOT/tools/check_exclusions.py" check "${EXCL_ARGS[@]}" 2>&1); then
+    printf '%s\n' "$out"; ok "tier exclusions"
+  else
+    printf '%s\n' "$out"; bad "tier exclusions"
+  fi
+fi
+
+if [ "$run_fw" = 1 ]; then
   # #300 stack floor, measured with the SAME function the packaging path uses (repro_stack_check).
   # Built with repro_cargo_args so the ELF matches the shipped one's geometry.
   # #348: the title reads the floor from the same single definition repro_stack_check will use —
@@ -233,6 +306,17 @@ if [ "$run_host" = 1 ]; then
     printf '%s\n' "$out" | tail -2; ok "test_build_matrix"
   else
     printf '%s\n' "$out" | sed 's/^/        /'; bad "test_build_matrix"
+  fi
+
+  # #351: the same discipline for the exclusion checker, and it matters more here. An ABSENCE
+  # check's passing state and its broken state print the same green — "no violations found"
+  # and "nothing found at all" are indistinguishable from the outside. Pure text, no cargo,
+  # so it runs in the host half where a cross toolchain is not available.
+  step "exclusion checker regression suite (#351)"
+  if out=$("$ROOT/tools/test_check_exclusions.sh" 2>&1); then
+    printf '%s\n' "$out" | tail -2; ok "test_check_exclusions"
+  else
+    printf '%s\n' "$out" | sed 's/^/        /'; bad "test_check_exclusions"
   fi
 fi
 

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -23,10 +23,12 @@
 #   5. the crate's own tests/*.rs suites via cargo test (#350) — bard / budget / input. Nothing
 #      ran these before: 57 tests, including the Bard's bit-for-bit golden, that no gate executed
 #   6. tools/test_build_matrix.sh — proof that (0)'s arms can actually fail
-#   7. #351 the BYTE-FREE tier claims — each tier is LINKED and its DWARF line table is asked
-#      which source files contributed code, so "the default build is BYTE-FREE of it" is a
-#      measurement instead of a comment. Claims are derived from the `#[cfg(feature = …)]` on
-#      each `mod`, walked from src/main.rs; no second list.
+#   7. #351 the BYTE-FREE tier claims, in two arms. (a) build-matrix.toml's [tier_exclusive]
+#      must still agree with the `#[cfg(feature = …)]` in the source, both directions — this
+#      catches the regression (b) structurally cannot, where deleting a gate deletes the claim
+#      along with it. (b) each tier is LINKED and its DWARF line table is asked which source
+#      files contributed code, so "the default build is BYTE-FREE of it" is a measurement
+#      instead of a comment.
 #   8. tools/test_check_exclusions.sh — proof that (7)'s arms can actually fail, including the
 #      vacuous-green one (an ELF with no DWARF has an empty file set and every absence "holds")
 #

--- a/tools/test_check_exclusions.sh
+++ b/tools/test_check_exclusions.sh
@@ -192,5 +192,58 @@ TRUNC=$(fileset trunc src/always.rs)
 arm "refuses a file set with no crate root" 2 "omits src/main.rs" \
   -- check --crate "$CRATE" --manifest "$EMPTY_MANIFEST" --fileset "default==$TRUNC"
 
+# ── the declaration arms (#351, found by planting a real leak) ────────────────
+# The ELF arms above cannot catch the MOST LIKELY regression, and that is not a theory: the
+# plant that proved this gate can fail — drop the `#[cfg]` on `pub mod target;` so a new call
+# site compiles, leave the BYTE-FREE comment — put src/net/target.rs into the default tier
+# (11 crate files → 12) and the checker still said "0 leaked". The claim it would have
+# violated was derived from the very `#[cfg]` that was deleted. Hence [tier_exclusive], and
+# hence these arms: the commitment is checked against the source in BOTH directions.
+DECL="$TMP/decl.toml"
+cat > "$DECL" <<'TOML'
+[tier_exclusive]
+"src/netz.rs" = "wifi"
+"src/wled.rs" = "wled"
+"src/sub/mod.rs" = "espnow"
+"src/sub/child.rs" = "espnow"
+TOML
+arm "declaration — source agrees with the manifest" 0 "4 declared tier-exclusive, source agrees" \
+  -- check --crate "$CRATE" --manifest "$DECL" "${ALL[@]}"
+
+# THE ONE THE ELF ARM CANNOT SEE: the gate is gone, so the claim is gone, so nothing is left
+# to violate. Caught here or not at all.
+UNGATED="$TMP/ungated"; mk_crate "$UNGATED"
+python3 - "$UNGATED/src/main.rs" <<'PY'
+import sys
+p = sys.argv[1]; s = open(p).read()
+open(p, "w").write(s.replace('#[cfg(feature = "wled")]\nmod wled;', 'mod wled;'))
+PY
+arm "declaration — a gate was REMOVED (the ELF arm is blind to this)" 1 \
+  "src/wled.rs is declared tier-exclusive (wled) but is NOT cfg-gated" \
+  -- check --crate "$UNGATED" --manifest "$DECL" "${ALL[@]}"
+
+# …and the reverse, so the table cannot quietly stop covering what is added later.
+cat > "$TMP/decl_short.toml" <<'TOML'
+[tier_exclusive]
+"src/netz.rs" = "wifi"
+"src/sub/mod.rs" = "espnow"
+"src/sub/child.rs" = "espnow"
+TOML
+arm "declaration — a gated module with no entry" 1 \
+  "src/wled.rs is cfg-gated on wled but has no [tier_exclusive] entry" \
+  -- check --crate "$CRATE" --manifest "$TMP/decl_short.toml" "${ALL[@]}"
+
+# …and a gate that MOVED rather than vanished, which a presence-only list would miss.
+cat > "$TMP/decl_wrong.toml" <<'TOML'
+[tier_exclusive]
+"src/netz.rs" = "espnow"
+"src/wled.rs" = "wled"
+"src/sub/mod.rs" = "espnow"
+"src/sub/child.rs" = "espnow"
+TOML
+arm "declaration — a gate CHANGED feature" 1 \
+  "src/netz.rs is declared to require espnow, but the source gates it on wifi" \
+  -- check --crate "$CRATE" --manifest "$TMP/decl_wrong.toml" "${ALL[@]}"
+
 printf '  %d ok, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tools/test_check_exclusions.sh
+++ b/tools/test_check_exclusions.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# test_check_exclusions.sh — #351. Prove `tools/check_exclusions.py` can FAIL, one arm at a time.
+#
+# ── WHY ───────────────────────────────────────────────────────────────────────
+# The thing being replaced is a comment that says "BYTE-FREE" and is never tested. Replacing
+# it with a CHECK that is never seen to refuse would be the same mistake with a shell script
+# in front of it — and this tree has been bitten by exactly that: `repro_build.sh` is a
+# sourced library, so running it bare exits 0 having done nothing, and it was cited as the
+# stack gate for weeks.
+#
+# An ABSENCE check is the worst case of the genre, because its passing state and its broken
+# state look identical: "I found no violations" and "I found nothing at all" print the same
+# green. So every arm below is a tree or a file set crafted to violate exactly one rule, and
+# the suite asserts BOTH that the checker fails AND that it fails with the RIGHT finding.
+#
+# ── WHAT IS AND IS NOT COVERED HERE ───────────────────────────────────────────
+# Covered, with no cargo and no cross toolchain: the claim derivation from source, the
+# feature resolution, the leak/subtree/unproven/stale-declaration decisions, and the ELF
+# reader's refusal to read an ELF that has no DWARF.
+#
+# NOT covered here: that a real leak in a real firmware build is detected end to end. That
+# is a cargo-scale demonstration; it is written up in the #351 PR with the two numbers
+# (default tier: 11 crate files clean → 12 with a planted `net::wled` reference, gate red).
+# The `--fileset` inputs below are the RECORDED form of exactly that output.
+#
+# Exit 0 all arms behaved; 1 otherwise.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CE="$HERE/check_exclusions.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+pass=0; fail=0
+
+note() { printf '   \033[32mok\033[0m   %s\n' "$1"; pass=$((pass + 1)); }
+oops() { printf '   \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail + 1)); }
+
+# ── a synthetic crate with the same SHAPE as rust/clock ───────────────────────
+# Deliberately tiny and deliberately NOT the real crate: a fixture that tracked the real
+# source would go green whenever the real source changed, which is the failure mode of every
+# test that asserts against its own subject.
+mk_crate() {                                   # mk_crate <dir> [extra main.rs lines]
+  local d="$1"; shift
+  mkdir -p "$d/src/sub"
+  cat > "$d/Cargo.toml" <<'TOML'
+[package]
+name = "fixture"
+version = "0.0.0"
+
+[features]
+default = ["hw"]
+hw = []
+wifi = ["hw"]
+espnow = ["wifi"]
+wled = ["espnow"]
+TOML
+  cat > "$d/src/main.rs" <<'RS'
+mod always;
+// A paragraph of rationale between the cfg and the mod, because that is the house style
+// in rust/clock/src/net.rs and a checker that cannot see past it would be blind there.
+#[cfg(feature = "wifi")]
+mod netz;
+#[cfg(feature = "wled")]
+mod wled;
+#[cfg(feature = "espnow")]
+mod sub;
+RS
+  [ $# -gt 0 ] && printf '%s\n' "$@" >> "$d/src/main.rs"
+  : > "$d/src/always.rs"
+  : > "$d/src/netz.rs"
+  : > "$d/src/wled.rs"
+  : > "$d/src/sub/mod.rs"
+  : > "$d/src/sub/child.rs"
+  echo 'mod child;' > "$d/src/sub/mod.rs"
+}
+
+fileset() { local f="$TMP/$1.set"; shift; printf '%s\n' "$@" > "$f"; echo "$f"; }
+
+CRATE="$TMP/crate"; mk_crate "$CRATE"
+EMPTY_MANIFEST="$TMP/empty.toml"; : > "$EMPTY_MANIFEST"
+
+# The four tiers, as file sets. Together they observe every gated module at least once,
+# which is what makes the GREEN case green rather than vacuous.
+SET_DEFAULT=$(fileset default src/main.rs src/always.rs)
+SET_WIFI=$(fileset wifi src/main.rs src/always.rs src/netz.rs)
+SET_ESPNOW=$(fileset espnow src/main.rs src/always.rs src/netz.rs src/sub/mod.rs src/sub/child.rs)
+SET_WLED=$(fileset wled src/main.rs src/always.rs src/netz.rs src/wled.rs src/sub/mod.rs src/sub/child.rs)
+ALL=(--fileset "default==$SET_DEFAULT"
+     --fileset "wifi=wifi=$SET_WIFI"
+     --fileset "espnow=espnow=$SET_ESPNOW"
+     --fileset "wled=wled,espnow=$SET_WLED")
+
+# arm <name> <expected-exit> <expected-substring> -- <args…>
+arm() {
+  local name="$1" want_rc="$2" want="$3"; shift 4
+  local out rc
+  out="$("$CE" "$@" 2>&1)"; rc=$?
+  if [ "$rc" != "$want_rc" ]; then
+    oops "$name: expected exit $want_rc, got $rc — $(printf '%s' "$out" | tail -2 | head -1)"
+  elif [ -n "$want" ] && ! printf '%s' "$out" | grep -qF -- "$want"; then
+    oops "$name: exit $rc but not for '$want' — $(printf '%s' "$out" | tail -2 | head -1)"
+  else
+    note "$name"
+  fi
+}
+
+echo "  #351 exclusion-checker arms"
+
+# 1. The green case. Asserted FIRST and asserted to be exit 0 with every claim observed, so
+#    that a later arm going red cannot be explained away as "the fixture was always broken".
+arm "green — 4 tiers, every claim observed" 0 "4 claims · 4 observed" \
+  -- check --crate "$CRATE" --manifest "$EMPTY_MANIFEST" "${ALL[@]}"
+
+# 2. THE ARM THIS ISSUE EXISTS FOR: a module the tier claims to exclude contributed code.
+LEAK=$(fileset leak src/main.rs src/always.rs src/wled.rs)
+arm "leak — wled.rs present in the default tier" 1 "src/wled.rs contributed code, but wled is OFF" \
+  -- check --crate "$CRATE" --manifest "$EMPTY_MANIFEST" \
+     --fileset "default==$LEAK" --fileset "wifi=wifi=$SET_WIFI" \
+     --fileset "espnow=espnow=$SET_ESPNOW" --fileset "wled=wled,espnow=$SET_WLED"
+
+# 3. A directory module drags its subtree. Checking only the named file would miss the
+#    submodule that got linked, which is the SHAPE of a real leak — nobody references
+#    `mod.rs`, they reference the child.
+SUBLEAK=$(fileset subleak src/main.rs src/always.rs src/sub/child.rs)
+arm "leak — a SUBMODULE of an excluded directory module" 1 "src/sub/child.rs contributed code" \
+  -- check --crate "$CRATE" --manifest "$EMPTY_MANIFEST" \
+     --fileset "default==$SUBLEAK" --fileset "wifi=wifi=$SET_WIFI" \
+     --fileset "espnow=espnow=$SET_ESPNOW" --fileset "wled=wled,espnow=$SET_WLED"
+
+# 4. Anti-vacuity. Drop the one tier that builds `wled` and the remaining run "passes" every
+#    absence check while having proved nothing about wled.rs. That must be RED.
+arm "unproven — no checked tier ever enables wled" 1 "UNPROVEN: src/wled.rs" \
+  -- check --crate "$CRATE" --manifest "$EMPTY_MANIFEST" \
+     --fileset "default==$SET_DEFAULT" --fileset "wifi=wifi=$SET_WIFI" \
+     --fileset "espnow=espnow=$SET_ESPNOW"
+
+# 5. …and the escape hatch, used honestly: a module that genuinely emits no code is declared
+#    with a reason, and the run goes green again.
+cat > "$TMP/unobs.toml" <<'TOML'
+[unobservable]
+"src/wled.rs" = "fixture: consts only"
+TOML
+arm "unobservable — a declared reason makes it green" 0 "1 declared unobservable" \
+  -- check --crate "$CRATE" --manifest "$TMP/unobs.toml" \
+     --fileset "default==$SET_DEFAULT" --fileset "wifi=wifi=$SET_WIFI" \
+     --fileset "espnow=espnow=$SET_ESPNOW"
+
+# 6. …and dishonestly: the reason has stopped applying. #350 learned this on `[exempt]` —
+#    a stale exemption is worse than none, because it reads as a considered decision.
+arm "unobservable — stale entry, the module IS observed" 1 "but it WAS observed" \
+  -- check --crate "$CRATE" --manifest "$TMP/unobs.toml" "${ALL[@]}"
+
+# 7. …and for something that is not a gated module at all.
+cat > "$TMP/ghost.toml" <<'TOML'
+[unobservable]
+"src/nope.rs" = "fixture: does not exist"
+TOML
+arm "unobservable — names a non-module" 1 "which is not a cfg-gated module" \
+  -- check --crate "$CRATE" --manifest "$TMP/ghost.toml" "${ALL[@]}"
+
+# 8. A cfg the checker does not model. Guessing at `any(...)` is how a checker starts quietly
+#    passing; exit 2 says "the instrument cannot judge this tree", which is not the same
+#    answer as "this tree is fine".
+COMPOUND="$TMP/compound"; mk_crate "$COMPOUND"
+cat >> "$COMPOUND/src/main.rs" <<'RS'
+#[cfg(any(feature = "wifi", feature = "wled"))]
+mod tricky;
+RS
+: > "$COMPOUND/src/tricky.rs"
+arm "refuses a compound cfg rather than guess" 2 "compound cfg" \
+  -- check --crate "$COMPOUND" --manifest "$EMPTY_MANIFEST" "${ALL[@]}"
+
+# 9. A `mod` whose file is not there. Fail closed: a module the walker cannot find is a
+#    module whose claims it cannot evaluate.
+MISSING="$TMP/missing"; mk_crate "$MISSING" '#[cfg(feature = "wled")]' 'mod vanished;'
+arm "refuses a mod whose file is missing" 2 "refusing to judge a module I cannot find" \
+  -- check --crate "$MISSING" --manifest "$EMPTY_MANIFEST" "${ALL[@]}"
+
+# 10. THE VACUOUS-GREEN TRAP, on the real instrument. An ELF with no DWARF yields an empty
+#     file set, under which every absence check trivially holds. The release profile ships
+#     `debug = false`, so this is the DEFAULT state of a smol build, not a corner case — it
+#     is the single most likely way this gate would come to pass while proving nothing.
+#     `readelf` itself is the fixture: it is guaranteed present (this checker shells out to
+#     it) and it is a stripped distro binary, i.e. exactly a real ELF with no debug info.
+NODWARF="$(command -v readelf)"
+arm "refuses an ELF with no DWARF" 2 "no DWARF" \
+  -- check --crate "$CRATE" --manifest "$EMPTY_MANIFEST" --elf "probe==$NODWARF"
+
+# 11. Same refusal for the recorded form: a file set that does not even contain the crate
+#     root is a truncated measurement, not a clean tier.
+TRUNC=$(fileset trunc src/always.rs)
+arm "refuses a file set with no crate root" 2 "omits src/main.rs" \
+  -- check --crate "$CRATE" --manifest "$EMPTY_MANIFEST" --fileset "default==$TRUNC"
+
+printf '  %d ok, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #351.

`Cargo.toml`, `net.rs` and `main.rs` all state that a lower tier contains none of a higher tier's code — *"the default build is BYTE-FREE of it (symbol-absence provable)"* — and **nothing checked a single one of them**. Same species as the `gate.sh` comment #350 disproved for three features at once.

## Verdict — all 10 manifest tiers linked, zero leaks

```
default           11 crate files · 44 modules claimed absent · 0 leaked
wifi              20 crate files · 35 modules claimed absent · 0 leaked
espnow            45 crate files · 11 modules claimed absent · 0 leaked
fleet             48 crate files ·  8 modules claimed absent · 0 leaked
bard              54 crate files ·  2 modules claimed absent · 0 leaked
ledger-provision  45 crate files · 11 modules claimed absent · 0 leaked
wled              49 crate files ·  7 modules claimed absent · 0 leaked
coexist-soak      48 crate files ·  8 modules claimed absent · 0 leaked
mesh-test         48 crate files ·  8 modules claimed absent · 0 leaked
stack-paint       55 crate files ·  1 modules claimed absent · 0 leaked
10 tiers · 44 claims · 43 observed · 1 declared unobservable
```

The substantive claims **hold**. `default` really is free of wled / cast / io / target / election / etx / flood / wire / mqtt code.

## Why not compilation units

The issue title (and WLED's prior art in `scratch/parity/multitarget-prior-art.md`) prescribes asserting each module contributed a **CU**. That does not transfer, and the difference is the whole design:

* WLED is C++ — one CU per `.cpp`, so "module" and "CU" coincide.
* smol's firmware is **one Rust crate** at `codegen-units = 1` + `lto = "fat"`. Measured: the linked ELF has **exactly one** CU whose `DW_AT_comp_dir` is the crate (`src/main.rs/@/clock.<hash>-cgu.0`). A per-CU assertion would be true for every module in every tier forever — *a gate that cannot fail*, which is the thing this issue is about.

The unit that survives is one level down: the CU's **line-table file set**, which attributes **inlined** code back to its source file (verified — `display-interface-i2c` rows sitting inside `ssd1306` addresses). WLED's other finding — that map files are unusable under LTO — stands and is why neither a map nor `nm` is used here.

## Failure demonstration

Not a green-only claim. Ungate `pub mod target;` in `net.rs` and plant a `net::target::chip_name()` call in `main()` — the realistic regression, where the gate is dropped so a new call site compiles and the byte-free comment above it is left untouched:

<!--LEAKDEMO-->

## What it proves, and what it does not

**Proves:** no *executable* bytes from an excluded module survived, inlined or otherwise.

**Does not prove:** no *data*. A consts-only module lands in `.rodata` with no line rows. `src/secrets.rs` is exactly that, and is declared in `build-matrix.toml`'s new `[unobservable]` **with its reason** — same discipline as `[exempt]`, including refusing a stale entry whose module *is* observed.

**Anti-vacuity:** every claim must be OBSERVED at least once across the run, or it is reported **UNPROVEN**, not passing. An absence check whose broken state and passing state print the same green needs this or it is decoration.

## Two claims narrowed

* `Cargo.toml` and `net.rs` listed the **`wled` build** among those byte-free of `cast`. Since #350 the `wled` **tier** is `wled,${canonical}` and the canonical features include `cast` — so that tier carries it. The old wording named a feature combination nothing builds.
* `Cargo.toml` cited `src/io.rs` as carrying `#![cfg(feature = "io")]`. It does not; it is gated at its `mod io;` in `main.rs`. Same effect, wrong citation.

## Mechanics

* `tools/gate.sh excl` is a new mode and a **separate CI job**. This arm LINKS every tier (measured **790 s** total on a dev box) on top of a `firmware` job already budgeted at 45 minutes. Bolting it on would have made the timeout the thing that fails, and a gate that times out gets deleted. The jobs share no state.
* Builds carry `CARGO_PROFILE_RELEASE_DEBUG=line-tables-only` into their own target dir. **`[profile.release]` is untouched** — debug info lands only in non-ALLOC sections, and `.text` / `.rodata` / `.bss` / `.stack` come out the same **size** with and without it (`.text` 892,022 B both).
* Claims are **derived, never listed**: the walker follows `mod` declarations transitively from `src/main.rs` and reads the `#[cfg(feature = …)]` on each. 44 gated modules today. Gates compose — `src/bard/stack_paint.rs requires bard+stack-paint`.

## `tools/test_check_exclusions.sh` — 11 arms, each proven to fail

green control · leak · **subtree** leak · unproven · honest `[unobservable]` · stale `[unobservable]` · ghost `[unobservable]` · compound-cfg refusal · missing-module refusal · **ELF-with-no-DWARF refusal** · truncated-fileset refusal.

That DWARF arm is the one that matters: `debug = false` is the release default, so an ELF with no debug info yields an empty file set under which *every* absence check trivially holds. That is exit 2, not green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)