### PR TITLE
ci: assert host verifiers test code the firmware actually compiles (#369)

### DIFF
--- a/tools/check_verifier_wiring.py
+++ b/tools/check_verifier_wiring.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""#367 — every host verifier must test code the firmware actually contains.
+
+The `experiments/*_verify` harnesses `#[path]`-include a firmware source file so a pure module
+can be host-tested without dragging in the no_std/riscv deps. That escape hatch is legitimate and
+worth keeping — it is how `wire`, `flood`, `treehead` and friends get real host coverage.
+
+What it does NOT do is prove the module is *wired in*. `#[path]` reads a FILE. It does not care
+whether the crate declares `mod <name>;` anywhere, so a verifier can be green against a source
+file that is compiled into no firmware tier at all.
+
+That is not hypothetical. `rust/clock/src/net/crdt.rs` (#185) has no `mod crdt;` anywhere in the
+crate: `experiments/185_crdt_verify` passes, `tools/gate.sh` goes green, and the fleet binary has
+never contained a byte of it. The gate cannot distinguish "wired and working" from "on disk and
+never compiled" — which makes a passing verifier read as evidence of delivery when it is not.
+
+This check closes that gap with one machine-checked fact per verifier:
+
+    for each `#[path]` target under the firmware crate, does the crate declare it as a module?
+
+VERDICTS
+  SOUND    declared → compiled into at least one tier → the verifier tests shipped code.
+  PHANTOM  no declaration anywhere → the verifier certifies code the fleet never runs. FAILS.
+
+A declaration's `#[cfg(...)]` is reported so a reader can see which tiers carry it; a module
+gated to a feature no tier enables is a narrower question this check deliberately does not try to
+answer (it would need the tier matrix, which lives in gate.sh and moves). Reporting the cfg
+verbatim is honest; inferring reachability from it would be a guess dressed as a fact.
+
+Usage:  tools/check_verifier_wiring.py [repo_root]
+Exit:   0 all sound · 1 at least one PHANTOM · 2 usage/IO error
+"""
+import re
+import sys
+from pathlib import Path
+
+# Phantoms that are KNOWN and TRACKED. An entry is a promise that someone owns the decision, so
+# each one must name the issue that owns it — an unexplained entry is just a way to make red go
+# green. The list is checked in BOTH directions: an unlisted phantom fails (a new one cannot slip
+# in), and a listed entry that has since become SOUND *also* fails, so the list cannot quietly rot
+# into a permanent excuse for something already fixed.
+KNOWN_PHANTOMS = {
+    "rust/clock/src/net/crdt.rs":
+        "#185 — L4 CRDT core landed + host-tested, but no consumer exists yet. Wiring it means "
+        "first deciding what multi-writer state smol has (RPG loot / gravestone / seen-set are "
+        "all still hypothetical), which is a design call, not a mechanical fix.",
+}
+
+PATH_ATTR = re.compile(r'#\[\s*path\s*=\s*"([^"]+)"\s*\]')
+# `mod x;` / `pub mod x;` / `pub(crate) mod x;` — declaration only, never `mod x { .. }` inline
+# (an inline module is not a file-backed one, so it cannot be a #[path] target).
+MOD_DECL = re.compile(r'^\s*(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;')
+CFG_ATTR = re.compile(r'^\s*#\[\s*(cfg|cfg_attr)\b')
+
+
+def crate_declarations(crate_src: Path):
+    """Map module name -> list of (file, line, cfg-lines-immediately-above)."""
+    decls = {}
+    for rs in sorted(crate_src.rglob("*.rs")):
+        try:
+            lines = rs.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError as e:
+            print(f"error: cannot read {rs}: {e}", file=sys.stderr)
+            raise SystemExit(2)
+        for i, line in enumerate(lines):
+            m = MOD_DECL.match(line)
+            if not m:
+                continue
+            # Walk back over contiguous attribute lines to capture the gating cfg(s).
+            cfgs, j = [], i - 1
+            while j >= 0 and (CFG_ATTR.match(lines[j]) or lines[j].lstrip().startswith("#[")):
+                if CFG_ATTR.match(lines[j]):
+                    cfgs.insert(0, lines[j].strip())
+                j -= 1
+            decls.setdefault(m.group(1), []).append((rs, i + 1, cfgs))
+    return decls
+
+
+def main() -> int:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+    experiments, crate_src = root / "experiments", root / "rust" / "clock" / "src"
+    if not experiments.is_dir() or not crate_src.is_dir():
+        print(f"error: run from the smol repo root (got {root})", file=sys.stderr)
+        return 2
+
+    decls = crate_declarations(crate_src)
+    rows, phantoms, missing_files = [], [], []
+
+    for main_rs in sorted(experiments.rglob("*.rs")):
+        text = main_rs.read_text(encoding="utf-8", errors="replace")
+        verifier = main_rs.relative_to(experiments).parts[0]
+        for rel in PATH_ATTR.findall(text):
+            target = (main_rs.parent / rel).resolve()
+            # Only firmware-crate sources are in scope; a verifier including another experiment's
+            # helper is not making a claim about shipped code.
+            try:
+                target.relative_to(crate_src)
+            except ValueError:
+                continue
+            if not target.exists():
+                missing_files.append((verifier, rel))
+                continue
+            name = target.stem
+            where = decls.get(name, [])
+            if where:
+                sites = "; ".join(
+                    f"{p.relative_to(root)}:{ln}" + (f" {' '.join(c)}" if c else " (no cfg)")
+                    for p, ln, c in where
+                )
+                rows.append((verifier, str(target.relative_to(root)), "yes", sites, "SOUND"))
+            else:
+                rows.append((verifier, str(target.relative_to(root)), "NO", "-", "PHANTOM"))
+                phantoms.append((verifier, str(target.relative_to(root))))
+
+    w = [max(len(str(r[i])) for r in rows + [("verifier", "module", "decl", "declared at", "verdict")])
+         for i in range(5)] if rows else [8] * 5
+    hdr = ("verifier", "#[path] target", "declared?", "declared at", "verdict")
+    print(f"{hdr[0]:<{w[0]}}  {hdr[1]:<{w[1]}}  {hdr[2]:<{w[2]}}  {hdr[3]:<{w[3]}}  {hdr[4]}")
+    print("-" * (sum(w) + 8))
+    for r in sorted(rows, key=lambda r: (r[4] != "PHANTOM", r[0])):
+        print(f"{r[0]:<{w[0]}}  {r[1]:<{w[1]}}  {r[2]:<{w[2]}}  {r[3]:<{w[3]}}  {r[4]}")
+
+    print(f"\n{len(rows)} #[path] include(s) into the firmware crate across "
+          f"{len({r[0] for r in rows})} verifier(s): "
+          f"{sum(1 for r in rows if r[4] == 'SOUND')} sound, {len(phantoms)} phantom.")
+
+    for verifier, rel in missing_files:
+        print(f"error: {verifier} includes {rel}, which does not exist", file=sys.stderr)
+
+    # Split phantoms into tracked (allowlisted, reported loudly) and new (fatal).
+    tracked = [(v, m) for v, m in phantoms if m in KNOWN_PHANTOMS]
+    untracked = [(v, m) for v, m in phantoms if m not in KNOWN_PHANTOMS]
+    sound_paths = {r[1] for r in rows if r[4] == "SOUND"}
+    stale = sorted(sound_paths & set(KNOWN_PHANTOMS))
+
+    if tracked:
+        print("\nKNOWN phantoms (tracked, not failing):")
+        for verifier, mod in tracked:
+            print(f"  {verifier} -> {mod}\n      {KNOWN_PHANTOMS[mod]}")
+
+    if stale:
+        print("\nSTALE allowlist — these are now WIRED and must be removed from KNOWN_PHANTOMS:",
+              file=sys.stderr)
+        for mod in stale:
+            print(f"  {mod}", file=sys.stderr)
+        print("An allowlist that outlives its reason is how a check stops checking.", file=sys.stderr)
+
+    if untracked:
+        print("\nPHANTOM — a green verifier over code no firmware tier compiles:", file=sys.stderr)
+        for verifier, mod in untracked:
+            print(f"  {verifier} -> {mod}", file=sys.stderr)
+        print("\nFix EITHER by wiring the module (add `mod <name>;` to the crate, with the cfg the\n"
+              "consumer needs) OR by removing the verifier. A verifier over uncompiled source is\n"
+              "worse than no verifier: it reports the code as covered.\n"
+              "If it is a deliberate, owned exception, add it to KNOWN_PHANTOMS with its issue.",
+              file=sys.stderr)
+
+    if untracked or stale or missing_files:
+        return 1 if (untracked or stale) else 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -118,6 +118,20 @@ if [ "$run_fw" = 1 ]; then
     printf '%s\n' "$out"; bad "diag budget"
   fi
 
+  # #367: a host verifier `#[path]`-includes a firmware source, which reads a FILE and does not
+  # care whether the crate declares it as a module. So a verifier can be green against code that
+  # is compiled into NO tier — `net/crdt.rs` (#185) is exactly that today, and the gate could not
+  # tell it apart from working code. This asserts the one bit that closes it: every `#[path]`
+  # target is also a declared module. Known, owned exceptions live in the script's KNOWN_PHANTOMS
+  # with their issue, and the check fails BOTH on a new phantom and on an allowlist entry that has
+  # since been wired — a list that outlives its reason is how a check stops checking.
+  step "host verifiers test code the firmware compiles (#367)"
+  if out=$("$ROOT/tools/check_verifier_wiring.py" "$ROOT" 2>&1); then
+    printf '%s\n' "$out"; ok "verifier wiring"
+  else
+    printf '%s\n' "$out"; bad "verifier wiring"
+  fi
+
   # #350: cheap and before any compile, because everything below DERIVES from this manifest —
   # a gate that builds the wrong tier list confidently is worse than one that refuses to start.
   # The arms: the canonical tier matches REPRO_FLEET_FEATURES (the packaging path's own
@@ -369,6 +383,17 @@ if [ "$run_host" = 1 ]; then
     printf '%s\n' "$out" | tail -2; ok "test_check_exclusions"
   else
     printf '%s\n' "$out" | sed 's/^/        /'; bad "test_check_exclusions"
+  fi
+
+  # #367: prove the verifier-wiring checker's arms can fail. Operates only on mktemp copies —
+  # never the working tree. Same reasoning as its siblings: this check exists BECAUSE a green
+  # signal over uncompiled code fooled us, so shipping it without watching it go red would be
+  # the same mistake one level up.
+  step "verifier-wiring checker regression suite (#367)"
+  if out=$("$ROOT/tools/test_verifier_wiring.sh" 2>&1); then
+    printf '%s\n' "$out" | tail -2; ok "test_verifier_wiring"
+  else
+    printf '%s\n' "$out" | sed 's/^/        /'; bad "test_verifier_wiring"
   fi
 fi
 

--- a/tools/test_verifier_wiring.sh
+++ b/tools/test_verifier_wiring.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# #367 host half — proves every arm of check_verifier_wiring.py CAN FAIL.
+#
+# A check nobody has watched fail is a claim, not a guard. This runs the real script against
+# deliberately broken copies of the tree and asserts the exit codes.
+#
+# ⚠️ SAFETY: this NEVER mutates the working tree. Every case operates on a fresh `cp -r` into a
+# mktemp dir, and the only writes are inside it. That is not defensive styling — this repo has
+# already lost ~200 lines of uncommitted work to a self-test that ran a repo-wide `git reset
+# --hard` from an EXIT trap. A test harness that edits the tree it is testing is a loaded gun
+# regardless of how careful its author was.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK="$ROOT/tools/check_verifier_wiring.py"
+PASS=0; FAIL=0
+
+# Copy only what the check reads, so a case is fast and cannot reach anything else.
+mkcopy() {
+  local d; d="$(mktemp -d)"
+  mkdir -p "$d/rust/clock" "$d/experiments" "$d/tools"
+  cp -r "$ROOT/rust/clock/src" "$d/rust/clock/src"
+  cp -r "$ROOT/experiments/." "$d/experiments/"
+  cp "$CHECK" "$d/tools/"
+  printf '%s' "$d"
+}
+
+case_run() { # <name> <want-exit> <mutator-fn>
+  local name="$1" want="$2" fn="$3" d out rc
+  d="$(mkcopy)"
+  "$fn" "$d"
+  out="$(python3 "$d/tools/check_verifier_wiring.py" "$d" 2>&1)"; rc=$?
+  rm -rf "$d"
+  if [ "$rc" -eq "$want" ]; then
+    printf '  \033[32mPASS\033[0m %s (exit %d)\n' "$name" "$rc"; PASS=$((PASS+1))
+  else
+    printf '  \033[31mFAIL\033[0m %s — wanted exit %d, got %d\n' "$name" "$want" "$rc"
+    printf '%s\n' "$out" | sed 's/^/        /'; FAIL=$((FAIL+1))
+  fi
+}
+
+noop() { :; }
+
+# A new phantom: drop a module declaration that a verifier includes. This is the exact shape of
+# the #185 defect, reproduced on a module that is currently wired.
+drop_decl() { sed -i 's/^pub mod etx;/\/\/ removed by test/' "$1/rust/clock/src/net.rs"; }
+
+# A stale allowlist entry: something listed as a known phantom that is in fact wired.
+stale_entry() {
+  python3 - "$1" <<'PY'
+import pathlib, sys
+p = pathlib.Path(sys.argv[1]) / "tools" / "check_verifier_wiring.py"
+t = p.read_text()
+p.write_text(t.replace('KNOWN_PHANTOMS = {', 'KNOWN_PHANTOMS = {\n    "rust/clock/src/net/etx.rs": "#000 — deliberately stale test entry",', 1))
+PY
+}
+
+# A verifier pointing at a file that does not exist — a rename that missed the harness.
+dangling_include() { rm -f "$1/rust/clock/src/net/etx.rs"; }
+
+echo "#367 verifier-wiring check — proving each arm can fail"
+case_run "clean tree passes (crdt tracked)"        0 noop
+case_run "a NEW phantom fails"                     1 drop_decl
+case_run "a STALE allowlist entry fails"           1 stale_entry
+case_run "a dangling #[path] target is an error"   2 dangling_include
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+  echo "test_verifier_wiring: OK — $PASS/$((PASS+FAIL)) arms proven able to fail"
+  exit 0
+fi
+echo "test_verifier_wiring: $FAIL of $((PASS+FAIL)) arms did NOT behave as specified"
+exit 1


### PR DESCRIPTION
Closes #369. Audit + structural fix for the `#[path]`-verifier class.

## Census: 15 verifiers, 16 includes — **15 sound, 1 phantom**

The worry was that the idiom had produced a fleet of decorative gates. It had not — only `185_crdt_verify` → `net/crdt.rs` is phantom, the one already known. **The count is part of the finding:** the idiom is legitimate and stays, and that is now backed by evidence rather than left as suspicion after one bad instance.

Full table in #369, machine-generated by the check itself, so the census cannot drift from the tool.

## The check

`tools/check_verifier_wiring.py`, in `gate.sh` beside `check_shed_order.py` / `check_diag_budget.py`. One machine-checked bit per include: **is the `#[path]` target also a declared module?**

Four design choices, each a place this could have become decorative itself:

- **Allowlisted exceptions name their issue.** `crdt` is listed against #185, whose residual is *choose a consumer* — a design call. Declaring it to green the gate would be gaming the check.
- **Fails in both directions.** New phantom fails; an allowlist entry that has since been wired *also* fails. A list that outlives its reason is how a check stops checking.
- **`cfg`s reported verbatim, not resolved to tiers.** Inferring reachability needs the tier matrix (#350's, and it moves). A guess dressed as a fact is the thing this issue is about.
- **`tools/test_verifier_wiring.sh` proves all four arms can fail** — clean / new phantom / stale entry / dangling target.

```
#367 verifier-wiring check — proving each arm can fail
  PASS clean tree passes (crdt tracked) (exit 0)
  PASS a NEW phantom fails (exit 1)
  PASS a STALE allowlist entry fails (exit 1)
  PASS a dangling #[path] target is an error (exit 2)
```

I watched it go red before believing it. Earlier today I claimed another suite couldn't catch a regression, then sabotaged the code and found it caught it immediately — so a guard I have only *read* is a claim, not a guard.

The self-test operates **only on `mktemp` copies**. This repo has already lost ~200 lines of uncommitted work to a self-test that mutated the tree it was testing; that is a property of the harness, not of its author's care.

## Not covered

A module declared but gated behind a feature **no tier enables** would pass. That needs the tier matrix and belongs with #350, which already owns that data. No such case exists today.

## Gate

`tools/gate.sh all` **GREEN**, including the two new steps. Stack **106,472 B** (floor 74,208) — unchanged; this is CI-only, no firmware bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)