### PR TITLE
fix(scan): record that `.with_max(16)` never bounded anything (#367)

### DIFF
--- a/rust/clock/src/budget.rs
+++ b/rust/clock/src/budget.rs
@@ -386,3 +386,59 @@ const _: () = assert!(
      fields and separate verdicts. Shrink the model, use a chip with a larger slot, or \
      re-cut the partition table (which is an OTA-compatibility change, not a build change)."
 );
+
+// ── #367: scan heap floor ──────────────────────────────────────────────────────────────────────
+
+/// Size of one `esp_radio::wifi::ap::AccessPointInfo`, **measured on this target** (compile-time
+/// probe: `const _: [(); 0] = [(); size_of::<AccessPointInfo>()]`, whose error reports the size).
+/// A const rather than a sentence so the derivation below can be checked, not merely believed.
+pub const SCAN_AP_INFO_BYTES: u32 = 47;
+
+/// Reference environment density. **UNMEASURED** — three instruments failed on 2026-08-01 (fleet
+/// on-demand scan returned nothing in 95 s; katana's WiFi is RF-killed with the driver
+/// unavailable; gatekeeper is a wired firewall with no radio). 150 is a reasoned stand-in for a
+/// dense house, NOT an observation. A real `bss_total` from a retained `smol/<id>/scan` record
+/// replaces this and becomes the check on the whole derivation.
+pub const SCAN_REF_BSSIDS: u32 = 150;
+
+/// Peak heap the scan itself can occupy, derived — see #367.
+///
+/// `scan_async` collects internally and `ScanResults` implements **only** `next()` (no
+/// `size_hint`, no `ExactSizeIterator`), so `collect()` cannot pre-allocate and the `Vec` grows by
+/// DOUBLING. Two consequences, and the second is the one that gets rescaled wrongly later:
+///
+/// 1. Final capacity is the power of two ≥ N — for 150 BSSIDs that is **256**, not 150.
+/// 2. Across the final realloc the OLD and NEW buffers are both live, so the transient is
+///    `(cap/2 + cap) × 47 B` = `1.5 × cap × 47 B`.
+///
+/// ⇒ `(128 + 256) × 47` = **18,048 B**.
+///
+/// ⚠️ **This is a STEP FUNCTION, not a curve. Do not rescale it linearly.** 150 and 250 BSSIDs
+/// cost exactly the same (both fit capacity 256). The next cliff is at **257** BSSIDs → capacity
+/// 512 → `(256 + 512) × 47` = 36,096 B, which is 2× this value in one step. A maintainer who
+/// resizes the heap and scales this proportionally will land in the wrong place.
+pub const SCAN_PEAK_BYTES: u32 = (128 + 256) * SCAN_AP_INFO_BYTES; // 18,048
+
+/// Free heap required before starting a scan (#367).
+///
+/// `= 2 × SCAN_PEAK_BYTES`. **The factor of 2 is an honest safety factor, NOT an enumeration** —
+/// stated plainly because the difference matters to anyone re-deriving it:
+///
+/// * The main superloop contributes **nothing**. The scan is awaited under
+///   `embassy_futures::block_on` with **no executor** (0 embassy-executor in the lockfile;
+///   `esp-rtos` without its `embassy` feature), so MQTT, DIAG, OTA and relay — all main-loop work
+///   — are parked for the duration. That part IS enumerated, and it is zero.
+/// * What could NOT be bounded from source is esp-radio's own demand-driven RX pool
+///   (`dynamic_rx 40` / `static_rx 16`, set in `net::radio_controller_config()`). How many of
+///   those are live during a scan await is driver-internal and traffic-dependent.
+///
+/// So: enumeration closed the main loop and failed on the driver, and the factor covers the gap.
+/// It happens to equal the 257-BSSID cliff (36,096 B) — **coincidence, not derivation.** If the
+/// RX pool is ever bounded properly, replace the factor with the sum and say so here.
+pub const SCAN_HEAP_FLOOR_BYTES: u32 = 2 * SCAN_PEAK_BYTES; // 36,096
+
+const _: () = assert!(
+    SCAN_HEAP_FLOOR_BYTES > SCAN_PEAK_BYTES,
+    "the scan heap floor must exceed the scan's own peak, or the guard cannot protect anything \
+     (src/budget.rs, #367)."
+);

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -651,6 +651,10 @@ struct DiagCounters {
     /// Lowest free-heap reading observed since boot (leak/pressure watermark). `u32::MAX` until
     /// the first sample so `min()` latches the true low-water on the first `diag_sample_heap`.
     heap_min: u32,
+    /// #367: scans DEFERRED because free heap was below `budget::SCAN_HEAP_FLOOR_BYTES`
+    /// (monotonic, saturating). Non-zero means the unbounded `scan_async` collect is genuinely
+    /// pressing on this board's heap — the signal that the latent bug became live here.
+    scan_skip: u16,
     /// BOOT-button SHORT-press count (monotonic, wraps). HA fires a `press` event on each change.
     btn: u16,
     /// BOOT-button LONG-press count (monotonic, wraps). HA fires a `long-press` event on change.
@@ -710,6 +714,7 @@ impl DiagCounters {
     const fn new() -> Self {
         Self {
             heap_min: u32::MAX,
+            scan_skip: 0,
             btn: 0,
             btnl: 0,
             flush_ok: 0,
@@ -3172,6 +3177,14 @@ impl RadioManager {
             log::info!("smol #71: scan skipped — mesh-OTA session active (coexist)");
             return;
         }
+        // #367 HEAP GATE: `scan_async` collects one AccessPointInfo per visible AP and the bound
+        // cannot be restored in esp-radio 0.18 (see the call site). Returning here DEFERS — it
+        // touches no state, so the caller's normal cadence retries on a later tick once heap
+        // recovers. Deliberately placed after the OTA gate: both are "not now", and OTA is the
+        // cheaper test.
+        if !self.scan_heap_ok() {
+            return;
+        }
         let ch_before = self.current_channel();
         // scan_n = scan_with_config_sync_max(Default, N): a synchronous full-band scan capped at N
         // results. We cap generously then keep the strongest few, so a busy band still yields the
@@ -3243,6 +3256,12 @@ impl RadioManager {
     /// re-measures downstream on the next flush; #155 channel-follow re-advertises the new channel.
     /// ⚠️ HW-CANARY-GATED: the scan + reassociate radio path — and whether ESP-NOW coexist follows
     /// the new STA channel — cannot be verified without hardware (same discipline as `run_scan`/OTA).
+    /// #367: deliberately NOT heap-gated, unlike `run_scan`. This returns a `CrownApDecision`, and
+    /// the only "skip" value available is `NoAp` — which the caller cannot distinguish from "no
+    /// usable AP exists" and would act on by shedding the crown. Trading a possible allocation
+    /// spike for a spurious crown shed is a bad trade: the shed is certain, the spike is not.
+    /// If this path ever needs guarding, give the decision an explicit `Deferred` variant first —
+    /// do NOT reuse `NoAp`.
     fn reassoc_ch6_prefer(&mut self) -> crate::net::coexist::CrownApDecision {
         use crate::net::coexist::{select_crown_ap, ApView, CrownApDecision};
         // COEXIST hard gate: never leave the mesh channel mid mesh-OTA transfer (mirrors run_scan).
@@ -3381,6 +3400,34 @@ impl RadioManager {
             let ctx = CrownCtx { reassoc_exhausted: true, better_successor_cc: false };
             self.crown_state = crown_next_state(CrownState::Shed, decision, self.shed_reclaims, ctx);
         }
+    }
+
+    /// #367: may a scan start right now? `false` ⇒ free heap is below
+    /// [`crate::budget::SCAN_HEAP_FLOOR_BYTES`], so `scan_async`'s unbounded per-AP collect could
+    /// exhaust the heap and panic-reboot (the bound cannot be restored in esp-radio 0.18 — see the
+    /// note at the call site).
+    ///
+    /// **DEFER, NEVER ABANDON.** Callers must leave whatever drives the retry untouched so the
+    /// scan happens on a later tick. A skipped-and-forgotten scan on the #269 recovery path would
+    /// convert "reboot" into "stranded, silently, while still looking alive" — which is worse,
+    /// because a reboot at least re-enters discovery.
+    ///
+    /// Trips are COUNTED (`diag.scan_skip`) so this is observable in the dense environment where
+    /// it fires. A guard that degrades silently is indistinguishable from dead code, and we would
+    /// have no way to tell whether it ever protected anything.
+    fn scan_heap_ok(&mut self) -> bool {
+        let free = esp_alloc::HEAP.free() as u32;
+        if free < crate::budget::SCAN_HEAP_FLOOR_BYTES {
+            self.diag.scan_skip = self.diag.scan_skip.saturating_add(1);
+            log::warn!(
+                "smol #367: scan DEFERRED — free heap {} B < floor {} B (skips={})",
+                free,
+                crate::budget::SCAN_HEAP_FLOOR_BYTES,
+                self.diag.scan_skip
+            );
+            return false;
+        }
+        true
     }
 
     /// #70: sample the live free-heap and lower the min-heap watermark. Cheap (one `HEAP.free()`);

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -3178,15 +3178,45 @@ impl RadioManager {
         // most-relevant APs.
         let record = match block_on(
             self.controller
-                // #233 REGRESSION FIX: esp-radio 0.18's scan_async(ScanConfig::default()) has
-                // max=None and returns EVERY AP in range as a heap Vec — the old esp-wifi
-                // scan_n(16) capped at 16. In a dense RF environment the unbounded Vec is an
-                // OOM-panic risk (alloc failure = rst=panic); .with_max(16) restores the bound.
+                // ⚠️ #367: `.with_max(16)` DOES NOT BOUND THE ALLOCATION. It is accepted and
+                // silently DISCARDED by esp-radio 0.18. Kept only because it is the documented
+                // intent and costs nothing if a future version starts honouring it.
+                //
+                // Why it does nothing (esp-radio-0.18.0, verified in source):
+                //   - `scan_async` collects internally at `wifi/mod.rs:2828` via
+                //     `ScanResults::new(self)?.collect::<Vec<_>>()`.
+                //   - `ScanResults::new(_controller)` (`wifi/scan.rs:138`) takes the CONTROLLER
+                //     only — the `ScanConfig` never reaches it. It sets `remaining = bss_total`
+                //     (the full driver AP count) and the iterator walks every one.
+                //   - So one `AccessPointInfo` is heap-allocated per AP the radio can see.
+                // Upstream: esp-hal#5583 (opened 2026-05-19, closed 2026-05-28) — the fix is NOT
+                // in 0.18.0. A matched-set bump is the real fix (#233's thesis: never piecemeal).
+                //
+                // DO NOT "fix" this with either obvious repair — both are dead ends:
+                //   1. `.take(16)` on the RETURNED value cannot help: `scan_async` returns an
+                //      already-collected `Vec`, so the allocation happened inside the callee
+                //      before we see a byte. It bounds our copy, never the peak.
+                //   2. Driving the scan ourselves to use the public `ScanResults` iterator is
+                //      UNREACHABLE: `wifi_start_scan` is `pub(crate)` (`wifi/mod.rs:1090`) and
+                //      `EVENT_CHANNEL` is private. `scan_async` is the crate's ONLY public scan
+                //      entry point.
+                //
+                // Measured magnitude (so the risk is sized, not feared): `AccessPointInfo` is
+                // 47 B on this target; the heap is 96 KB (`net.rs`). 150 BSSIDs ≈ 7 KB steady,
+                // ~14 KB if the Vec doubles while growing. Real, density-dependent, and invisible
+                // on a 3-AP bench — but not the tens-of-KB spike an earlier estimate suggested.
                 .scan_async(&ScanConfig::default().with_max(16)),
         ) {
             Ok(mut aps) => {
                 // Strongest RSSI first (descending → Reverse of the ascending key).
                 aps.sort_by_key(|a| core::cmp::Reverse(a.signal_strength));
+                // #367 RETAINED-COPY BOUND — deliberately NOT an OOM guard. The peak allocation
+                // already happened inside `scan_async` (see the note above); this cannot undo it.
+                // What it DOES do is bound everything downstream of here — the record we format,
+                // publish and relay — to the 16 strongest, which is the behaviour the old
+                // esp-wifi `scan_n(16)` gave callers. Truncating AFTER the sort keeps the
+                // strongest 16 rather than an arbitrary 16.
+                aps.truncate(16);
                 format_scan_record(&aps)
             }
             Err(_) => alloc::string::String::from("SCAN|err"),
@@ -3234,13 +3264,41 @@ impl RadioManager {
         // co-channel vs the strand fallback in ONE pass). Filter to our SSID; feed the pure selector.
         let decision = match block_on(
             self.controller
-                // #233 REGRESSION FIX: esp-radio 0.18's scan_async(ScanConfig::default()) has
-                // max=None and returns EVERY AP in range as a heap Vec — the old esp-wifi
-                // scan_n(16) capped at 16. In a dense RF environment the unbounded Vec is an
-                // OOM-panic risk (alloc failure = rst=panic); .with_max(16) restores the bound.
+                // ⚠️ #367: `.with_max(16)` DOES NOT BOUND THE ALLOCATION. It is accepted and
+                // silently DISCARDED by esp-radio 0.18. Kept only because it is the documented
+                // intent and costs nothing if a future version starts honouring it.
+                //
+                // Why it does nothing (esp-radio-0.18.0, verified in source):
+                //   - `scan_async` collects internally at `wifi/mod.rs:2828` via
+                //     `ScanResults::new(self)?.collect::<Vec<_>>()`.
+                //   - `ScanResults::new(_controller)` (`wifi/scan.rs:138`) takes the CONTROLLER
+                //     only — the `ScanConfig` never reaches it. It sets `remaining = bss_total`
+                //     (the full driver AP count) and the iterator walks every one.
+                //   - So one `AccessPointInfo` is heap-allocated per AP the radio can see.
+                // Upstream: esp-hal#5583 (opened 2026-05-19, closed 2026-05-28) — the fix is NOT
+                // in 0.18.0. A matched-set bump is the real fix (#233's thesis: never piecemeal).
+                //
+                // DO NOT "fix" this with either obvious repair — both are dead ends:
+                //   1. `.take(16)` on the RETURNED value cannot help: `scan_async` returns an
+                //      already-collected `Vec`, so the allocation happened inside the callee
+                //      before we see a byte. It bounds our copy, never the peak.
+                //   2. Driving the scan ourselves to use the public `ScanResults` iterator is
+                //      UNREACHABLE: `wifi_start_scan` is `pub(crate)` (`wifi/mod.rs:1090`) and
+                //      `EVENT_CHANNEL` is private. `scan_async` is the crate's ONLY public scan
+                //      entry point.
+                //
+                // Measured magnitude (so the risk is sized, not feared): `AccessPointInfo` is
+                // 47 B on this target; the heap is 96 KB (`net.rs`). 150 BSSIDs ≈ 7 KB steady,
+                // ~14 KB if the Vec doubles while growing. Real, density-dependent, and invisible
+                // on a 3-AP bench — but not the tens-of-KB spike an earlier estimate suggested.
                 .scan_async(&ScanConfig::default().with_max(16)),
         ) {
             Ok(aps) => {
+                // #367: NO `truncate` here, unlike the scan-record path above — deliberate.
+                // `select_crown_ap` takes a `max_by_key` over these views, so dropping any entry
+                // risks discarding the very AP it exists to find. `views` is already bounded far
+                // below the raw AP count by the SSID filter below (only our own network), so an
+                // arbitrary cap would trade correctness for memory we do not need back here.
                 let mut views: alloc::vec::Vec<ApView> = alloc::vec::Vec::new();
                 for a in aps.iter() {
                     if a.ssid.as_str() == net.ssid {


### PR DESCRIPTION
Closes #367. Found by **nebula** during the #368 upstream sweep; the defective comment is mine, from `b2537c4`. Two commits: **record the truth**, then **guard the entry**.

## What was wrong

The #233 comment said `.with_max(16)` *"restores the bound"*. **It doesn't.** esp-radio 0.18 accepts `ScanConfig.max` and silently discards it, so the unbounded per-AP heap allocation has been on main since `b2537c4` — on the scan path best-gateway election depends on, failing as an OOM reboot.

## Commit 1 — why both obvious repairs are dead ends

Verified in `esp-radio-0.18.0` source. This is the load-bearing part: without it the next reader re-derives one of these and "fixes" it back to broken.

1. `scan_async` collects **internally** (`wifi/mod.rs:2828`) and returns an already-built `Vec`. ⇒ **`.take(16)` on the returned value cannot help** — the allocation happened inside the callee before we see a byte. It bounds our copy, never the peak.
2. `ScanResults::new(_controller)` (`wifi/scan.rs:138`) takes the **controller only**; the `ScanConfig` never reaches it. It sets `remaining = bss_total` and walks every AP.
3. `wifi_start_scan` is `pub(crate)` and `EVENT_CHANNEL` is private ⇒ **the "drive the scan yourself and use the public `ScanResults` iterator" bypass is unreachable.** `scan_async` is the crate's only public scan entry point.

**In esp-radio 0.18 the bound cannot be restored from application code at all.** Upstream esp-hal#5583 is closed but **not in 0.18.0**; a matched-set bump is the real fix (#233's thesis: never piecemeal).

Also converts trimming to `aps.truncate(16)` **after** the sort, labelled honestly as a bound on the **retained copy** (the record we format, publish and relay) — matching what esp-wifi's `scan_n(16)` gave callers. Explicitly **not** an OOM guard. The crown-AP path is deliberately **not** truncated, and says so: `select_crown_ap` takes a `max_by_key` over those views, so a cap could discard the AP it exists to find.

## Commit 2 — guard the entry, since the allocation can't be bounded

Refuse to **start** a scan unless the heap can absorb its worst case. Constants live in `budget.rs` beside the stack floor, so there is one place to propagate; each is a named const with its arithmetic shown rather than a literal:

| const | value | status |
|---|---|---|
| `SCAN_AP_INFO_BYTES` | 47 | **measured** on target (compile-time size probe) |
| `SCAN_REF_BSSIDS` | 150 | ⚠️ **UNMEASURED** — reasoned stand-in |
| `SCAN_PEAK_BYTES` | `(128 + 256) × 47` = 18,048 | derived |
| `SCAN_HEAP_FLOOR_BYTES` | `2 × SCAN_PEAK_BYTES` = 36,096 | derived + honest factor |

`ScanResults` implements **only `next()`** — no `size_hint`, no `ExactSizeIterator` — so `collect()` cannot pre-allocate and the `Vec` **doubles**. Hence capacity 256 for 150 APs, and both buffers live across the final realloc.

⚠️ **STEP FUNCTION, not a curve.** 150 and 250 BSSIDs cost identically (both fit capacity 256). The next cliff is **257** → capacity 512 → 36,096 B, double in one step. Anything derived from this must not be rescaled linearly — the comment says so explicitly.

**The ×2 is an honest safety factor, not an enumeration**, and is labelled as such:
- The **main loop contributes zero, and that half IS enumerated**: the scan is awaited under `embassy_futures::block_on` with **no executor** (0 `embassy-executor` in the lockfile; `esp-rtos` without its `embassy` feature), so MQTT/DIAG/OTA/relay are parked for the duration.
- esp-radio's demand-driven RX pool (`dynamic_rx 40` / `static_rx 16`) could **not** be bounded from source. The factor covers that gap and nothing else. Its equality with the 257-cliff is **coincidence, not derivation**.

**Behaviour:**
- **Defers, never abandons** — `run_scan` returns early touching no state, so the normal cadence retries once heap recovers. A skipped-and-forgotten scan on the #269 recovery path would convert "reboot" into "stranded silently while still looking alive", which is worse: a reboot at least re-enters discovery.
- **Emits evidence** — new `diag.scan_skip` counter plus a `warn!` carrying free/floor/count. A guard that degrades silently is indistinguishable from dead code in exactly the dense environment where it matters.
- `reassoc_ch6_prefer` is **deliberately unguarded**, and says why: it returns a `CrownApDecision` whose only "skip" value is `NoAp`, which the caller cannot distinguish from "no usable AP exists" and would act on by **shedding the crown**. That trades a *possible* allocation spike for a *certain* crown shed. A `Deferred` variant must be added first; `NoAp` must not be reused.

## Known gap, stated rather than hidden

`SCAN_REF_BSSIDS = 150` is **unmeasured**. Three instruments failed on 2026-08-01: the fleet on-demand scan returned nothing in 95 s, katana's WiFi is RF-killed with the driver unavailable, and gatekeeper is a wired firewall with no radio. A real `bss_total` from a retained `smol/<id>/scan` record replaces it **and becomes the check on this whole derivation**.

**Gate: 45 PASS / 0 FAIL, `GATE GREEN`.** Stack 106,472 B against the 74,208 B floor (unchanged — the guard adds no `.bss`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)