### PR TITLE
fix(ci): resolve verifier reachability PER-ROOT, not by module name (#367 follow-up)

### DIFF
--- a/tools/check_verifier_wiring.py
+++ b/tools/check_verifier_wiring.py
@@ -48,32 +48,60 @@ KNOWN_PHANTOMS = {
 
 PATH_ATTR = re.compile(r'#\[\s*path\s*=\s*"([^"]+)"\s*\]')
 # `mod x;` / `pub mod x;` / `pub(crate) mod x;` — declaration only, never `mod x { .. }` inline
-# (an inline module is not a file-backed one, so it cannot be a #[path] target).
+# (an inline module is not file-backed, so it cannot be a #[path] target).
 MOD_DECL = re.compile(r'^\s*(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;')
-CFG_ATTR = re.compile(r'^\s*#\[\s*(cfg|cfg_attr)\b')
 
 
-def crate_declarations(crate_src: Path):
-    """Map module name -> list of (file, line, cfg-lines-immediately-above)."""
-    decls = {}
-    for rs in sorted(crate_src.rglob("*.rs")):
-        try:
-            lines = rs.read_text(encoding="utf-8", errors="replace").splitlines()
-        except OSError as e:
-            print(f"error: cannot read {rs}: {e}", file=sys.stderr)
-            raise SystemExit(2)
+def reachable_from(root: Path, crate_src: Path):
+    """Every source file in the module tree rooted at `root`, resolved the way rustc resolves it.
+
+    THIS IS A PER-ROOT WALK, AND THAT IS THE ENTIRE POINT. The clock crate has TWO roots that
+    declare overlapping files with different gating: `main.rs` (the firmware bin) and `lib.rs`
+    (the `hostsim` library the web emulator builds). Keying on a module NAME and searching the
+    whole tree conflates them — #351's first checker did exactly that, picked up `lib.rs`'s
+    `#[cfg(feature = "hostsim")]`, and declared `app`/`clock`/`input`/`sensors`/`snake` excluded
+    from a firmware image that plainly contains them. Five false negatives from one shortcut.
+
+    Walking each root separately also makes this immune to three traps that bite gate-parsing
+    tools on this crate, because the verdict never consults a `cfg` at all:
+      * `#![cfg_attr(not(espnow), allow(dead_code))]` in `wifi.rs` is a LINT attribute, not a
+        gate — a checker that greps for cfg-shaped things near a module reads it as one;
+      * a module's gate can live in a different file (`net/cast.rs` is gated from `net.rs`);
+      * feature membership is transitive (`espnow` -> `wifi` -> `hw`), so direct membership
+        under-approximates.
+    Reachability answers "is this file in the tree rustc compiles for this root", which is the
+    question, and needs none of that modelling.
+    """
+    seen, out, stack = set(), set(), [root]
+    while stack:
+        f = stack.pop()
+        if f in seen or not f.exists():
+            continue
+        seen.add(f)
+        out.add(f.resolve())
+        lines = f.read_text(encoding="utf-8", errors="replace").splitlines()
         for i, line in enumerate(lines):
             m = MOD_DECL.match(line)
             if not m:
                 continue
-            # Walk back over contiguous attribute lines to capture the gating cfg(s).
-            cfgs, j = [], i - 1
-            while j >= 0 and (CFG_ATTR.match(lines[j]) or lines[j].lstrip().startswith("#[")):
-                if CFG_ATTR.match(lines[j]):
-                    cfgs.insert(0, lines[j].strip())
-                j -= 1
-            decls.setdefault(m.group(1), []).append((rs, i + 1, cfgs))
-    return decls
+            name = m.group(1)
+            # A `#[path = ".."]` attribute on the declaration overrides the filename. `lib.rs`
+            # uses this for the bard cores, so it is not hypothetical.
+            override = None
+            for j in range(max(0, i - 4), i):
+                pm = PATH_ATTR.search(lines[j])
+                if pm:
+                    override = pm.group(1)
+            if override:
+                cands = [f.parent / override, crate_src / override]
+            else:
+                base = f.parent if f.name in ("main.rs", "lib.rs") else f.parent / f.stem
+                cands = [base / f"{name}.rs", base / name / "mod.rs"]
+            for c in cands:
+                if c.exists():
+                    stack.append(c)
+                    break
+    return out
 
 
 def main() -> int:
@@ -83,54 +111,61 @@ def main() -> int:
         print(f"error: run from the smol repo root (got {root})", file=sys.stderr)
         return 2
 
-    decls = crate_declarations(crate_src)
-    rows, phantoms, missing_files = [], [], []
+    ships = reachable_from(crate_src / "main.rs", crate_src)   # the firmware bin
+    hostsim = reachable_from(crate_src / "lib.rs", crate_src)  # the hostsim/web-emu library
+    if not ships:
+        print("error: main.rs reached no modules — the walk is broken, refusing to report",
+              file=sys.stderr)
+        return 2
 
+    rows, phantoms, missing_files = [], [], []
     for main_rs in sorted(experiments.rglob("*.rs")):
         text = main_rs.read_text(encoding="utf-8", errors="replace")
         verifier = main_rs.relative_to(experiments).parts[0]
         for rel in PATH_ATTR.findall(text):
             target = (main_rs.parent / rel).resolve()
-            # Only firmware-crate sources are in scope; a verifier including another experiment's
-            # helper is not making a claim about shipped code.
             try:
                 target.relative_to(crate_src)
             except ValueError:
-                continue
+                continue  # including another experiment's helper claims nothing about firmware
             if not target.exists():
                 missing_files.append((verifier, rel))
                 continue
-            name = target.stem
-            where = decls.get(name, [])
-            if where:
-                sites = "; ".join(
-                    f"{p.relative_to(root)}:{ln}" + (f" {' '.join(c)}" if c else " (no cfg)")
-                    for p, ln, c in where
-                )
-                rows.append((verifier, str(target.relative_to(root)), "yes", sites, "SOUND"))
+            shown = str(target.relative_to(root))
+            if target in ships:
+                verdict, where = "SOUND", "main.rs tree"
+            elif target in hostsim:
+                verdict, where = "HOST-ONLY", "lib.rs tree (hostsim)"
             else:
-                rows.append((verifier, str(target.relative_to(root)), "NO", "-", "PHANTOM"))
-                phantoms.append((verifier, str(target.relative_to(root))))
+                verdict, where = "PHANTOM", "neither root"
+                phantoms.append((verifier, shown))
+            rows.append((verifier, shown, where, verdict))
 
-    w = [max(len(str(r[i])) for r in rows + [("verifier", "module", "decl", "declared at", "verdict")])
-         for i in range(5)] if rows else [8] * 5
-    hdr = ("verifier", "#[path] target", "declared?", "declared at", "verdict")
-    print(f"{hdr[0]:<{w[0]}}  {hdr[1]:<{w[1]}}  {hdr[2]:<{w[2]}}  {hdr[3]:<{w[3]}}  {hdr[4]}")
-    print("-" * (sum(w) + 8))
-    for r in sorted(rows, key=lambda r: (r[4] != "PHANTOM", r[0])):
-        print(f"{r[0]:<{w[0]}}  {r[1]:<{w[1]}}  {r[2]:<{w[2]}}  {r[3]:<{w[3]}}  {r[4]}")
+    if rows:
+        w = [max(len(str(r[i])) for r in rows) for i in range(3)]
+    else:
+        w = [8, 8, 8]
+    print(f"{'verifier':<{w[0]}}  {'#[path] target':<{w[1]}}  {'reachable from':<{w[2]}}  verdict")
+    print("-" * (sum(w) + 14))
+    order = {"PHANTOM": 0, "HOST-ONLY": 1, "SOUND": 2}
+    for r in sorted(rows, key=lambda r: (order[r[3]], r[0])):
+        print(f"{r[0]:<{w[0]}}  {r[1]:<{w[1]}}  {r[2]:<{w[2]}}  {r[3]}")
 
+    n_sound = sum(1 for r in rows if r[3] == "SOUND")
+    n_host = sum(1 for r in rows if r[3] == "HOST-ONLY")
     print(f"\n{len(rows)} #[path] include(s) into the firmware crate across "
           f"{len({r[0] for r in rows})} verifier(s): "
-          f"{sum(1 for r in rows if r[4] == 'SOUND')} sound, {len(phantoms)} phantom.")
+          f"{n_sound} sound, {n_host} host-only, {len(phantoms)} phantom.")
+    if n_host:
+        print("HOST-ONLY = reachable from lib.rs but not main.rs: real code, but it ships in the\n"
+              "web emulator rather than the firmware. Not a defect; just not a firmware claim.")
 
     for verifier, rel in missing_files:
         print(f"error: {verifier} includes {rel}, which does not exist", file=sys.stderr)
 
-    # Split phantoms into tracked (allowlisted, reported loudly) and new (fatal).
     tracked = [(v, m) for v, m in phantoms if m in KNOWN_PHANTOMS]
     untracked = [(v, m) for v, m in phantoms if m not in KNOWN_PHANTOMS]
-    sound_paths = {r[1] for r in rows if r[4] == "SOUND"}
+    sound_paths = {r[1] for r in rows if r[3] in ("SOUND", "HOST-ONLY")}
     stale = sorted(sound_paths & set(KNOWN_PHANTOMS))
 
     if tracked:
@@ -139,25 +174,25 @@ def main() -> int:
             print(f"  {verifier} -> {mod}\n      {KNOWN_PHANTOMS[mod]}")
 
     if stale:
-        print("\nSTALE allowlist — these are now WIRED and must be removed from KNOWN_PHANTOMS:",
+        print("\nSTALE allowlist — these are now reachable and must be removed from KNOWN_PHANTOMS:",
               file=sys.stderr)
         for mod in stale:
             print(f"  {mod}", file=sys.stderr)
         print("An allowlist that outlives its reason is how a check stops checking.", file=sys.stderr)
 
     if untracked:
-        print("\nPHANTOM — a green verifier over code no firmware tier compiles:", file=sys.stderr)
+        print("\nPHANTOM — a green verifier over code NEITHER crate root compiles:", file=sys.stderr)
         for verifier, mod in untracked:
             print(f"  {verifier} -> {mod}", file=sys.stderr)
-        print("\nFix EITHER by wiring the module (add `mod <name>;` to the crate, with the cfg the\n"
-              "consumer needs) OR by removing the verifier. A verifier over uncompiled source is\n"
-              "worse than no verifier: it reports the code as covered.\n"
+        print("\nFix EITHER by wiring the module (declare it in the root that should carry it) OR by\n"
+              "removing the verifier. A verifier over uncompiled source is worse than no verifier:\n"
+              "it reports the code as covered.\n"
               "If it is a deliberate, owned exception, add it to KNOWN_PHANTOMS with its issue.",
               file=sys.stderr)
 
-    if untracked or stale or missing_files:
-        return 1 if (untracked or stale) else 2
-    return 0
+    if untracked or stale:
+        return 1
+    return 2 if missing_files else 0
 
 
 if __name__ == "__main__":

--- a/tools/test_verifier_wiring.sh
+++ b/tools/test_verifier_wiring.sh
@@ -41,6 +41,22 @@ case_run() { # <name> <want-exit> <mutator-fn>
 
 noop() { :; }
 
+# Assert a PATTERN in the output, not just an exit code. Needed for HOST-ONLY, which is a
+# reportable state rather than a failure — exit 0 alone would not prove it was noticed.
+case_grep() { # <name> <want-exit> <pattern> <mutator-fn>
+  local name="$1" want="$2" pat="$3" fn="$4" d out rc
+  d="$(mkcopy)"
+  "$fn" "$d"
+  out="$(python3 "$d/tools/check_verifier_wiring.py" "$d" 2>&1)"; rc=$?
+  rm -rf "$d"
+  if [ "$rc" -eq "$want" ] && printf '%s' "$out" | grep -q "$pat"; then
+    printf '  \033[32mPASS\033[0m %s (exit %d, matched %s)\n' "$name" "$rc" "$pat"; PASS=$((PASS+1))
+  else
+    printf '  \033[31mFAIL\033[0m %s — wanted exit %d + /%s/, got exit %d\n' "$name" "$want" "$pat" "$rc"
+    printf '%s\n' "$out" | sed 's/^/        /'; FAIL=$((FAIL+1))
+  fi
+}
+
 # A new phantom: drop a module declaration that a verifier includes. This is the exact shape of
 # the #185 defect, reproduced on a module that is currently wired.
 drop_decl() { sed -i 's/^pub mod etx;/\/\/ removed by test/' "$1/rust/clock/src/net.rs"; }
@@ -55,6 +71,15 @@ p.write_text(t.replace('KNOWN_PHANTOMS = {', 'KNOWN_PHANTOMS = {\n    "rust/cloc
 PY
 }
 
+# THE TWO-ROOT TRAP (#351/#366). Move a module out of the firmware root and into the hostsim
+# library root. A name-keyed checker sees "etx is declared somewhere" and says SOUND; the truth is
+# that the firmware no longer contains it. This is the exact shortcut that produced five false
+# negatives on app/clock/input/sensors/snake, reproduced here so this tool cannot regress into it.
+lib_only() {
+  sed -i 's/^pub mod etx;/\/\/ moved to lib.rs by test/' "$1/rust/clock/src/net.rs"
+  printf '\n#[cfg(feature = "hostsim")]\n#[path = "net/etx.rs"]\npub mod etx;\n' >> "$1/rust/clock/src/lib.rs"
+}
+
 # A verifier pointing at a file that does not exist — a rename that missed the harness.
 dangling_include() { rm -f "$1/rust/clock/src/net/etx.rs"; }
 
@@ -62,6 +87,7 @@ echo "#367 verifier-wiring check — proving each arm can fail"
 case_run "clean tree passes (crdt tracked)"        0 noop
 case_run "a NEW phantom fails"                     1 drop_decl
 case_run "a STALE allowlist entry fails"           1 stale_entry
+case_grep "lib.rs-only module reads HOST-ONLY, not SOUND" 0 "HOST-ONLY" lib_only
 case_run "a dangling #[path] target is an error"   2 dangling_include
 
 echo


### PR DESCRIPTION
Follow-up to #370, which merged before I had this. **The shipped check has the exact bug morpheus warned about on #351, and I proved it against the merged code rather than arguing about it.**

## The defect

#370 keys on module **name**, scanning every `.rs` for a matching `mod` declaration. The clock crate has **two roots** that declare overlapping files with different gating — `main.rs` (firmware bin) and `lib.rs` (the `hostsim` library the web emulator builds). A name-keyed lookup cannot tell them apart.

Reproduced against the merged checker by moving `etx` out of the firmware root into `lib.rs` under `hostsim`:

```
old (name-keyed):  etx_verify -> net/etx.rs   ...lib.rs:185 #[cfg(hostsim)]   SOUND
new (per-root):    etx_verify -> net/etx.rs   lib.rs tree (hostsim)       HOST-ONLY
```

The old form certifies a verifier as testing shipped code on the strength of a declaration in a root the firmware never builds — which is this check's own failure mode, one level up. morpheus hit it first on #351, where it declared `app`/`clock`/`input`/`sensors`/`snake` excluded from an image that plainly contains them.

## The fix

A walk of the module tree from **each root**, resolving `mod x;` the way rustc does — `#[path]` overrides (which `lib.rs` uses for the bard cores) and `x/mod.rs` included. Three verdicts now:

| verdict | meaning |
|---|---|
| **SOUND** | reachable from `main.rs` — the verifier tests firmware code |
| **HOST-ONLY** | only from `lib.rs` — real code, but it ships in the web emulator, not the firmware. Reported, not failed: a different claim, not a defect |
| **PHANTOM** | neither root — fails, unless tracked in `KNOWN_PHANTOMS` |

**The verdict consults no `cfg` at all**, which makes it immune *by construction* to the three traps that bite gate-parsing tools on this crate:

- `wifi.rs`'s `#![cfg_attr(not(espnow), allow(dead_code))]` is a **lint** attribute that reads as a gate;
- a module's gate can live in **another file** (`net/cast.rs` is gated from `net.rs`);
- feature membership is **transitive** (`espnow` → `wifi` → `hw`), so direct membership under-approximates.

Reachability needs none of that modelling, which is why it's the right question. I deliberately did *not* reuse #351's feature-closure logic — not because it's wrong, but because this check no longer needs to model features at all, and the least powerful mechanism that answers the question is the one least able to be wrong about a healthy tree.

## The census is unchanged

**15 sound, 0 host-only, 1 phantom.** The previously reported answer stands — it was right by luck, and is now right by construction. Independently cross-confirmed by nebula's #371 module-graph sweep: `crdt.rs` is the repo's only orphan. Two methods, two passes, same answer.

## Regression arm

`test_verifier_wiring.sh` gains a fifth arm reproducing the two-root case and asserting **HOST-ONLY**, not SOUND — so this tool cannot regress into the bug it was just fixed for. It asserts on output text, not just exit code, because HOST-ONLY is a reportable state rather than a failure and an exit code alone wouldn't prove it was noticed.

```
  PASS clean tree passes (crdt tracked) (exit 0)
  PASS a NEW phantom fails (exit 1)
  PASS a STALE allowlist entry fails (exit 1)
  PASS lib.rs-only module reads HOST-ONLY, not SOUND (exit 0, matched HOST-ONLY)
  PASS a dangling #[path] target is an error (exit 2)
```

5/5 arms proven able to fail, `mktemp` copies only.

## Gate

`tools/gate.sh host` GREEN including both new steps. CI-only; no firmware bytes, stack untouched.

Refs #367, #369, #370, #351/#366 (where the two-root trap was first found), #371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)