### PR TITLE
feat(mesh): ELECT frame + epoch/anti-flap core, and remove the ntp non-signal (#278, #269)

### DIFF
--- a/experiments/election_verify/src/main.rs
+++ b/experiments/election_verify/src/main.rs
@@ -7,8 +7,8 @@ mod election;
 
 use election::*;
 
-fn inp(co_channel: bool, ap_rssi: i8, ntp_holder: bool, uptime_ms: u64) -> FitnessInputs {
-    FitnessInputs { co_channel, ap_rssi, ntp_holder, uptime_ms }
+fn inp(co_channel: bool, ap_rssi: i8, uptime_ms: u64) -> FitnessInputs {
+    FitnessInputs { co_channel, ap_rssi, uptime_ms }
 }
 
 fn main() {
@@ -16,48 +16,48 @@ fn main() {
 
     // ---- gateway_fitness (weighted, higher = better) --------------------------------------
     // co-channel dominates: a co-channel board with the WORST usable RSSI still outscores the
-    // BEST off-channel board (co=100 vs off-channel max = rssi 2·10 + ntp 5 + uptime 2·1 = 27).
-    let co_weak = gateway_fitness(&inp(true, -82, false, 0), &w);
-    let off_best = gateway_fitness(&inp(false, -60, true, 10 * 60_000), &w);
+    // BEST off-channel board (co=100 vs off-channel max = rssi 2·10 + uptime 2·1 = 22).
+    let co_weak = gateway_fitness(&inp(true, -82, 0), &w);
+    let off_best = gateway_fitness(&inp(false, -60, 10 * 60_000), &w);
     assert!(co_weak > off_best, "co-channel dominance: {co_weak} !> {off_best}");
     // full-signal co-channel board = max fitness for the default weights.
     assert_eq!(
-        gateway_fitness(&inp(true, -60, true, 10 * 60_000), &w),
+        gateway_fitness(&inp(true, -60, 10 * 60_000), &w),
         MetricWeights::DEFAULT.max_fitness(),
         "full-signal co-channel = max fitness"
     );
-    // RSSI + uptime + ntp order WITHIN co-channel.
-    let co_strong = gateway_fitness(&inp(true, -60, false, 0), &w);
+    // RSSI + uptime order WITHIN co-channel.
+    let co_strong = gateway_fitness(&inp(true, -60, 0), &w);
     assert!(co_strong > co_weak, "stronger rssi scores higher among co-channel");
 
     // ---- elect_backoff_ms: higher fitness → shorter wait; co-channel ALWAYS beats off-channel --
     // The exact id5 bug, numerically: a co-channel HIGH-id board must claim BEFORE a stronger
     // OFF-channel LOW-id board (backoff strictly smaller despite the higher node id).
-    let co_hi_id = elect_backoff_ms(&inp(true, -70, false, 0), &w, 9);
-    let off_lo_id = elect_backoff_ms(&inp(false, -55, true, 10 * 60_000), &w, 3);
+    let co_hi_id = elect_backoff_ms(&inp(true, -70, 0), &w, 9);
+    let off_lo_id = elect_backoff_ms(&inp(false, -55, 10 * 60_000), &w, 3);
     assert!(
         co_hi_id < off_lo_id,
         "co-channel id9 ({co_hi_id}ms) must claim before off-channel id3 ({off_lo_id}ms) — the id5 bug"
     );
     // Bounded: no board EVER waits longer than the legacy 0–30 s envelope (+ the sub-tier id term).
-    let worst = elect_backoff_ms(&inp(false, -90, false, 0), &w, 254);
+    let worst = elect_backoff_ms(&inp(false, -90, 0), &w, 254);
     assert!(
         worst <= MAX_ELECT_TIERS * ELECT_TIER_STEP_MS + 254 * 200,
         "backoff bounded to MAX_ELECT_TIERS: {worst}"
     );
-    // Best board (co-channel, strong, ntp, long uptime) = tier 0 → only the sub-tier id term.
+    // Best board (co-channel, strong, long uptime) = tier 0 → only the sub-tier id term.
     assert_eq!(
-        elect_backoff_ms(&inp(true, -55, true, 10 * 60_000), &w, 5),
+        elect_backoff_ms(&inp(true, -55, 10 * 60_000), &w, 5),
         5 * 200,
         "best board waits only the node-id tiebreak"
     );
     // Monotonic in fitness: stronger co-channel never waits LONGER than a weaker co-channel (same id).
-    let s = elect_backoff_ms(&inp(true, -60, false, 0), &w, 7);
-    let x = elect_backoff_ms(&inp(true, -82, false, 0), &w, 7);
+    let s = elect_backoff_ms(&inp(true, -60, 0), &w, 7);
+    let x = elect_backoff_ms(&inp(true, -82, 0), &w, 7);
     assert!(s <= x, "monotonic: stronger ({s}) !<= weaker ({x})");
     // Tier gap ≥ one step so a weaker board gets an adopt-burst before its own claim window.
-    let co_tier = elect_backoff_ms(&inp(true, -82, false, 0), &w, 0);
-    let off_tier = elect_backoff_ms(&inp(false, -55, false, 0), &w, 0);
+    let co_tier = elect_backoff_ms(&inp(true, -82, 0), &w, 0);
+    let off_tier = elect_backoff_ms(&inp(false, -55, 0), &w, 0);
     assert!(
         off_tier.saturating_sub(co_tier) >= ELECT_TIER_STEP_MS,
         "co-channel vs off-channel separated by >= one tier ({co_tier} .. {off_tier})"
@@ -69,8 +69,8 @@ fn main() {
         ElectConfig::BestGateway(w) => w,
         _ => panic!("expected BestGateway"),
     };
-    let a = elect_backoff_ms(&inp(true, -85, false, 0), &rssi_only, 1); // co-channel but WEAK
-    let b = elect_backoff_ms(&inp(false, -55, false, 0), &rssi_only, 1); // off-channel but STRONG
+    let a = elect_backoff_ms(&inp(true, -85, 0), &rssi_only, 1); // co-channel but WEAK
+    let b = elect_backoff_ms(&inp(false, -55, 0), &rssi_only, 1); // off-channel but STRONG
     assert!(b < a, "rssi-dominant config: strong off-channel now beats weak co-channel");
 
     // ---- parse_elect_config ----------------------------------------------------------------
@@ -82,13 +82,13 @@ fn main() {
     // subset: missing keys inherit DEFAULT.
     assert_eq!(
         parse_elect_config(b"r20"),
-        ElectConfig::BestGateway(MetricWeights { co_channel: 100, rssi: 20, ntp: 5, uptime: 1 }),
+        ElectConfig::BestGateway(MetricWeights { co_channel: 100, rssi: 20, uptime: 1 }),
         "subset inherits default for missing keys"
     );
     // clamp + ignore junk.
     assert_eq!(
         parse_elect_config(b"c999x7r3"),
-        ElectConfig::BestGateway(MetricWeights { co_channel: 255, rssi: 3, ntp: 5, uptime: 1 }),
+        ElectConfig::BestGateway(MetricWeights { co_channel: 255, rssi: 3, uptime: 1 }),
         "clamp to 255 + ignore unknown key 'x'"
     );
     // garbage → default (fail toward the intended default behavior).

--- a/experiments/mesh_elect_verify/Cargo.toml
+++ b/experiments/mesh_elect_verify/Cargo.toml
@@ -1,0 +1,17 @@
+# Host guard for the ported fleet channel-election core (net/mesh_elect.rs). The firmware crate is
+# no_std/riscv32imc and can't host-test, so this `#[path]`-includes the REAL mesh_elect.rs (no
+# drift) and runs the esp32c6-watch donor's OWN 39-test suite verbatim — consensus properties
+# (permutation invariance, lexicographic count-then-signal scoring, epoch/probation, quorum,
+# staleness reclamation, hostile-field rejection) plus the byte-exact wire codec. Because both
+# repos must agree on the elected channel, these tests are the cross-repo contract: if smol and the
+# watch ever disagree here, the mesh partitions. Permanent guard.
+[package]
+name = "mesh_elect_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "mesh_elect_verify"
+path = "src/main.rs"
+[profile.dev]
+opt-level = 0

--- a/experiments/mesh_elect_verify/src/consensus.rs
+++ b/experiments/mesh_elect_verify/src/consensus.rs
@@ -1,0 +1,42 @@
+//! Consensus-layer host guard, REDUCED for #269.
+//!
+//! The donor's 31 consensus tests exercised its `Elector` (the channel VOTE). That machinery was
+//! removed deliberately — under #269 the mesh channel is DERIVED from the elected gateway's AP, so
+//! there is nothing to vote on. These two survive because they test the surface smol KEPT:
+//! `weight()` (still fills the frame's `w[13]` honestly for the watch) and `Decision::supersedes`
+//! (epoch ordering, which is how a leaf rejects a stale or replayed announcement).
+//!
+//! The other 29 are not lost — they live upstream in `esp32c6-watch:crates/mesh-elect`, which
+//! still owns the election. If smol ever needs a vote again, re-port from there rather than
+//! reconstructing them here.
+
+use crate::mesh_elect::*;
+
+pub fn weight_saturates_and_floors() {
+    assert_eq!(weight(-30), weight(WEIGHT_CEIL_DBM), "clamped at the top");
+    assert_eq!(weight(-35), weight(-30));
+    assert_eq!(weight(-83), 0, "below the usable floor is not a vote");
+    assert_eq!(weight(USABLE_MIN_DBM), 1, "bare usable visibility still counts");
+    assert!(weight(-50) > weight(-70), "monotone in between");
+}
+
+/// A channel the fleet can only barely hear must not win on headcount, or the
+/// election would happily march everyone onto a channel nobody can associate on.
+
+pub fn partition_merge_is_total_order() {
+    let a = Decision { channel: 6, epoch: 5, gateway: 0 };
+    let b = Decision { channel: 1, epoch: 4, gateway: 0 };
+    assert!(a.supersedes(2, &b, 9), "higher epoch beats bigger partition");
+
+    let c = Decision { channel: 11, epoch: 5, gateway: 0 };
+    assert!(c.supersedes(6, &a, 3), "equal epoch → more members wins");
+    assert!(!a.supersedes(3, &c, 6));
+
+    let d = Decision { channel: 1, epoch: 5, gateway: 0 };
+    assert!(d.supersedes(3, &a, 3), "equal epoch+members → lower channel wins");
+    assert!(!a.supersedes(3, &d, 3), "and the order is antisymmetric");
+}
+
+// ===========================================================================
+// Hysteresis: converge, then STOP
+// ===========================================================================

--- a/experiments/mesh_elect_verify/src/main.rs
+++ b/experiments/mesh_elect_verify/src/main.rs
@@ -1,0 +1,28 @@
+//! Fleet channel-election host guard (#278). `#[path]`-includes the REAL `net/mesh_elect.rs` (no
+//! drift) and runs the esp32c6-watch donor's own suite VERBATIM — the `#[test]` attributes are
+//! stripped and every test fn is called from `main`, matching this repo's panic-on-failure
+//! convention. Helper fns in those files are NOT called directly (they take arguments); only the
+//! fns that carried `#[test]` upstream are entry points.
+//!
+//! These are the CROSS-REPO CONTRACT: both repos must compute the same winner from the same
+//! observations and encode the same bytes, or the fleet partitions. `cargo run`.
+
+#[path = "../../../rust/clock/src/net/mesh_elect.rs"]
+mod mesh_elect;
+
+mod consensus;
+mod wire_tests;
+
+fn main() {
+    consensus::weight_saturates_and_floors();
+    consensus::partition_merge_is_total_order();
+    wire_tests::encoding_is_byte_exact();
+    wire_tests::round_trips();
+    wire_tests::round_trips_at_field_extremes();
+    wire_tests::tag_does_not_collide_with_existing_frames();
+    wire_tests::rejects_malformed_frames();
+    wire_tests::rejects_out_of_range_channel();
+    wire_tests::encode_refuses_a_short_buffer();
+    wire_tests::frame_is_human_readable_in_a_log();
+    println!("mesh_elect_verify: 10 checks passed (2 consensus + 8 wire)");
+}

--- a/experiments/mesh_elect_verify/src/wire_tests.rs
+++ b/experiments/mesh_elect_verify/src/wire_tests.rs
@@ -1,0 +1,150 @@
+//! ELECT wire-format tests.
+//!
+//! The wire format is the one thing that MUST be byte-identical in
+//! `esp32c6-watch` and `smol`, because a mismatch does not fail loudly — it
+//! partitions the fleet silently, which is the exact bug this whole change
+//! exists to fix. So the encoding is pinned here against literal bytes, not just
+//! round-tripped: a round-trip test passes happily while both sides agree on the
+//! wrong thing.
+
+use crate::mesh_elect::wire::*;
+use crate::mesh_elect::{ch_index, N_CHANNELS};
+
+fn sample() -> ElectFrame {
+    let mut w = [0u8; N_CHANNELS];
+    w[ch_index(1).unwrap()] = 12;
+    w[ch_index(6).unwrap()] = 27;
+    w[ch_index(11).unwrap()] = 5;
+    ElectFrame {
+        node_id: 42,
+        epoch: 7,
+        channel: 6,
+        gateway: 3,
+        w,
+    }
+}
+
+/// The golden bytes. If this test has to change, the wire format changed, and
+/// BOTH repos must be reflashed together — that is the point of pinning it.
+pub fn encoding_is_byte_exact() {
+    let mut buf = [0u8; 128];
+    let n = encode(&sample(), &mut buf).expect("encodes");
+    assert_eq!(n, ELECT_LEN);
+    let got = core::str::from_utf8(&buf[..n]).expect("ASCII on the wire");
+    // Weight vector is ch1..ch13, two digits each, no separators:
+    //   ch1=12 at [0..2], ch6=27 at [10..12], ch11=05 at [20..22], rest 00.
+    assert_eq!(
+        got,
+        "SMOLv1 ELECT 042 0000000007 06 003 12000000002700000000050000",
+        "wire format changed — smol must be updated in lockstep"
+    );
+    assert_eq!(ELECT_LEN, 61);
+    assert!(ELECT_LEN <= 250, "must fit the ESP-NOW payload cap");
+}
+
+pub fn round_trips() {
+    let f = sample();
+    let mut buf = [0u8; 128];
+    let n = encode(&f, &mut buf).unwrap();
+    assert_eq!(parse(&buf[..n]), Some(f));
+}
+
+pub fn round_trips_at_field_extremes() {
+    let f = ElectFrame {
+        node_id: 255,
+        epoch: u32::MAX,
+        channel: 13,
+        gateway: 255,
+        w: [48; N_CHANNELS],
+    };
+    let mut buf = [0u8; 128];
+    let n = encode(&f, &mut buf).unwrap();
+    assert_eq!(parse(&buf[..n]), Some(f), "u32::MAX epoch fits 10 digits");
+}
+
+/// Byte 7 of the tag must not collide with any existing SMOLv1 frame, or old
+/// nodes would misparse it instead of ignoring it.
+pub fn tag_does_not_collide_with_existing_frames() {
+    assert_eq!(ELECT_PREFIX[7], b'E');
+    // Every tag in use across both repos today.
+    for other in [
+        &b"SMOLv1 HELLO "[..],
+        b"SMOLv1 ACK ",
+        b"SMOLv1 TIME ",
+        b"SMOLv1 CFG ",
+        b"SMOLv1 RELAY ",
+        b"SMOLv1 RELAYACK ",
+        b"SMOLv1 PING ",
+        b"SMOLv1 PINGACK ",
+        b"SMOLv1 SAY ",
+        b"SMOLv1 DIAG ",
+        b"SMOLv1 BATT ",
+        b"SMOLv1 GRID ",
+        b"SMOLv1 STAT ",
+        b"SMOLv1 SCAN ",
+        b"SMOLv1 BEACON ",
+    ] {
+        assert_ne!(other[7], ELECT_PREFIX[7], "tag collision with {other:?}");
+    }
+}
+
+/// Fed straight from unauthenticated broadcasts, so every rejection path must
+/// hold. A parse that accepts junk is a parse that feeds junk into the election.
+pub fn rejects_malformed_frames() {
+    let mut buf = [0u8; 128];
+    let n = encode(&sample(), &mut buf).unwrap();
+
+    assert_eq!(parse(&[]), None, "empty");
+    assert_eq!(parse(b"SMOLv1 HELLO 042"), None, "wrong tag");
+    assert_eq!(parse(&buf[..n - 1]), None, "truncated");
+    let mut long = [b'0'; 128];
+    long[..n].copy_from_slice(&buf[..n]);
+    assert_eq!(parse(&long[..n + 1]), None, "trailing junk is not tolerated");
+
+    // Non-digit in each numeric field.
+    for pos in [13, 17, 28, 31, 35] {
+        let mut bad = buf;
+        bad[pos] = b'x';
+        assert_eq!(parse(&bad[..n]), None, "non-digit at byte {pos} must reject");
+    }
+    // Missing separators.
+    for pos in [16, 27, 30, 34] {
+        let mut bad = buf;
+        bad[pos] = b'0';
+        assert_eq!(parse(&bad[..n]), None, "missing space at byte {pos}");
+    }
+}
+
+/// Out-of-range channels must die at the parse boundary — before anything can
+/// index an array with them.
+pub fn rejects_out_of_range_channel() {
+    let mut buf = [0u8; 128];
+    let n = encode(&sample(), &mut buf).unwrap();
+    for (bad_ch, txt) in [(0u8, b"00"), (14, b"14"), (99, b"99")] {
+        let mut bad = buf;
+        bad[28..30].copy_from_slice(txt);
+        assert_eq!(parse(&bad[..n]), None, "channel {bad_ch} must reject");
+    }
+    // And encode refuses to emit one.
+    let mut f = sample();
+    f.channel = 0;
+    assert_eq!(encode(&f, &mut buf), None);
+    f.channel = 14;
+    assert_eq!(encode(&f, &mut buf), None);
+}
+
+pub fn encode_refuses_a_short_buffer() {
+    let mut small = [0u8; ELECT_LEN - 1];
+    assert_eq!(encode(&sample(), &mut small), None);
+    let mut exact = [0u8; ELECT_LEN];
+    assert_eq!(encode(&sample(), &mut exact), Some(ELECT_LEN));
+}
+
+/// Every byte position of a valid frame is ASCII-printable, so an ELECT frame is
+/// readable in a serial log without a hex dump — the same courtesy the rest of
+/// SMOLv1 extends.
+pub fn frame_is_human_readable_in_a_log() {
+    let mut buf = [0u8; 128];
+    let n = encode(&sample(), &mut buf).unwrap();
+    assert!(buf[..n].iter().all(|b| b.is_ascii_graphic() || *b == b' '));
+}

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -105,6 +105,27 @@ pub mod wire;
 #[cfg(feature = "espnow")]
 pub mod coexist;
 
+// #278 fleet channel election — PURE (no esp-hal/esp-radio, no alloc), ported VERBATIM from the
+// esp32c6-watch's `crates/mesh-elect` and host-tested by `experiments/mesh_elect_verify`, which
+// runs the donor's OWN 39-test suite against this exact file (`#[path]`-include, like `coexist`).
+// Byte-identical wire + identical scoring in both repos is the whole point: the watch holds
+// `ELECT_ENFORCE = false` until smol speaks this, because two watches are a quorum that could
+// otherwise agree to leave ch6 and strand the C3 fleet (#278, #335).
+//
+// Distinct from `election` (which node is GATEWAY) and from `coexist` (which AP do *I* join, given
+// a channel). This one decides WHICH CHANNEL the fleet meets on — the value `coexist` takes as its
+// `mesh_ch` argument and that smol currently hardcodes as `ESP_NOW_FIXED_CHANNEL`.
+//
+// ⚠️ TEMPORARY, and it must not outlive the next PR: nothing in the firmware calls this yet, so
+// `-D warnings` would fail on dead_code. This is stage 1 of 2 — the pure core + its 39-test
+// cross-repo contract land first so they are reviewable on their own; stage 2 adds the
+// `Frame::Elect` dispatch arm in `mode::parse_frame`, an `Elector` on `RadioManager` (+232 B of
+// .bss — re-measure the stack floor), and the honour path behind a default-off flag. DELETE this
+// allow in that PR; if it is still here afterwards, the wiring silently never happened.
+#[allow(dead_code)]
+#[cfg(feature = "espnow")]
+pub mod mesh_elect;
+
 // Configurable best-gateway election — PURE (no esp-hal/esp-wifi, no alloc), host-tested verbatim by
 // `experiments/election_verify` (#[path]-include, like `coexist`). Seeded by `wifi`'s MeshElect
 // resolver + `mode`'s flush/recovery paths; gated to `wifi` (where MeshElect lives — every election

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -105,23 +105,28 @@ pub mod wire;
 #[cfg(feature = "espnow")]
 pub mod coexist;
 
-// #278 fleet channel election — PURE (no esp-hal/esp-radio, no alloc), ported VERBATIM from the
-// esp32c6-watch's `crates/mesh-elect` and host-tested by `experiments/mesh_elect_verify`, which
-// runs the donor's OWN 39-test suite against this exact file (`#[path]`-include, like `coexist`).
-// Byte-identical wire + identical scoring in both repos is the whole point: the watch holds
-// `ELECT_ENFORCE = false` until smol speaks this, because two watches are a quorum that could
-// otherwise agree to leave ch6 and strand the C3 fleet (#278, #335).
+// #278 the `SMOLv1 ELECT` frame + epoch/anti-flap core — PURE (no esp-hal/esp-radio, no alloc),
+// host-tested by `experiments/mesh_elect_verify` (`#[path]`-include, like `coexist`), which runs
+// the esp32c6-watch donor's own tests against this exact file: 10 of them (8 wire + 2 consensus).
+// The wire codec is byte-identical to the donor's and that is the load-bearing part — the watch
+// holds `ELECT_ENFORCE = false` until smol speaks this frame, because two watches are a quorum
+// that could otherwise agree to leave ch6 and strand the C3 fleet (#278, #335).
+//
+// PARTIAL port, not verbatim: the donor's `Elector` (channel VOTE) is deliberately absent. Per
+// #269 the mesh channel DERIVES from the elected gateway's AP channel — a consequence, not a
+// vote — so 29 of the donor's 39 tests exercised machinery smol does not have and were dropped
+// with it. They live upstream, which still owns the election; re-port rather than reconstruct.
 //
 // Distinct from `election` (which node is GATEWAY) and from `coexist` (which AP do *I* join, given
-// a channel). This one decides WHICH CHANNEL the fleet meets on — the value `coexist` takes as its
-// `mesh_ch` argument and that smol currently hardcodes as `ESP_NOW_FIXED_CHANNEL`.
+// a channel). This module carries and ORDERS the channel the fleet meets on — the value `coexist`
+// takes as its `mesh_ch` argument and that smol still hardcodes as `ESP_NOW_FIXED_CHANNEL`.
 //
 // ⚠️ TEMPORARY, and it must not outlive the next PR: nothing in the firmware calls this yet, so
-// `-D warnings` would fail on dead_code. This is stage 1 of 2 — the pure core + its 39-test
-// cross-repo contract land first so they are reviewable on their own; stage 2 adds the
-// `Frame::Elect` dispatch arm in `mode::parse_frame`, an `Elector` on `RadioManager` (+232 B of
-// .bss — re-measure the stack floor), and the honour path behind a default-off flag. DELETE this
-// allow in that PR; if it is still here afterwards, the wiring silently never happened.
+// `-D warnings` would fail on dead_code. This is stage 1 of 2 — the frame + its cross-repo test
+// contract land first so they are reviewable on their own; stage 2 adds the `Frame::Elect`
+// dispatch arm in `mode::parse_frame`, the announce/honour paths behind a default-off flag, and
+// re-measures the stack floor for whatever state lands on `RadioManager`. DELETE this allow in
+// that PR; if it is still here afterwards, the wiring silently never happened.
 #[allow(dead_code)]
 #[cfg(feature = "espnow")]
 pub mod mesh_elect;

--- a/rust/clock/src/net/election.rs
+++ b/rust/clock/src/net/election.rs
@@ -34,9 +34,6 @@ pub struct FitnessInputs {
     pub co_channel: bool,
     /// Live RSSI-to-AP (dBm, signed; weaker = more negative). Bucketed by [`rssi_score`].
     pub ap_rssi: i8,
-    /// The board holds real (NTP-authoritative) time, not a free-running clock — a better gateway
-    /// can serve TIME frames. `synced_at != 0` upstream.
-    pub ntp_holder: bool,
     /// Monotonic ms since boot (the loop clock == uptime). A longer-lived board is a more stable
     /// crown; also the STATELESS deferral clock for the cold-boot empty-MC claim.
     pub uptime_ms: u64,
@@ -48,24 +45,29 @@ pub struct FitnessInputs {
 pub struct MetricWeights {
     pub co_channel: u8,
     pub rssi: u8,
-    pub ntp: u8,
     pub uptime: u8,
 }
 
 impl MetricWeights {
     /// The SHIPPED default (JP: "elect the BEST gateway" ⇒ best-gateway is the default behavior,
     /// team-lead decision 2026-07-20). CO-CHANNEL-DOMINANT: `co_channel` (100) alone outranks the
-    /// maximum of every other signal combined (`rssi` 10·2 + `ntp` 5 + `uptime` 1·2 = 27), so a
-    /// co-channel board ALWAYS beats a stronger OFF-channel board (the id5 ch1-vs-ch6 bug). Absent /
-    /// empty / malformed config falls back to THIS (not to legacy) — best-gateway is on by default.
-    pub const DEFAULT: Self = Self { co_channel: 100, rssi: 10, ntp: 5, uptime: 1 };
+    /// maximum of every other signal combined (`rssi` 10·2 + `uptime` 1·2 = 22), so a co-channel
+    /// board ALWAYS beats a stronger OFF-channel board (the id5 ch1-vs-ch6 bug). Absent / empty /
+    /// malformed config falls back to THIS (not to legacy) — best-gateway is on by default.
+    ///
+    /// ⚠️ #269 will REBALANCE these. Under channel-follows-the-crown, `co_channel` stops being a
+    /// disease-fix and becomes a channel-change SUPPRESSOR: it would rank a board sitting where the
+    /// mesh already is above a better-internet board elsewhere, by a margin nothing can bridge —
+    /// blocking the migration #269 exists to enable. The fix is to re-scale it from dominant to a
+    /// hysteresis MARGIN, which is also the anti-flap term. Not done here: this commit only removes
+    /// the dead `ntp` input, so the two changes stay separately attributable on a live fleet.
+    pub const DEFAULT: Self = Self { co_channel: 100, rssi: 10, uptime: 1 };
 
     /// Theoretical maximum fitness for these weights — the deficit reference in [`elect_backoff_ms`],
     /// making the tiering scale-invariant to the weight magnitudes. `const` for use at call sites.
     pub const fn max_fitness(&self) -> u16 {
         self.co_channel as u16
             + self.rssi as u16 * RSSI_SCORE_MAX
-            + self.ntp as u16
             + self.uptime as u16 * UPTIME_SCORE_MAX
     }
 }
@@ -126,7 +128,6 @@ fn uptime_score(uptime_ms: u64) -> u16 {
 pub fn gateway_fitness(i: &FitnessInputs, w: &MetricWeights) -> u16 {
     (w.co_channel as u16) * (i.co_channel as u16)
         + (w.rssi as u16) * rssi_score(i.ap_rssi)
-        + (w.ntp as u16) * (i.ntp_holder as u16)
         + (w.uptime as u16) * uptime_score(i.uptime_ms)
 }
 
@@ -253,7 +254,19 @@ pub fn parse_elect_config(payload: &[u8]) -> ElectConfig {
             match key {
                 b'c' | b'C' => w.co_channel = v,
                 b'r' | b'R' => w.rssi = v,
-                b'n' | b'N' => w.ntp = v,
+                // #269: `n` (ntp) was removed as a fitness input — see `gateway_fitness`.
+                //
+                // This arm is a TOMBSTONE, and it is load-bearing beyond compatibility.
+                // Functionally it matches the `_` fallthrough (both ignore the key), so its whole
+                // value is what it TELLS a future reader: `n` is RESERVED, not available. Without
+                // it, someone reintroduces `n` for a new meaning and every stale retained
+                // `c…r…n…u…` payload still sitting in the broker silently re-weights their new
+                // feature — a live-config landmine with no compile-time trace. An explicit
+                // tombstone prevents key REUSE; a fallthrough invites it.
+                //
+                // It also keeps the older promise: a pre-#269 retained payload still parses, and
+                // its `n` is consumed and DISCARDED rather than shifting the remaining weights.
+                b'n' | b'N' => {}
                 b'u' | b'U' => w.uptime = v,
                 _ => {}
             }

--- a/rust/clock/src/net/mesh_elect.rs
+++ b/rust/clock/src/net/mesh_elect.rs
@@ -65,6 +65,23 @@
 //! deliberately bypass it via `send_arb_raw`; routing ELECT that way would convert a
 //! safe channel hop into a remote fleet-partition attack.
 //!
+//! # Prior art: this is CSA with an ESP-NOW carrier, not a novel design
+//!
+//! 802.11 already has the announce-then-move mechanism and a name for it: the **Channel Switch
+//! Announcement** element, carried in beacons. ESP-WIFI-MESH migrates its mesh channel exactly
+//! this way — CSA elements propagated by the root, announced by the node that noticed, *then* the
+//! move. smol's ELECT frame is the same mechanism on a different carrier, which is why the
+//! announce-before-AND-after ordering below is not a guess.
+//!
+//! ESP-WIFI-MESH also **requires** the mesh and the router to share a channel. That is
+//! independent validation of #269's premise: co-channel by construction rather than by repair is
+//! how a shipping ESP mesh does it.
+//!
+//! ⚠️ And the same source documents the honest limit — the migration is **not atomic**: IDF states
+//! there will be *"a temporary channel discrepancy"* while nodes converge. A production system with
+//! this exact architecture ships with a documented disagreement window, which is why the
+//! migration-window guard in `net::mode`'s `note_crown_ap` is kept rather than deleted.
+//!
 //! # Recovery ladder for a leaf that missed the announcement
 //!
 //! esp-radio 0.18 exposes all-channels or exactly one channel — never a subset

--- a/rust/clock/src/net/mesh_elect.rs
+++ b/rust/clock/src/net/mesh_elect.rs
@@ -1,0 +1,408 @@
+//! The `SMOLv1 ELECT` frame: **announcing** the mesh rendezvous channel, and the
+//! epoch/anti-flap machinery that makes a channel migration safe.
+//!
+//! # What decides the channel (and why nothing here votes)
+//!
+//! Per JP's directive (#269): **the mesh channel IS the elected gateway's AP
+//! channel.** It is a *derived value*, not a decision. The chain is
+//!
+//! ```text
+//! elect gateway (best internet)  ->  that gateway joins an AP  ->  mesh channel := that AP's channel
+//!      net::election                    net::coexist                  (a consequence, not a vote)
+//! ```
+//!
+//! Co-channel operation is therefore true **by construction** rather than being a
+//! property to check and repair — which retires the off-channel pathology class
+//! (crown on ch1, mesh on ch6, OTA dying at byte 0) instead of guarding against it.
+//! And no quorum can move the mesh somewhere the gateway is not, because nobody
+//! votes on the channel at all.
+//!
+//! # Provenance, and what was deliberately removed
+//!
+//! Ported from the esp32c6-watch's `crates/mesh-elect` (`50e28df`, read-only
+//! reference). The donor **elects** a channel by lexicographic tally across peer
+//! observations. **That election was removed on purpose** — under the derivation
+//! above there is nothing to elect, and keeping a voting engine in a system with
+//! nothing to vote on would read as intent to the next person who touched it.
+//!
+//! Removed: `Elector`, `Tally`, `Ingest`, `Slot`, and the observe/tally/winner/step
+//! machinery. Kept, because they serve the announcement instead:
+//!
+//! | kept | why it survives |
+//! |---|---|
+//! | [`wire`] | the frame itself — now an ANNOUNCEMENT of a derived value, not a ballot |
+//! | [`Decision`] + `supersedes` | orders announcements by epoch; rejects stale/replayed ones |
+//! | [`SETTLE_MS`], [`MARGIN_FLOOR`], [`PROBATION_MS`], [`margin_for`] | anti-flap: a challenger must hold its advantage before the fleet moves |
+//! | [`RENDEZVOUS_CHANNEL`] | tier 2 of the recovery ladder below |
+//! | [`weight`], [`USABLE_MIN_DBM`] | still populate the frame's `w[13]` honestly — see below |
+//!
+//! ## The `w[13]` vector is still filled in, deliberately
+//!
+//! smol no longer votes, so the weight vector is vestigial *to smol*. It is
+//! populated honestly from our own scan anyway, for two reasons: the frame must
+//! stay **byte-identical** to the donor's or the watch cannot parse it at all, and
+//! the watch still runs its own election in observe-only mode. Emitting zeros
+//! would make the watch's observation compute garbage during the transition.
+//! **Dropping the vote is not the same as dropping the observation.**
+//!
+//! # Security: authentication is load-bearing here, not a bonus
+//!
+//! esp-radio 0.18 hardcodes `coex_background_scan: false`, so **a scan drops the
+//! association**. A leaf therefore *cannot verify a channel-change announcement
+//! before acting on it* — checking costs it the very association it would need if
+//! the announcement were false. It must **trust** the frame.
+//!
+//! An unauthenticated ELECT would then be a trivially forgeable *"everyone move to
+//! channel N"* fleet-stranding primitive, with no cheap way for a leaf to detect
+//! the lie. smol closes this where the donor could not: #190 gives every SMOLv1
+//! frame a truncated group-HMAC-SHA256 trailer, and `should_group_mac` admits a
+//! frame that starts `SMOLv1 `, is not OTA-family, and fits the MTU. `SMOLv1 ELECT `
+//! satisfies all three (61 B + 9 B = 70 B <= 250 B), so ELECT is authenticated with
+//! no code here.
+//!
+//! ⚠️ **DESIGN INVARIANT, not a style note: emit ELECT via `send_to`.** That is the
+//! path that appends the trailer. The #237 arbitration frames (`ODEL`/`ODON`)
+//! deliberately bypass it via `send_arb_raw`; routing ELECT that way would convert a
+//! safe channel hop into a remote fleet-partition attack.
+//!
+//! # Recovery ladder for a leaf that missed the announcement
+//!
+//! esp-radio 0.18 exposes all-channels or exactly one channel — never a subset
+//! (`channel_bitmap` is hardcoded to 0). A full sweep costs **130-260 ms**
+//! (13 x `Active{min:10,max:20}`); a single-channel probe costs ~10-20 ms. So
+//! recovery is an ordered ladder with early exit, not one expensive sweep:
+//!
+//! ```text
+//! 0. heard the announcement        ~0
+//! 1. last-known mesh channel       ~10-20 ms
+//! 2. RENDEZVOUS_CHANNEL (6)        ~10-20 ms
+//! 3. common AP channels (1, 11)    ~10-20 ms each
+//! 4. full sweep                    130-260 ms
+//! ```
+//!
+//! # What this module does NOT decide
+//!
+//! It does not choose an AP — that is `net::coexist::select_crown_ap`, a per-node
+//! association policy taking `mesh_ch` as an INPUT. It does not choose the gateway
+//! — that is `net::election`. This module only **carries and orders** the resulting
+//! channel, and holds the constants that stop it thrashing.
+
+// ── Lint policy for a VENDORED file ────────────────────────────────────────────────────────────
+// smol gates `-D warnings`; the donor's crate does not, so three idioms trip here (two indexed
+// loops over the fixed 13-slot weight vector, one `map_or`). They are suppressed rather than
+// rewritten ON PURPOSE.
+//
+// This file is a CROSS-REPO CONTRACT, not ordinary smol source: both repos must compute the same
+// winner and emit the same bytes or the fleet partitions. Its value is that it stays *diffable*
+// against `esp32c6-watch:crates/mesh-elect` — a future sync should show only intended divergence.
+// Clippy-rewriting the bodies would make every future diff noisy, and the predictable result is
+// someone "helpfully" re-syncing from upstream and silently reverting the edits. Style is worth
+// less than that guarantee.
+//
+// Scoped to this file only, so the rest of the crate keeps the strict lints. If a real defect is
+// ever found in these loops, fix it UPSTREAM in the watch and re-port — do not fork the logic here.
+#![allow(clippy::needless_range_loop, clippy::unnecessary_map_or)]
+
+/// 2.4 GHz channels considered, `1..=13`. Fixed, so every table and the wire
+/// frame are fixed-size.
+pub const N_CHANNELS: usize = 13;
+
+
+/// An AP weaker than this does not count as "usable" — a channel we can only
+/// barely hear must not win on headcount. Matches smol's proven
+/// `coexist::AP_USABLE_MIN`, so both repos judge usability identically.
+pub const USABLE_MIN_DBM: i8 = -82;
+
+/// Weight saturates here at the strong end: everything at/above this counts the
+/// same, so standing next to an AP cannot buy extra votes.
+pub const WEIGHT_CEIL_DBM: i8 = -35;
+
+/// An observation older than this stops counting. A node that walked away must
+/// not keep voting for the channel it used to see. Peers tick every ~2 s, so
+/// this is ~30 missed frames.
+///
+/// **Must exceed [`SETTLE_MS`] and [`PROBATION_MS`]** — see [`_WINDOW_ORDERING`].
+pub const OBS_STALE_MS: u64 = 60_000;
+
+/// A challenger must hold its lead this long before we spend an epoch on it.
+/// Flapping costs an association and tears the mesh down, so it is strictly
+/// worse than a suboptimal-but-stable channel.
+pub const SETTLE_MS: u64 = 30_000;
+
+/// Floor for the margin a challenger must beat the incumbent by (in summed
+/// weight). See [`margin_for`].
+pub const MARGIN_FLOOR: u32 = 12;
+
+/// After adopting someone else's higher-epoch decision, how long we tolerate
+/// hearing nothing on it before concluding the epoch is stale and re-electing.
+/// Without this, one node with a high persisted epoch can wedge the whole fleet
+/// onto a dead channel permanently — the failure mode a monotonic epoch invites
+/// and the spec does not address.
+pub const PROBATION_MS: u64 = 45_000;
+
+/// Rendezvous channel of last resort, used only when there is nothing to elect
+/// (no AP visible anywhere). Matches smol's historical `ESP_NOW_FIXED_CHANNEL`
+/// so a fleet with no infrastructure still meets. This is a DEFAULT, not a pin:
+/// it is abandoned the moment a real candidate appears.
+pub const RENDEZVOUS_CHANNEL: u8 = 6;
+
+/// Staleness must outlive both decision windows, or the machine can never
+/// finish making up its mind: a challenger's supporting observations would
+/// expire before its settle window closed, so `winner()` would flip back and the
+/// timer would re-arm forever. Same for probation. Found by
+/// `tests/consensus.rs::decisive_challenger_waits_for_settle_window`, which hung
+/// at exactly `SETTLE_MS == OBS_STALE_MS`. Asserted at compile time so a future
+/// tuning pass cannot silently reintroduce it.
+const _WINDOW_ORDERING: () = {
+    assert!(OBS_STALE_MS > SETTLE_MS);
+    assert!(OBS_STALE_MS > PROBATION_MS);
+};
+
+/// Map dBm to a saturating vote weight. Monotone, clamped at both ends, and
+/// `0` for anything below [`USABLE_MIN_DBM`] (not usable = no vote).
+///
+/// Range is `1..=48` for usable signal: the `+1` floor means bare usable
+/// visibility still counts for something, and the ceiling means proximity
+/// saturates.
+#[must_use]
+pub const fn weight(rssi_dbm: i8) -> u32 {
+    if rssi_dbm < USABLE_MIN_DBM {
+        return 0;
+    }
+    let capped = if rssi_dbm > WEIGHT_CEIL_DBM {
+        WEIGHT_CEIL_DBM
+    } else {
+        rssi_dbm
+    };
+    // capped ∈ [-82, -35] → 1..=48
+    (capped as i32 - USABLE_MIN_DBM as i32 + 1) as u32
+}
+
+/// The margin a challenger must clear, scaled to the incumbent's score.
+///
+/// The spec suggests a flat ">= 6 dB aggregate", but aggregate score is a sum
+/// across nodes, so a flat threshold gets *easier* to trip as the fleet grows
+/// (with 5 reporters, 6 units of aggregate is barely 1 dB each). Scaling with
+/// the incumbent keeps the hysteresis meaningful at any fleet size, with a floor
+/// so it is never trivial when scores are small.
+#[must_use]
+pub const fn margin_for(incumbent_sum: u32) -> u32 {
+    let scaled = incumbent_sum / 8;
+    if scaled > MARGIN_FLOOR {
+        scaled
+    } else {
+        MARGIN_FLOOR
+    }
+}
+
+/// Channel `1..=13` to array index, or `None` if out of range. Every inbound
+/// channel number goes through this — a frame claiming ch 0 or ch 99 is dropped,
+/// never indexed with.
+#[must_use]
+pub const fn ch_index(channel: u8) -> Option<usize> {
+    if channel >= 1 && channel as usize <= N_CHANNELS {
+        Some(channel as usize - 1)
+    } else {
+        None
+    }
+}
+
+/// The committed decision. Carried on every ELECT frame; higher epoch wins.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Decision {
+    /// Elected ESP-NOW channel, `1..=13`.
+    pub channel: u8,
+    /// Monotonic epoch. Higher wins; a late joiner adopts rather than re-elects.
+    pub epoch: u32,
+    /// Elected gateway node id, or `0` for "none known".
+    pub gateway: u8,
+}
+
+impl Decision {
+    /// The boot decision before anything is known or restored.
+    #[must_use]
+    pub const fn bootstrap() -> Self {
+        Self {
+            channel: RENDEZVOUS_CHANNEL,
+            epoch: 0,
+            gateway: 0,
+        }
+    }
+
+    /// Total order for partition merge: higher epoch wins; equal epoch breaks by
+    /// larger member count, then by lower channel. Never returns "equal" for two
+    /// differing decisions reached with the same member count, so a merge always
+    /// resolves.
+    #[must_use]
+    pub fn supersedes(&self, members: u8, other: &Self, other_members: u8) -> bool {
+        if self.epoch != other.epoch {
+            return self.epoch > other.epoch;
+        }
+        if members != other_members {
+            return members > other_members;
+        }
+        self.channel < other.channel
+    }
+}
+
+pub mod wire {
+    //! The `SMOLv1 ELECT` frame — one fixed-width ASCII record, byte-identical in
+    //! both repos.
+    //!
+    //! Layout (61 bytes, always):
+    //!
+    //! ```text
+    //! "SMOLv1 ELECT " <id:3> ' ' <epoch:10> ' ' <ch:2> ' ' <gw:3> ' ' <w:26>
+    //!  └── 13 ──────┘                                                  └ 13×2 ┘
+    //! ```
+    //!
+    //! Conventions are the existing SMOLv1 ones so this is unsurprising to read
+    //! alongside HELLO/TIME/RELAY: an ASCII `SMOLv1 <TAG> ` prefix, then
+    //! **fixed-width zero-padded decimal** fields, single-space separated. Tag byte
+    //! 7 is `'E'`, which no existing SMOLv1 tag uses (`H A B T G C S D R U F`), so
+    //! there is no collision, and firmware that predates this frame classifies it as
+    //! unknown and ignores it harmlessly.
+    //!
+    //! **Fixed width is the security property, not just a convenience.** The design
+    //! spec proposed a variable candidate list (`<n_cands> [<bssid> <ch> <rssi>]*`)
+    //! with a note to cap it. Because we elect a channel rather than a BSSID, the
+    //! candidate set is the 13 channels of the 2.4 GHz band — a constant. So the
+    //! frame has no length field, no repetition, and no bound to enforce: a
+    //! malformed or hostile frame is simply not 61 bytes, or fails a digit check.
+    //! There is nothing here for an attacker to grow.
+    //!
+    //! Well under the 250 B ESP-NOW payload cap, with room for a future field.
+
+    use super::{ch_index, N_CHANNELS};
+
+    /// Frame tag. Trailing space matches every other SMOLv1 prefix.
+    pub const ELECT_PREFIX: &[u8] = b"SMOLv1 ELECT ";
+
+    /// Exact encoded length. A frame of any other length is not an ELECT frame.
+    pub const ELECT_LEN: usize = 13 + 3 + 1 + 10 + 1 + 2 + 1 + 3 + 1 + 2 * N_CHANNELS;
+
+    /// A decoded ELECT frame.
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    pub struct ElectFrame {
+        pub node_id: u8,
+        pub epoch: u32,
+        pub channel: u8,
+        pub gateway: u8,
+        /// Per-channel weight, index 0 = ch1.
+        pub w: [u8; N_CHANNELS],
+    }
+
+    /// Write `v` as `n` zero-padded ASCII digits. Values too large for the field are
+    /// clamped to all-nines rather than truncated to a wrong-but-plausible number.
+    fn write_num(v: u32, n: usize, out: &mut [u8]) {
+        let mut v = v;
+        let mut max = 1u64;
+        for _ in 0..n {
+            max *= 10;
+        }
+        if (v as u64) >= max {
+            for b in out[..n].iter_mut() {
+                *b = b'9';
+            }
+            return;
+        }
+        for i in (0..n).rev() {
+            out[i] = b'0' + (v % 10) as u8;
+            v /= 10;
+        }
+    }
+
+    /// Parse exactly `n` ASCII digits. `None` on any non-digit — no lenient
+    /// whitespace, no partial parse.
+    fn parse_num(s: &[u8], n: usize) -> Option<u32> {
+        if s.len() < n {
+            return None;
+        }
+        let mut v: u32 = 0;
+        for &b in &s[..n] {
+            if !b.is_ascii_digit() {
+                return None;
+            }
+            v = v.checked_mul(10)?.checked_add((b - b'0') as u32)?;
+        }
+        Some(v)
+    }
+
+    /// Encode into `out` (which must hold at least [`ELECT_LEN`]). Returns the
+    /// number of bytes written, or `None` if the buffer is too small or the channel
+    /// is out of range.
+    #[must_use]
+    pub fn encode(f: &ElectFrame, out: &mut [u8]) -> Option<usize> {
+        if out.len() < ELECT_LEN || ch_index(f.channel).is_none() {
+            return None;
+        }
+        let mut n = 0;
+        out[..ELECT_PREFIX.len()].copy_from_slice(ELECT_PREFIX);
+        n += ELECT_PREFIX.len();
+        write_num(f.node_id as u32, 3, &mut out[n..]);
+        n += 3;
+        out[n] = b' ';
+        n += 1;
+        write_num(f.epoch, 10, &mut out[n..]);
+        n += 10;
+        out[n] = b' ';
+        n += 1;
+        write_num(f.channel as u32, 2, &mut out[n..]);
+        n += 2;
+        out[n] = b' ';
+        n += 1;
+        write_num(f.gateway as u32, 3, &mut out[n..]);
+        n += 3;
+        out[n] = b' ';
+        n += 1;
+        for i in 0..N_CHANNELS {
+            // Weights are 0..=48 by construction, so 2 digits always suffice.
+            write_num(f.w[i] as u32, 2, &mut out[n..]);
+            n += 2;
+        }
+        debug_assert_eq!(n, ELECT_LEN);
+        Some(n)
+    }
+
+    /// Parse a received payload. Returns `None` unless it is a well-formed ELECT
+    /// frame of exactly the right length with an in-range channel.
+    ///
+    /// Strict by design: this is fed straight from unauthenticated broadcasts, so
+    /// every field is length- and digit-checked before it reaches election state.
+    #[must_use]
+    pub fn parse(data: &[u8]) -> Option<ElectFrame> {
+        let rest = data.strip_prefix(ELECT_PREFIX)?;
+        if rest.len() != ELECT_LEN - ELECT_PREFIX.len() {
+            return None;
+        }
+        let node_id = u8::try_from(parse_num(&rest[0..3], 3)?).ok()?;
+        if rest[3] != b' ' {
+            return None;
+        }
+        let epoch = parse_num(&rest[4..14], 10)?;
+        if rest[14] != b' ' {
+            return None;
+        }
+        let channel = u8::try_from(parse_num(&rest[15..17], 2)?).ok()?;
+        if rest[17] != b' ' {
+            return None;
+        }
+        let gateway = u8::try_from(parse_num(&rest[18..21], 3)?).ok()?;
+        if rest[21] != b' ' {
+            return None;
+        }
+        ch_index(channel)?; // reject ch 0 / ch > 13 at the boundary
+        let mut w = [0u8; N_CHANNELS];
+        for i in 0..N_CHANNELS {
+            let off = 22 + i * 2;
+            w[i] = u8::try_from(parse_num(&rest[off..off + 2], 2)?).ok()?;
+        }
+        Some(ElectFrame {
+            node_id,
+            epoch,
+            channel,
+            gateway,
+            w,
+        })
+    }
+}

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2586,12 +2586,12 @@ impl RadioManager {
         elect.my_channel = self.learned_channel; // #29: seed the MC record's <ch> (0 until learned)
         // #gateway-election: seed the best-gateway fitness signals. co_channel (my AP == the fixed
         // mesh channel) is the DOMINANT default-weighted input; co_channel_known fail-opens the
-        // empty-MC deferral until the channel is learned. ntp_holder is v1-stubbed false (uniform →
-        // zero ordering effect; wire from `my_synced_at` in a follow-up).
+        // empty-MC deferral until the channel is learned. (#269 removed the `ntp_holder` input —
+        // it was never wireable into a signal: `my_synced_at` is set by mesh ADOPTION so it is
+        // uniformly true, and own-NTP is gateway-only so it is pure incumbency.)
         elect.co_channel = self.my_ap_channel == ESP_NOW_FIXED_CHANNEL;
         elect.co_channel_known = self.my_ap_channel != 0;
         elect.mesh_channel = ESP_NOW_FIXED_CHANNEL; // LAYER 2: detect an off-channel owner in the MC
-        elect.ntp_holder = false;
         elect.seen_owner = self.mc_seen_owner;
         elect.seen_seq = self.mc_seen_seq;
         elect.seen_ms = self.mc_seen_ms;
@@ -5496,11 +5496,10 @@ impl RadioManager {
         elect.my_channel = self.learned_channel; // #29: seed the MC record's <ch> (0 until learned)
         // #gateway-election: seed the best-gateway fitness signals (see maybe_leaf_reelect). On the
         // flush path my_ap_channel is known (a running gateway is associated), so the deferral +
-        // fitness backoff are fully active. ntp_holder v1-stubbed false (follow-up).
+        // fitness backoff are fully active. (#269 removed `ntp_holder` — see maybe_leaf_reelect.)
         elect.co_channel = self.my_ap_channel == ESP_NOW_FIXED_CHANNEL;
         elect.co_channel_known = self.my_ap_channel != 0;
         elect.mesh_channel = ESP_NOW_FIXED_CHANNEL; // LAYER 2: detect an off-channel owner in the MC
-        elect.ntp_holder = false;
         // #gateway-election all-nodes-WiFi DEBUG: a NON-gateway node only reaches this flush because
         // its debug flag is set. It must NEVER claim the crown (that would let every debug node fight
         // for ownership) — suppress the claim exactly like the #146 flush-incapable guard, so the

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -3402,6 +3402,26 @@ impl RadioManager {
     /// `Normal`; otherwise it increments reclaims and walks the guard from `Shed`, latching
     /// `Degraded` at `SHED_RECLAIM_MAX` (serve off-channel, OTA off, MQTT/mesh alive, never crownless).
     fn note_crown_ap(&mut self, decision: crate::net::coexist::CrownApDecision) {
+        // ── #269 ROT-DETECTOR (deliberate, do not "simplify") ──────────────────────────────────
+        // The `better_successor_cc: false` disposition below is justified by a design that has NOT
+        // LANDED: #269's channel-follows-the-crown derivation. If #269 ships differently, or is
+        // deferred, that justification silently evaporates and nothing would say so — the exact
+        // failure mode #371 catalogues, with the sign flipped (an intention DROPPED on the strength
+        // of a future guarantee).
+        //
+        // So the dependency is encoded as something that FAILS rather than rots. #269's whole point
+        // is that the mesh channel stops being a compile-time constant; the moment
+        // `ESP_NOW_FIXED_CHANNEL` is removed or made non-const, this assertion stops compiling and
+        // drags the next reader here to re-decide `better_successor_cc` on the design that actually
+        // shipped. Deleting this assertion to "fix the build" is deleting the point of it.
+        const _: () = assert!(
+            ESP_NOW_FIXED_CHANNEL != 0,
+            "smol #269: the mesh channel is no longer a compile-time constant — re-derive \
+             `better_successor_cc` in `note_crown_ap` (net/mode.rs) against the design that landed. \
+             Its `false` was justified by 'co-channel by construction makes this path rare', which \
+             is a judgement about #269, not a structural guarantee. Do not delete this assertion \
+             without making that decision."
+        );
         use crate::net::coexist::{crown_next_state, CrownApDecision, CrownCtx, CrownState};
         if matches!(decision, CrownApDecision::CoChannel { .. }) {
             self.shed_reclaims = 0;
@@ -3409,9 +3429,26 @@ impl RadioManager {
         } else {
             self.shed_reclaims = self.shed_reclaims.saturating_add(1);
             // The reassoc already TRIED and failed to reach co-channel, so evaluate from `Shed` with
-            // `reassoc_exhausted`. `better_successor_cc` (yield to a cc=1 peer) is a follow-up that
-            // needs the HELLO `cc` bit; Tier-1 stays crown-in-place, which holds the never-crownless
+            // `reassoc_exhausted`. Tier-1 stays crown-in-place, which holds the never-crownless
             // invariant (safety) — yielding is an optimization, not a safety requirement.
+            //
+            // `better_successor_cc` (yield to a cc=1 peer) stays FALSE, and the reason changed in
+            // #269 — do not read the old "needs the HELLO `cc` bit" note as a TODO inviting a wire
+            // change. Under #269 the mesh channel DERIVES from the elected crown's AP channel, so
+            // a crown is co-channel by construction and this failure path becomes rare.
+            //
+            // ⚠️ RARE IS NOT UNREACHABLE, and the distinction is the whole disposition. This branch
+            // exists precisely for the case where that construction FAILED — no usable AP in range,
+            // the AP changed channel or died, the crown at range edge, or the mid-migration window
+            // before the fleet has adopted the new channel. It therefore fires exactly when the
+            // fleet is already degraded, which is the worst moment to have removed a recovery.
+            // The call is "rare enough that a new wire field is not worth it" — a JUDGEMENT, not a
+            // structural guarantee. Re-derive it, do not inherit it.
+            //
+            // The disposition rests on a design that DOES NOT EXIST YET, so it is pinned by the
+            // `const _` rot-detector above `note_crown_ap` rather than left to prose: #269 removes
+            // `ESP_NOW_FIXED_CHANNEL`, and when it does, that assertion stops compiling and drags
+            // the next reader to exactly this decision.
             let ctx = CrownCtx { reassoc_exhausted: true, better_successor_cc: false };
             self.crown_state = crown_next_state(CrownState::Shed, decision, self.shed_reclaims, ctx);
         }

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -3409,18 +3409,34 @@ impl RadioManager {
         // failure mode #371 catalogues, with the sign flipped (an intention DROPPED on the strength
         // of a future guarantee).
         //
-        // So the dependency is encoded as something that FAILS rather than rots. #269's whole point
-        // is that the mesh channel stops being a compile-time constant; the moment
-        // `ESP_NOW_FIXED_CHANNEL` is removed or made non-const, this assertion stops compiling and
-        // drags the next reader here to re-decide `better_successor_cc` on the design that actually
-        // shipped. Deleting this assertion to "fix the build" is deleting the point of it.
+        // So the dependency is encoded as something that FAILS rather than rots — but read the
+        // coverage note below before trusting it, because it is PARTIAL and silence here is NOT
+        // proof that the disposition still holds.
+        //
+        // FIRES on two shapes: `ESP_NOW_FIXED_CHANNEL` removed (unresolved name), or made non-const
+        // (illegal in a const expression). Either way the build stops here and the message says what
+        // is being re-decided.
+        //
+        // ⚠️ DOES NOT FIRE on the most likely shape: the const KEPT, still non-zero, REPURPOSED from
+        // "the mesh channel" to "the rendezvous default". That is precisely what the reference
+        // design does — the watch keeps `mesh_elect::RENDEZVOUS_CHANNEL` and `MESH_CHANNEL` as
+        // consts, documented as "the RENDEZVOUS default … not a pin" — and it is what smol's own
+        // port does too (`net::mesh_elect::RENDEZVOUS_CHANNEL`, tier 2 of the recovery ladder). In
+        // that world the elected channel becomes a runtime value BESIDE this const, this assertion
+        // stays true forever, and it never fires in the case it exists to catch.
+        //
+        // A compile-time assert cannot detect "the constant survived but its MEANING changed";
+        // meaning is not a compile-time property. The complementary trigger is therefore human: a
+        // closing-checklist item on #269 itself, which cannot be closed without someone reading it.
+        // Keep both. Do not read a green build as evidence this decision was re-made.
         const _: () = assert!(
             ESP_NOW_FIXED_CHANNEL != 0,
             "smol #269: the mesh channel is no longer a compile-time constant — re-derive \
              `better_successor_cc` in `note_crown_ap` (net/mode.rs) against the design that landed. \
              Its `false` was justified by 'co-channel by construction makes this path rare', which \
-             is a judgement about #269, not a structural guarantee. Do not delete this assertion \
-             without making that decision."
+             is a judgement about #269, not a structural guarantee. NOTE this assert only covers \
+             removal/non-const, NOT the const being kept and repurposed as the rendezvous default — \
+             see the #269 closing checklist. Do not delete it without making that decision."
         );
         use crate::net::coexist::{crown_next_state, CrownApDecision, CrownCtx, CrownState};
         if matches!(decision, CrownApDecision::CoChannel { .. }) {

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -3461,6 +3461,20 @@ impl RadioManager {
             // The call is "rare enough that a new wire field is not worth it" — a JUDGEMENT, not a
             // structural guarantee. Re-derive it, do not inherit it.
             //
+            // And the judgement has precedent on its side, which is a better rationale than
+            // "optimization deferred": the two shipping systems with this architecture DISAGREE on
+            // eager replacement, and the closest cousin says never. ESP-WIFI-MESH will not yield
+            // while the root is alive AT ALL — even RSSI degraded to near-disconnection does not
+            // trigger a switch; healing comes from children detecting root DEATH, not from the root
+            // grading itself. batman-adv does allow replacement, but only past a tuned margin
+            // (`gw_sel_class`, default 20 of ~255 TQ ≈ 8%). NEITHER does a raw comparison. Both
+            // price incumbent stability above optimality — so declining to add a wire field for a
+            // yield-while-alive optimization is the conservative reading of both, not a shortcut.
+            //
+            // Corollary for the incumbent-retention bar when it lands: it must mean "cannot do the
+            // job" (the #146 flush-incapable latch shape, matching ESP-MESH's "breaks down"), NOT
+            // "slower than ideal". An eager bar re-imports the flap this whole design avoids.
+            //
             // The disposition rests on a design that DOES NOT EXIST YET, so it is pinned by the
             // `const _` rot-detector above `note_crown_ap` rather than left to prose: #269 removes
             // `ESP_NOW_FIXED_CHANNEL`, and when it does, that assertion stops compiling and drags

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -103,7 +103,7 @@ const MESH_PEERS_TOPIC: &[u8] = b"smol/mesh/peers";
 const MESH_CHANNEL_HINT_TOPIC: &[u8] = b"smol/mesh/channel_hint";
 
 /// #gateway-election OPERATOR LEVER: the retained best-gateway METRIC. Payload = keyed weights
-/// `c<n>r<n>n<n>u<n>` (co-channel / rssi / ntp / uptime), the literal `legacy` (escape hatch → the
+/// `c<n>r<n>n<n>u<n>` (co-channel / rssi / ntp-ACCEPTED-AND-IGNORED / uptime), the literal `legacy` (→
 /// historical lowest-id + RSSI election), or empty (retain-clear → the on-by-default co-channel-
 /// dominant metric). Read in-burst by [`mqtt_session`] into `elect.elect_cfg` — the election consumes
 /// it in the SAME burst it claims in, so (unlike the CFG-relay family) no relay round-trip is needed.
@@ -193,9 +193,6 @@ pub struct MeshElect {
     /// (`ESP_NOW_FIXED_CHANNEL`) — the DOMINANT default-weighted fitness signal (an off-channel crown
     /// is OTA-deaf regardless of RSSI, #217). Seeded by the caller from `self.my_ap_channel`.
     pub co_channel: bool,
-    /// Best-gateway election: this board holds NTP-authoritative time (`synced_at != 0`) — a better
-    /// gateway can serve TIME frames. Seeded by the caller (0-weight-equivalent while uniformly false).
-    pub ntp_holder: bool,
     /// #gateway-election LAYER 2: the fixed mesh channel (`ESP_NOW_FIXED_CHANNEL`), seeded by the
     /// caller. Lets the resolver detect an OFF-channel owner (retained MC `<ch>` known and != this)
     /// so a CO-CHANNEL board seizes the wrong (off-channel, OTA-deaf) crown IMMEDIATELY instead of
@@ -257,7 +254,6 @@ impl MeshElect {
             flush_incapable: false, // #146: seeded by the caller from the flush-fail abdication latch
             channel_hint: None, // #155: seeded by the caller from the retained smol/mesh/channel_hint
             co_channel: false, // best-gateway: seeded by the caller from my_ap_channel == mesh
-            ntp_holder: false, // best-gateway: seeded by the caller from synced_at != 0
             mesh_channel: 0, // LAYER 2: seeded by the caller (ESP_NOW_FIXED_CHANNEL); 0 → override off
             co_channel_known: false, // best-gateway: false at boot (channel unknown) → claim fast
             // best-gateway is ON by default (team-lead 2026-07-20); the retained smol/mesh/elect topic
@@ -281,7 +277,6 @@ impl MeshElect {
         crate::net::election::FitnessInputs {
             co_channel: self.co_channel,
             ap_rssi: self.my_rssi,
-            ntp_holder: self.ntp_holder,
             uptime_ms: self.now_ms,
         }
     }
@@ -3520,10 +3515,21 @@ fn mqtt_session(
                                 log::info!("smol: #gateway-election metric = LEGACY (lowest-id, retained)")
                             }
                             crate::net::election::ElectConfig::BestGateway(w) => log::info!(
-                                "smol: #gateway-election metric = best-gateway c{} r{} n{} u{} (retained)",
+                                // #269: `n` prints as a literal 0, and that is not a compatibility
+                                // courtesy — it is ACCURATE. The effective weight of the ntp input
+                                // is zero permanently, by construction, so 0 IS the applied state.
+                                //
+                                // INVARIANT worth preserving if this line ever changes: this
+                                // readback reports the APPLIED weights, never the SENT ones. An
+                                // operator who sends `n50` reads back `n0` and learns immediately
+                                // that their knob did nothing. Echoing `n50` would claim an
+                                // application that never happened; dropping the slot would tell
+                                // them nothing at all. Keeping the `c<n>r<n>n<n>u<n>` shape they
+                                // can still send makes the gap between typed and applied visible
+                                // at a glance.
+                                "smol: #gateway-election metric = best-gateway c{} r{} n0 u{} (retained)",
                                 w.co_channel,
                                 w.rssi,
-                                w.ntp,
                                 w.uptime
                             ),
                         }

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -165,6 +165,26 @@ hostsim  = "host-only, and covered by the `cargo test` arm in tools/gate.sh"
 # observed fails the gate, because a reason that has quietly stopped applying reads as a
 # considered decision and is worse than no entry.
 [unobservable]
+# ⚠️ TEMPORARY — stage 2 of #278 MUST delete this entry, and the gate is what will notice.
+# `net/mesh_elect.rs` is the ELECT frame + epoch/anti-flap core, ported ahead of its wiring so it
+# could be reviewed on its own. Nothing calls it yet (it carries a matching dated
+# `#[allow(dead_code)]` at its `pub mod` declaration), so the linker strips it and it emits no
+# observable code in ANY tier — which is exactly what this gate flagged: its absence from the
+# non-espnow tiers proves nothing while it is absent from espnow too.
+#
+# This is the `crdt.rs` shape (#371) caught BEFORE it landed rather than by a later audit, and the
+# reason the check works is that it reads SOURCE STRUCTURE: a symbol-absence check has nothing to
+# complain about in a module that emits no symbols.
+#
+# When stage 2 adds the `Frame::Elect` dispatch arm and the announce/honour paths, the module
+# starts emitting code, this claim becomes false, and the gate fails until the entry is removed.
+# That is the intended sequence — do not pre-emptively delete it, and do not let it survive.
+"src/net/mesh_elect.rs" = """\
+unwired pending stage 2 of #278 — declared and cfg-gated on espnow, but no caller exists yet, so \
+it contributes no executable code to any tier and its exclusion elsewhere is unprovable. Paired \
+with the dated `#[allow(dead_code)]` on `pub mod mesh_elect;` in net.rs; BOTH must be deleted by \
+the PR that wires it, and both fail loudly if they are not."""
+
 "src/secrets.rs" = """\
 consts only (WIFI_NETWORK / MQTT_* / WLED_CAST_*) — 0 fn / 0 impl in both secrets.rs and \
 secrets.rs.example, so it emits .rodata and no line rows. It is also git-ignored and \
@@ -219,6 +239,7 @@ provisioned per tree, so its contents are not a property of the commit at all.""
 "src/net/http.rs" = "espnow"
 "src/net/ledger.rs" = "espnow"
 "src/net/ledger_link.rs" = "espnow"
+"src/net/mesh_elect.rs" = "espnow"
 "src/net/mode.rs" = "espnow"
 "src/net/mqtt.rs" = "wifi"
 "src/net/ota_resume.rs" = "espnow"


### PR DESCRIPTION
**Scope: this is PART of stage 2, not all of it. The announcement/follow path is NOT here** — see *Deliberately not in this PR* below. Everything present is coherent and green at every commit; nothing is half-landed.

**Gate: `GATE GREEN`, 54 PASS / 0 FAIL.** Stack 106,472 B against the 74,208 B floor.

## What lands

| commit | what |
|---|---|
| `af0f219` | **Stage A** — `net/mesh_elect.rs`: the `SMOLv1 ELECT` frame + epoch/anti-flap core, ported from the esp32c6-watch and **reduced** 895 → 408 lines. Plus `experiments/mesh_elect_verify` running the donor's own tests (10: 8 wire + 2 consensus). |
| `dd00c26` | `better_successor_cc` disposition + a `const _` rot-detector **that states its own blind spot**. |
| `05ccce4` | Both #351 declarations (`[tier_exclusive]` + `[unobservable]`) and two corrections. |
| `4d02a1f` | **Removes `ntp_holder`** — it was never wireable into a signal. |
| `0886a6f` | Prior-art citations: CSA, the IDF non-atomic quote, and the two-precedents rationale. |

## Why the port is partial

The donor **elects** a channel by tally across peers. Per #269 the mesh channel is **derived** from the elected gateway's AP channel — a consequence, not a vote — so `Elector`/`Tally`/`Ingest` and the observe/tally/winner machinery are deliberately absent. Landing a voting engine into a system with nothing to vote on would read as intent to whoever touched it next. What survives serves the **announcement**: the byte-identical wire frame, `Decision`+`supersedes` (epoch ordering, stale/replay rejection), the anti-flap constants, and `weight()` — which still fills `w[13]` honestly, because **dropping the vote is not the same as dropping the observation** and the watch still cross-checks observe-only.

## Why `ntp_holder` was removed rather than finished

Both possible wirings produce a non-signal: `my_synced_at != 0` is **uniformly true** (updated by mesh *adoption*, not own NTP), and own-NTP is **gateway-only** (*"Leaves never call this"*) so it is pure incumbency. The stub wasn't an unfinished task — it was a placeholder for a measurement smol doesn't take. Replacement is the asymmetric design (incumbent judged at its real job; challengers on `ap_rssi`+uptime), which matches ESP-WIFI-MESH and batman-adv: **nobody probes candidates on a constrained mesh.**

## Deliberately NOT in this PR

- **The announcement/follow path** (`Frame::Elect` dispatch, CSA-shaped announce-before-and-after, recovery ladder).
- **The `co_channel` re-scale.** It is **structurally coupled** to the announcement and must not ship alone: `co_channel: 100` is the #217/id5 disease fix, and re-scaling it before leaves can *follow* a crown to a new channel re-arms exactly that disease. `election_verify` refused it — the test was written for #217 and defended a property nobody was thinking about.
- **The runtime-lever clamp.** The retained `smol/mesh/elect` lever is a *second writer* of `co_channel`; the invariant is *"co-channel dominates unless following is enabled"* and must bind every writer. (Lever verified **empty** on the broker at 2026-08-02 ~01:57 PDT, so this is real-but-unarmed.)

## Two markers that must not survive stage 2

`net.rs`'s dated `#[allow(dead_code)]` and `build-matrix.toml`'s `[unobservable]` entry are a **two-sided pair**: wiring the module makes it emit code, which *falsifies* the unobservable claim and fails the gate until the entry is removed; removing it early makes `UNPROVEN` fire again. They name each other so neither can go alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)