### PR TITLE
refactor(ui): name the two display clips for their unit (#274 follow-up)

### DIFF
--- a/experiments/clip_verify/src/main.rs
+++ b/experiments/clip_verify/src/main.rs
@@ -6,10 +6,13 @@
 //! "magical nouns are ASCII". True, but unenforced — the corpus held the invariant, not the code.
 //! The panic would have surfaced as a reboot on whichever board first rendered a non-ASCII string.
 
+#[path = "../../../rust/clock/src/textclip.rs"]
+mod textclip;
+// Still included for `Line` — the buffer that feeds clip_bytes at every real call site.
 #[path = "../../../rust/clock/src/rssi.rs"]
 mod rssi;
 
-use rssi::clip;
+use textclip::{clip_bytes as clip, clip_chars};
 
 /// Every prefix length of `s`, including 0 and past the end. If any budget panics, the harness dies
 /// with the byte index that did it, which is the number you need to debug it.
@@ -73,6 +76,33 @@ fn main() {
         }
     }
 
+    // ---- clip_chars: the OTHER unit, and the #274-follow-up rename's core promise -----------
+    // batt.rs / grid.rs budget in GLYPHS (LINE_CHARS), not bytes. That function moved here under
+    // its own name; it must behave exactly as it did in those files, or their line layout shifts.
+    assert_eq!(clip_chars("café", 4), "café", "4 CHARS is the whole word (4 chars, 5 bytes)");
+    assert_eq!(clip_chars("café", 3), "caf");
+    assert_eq!(clip_chars("🐉🔥", 1), "🐉", "one char, not one byte");
+    assert_eq!(clip_chars("", 3), "");
+    for s in ["café", "Ωμέγα", "🐉🔥", "a\u{00e9}\u{20ac}\u{1f409}z", ""] {
+        for n in 0..=s.chars().count() + 3 {
+            let out = clip_chars(s, n);
+            assert!(s.starts_with(out), "clip_chars({s:?}, {n}) is not a prefix");
+            assert!(out.chars().count() <= n, "clip_chars({s:?}, {n}) kept too many chars");
+        }
+    }
+
+    // THE RENAME'S GUARANTEE. On ASCII the two units coincide, so every call site that moved
+    // between names must render identically — that is what makes "no semantic change" a checked
+    // claim rather than an assurance. Compared against the pre-#274 byte expression, which is
+    // also what batt/grid's char version reduced to on ASCII.
+    for s in ["Ember", "Molten Engine", "smol", "", "v905 12/48", "from 10.0.0.1"] {
+        for n in 0..=s.len() + 4 {
+            let expect = &s[..s.len().min(n)];
+            assert_eq!(clip(s, n), expect, "clip_bytes changed for {s:?}@{n} — screens reflow");
+            assert_eq!(clip_chars(s, n), expect, "clip_chars changed for {s:?}@{n} — screens reflow");
+        }
+    }
+
     // ---- the Line buffer that feeds clip() at every real call site --------------------------
     // ota_screen.rs builds a Line, then clips it. Line truncates at 24 bytes on write, which can
     // itself tear a multibyte char; as_str() is from_utf8(..).unwrap_or(""), so clip() receives
@@ -90,5 +120,6 @@ fn main() {
     sweep(s, "Line-truncated emoji run");
 
     println!("clip_verify: OK — no budget panics across multibyte, emoji, mixed-width and Line-torn input;");
-    println!("             ASCII truncation byte-identical to the pre-#274 implementation.");
+    println!("             clip_bytes AND clip_chars byte-identical to the pre-#274 implementation");
+    println!("             on all-ASCII input, so the #274-follow-up rename is provably inert.");
 }

--- a/rust/clock/src/batt.rs
+++ b/rust/clock/src/batt.rs
@@ -44,6 +44,7 @@ use embedded_graphics::{
     text::{Baseline, Text},
 };
 
+use crate::textclip::clip_chars;
 use crate::app::{AppKind, Ctx, Plugin, Transition};
 use crate::input::Press;
 
@@ -286,21 +287,21 @@ fn render(ctx: &mut Ctx, age_s: Option<u64>, page: u8) {
         let body = ctx.batt.payload().strip_prefix("BATT|").unwrap_or("");
         for (i, seg) in body.split('|').take(3).enumerate() {
             let y = 12 + i as i32 * 9;
-            Text::with_baseline(clip(seg, LINE_CHARS), Point::new(2, y), small, Baseline::Top)
+            Text::with_baseline(clip_chars(seg, LINE_CHARS), Point::new(2, y), small, Baseline::Top)
                 .draw(ctx.display)
                 .ok();
         }
     } else if let Some(seg) = ctx.batt.detail_segment((p - 1) as usize) {
         // Big detail page: `<label> <value>` → small label on top, BIG value below.
         let (label, value) = seg.split_once(' ').unwrap_or(("", seg));
-        Text::with_baseline(clip(label, LINE_CHARS), Point::new(2, 1), small, Baseline::Top)
+        Text::with_baseline(clip_chars(label, LINE_CHARS), Point::new(2, 1), small, Baseline::Top)
             .draw(ctx.display)
             .ok();
         // Tiny age top-right so freshness stays visible on the big page too.
         Text::with_baseline(age.as_str(), Point::new(56, 1), small, Baseline::Top)
             .draw(ctx.display)
             .ok();
-        let v = clip(value, 7); // ≤ 7 glyphs @ 10 px advance fits 72 px
+        let v = clip_chars(value, 7); // ≤ 7 glyphs @ 10 px advance fits 72 px
         let w = v.chars().count() as i32 * 10;
         let x = ((72 - w) / 2).max(1);
         Text::with_baseline(v, Point::new(x, 14), big, Baseline::Top)
@@ -311,14 +312,6 @@ fn render(ctx: &mut Ctx, age_s: Option<u64>, page: u8) {
     ctx.display.flush().ok();
 }
 
-/// Clip `s` to at most `max` characters on a UTF-8 boundary (protocol is ASCII,
-/// but this is boundary-safe regardless — never panics on a byte-slice).
-fn clip(s: &str, max: usize) -> &str {
-    match s.char_indices().nth(max) {
-        Some((idx, _)) => &s[..idx],
-        None => s,
-    }
-}
 
 /// Write a compact fetch age (`45s` / `12m` / `3h`) into `out`. Bounded to ≤ 4
 /// glyphs so it always fits beside the title (48 px..72 px = 24 px = 4 chars).

--- a/rust/clock/src/bench.rs
+++ b/rust/clock/src/bench.rs
@@ -29,7 +29,7 @@ use crate::app::{AppKind, Ctx, MeshStatus, Plugin, TimeSource, Transition};
 use crate::input::Press;
 use crate::led::LedState;
 use crate::net::mode::{BenchStats, NodeView, RosterView};
-use crate::rssi::clip;
+use crate::textclip::clip_bytes;
 
 /// Per-peer rows per NODES page (3 rows + 1 own-status line fills the 5×8 grid).
 const PEERS_PER_PAGE: usize = 3;
@@ -230,7 +230,7 @@ where
     let noun = short.as_str();
 
     let mut left = Line::new();
-    let _ = write!(left, "{} ", clip(noun, 6));
+    let _ = write!(left, "{} ", clip_bytes(noun, 6));
     match mesh.source {
         TimeSource::NtpRoot => {
             let _ = write!(left, "root");

--- a/rust/clock/src/grid.rs
+++ b/rust/clock/src/grid.rs
@@ -46,6 +46,7 @@ use embedded_graphics::{
     text::{Baseline, Text},
 };
 
+use crate::textclip::clip_chars;
 use crate::app::{AppKind, Ctx, Plugin, Transition};
 use crate::input::Press;
 
@@ -266,13 +267,13 @@ fn render(ctx: &mut Ctx, age_s: Option<u64>, page: u8) {
         let lines = ctx.grid.payload().strip_prefix("GRID|").unwrap_or("");
         for (i, seg) in lines.split('|').take(3).enumerate() {
             let y = 12 + i as i32 * 9;
-            Text::with_baseline(clip(seg, LINE_CHARS), Point::new(2, y), small, Baseline::Top)
+            Text::with_baseline(clip_chars(seg, LINE_CHARS), Point::new(2, y), small, Baseline::Top)
                 .draw(ctx.display)
                 .ok();
         }
     } else {
         // JP's "just the power, whole window": the TOTAL as a big centred number.
-        let total = clip(ctx.grid.total(), 7); // ≤ 7 glyphs @ 10 px advance fits 72 px
+        let total = clip_chars(ctx.grid.total(), 7); // ≤ 7 glyphs @ 10 px advance fits 72 px
         let w = total.chars().count() as i32 * 10;
         let x = ((72 - w) / 2).max(1); // centre like the CLOCK (10 px/char)
         Text::with_baseline(total, Point::new(x, 11), big, Baseline::Top)
@@ -287,14 +288,6 @@ fn render(ctx: &mut Ctx, age_s: Option<u64>, page: u8) {
     ctx.display.flush().ok();
 }
 
-/// Clip `s` to at most `max` characters on a UTF-8 boundary (protocol is ASCII,
-/// but this is boundary-safe regardless — never panics on a byte-slice).
-fn clip(s: &str, max: usize) -> &str {
-    match s.char_indices().nth(max) {
-        Some((idx, _)) => &s[..idx],
-        None => s,
-    }
-}
 
 /// Write a compact fetch age (`45s` / `12m` / `3h`) into `out`. Bounded to ≤ 4
 /// glyphs so it always fits beside the title (48 px..72 px = 24 px = 4 chars).

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -109,6 +109,12 @@ mod clock;
 // #282 SIGIL screen — the node's identity nameplate (fantasy name + version sigil). Its own
 // navigable plugin + menu row; compiled in EVERY build (identity needs no radio, like About).
 mod sigil;
+// #274 follow-up: the two display-text truncators, named for their unit (`clip_bytes` /
+// `clip_chars`). PURE — host-tested verbatim by `experiments/clip_verify`. `wifi`-gated because
+// the consumers span tiers: batt/grid are wifi, bench/rssi/ota_screen are espnow. The previous
+// shared home (rssi.rs) is espnow-only, which is why batt/grid could not share it.
+#[cfg(feature = "wifi")]
+mod textclip;
 // BENCH mode (ESP-NOW link stats + mesh roster). ESP-NOW-only.
 #[cfg(feature = "espnow")]
 mod bench;

--- a/rust/clock/src/ota_screen.rs
+++ b/rust/clock/src/ota_screen.rs
@@ -40,7 +40,8 @@ use embedded_graphics::{
 
 use crate::app::Oled;
 use crate::net::names::{name_for_seed, FORGE};
-use crate::rssi::{clip, Line};
+use crate::rssi::Line;
+use crate::textclip::clip_bytes;
 
 /// Panel geometry (matches the other screens).
 const PANEL_W: i32 = 72;
@@ -233,7 +234,7 @@ pub fn draw(display: &mut Oled, v: &OtaView) {
     let (adj, noun) = name_for_seed(v.build, &FORGE);
     let mut hero = Line::new();
     let _ = write!(hero, "{} {}", adj, noun);
-    Text::with_baseline(clip(hero.as_str(), 12), Point::new(0, 0), style_6x10(), Baseline::Top)
+    Text::with_baseline(clip_bytes(hero.as_str(), 12), Point::new(0, 0), style_6x10(), Baseline::Top)
         .draw(display)
         .ok();
 
@@ -262,7 +263,7 @@ pub fn draw(display: &mut Oled, v: &OtaView) {
             let _ = write!(src, "from {}", host);
         }
     }
-    Text::with_baseline(clip(src.as_str(), 14), Point::new(0, 11), style_5x8(), Baseline::Top)
+    Text::with_baseline(clip_bytes(src.as_str(), 14), Point::new(0, 11), style_5x8(), Baseline::Top)
         .draw(display)
         .ok();
 
@@ -276,7 +277,7 @@ pub fn draw(display: &mut Oled, v: &OtaView) {
             let _ = write!(stat, "v{} {}/{}K", v.build, v.done / 1024, v.total / 1024);
         }
     }
-    Text::with_baseline(clip(stat.as_str(), 14), Point::new(0, 20), style_5x8(), Baseline::Top)
+    Text::with_baseline(clip_bytes(stat.as_str(), 14), Point::new(0, 20), style_5x8(), Baseline::Top)
         .draw(display)
         .ok();
 

--- a/rust/clock/src/rssi.rs
+++ b/rust/clock/src/rssi.rs
@@ -167,29 +167,6 @@ impl core::fmt::Write for Line {
     }
 }
 
-/// Left-truncate to **at most `n` bytes**, never splitting a UTF-8 character.
-///
-/// This is the fleet's one byte-budget truncator: `bench.rs` calls it rather than keeping its own
-/// copy, and the watch's `crates/rssi` carries the identical implementation (#274).
-///
-/// **Why the boundary walk, when the corpus is ASCII.** The previous version was
-/// `&s[..s.len().min(n)]`, documented as safe because "magical nouns are ASCII, so a byte boundary
-/// is a char boundary". That invariant was true but *unenforced* — held only by the wordlist's
-/// contents and by [`crate::ota`]'s `!url.is_ascii()` rejection of announce URLs. Nothing in the
-/// type system stopped a future caller from rendering a peer- or operator-supplied string here, and
-/// the panic would have arrived as a reboot on whichever board first displayed it. A truncator that
-/// cannot panic for *any* input costs three lines and removes the invariant from the list of things
-/// a reviewer must remember. See `net::names::write_short`, which already reasoned this way.
-///
-/// Walking backwards (rather than forwards) keeps the result within the caller's budget: a
-/// character straddling `n` is dropped, never half-emitted.
-pub fn clip(s: &str, n: usize) -> &str {
-    if s.len() <= n {
-        return s;
-    }
-    let mut end = n;
-    while end > 0 && !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    &s[..end]
-}
+// #274 follow-up: `clip()` moved to `crate::textclip::clip_bytes` — same implementation, but
+// named for its unit and in a `wifi`-gated home that `batt`/`grid` can also reach. This module is
+// espnow-only, which is what kept those two on their own copy.

--- a/rust/clock/src/textclip.rs
+++ b/rust/clock/src/textclip.rs
@@ -1,0 +1,71 @@
+//! #274 follow-up — the fleet's display-text truncators, in one place and **named for their
+//! unit**.
+//!
+//! # Why two functions and not one
+//!
+//! #274 left the crate with two correct-but-different truncators, both called `clip`:
+//!
+//! | where | unit | callers |
+//! |---|---|---|
+//! | `rssi.rs` | **bytes** | `bench.rs`, `ota_screen.rs` |
+//! | `batt.rs`, `grid.rs` | **characters** | their own line layout |
+//!
+//! Both are boundary-safe, so neither can panic; the hazard is subtler than that. Two functions
+//! with the same name and different units, in one crate, is a trap for whoever next moves a call
+//! site between them — the code compiles, the ASCII output is identical, and the difference only
+//! appears the day a non-ASCII string reaches a screen.
+//!
+//! Unifying them would have been the wrong fix. The units are not an accident:
+//!
+//! * `ota_screen.rs` budgets against a fixed pixel width and a `Line` buffer measured in bytes;
+//! * `batt.rs`/`grid.rs` budget in `LINE_CHARS`, a glyph count.
+//!
+//! Neither is truly "display width" — a wide or combining character is neither one byte nor one
+//! cell — and pretending otherwise would need font metrics, not string surgery. So both units
+//! survive, each keeps its exact current behaviour, and the names now say which is which.
+//!
+//! **No semantic change.** Every call site keeps the function it already had; only the name and
+//! the home move. `experiments/clip_verify` asserts byte-identical output against the previous
+//! implementations across all-ASCII input, which is what makes that claim checkable rather than
+//! asserted.
+//!
+//! # Placement
+//!
+//! `wifi`-gated, because the consumers span two tiers: `batt`/`grid` are `wifi`, while
+//! `bench`/`rssi`/`ota_screen` are `espnow` (⊃ `wifi`). The previous shared home was `rssi.rs`,
+//! which is **espnow**-only — so `batt`/`grid` structurally could not have used it, which is
+//! precisely why the duplication survived #274.
+
+/// Truncate to at most `n` **bytes**, never splitting a UTF-8 character.
+///
+/// Walks backwards from `n`, so a character straddling the budget is dropped rather than
+/// half-emitted and the result is always within the caller's byte budget. Was `rssi::clip`.
+///
+/// Use this where the budget comes from a buffer size or a byte-measured layout.
+///
+/// Both consumers (`bench`, `ota_screen`) are `espnow`, but this module is `wifi`-gated because
+/// `clip_chars`'s consumers are — so on a wifi-without-espnow build this is genuinely unused.
+/// Narrow `cfg_attr` rather than a blanket `allow`, matching `net.rs::assert_max_tx_power`: a
+/// blanket allow would also hide it going unused on the tiers that DO ship it.
+#[cfg_attr(not(feature = "espnow"), allow(dead_code))]
+pub fn clip_bytes(s: &str, n: usize) -> &str {
+    if s.len() <= n {
+        return s;
+    }
+    let mut end = n;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// Truncate to at most `max` **characters** (Unicode scalar values). Was the `clip` in
+/// `batt.rs` / `grid.rs`.
+///
+/// Use this where the budget is a glyph count — a fixed-width font's columns, say.
+pub fn clip_chars(s: &str, max: usize) -> &str {
+    match s.char_indices().nth(max) {
+        Some((idx, _)) => &s[..idx],
+        None => s,
+    }
+}

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -191,6 +191,7 @@ provisioned per tree, so its contents are not a property of the commit at all.""
 #
 # Regenerate with: tools/check_exclusions.py claims --toml
 [tier_exclusive]
+"src/textclip.rs" = "wifi"
 "src/bard/delivery.rs" = "bard"
 "src/bard/mod.rs" = "bard"
 "src/bard/nano_llm.rs" = "bard"

--- a/tools/check_verifier_wiring.py
+++ b/tools/check_verifier_wiring.py
@@ -48,32 +48,60 @@ KNOWN_PHANTOMS = {
 
 PATH_ATTR = re.compile(r'#\[\s*path\s*=\s*"([^"]+)"\s*\]')
 # `mod x;` / `pub mod x;` / `pub(crate) mod x;` — declaration only, never `mod x { .. }` inline
-# (an inline module is not a file-backed one, so it cannot be a #[path] target).
+# (an inline module is not file-backed, so it cannot be a #[path] target).
 MOD_DECL = re.compile(r'^\s*(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;')
-CFG_ATTR = re.compile(r'^\s*#\[\s*(cfg|cfg_attr)\b')
 
 
-def crate_declarations(crate_src: Path):
-    """Map module name -> list of (file, line, cfg-lines-immediately-above)."""
-    decls = {}
-    for rs in sorted(crate_src.rglob("*.rs")):
-        try:
-            lines = rs.read_text(encoding="utf-8", errors="replace").splitlines()
-        except OSError as e:
-            print(f"error: cannot read {rs}: {e}", file=sys.stderr)
-            raise SystemExit(2)
+def reachable_from(root: Path, crate_src: Path):
+    """Every source file in the module tree rooted at `root`, resolved the way rustc resolves it.
+
+    THIS IS A PER-ROOT WALK, AND THAT IS THE ENTIRE POINT. The clock crate has TWO roots that
+    declare overlapping files with different gating: `main.rs` (the firmware bin) and `lib.rs`
+    (the `hostsim` library the web emulator builds). Keying on a module NAME and searching the
+    whole tree conflates them — #351's first checker did exactly that, picked up `lib.rs`'s
+    `#[cfg(feature = "hostsim")]`, and declared `app`/`clock`/`input`/`sensors`/`snake` excluded
+    from a firmware image that plainly contains them. Five false negatives from one shortcut.
+
+    Walking each root separately also makes this immune to three traps that bite gate-parsing
+    tools on this crate, because the verdict never consults a `cfg` at all:
+      * `#![cfg_attr(not(espnow), allow(dead_code))]` in `wifi.rs` is a LINT attribute, not a
+        gate — a checker that greps for cfg-shaped things near a module reads it as one;
+      * a module's gate can live in a different file (`net/cast.rs` is gated from `net.rs`);
+      * feature membership is transitive (`espnow` -> `wifi` -> `hw`), so direct membership
+        under-approximates.
+    Reachability answers "is this file in the tree rustc compiles for this root", which is the
+    question, and needs none of that modelling.
+    """
+    seen, out, stack = set(), set(), [root]
+    while stack:
+        f = stack.pop()
+        if f in seen or not f.exists():
+            continue
+        seen.add(f)
+        out.add(f.resolve())
+        lines = f.read_text(encoding="utf-8", errors="replace").splitlines()
         for i, line in enumerate(lines):
             m = MOD_DECL.match(line)
             if not m:
                 continue
-            # Walk back over contiguous attribute lines to capture the gating cfg(s).
-            cfgs, j = [], i - 1
-            while j >= 0 and (CFG_ATTR.match(lines[j]) or lines[j].lstrip().startswith("#[")):
-                if CFG_ATTR.match(lines[j]):
-                    cfgs.insert(0, lines[j].strip())
-                j -= 1
-            decls.setdefault(m.group(1), []).append((rs, i + 1, cfgs))
-    return decls
+            name = m.group(1)
+            # A `#[path = ".."]` attribute on the declaration overrides the filename. `lib.rs`
+            # uses this for the bard cores, so it is not hypothetical.
+            override = None
+            for j in range(max(0, i - 4), i):
+                pm = PATH_ATTR.search(lines[j])
+                if pm:
+                    override = pm.group(1)
+            if override:
+                cands = [f.parent / override, crate_src / override]
+            else:
+                base = f.parent if f.name in ("main.rs", "lib.rs") else f.parent / f.stem
+                cands = [base / f"{name}.rs", base / name / "mod.rs"]
+            for c in cands:
+                if c.exists():
+                    stack.append(c)
+                    break
+    return out
 
 
 def main() -> int:
@@ -83,54 +111,61 @@ def main() -> int:
         print(f"error: run from the smol repo root (got {root})", file=sys.stderr)
         return 2
 
-    decls = crate_declarations(crate_src)
-    rows, phantoms, missing_files = [], [], []
+    ships = reachable_from(crate_src / "main.rs", crate_src)   # the firmware bin
+    hostsim = reachable_from(crate_src / "lib.rs", crate_src)  # the hostsim/web-emu library
+    if not ships:
+        print("error: main.rs reached no modules — the walk is broken, refusing to report",
+              file=sys.stderr)
+        return 2
 
+    rows, phantoms, missing_files = [], [], []
     for main_rs in sorted(experiments.rglob("*.rs")):
         text = main_rs.read_text(encoding="utf-8", errors="replace")
         verifier = main_rs.relative_to(experiments).parts[0]
         for rel in PATH_ATTR.findall(text):
             target = (main_rs.parent / rel).resolve()
-            # Only firmware-crate sources are in scope; a verifier including another experiment's
-            # helper is not making a claim about shipped code.
             try:
                 target.relative_to(crate_src)
             except ValueError:
-                continue
+                continue  # including another experiment's helper claims nothing about firmware
             if not target.exists():
                 missing_files.append((verifier, rel))
                 continue
-            name = target.stem
-            where = decls.get(name, [])
-            if where:
-                sites = "; ".join(
-                    f"{p.relative_to(root)}:{ln}" + (f" {' '.join(c)}" if c else " (no cfg)")
-                    for p, ln, c in where
-                )
-                rows.append((verifier, str(target.relative_to(root)), "yes", sites, "SOUND"))
+            shown = str(target.relative_to(root))
+            if target in ships:
+                verdict, where = "SOUND", "main.rs tree"
+            elif target in hostsim:
+                verdict, where = "HOST-ONLY", "lib.rs tree (hostsim)"
             else:
-                rows.append((verifier, str(target.relative_to(root)), "NO", "-", "PHANTOM"))
-                phantoms.append((verifier, str(target.relative_to(root))))
+                verdict, where = "PHANTOM", "neither root"
+                phantoms.append((verifier, shown))
+            rows.append((verifier, shown, where, verdict))
 
-    w = [max(len(str(r[i])) for r in rows + [("verifier", "module", "decl", "declared at", "verdict")])
-         for i in range(5)] if rows else [8] * 5
-    hdr = ("verifier", "#[path] target", "declared?", "declared at", "verdict")
-    print(f"{hdr[0]:<{w[0]}}  {hdr[1]:<{w[1]}}  {hdr[2]:<{w[2]}}  {hdr[3]:<{w[3]}}  {hdr[4]}")
-    print("-" * (sum(w) + 8))
-    for r in sorted(rows, key=lambda r: (r[4] != "PHANTOM", r[0])):
-        print(f"{r[0]:<{w[0]}}  {r[1]:<{w[1]}}  {r[2]:<{w[2]}}  {r[3]:<{w[3]}}  {r[4]}")
+    if rows:
+        w = [max(len(str(r[i])) for r in rows) for i in range(3)]
+    else:
+        w = [8, 8, 8]
+    print(f"{'verifier':<{w[0]}}  {'#[path] target':<{w[1]}}  {'reachable from':<{w[2]}}  verdict")
+    print("-" * (sum(w) + 14))
+    order = {"PHANTOM": 0, "HOST-ONLY": 1, "SOUND": 2}
+    for r in sorted(rows, key=lambda r: (order[r[3]], r[0])):
+        print(f"{r[0]:<{w[0]}}  {r[1]:<{w[1]}}  {r[2]:<{w[2]}}  {r[3]}")
 
+    n_sound = sum(1 for r in rows if r[3] == "SOUND")
+    n_host = sum(1 for r in rows if r[3] == "HOST-ONLY")
     print(f"\n{len(rows)} #[path] include(s) into the firmware crate across "
           f"{len({r[0] for r in rows})} verifier(s): "
-          f"{sum(1 for r in rows if r[4] == 'SOUND')} sound, {len(phantoms)} phantom.")
+          f"{n_sound} sound, {n_host} host-only, {len(phantoms)} phantom.")
+    if n_host:
+        print("HOST-ONLY = reachable from lib.rs but not main.rs: real code, but it ships in the\n"
+              "web emulator rather than the firmware. Not a defect; just not a firmware claim.")
 
     for verifier, rel in missing_files:
         print(f"error: {verifier} includes {rel}, which does not exist", file=sys.stderr)
 
-    # Split phantoms into tracked (allowlisted, reported loudly) and new (fatal).
     tracked = [(v, m) for v, m in phantoms if m in KNOWN_PHANTOMS]
     untracked = [(v, m) for v, m in phantoms if m not in KNOWN_PHANTOMS]
-    sound_paths = {r[1] for r in rows if r[4] == "SOUND"}
+    sound_paths = {r[1] for r in rows if r[3] in ("SOUND", "HOST-ONLY")}
     stale = sorted(sound_paths & set(KNOWN_PHANTOMS))
 
     if tracked:
@@ -139,25 +174,25 @@ def main() -> int:
             print(f"  {verifier} -> {mod}\n      {KNOWN_PHANTOMS[mod]}")
 
     if stale:
-        print("\nSTALE allowlist — these are now WIRED and must be removed from KNOWN_PHANTOMS:",
+        print("\nSTALE allowlist — these are now reachable and must be removed from KNOWN_PHANTOMS:",
               file=sys.stderr)
         for mod in stale:
             print(f"  {mod}", file=sys.stderr)
         print("An allowlist that outlives its reason is how a check stops checking.", file=sys.stderr)
 
     if untracked:
-        print("\nPHANTOM — a green verifier over code no firmware tier compiles:", file=sys.stderr)
+        print("\nPHANTOM — a green verifier over code NEITHER crate root compiles:", file=sys.stderr)
         for verifier, mod in untracked:
             print(f"  {verifier} -> {mod}", file=sys.stderr)
-        print("\nFix EITHER by wiring the module (add `mod <name>;` to the crate, with the cfg the\n"
-              "consumer needs) OR by removing the verifier. A verifier over uncompiled source is\n"
-              "worse than no verifier: it reports the code as covered.\n"
+        print("\nFix EITHER by wiring the module (declare it in the root that should carry it) OR by\n"
+              "removing the verifier. A verifier over uncompiled source is worse than no verifier:\n"
+              "it reports the code as covered.\n"
               "If it is a deliberate, owned exception, add it to KNOWN_PHANTOMS with its issue.",
               file=sys.stderr)
 
-    if untracked or stale or missing_files:
-        return 1 if (untracked or stale) else 2
-    return 0
+    if untracked or stale:
+        return 1
+    return 2 if missing_files else 0
 
 
 if __name__ == "__main__":

--- a/tools/test_verifier_wiring.sh
+++ b/tools/test_verifier_wiring.sh
@@ -41,6 +41,22 @@ case_run() { # <name> <want-exit> <mutator-fn>
 
 noop() { :; }
 
+# Assert a PATTERN in the output, not just an exit code. Needed for HOST-ONLY, which is a
+# reportable state rather than a failure — exit 0 alone would not prove it was noticed.
+case_grep() { # <name> <want-exit> <pattern> <mutator-fn>
+  local name="$1" want="$2" pat="$3" fn="$4" d out rc
+  d="$(mkcopy)"
+  "$fn" "$d"
+  out="$(python3 "$d/tools/check_verifier_wiring.py" "$d" 2>&1)"; rc=$?
+  rm -rf "$d"
+  if [ "$rc" -eq "$want" ] && printf '%s' "$out" | grep -q "$pat"; then
+    printf '  \033[32mPASS\033[0m %s (exit %d, matched %s)\n' "$name" "$rc" "$pat"; PASS=$((PASS+1))
+  else
+    printf '  \033[31mFAIL\033[0m %s — wanted exit %d + /%s/, got exit %d\n' "$name" "$want" "$pat" "$rc"
+    printf '%s\n' "$out" | sed 's/^/        /'; FAIL=$((FAIL+1))
+  fi
+}
+
 # A new phantom: drop a module declaration that a verifier includes. This is the exact shape of
 # the #185 defect, reproduced on a module that is currently wired.
 drop_decl() { sed -i 's/^pub mod etx;/\/\/ removed by test/' "$1/rust/clock/src/net.rs"; }
@@ -55,6 +71,15 @@ p.write_text(t.replace('KNOWN_PHANTOMS = {', 'KNOWN_PHANTOMS = {\n    "rust/cloc
 PY
 }
 
+# THE TWO-ROOT TRAP (#351/#366). Move a module out of the firmware root and into the hostsim
+# library root. A name-keyed checker sees "etx is declared somewhere" and says SOUND; the truth is
+# that the firmware no longer contains it. This is the exact shortcut that produced five false
+# negatives on app/clock/input/sensors/snake, reproduced here so this tool cannot regress into it.
+lib_only() {
+  sed -i 's/^pub mod etx;/\/\/ moved to lib.rs by test/' "$1/rust/clock/src/net.rs"
+  printf '\n#[cfg(feature = "hostsim")]\n#[path = "net/etx.rs"]\npub mod etx;\n' >> "$1/rust/clock/src/lib.rs"
+}
+
 # A verifier pointing at a file that does not exist — a rename that missed the harness.
 dangling_include() { rm -f "$1/rust/clock/src/net/etx.rs"; }
 
@@ -62,6 +87,7 @@ echo "#367 verifier-wiring check — proving each arm can fail"
 case_run "clean tree passes (crdt tracked)"        0 noop
 case_run "a NEW phantom fails"                     1 drop_decl
 case_run "a STALE allowlist entry fails"           1 stale_entry
+case_grep "lib.rs-only module reads HOST-ONLY, not SOUND" 0 "HOST-ONLY" lib_only
 case_run "a dangling #[path] target is an error"   2 dangling_include
 
 echo


### PR DESCRIPTION
Approved low-priority follow-up to #274. **Based on `fix/367-per-root-reachability` (#374), not `main`** — it was written on top of that branch and the two are independent in content; retarget to `main` once #374 lands, or merge them in order.

## The remaining hazard

#274 collapsed four copies into two correct-but-differently-behaved truncators, **both called `clip`**:

| where | unit | callers |
|---|---|---|
| `rssi.rs` | **bytes** | `bench.rs`, `ota_screen.rs` |
| `batt.rs`, `grid.rs` | **characters** | their own line layout |

Both are boundary-safe, so neither can panic — the hazard is subtler than that. Two functions with the same name and different units, in one crate, is a trap for whoever next moves a call site between them: it compiles, the ASCII output is identical, and the difference only shows up the day a non-ASCII string reaches a screen.

## Why two functions and not one

Unifying them would have been the wrong fix. The units aren't an accident — `ota_screen` budgets against a byte-measured `Line`, `batt`/`grid` against `LINE_CHARS`, a glyph count. Neither is true *display width* (a wide character is neither one byte nor one cell), and pretending otherwise needs font metrics, not string surgery.

So both units survive, under names that say which is which:

```
crate::textclip::clip_bytes   (was rssi::clip)
crate::textclip::clip_chars   (was the batt.rs/grid.rs copy)
```

## No semantic change — checked, not asserted

Every call site keeps the function it already had. `clip_verify` asserts **both** functions are byte-identical to the pre-#274 expression across all-ASCII input. That's the condition you set, and it matters precisely because on ASCII the two units coincide — which is exactly why a silent mix-up would otherwise be invisible.

## Placement, and the structural reason the duplication survived

The new home is **`wifi`**-gated, because the consumers span tiers: `batt`/`grid` are `wifi`, `bench`/`rssi`/`ota_screen` are `espnow`. The previous shared home (`rssi.rs`) is **espnow-only** — so `batt`/`grid` structurally *could not* have used it. That, not inattention, is why #274 left two copies.

`clip_bytes` gets a narrow `cfg_attr(not(espnow), allow(dead_code))` rather than a blanket allow: on wifi-without-espnow it genuinely has no caller, but a blanket allow would also hide it going unused on the tiers that *do* ship it.

## Two gates earned their keep

- **#351's exclusion checker** required the new cfg-gated file to be declared in `build-matrix.toml`, so ungating it later can't pass unnoticed. It caught this immediately; I'd have missed it.
- **#367's verifier-wiring check — mine — stayed green across the moved `#[path]`**, which was your second condition. `clip_verify` now includes `textclip.rs` for the functions *and* `rssi.rs` for the `Line` buffer that feeds them; both resolve from the `main.rs` root:

```
clip_verify  rust/clock/src/textclip.rs  main.rs tree  SOUND
clip_verify  rust/clock/src/rssi.rs      main.rs tree  SOUND
```

Fitting that the first PR it polices is this one.

## Gate

`tools/gate.sh all` **GREEN** — full tier matrix, clippy `-D warnings` on every tier, exclusions, host suites, crate tests. Stack **106,472 B** (floor 74,208), unchanged.

One note for the record: I briefly mis-attributed a transient `tier exclusions` failure to this change. A differential test looked conclusive, but the "pristine" run also rebuilt the tier ELFs — the real cause was a stale `default` ELF in the shared `/tmp/gate-exclusions` carrying a `comp_dir` from another worktree path. Two variables moved and I blamed the wrong one; clearing the artifact directory resolves it, and a clean run is green.

Refs #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)