### PR TITLE
feat(mesh): ELECT announce/follow + the coupled co_channel re-scale and lever clamp (#278, #269)

### DIFF
--- a/experiments/election_verify/src/main.rs
+++ b/experiments/election_verify/src/main.rs
@@ -11,8 +11,34 @@ fn inp(co_channel: bool, ap_rssi: i8, uptime_ms: u64) -> FitnessInputs {
     FitnessInputs { co_channel, ap_rssi, uptime_ms }
 }
 
+/// Build a `c<n>r<n>u<n>` lever payload into `buf`, returning the used slice. Hand-rolled rather
+/// than `format!` so the sweep below allocates nothing and stays as cheap as the parser it drives.
+fn fmt_cru(buf: &mut [u8; 24], c: u8, r: u8, u: u8) -> &[u8] {
+    let mut n = 0;
+    for (key, val) in [(b'c', c), (b'r', r), (b'u', u)] {
+        buf[n] = key;
+        n += 1;
+        if val >= 100 {
+            buf[n] = b'0' + val / 100;
+            n += 1;
+        }
+        if val >= 10 {
+            buf[n] = b'0' + (val / 10) % 10;
+            n += 1;
+        }
+        buf[n] = b'0' + val % 10;
+        n += 1;
+    }
+    &buf[..n]
+}
+
 fn main() {
-    let w = MetricWeights::DEFAULT;
+    // The DOMINANT weights — what ships while `FOLLOW_ENABLED` is false. Named explicitly rather
+    // than taken from a `DEFAULT`, because after #269 there is no single default: the weights are a
+    // function of whether leaves can follow, and every caller has to say which world it is in.
+    let w = MetricWeights::default_for(false);
+    assert_eq!(w, MetricWeights::DOMINANT, "following off => the co-channel veto ships");
+    assert!(!FOLLOW_ENABLED, "and the shipped flag IS off — #278 gates the flip on a fleet roll");
 
     // ---- gateway_fitness (weighted, higher = better) --------------------------------------
     // co-channel dominates: a co-channel board with the WORST usable RSSI still outscores the
@@ -23,7 +49,7 @@ fn main() {
     // full-signal co-channel board = max fitness for the default weights.
     assert_eq!(
         gateway_fitness(&inp(true, -60, 10 * 60_000), &w),
-        MetricWeights::DEFAULT.max_fitness(),
+        MetricWeights::DOMINANT.max_fitness(),
         "full-signal co-channel = max fitness"
     );
     // RSSI + uptime order WITHIN co-channel.
@@ -65,7 +91,7 @@ fn main() {
 
     // ---- re-weighting via config changes ordering -----------------------------------------
     // RSSI-dominant with co-channel OFF: now the stronger board wins regardless of channel.
-    let rssi_only = match parse_elect_config(b"c0r100") {
+    let rssi_only = match parse_elect_config(b"c0r100", true) {
         ElectConfig::BestGateway(w) => w,
         _ => panic!("expected BestGateway"),
     };
@@ -74,25 +100,118 @@ fn main() {
     assert!(b < a, "rssi-dominant config: strong off-channel now beats weak co-channel");
 
     // ---- parse_elect_config ----------------------------------------------------------------
-    assert_eq!(parse_elect_config(b""), ElectConfig::BestGateway(MetricWeights::DEFAULT), "empty → default (best-gateway ON)");
-    assert_eq!(parse_elect_config(b"   "), ElectConfig::BestGateway(MetricWeights::DEFAULT), "whitespace → default");
-    assert_eq!(parse_elect_config(b"legacy"), ElectConfig::Legacy, "legacy keyword → escape hatch");
-    assert_eq!(parse_elect_config(b"LEGACY"), ElectConfig::Legacy, "case-insensitive legacy");
-    assert_eq!(parse_elect_config(b"c100r10n5u1"), ElectConfig::BestGateway(MetricWeights::DEFAULT), "explicit default weights");
+    assert_eq!(parse_elect_config(b"", false), ElectConfig::BestGateway(MetricWeights::DOMINANT), "empty → default (best-gateway ON)");
+    assert_eq!(parse_elect_config(b"   ", false), ElectConfig::BestGateway(MetricWeights::DOMINANT), "whitespace → default");
+    assert_eq!(parse_elect_config(b"legacy", false), ElectConfig::Legacy, "legacy keyword → escape hatch");
+    assert_eq!(parse_elect_config(b"LEGACY", false), ElectConfig::Legacy, "case-insensitive legacy");
+    assert_eq!(parse_elect_config(b"c100r10n5u1", false), ElectConfig::BestGateway(MetricWeights::DOMINANT), "explicit default weights");
     // subset: missing keys inherit DEFAULT.
     assert_eq!(
-        parse_elect_config(b"r20"),
+        parse_elect_config(b"r20", false),
         ElectConfig::BestGateway(MetricWeights { co_channel: 100, rssi: 20, uptime: 1 }),
         "subset inherits default for missing keys"
     );
     // clamp + ignore junk.
     assert_eq!(
-        parse_elect_config(b"c999x7r3"),
+        parse_elect_config(b"c999x7r3", false),
         ElectConfig::BestGateway(MetricWeights { co_channel: 255, rssi: 3, uptime: 1 }),
         "clamp to 255 + ignore unknown key 'x'"
     );
     // garbage → default (fail toward the intended default behavior).
-    assert_eq!(parse_elect_config(b"????"), ElectConfig::BestGateway(MetricWeights::DEFAULT), "garbage → default");
+    assert_eq!(parse_elect_config(b"????", false), ElectConfig::BestGateway(MetricWeights::DOMINANT), "garbage → default");
+
+    // ---- #269 THE id5 INVARIANT, asserted in BOTH flag states -------------------------------
+    // The numeric backoff assertion above is the id5 bug in the world it was found in — a fleet
+    // that CANNOT follow a crown to another channel. It does not survive the re-scale, and it
+    // should not: under following, an off-channel crown is a migration rather than a stranding.
+    //
+    // So the property that holds in both worlds is stated once, over the harm rather than over the
+    // mechanism: an off-channel crown strands the fleet iff leaves cannot follow it AND co-channel
+    // does not dominate. Inability to follow is exactly what the flag names, which is why one
+    // predicate covers both states instead of two unrelated assertions that only look like a pair.
+    for follow in [false, true] {
+        let w = MetricWeights::default_for(follow);
+        assert!(
+            !off_channel_crown_can_strand(&w, follow),
+            "id5 cannot recur with follow={follow} (weights {w:?})"
+        );
+    }
+    // …and the two states get there by DIFFERENT means, which is the whole content of the coupling:
+    assert!(
+        co_channel_dominates(&MetricWeights::DOMINANT),
+        "following off: the veto is what prevents the stranding"
+    );
+    assert!(
+        !co_channel_dominates(&MetricWeights::FOLLOWING),
+        "following on: the veto is deliberately GONE — otherwise #269 could never migrate"
+    );
+
+    // The margin is exactly one RSSI bucket, which is the derivation the comment claims.
+    assert_eq!(
+        MetricWeights::FOLLOWING.co_channel, MetricWeights::FOLLOWING.rssi,
+        "margin == one rssi bucket == the jitter amplitude at the −65/−78 boundaries"
+    );
+    // A ONE-bucket challenger TIES (jitter must not move the fleet); TWO buckets WIN (a real gain
+    // must). −60 is bucket 2, −70 bucket 1, −85 bucket 0; uptime held equal so only rssi varies.
+    let f = MetricWeights::FOLLOWING;
+    let co_1bucket = gateway_fitness(&inp(true, -85, 0), &f); // co-channel, bucket 0
+    let off_1bucket = gateway_fitness(&inp(false, -70, 0), &f); // off-channel, bucket 1
+    let off_2bucket = gateway_fitness(&inp(false, -60, 0), &f); // off-channel, bucket 2
+    assert_eq!(co_1bucket, off_1bucket, "a one-bucket challenger only TIES: {co_1bucket} vs {off_1bucket}");
+    assert!(off_2bucket > co_1bucket, "a two-bucket challenger WINS: {off_2bucket} > {co_1bucket}");
+    // The post-re-scale max, named because the `10/122 = 8.2%` unit error used the PRE-re-scale
+    // denominator (which still contained the co_channel: 100 being removed). The real share is
+    // 10/32 ≈ 31%, ~4x batman-adv's ~8% — a deliberate divergence, not a convergence.
+    assert_eq!(f.max_fitness(), 32, "post-re-scale max_fitness");
+
+    // ---- #269 THE RUNTIME LEVER CANNOT RE-ARM THE DISEASE -----------------------------------
+    // The retained `smol/mesh/elect` topic is a SECOND WRITER of these weights and needs no code
+    // change to demote co-channel dominance — `c10r10` does it. A compile-time assert binds the
+    // other writer and says nothing about this one. Asserted over a SWEEP rather than the handful
+    // of payloads someone thought of, because "the cases I imagined" is how the first version of
+    // this invariant would have been passed.
+    for c in [0u8, 1, 9, 10, 22, 23, 100, 200, 255] {
+        for r in [0u8, 1, 10, 50, 63, 64, 200, 255] {
+            for u in [0u8, 1, 63, 255] {
+                let mut buf = [0u8; 24];
+                let payload = fmt_cru(&mut buf, c, r, u);
+                match parse_elect_config(payload, false) {
+                    ElectConfig::BestGateway(got) => assert!(
+                        co_channel_dominates(&got),
+                        "following OFF: `{}` must not be able to demote dominance — got {got:?}",
+                        core::str::from_utf8(payload).unwrap()
+                    ),
+                    ElectConfig::Legacy => panic!("keyed weights are never Legacy"),
+                }
+                // With following ON the operator gets what they asked for: the clamp exists to
+                // protect a fleet that cannot follow, and imposing it in both worlds would silently
+                // veto exactly the migration #269 is for.
+                match parse_elect_config(payload, true) {
+                    ElectConfig::BestGateway(got) => {
+                        assert_eq!(got.co_channel, c, "following ON: `c{c}` applied verbatim");
+                        assert_eq!(got.rssi, r, "following ON: `r{r}` applied verbatim");
+                        assert_eq!(got.uptime, u, "following ON: `u{u}` applied verbatim");
+                    }
+                    ElectConfig::Legacy => panic!("keyed weights are never Legacy"),
+                }
+            }
+        }
+    }
+    // The worked example from the finding: `c10r10` is precisely the payload that re-arms id5.
+    let clamped = match parse_elect_config(b"c10r10", false) {
+        ElectConfig::BestGateway(w) => w,
+        _ => panic!("expected BestGateway"),
+    };
+    assert_eq!(clamped.co_channel, 23, "c10r10 → co_channel clamped up to 2·10 + 2·1 + 1");
+    assert!(co_channel_dominates(&clamped));
+    // An extreme lever is capped so the floor stays EXPRESSIBLE in a u8, rather than clamped
+    // toward a dominance that no legal `co_channel` could reach.
+    let capped = match parse_elect_config(b"c255r200u200", false) {
+        ElectConfig::BestGateway(w) => w,
+        _ => panic!("expected BestGateway"),
+    };
+    assert_eq!((capped.rssi, capped.uptime), (DOMINANCE_LEVER_CAP, DOMINANCE_LEVER_CAP));
+    assert!(co_channel_dominates(&capped), "even at the cap, dominance holds");
 
     // ---- LAYER 2: co-channel seizes a proven off-channel owner (crown migration) -----------
     const MESH: u8 = 6;
@@ -140,5 +259,5 @@ fn main() {
     assert_eq!(legacy_recovery_backoff_ms(-70, 5), 1 * ELECT_TIER_STEP_MS + 5 * 200, "legacy mid bucket 1");
     assert_eq!(legacy_recovery_backoff_ms(-85, 5), 2 * ELECT_TIER_STEP_MS + 5 * 200, "legacy weak bucket 2");
 
-    println!("election_verify: ALL CHECKS PASSED (co-channel dominance + weighted fitness + bounded/monotonic backoff tiering + config parser + legacy backoff)");
+    println!("election_verify: ALL CHECKS PASSED (co-channel dominance + weighted fitness + bounded/monotonic backoff tiering + config parser + legacy backoff + #269 id5-in-both-flag-states + the one-bucket margin + a 288-payload sweep proving the lever cannot re-arm the disease)");
 }

--- a/experiments/mac_verify/src/main.rs
+++ b/experiments/mac_verify/src/main.rs
@@ -148,6 +148,35 @@ fn main() {
         assert!(should_group_mac(tag), "ordinary SMOLv1 frame IS MAC'd: {:?}", core::str::from_utf8(tag));
     }
     assert!(!should_group_mac(b"\x91\x0b\x00..wled-wizmote.."), "non-SMOLv1 (WLED) sent verbatim");
+    // --- 7b. #278 ELECT MUST be MAC'd, and this is the one shape the send-path gate cannot see ---
+    // `tools/check_elect_send_path.py` proves ELECT can only travel via `send_to`. It says nothing
+    // about whether `send_to` still appends the trailer for THIS frame — a change to
+    // `should_group_mac` (a new exemption, a tightened MTU bound) would strip the authentication
+    // with the send path untouched and every arm of that checker still green.
+    //
+    // That matters more here than for any other frame. A leaf cannot verify a channel announcement
+    // before acting on it: a scan drops the association (`coex_background_scan` is hardcoded false),
+    // so checking costs the leaf the very thing it would need if the announcement were a lie. An
+    // unauthenticated ELECT is a remote "everybody move to channel N" fleet-stranding primitive.
+    //
+    // Asserted at the REAL length, not a stub prefix, because the MTU arm of `should_group_mac` is
+    // length-sensitive and a 13 B prefix would pass a bound the 61 B record might not: 61 + 9 = 70,
+    // comfortably inside the 250 B cap, with the arithmetic on the page rather than assumed.
+    const ELECT_LEN: usize = 61;
+    let elect_frame = {
+        let mut f = Vec::from(&b"SMOLv1 ELECT "[..]);
+        f.resize(ELECT_LEN, b'0');
+        f
+    };
+    assert_eq!(elect_frame.len(), ELECT_LEN, "the fixed-width ELECT record");
+    assert!(!is_ota_family(&elect_frame), "ELECT is not OTA-family — it must NOT be exempt");
+    assert!(should_group_mac(&elect_frame), "ELECT MUST carry the group-MAC trailer (#278)");
+    assert!(
+        elect_frame.len() + MAC_TRAILER_LEN <= ESP_NOW_MTU,
+        "ELECT + trailer fits the MTU: {} + {} <= {}",
+        elect_frame.len(), MAC_TRAILER_LEN, ESP_NOW_MTU
+    );
+
     // An over-MTU SMOLv1 frame is sent verbatim (never emit > MTU): ceiling+1 with a real prefix.
     let mut over = Vec::from(&b"SMOLv1 DIAG 007"[..]);
     over.resize(ESP_NOW_MTU - MAC_TRAILER_LEN + 1, b'x');

--- a/experiments/mesh_elect_verify/src/follow_tests.rs
+++ b/experiments/mesh_elect_verify/src/follow_tests.rs
@@ -1,0 +1,297 @@
+//! SMOL-ONLY half of the guard (#278 stage 2) — the announce schedule, the leaf follow state, the
+//! recovery ladder, and the send-path seal. None of this exists in the donor crate, so it is kept in
+//! its own file: `consensus.rs` and `wire_tests.rs` stay verbatim-diffable against
+//! `esp32c6-watch:crates/mesh-elect/tests/`, exactly as the source file itself is split.
+
+use crate::mesh_elect::{
+    recovery_ladder, wire, Announcer, Decision, Follow, Follower, GroupMacSink, Phase, SealedElect,
+    ANNOUNCE_BURST, ANNOUNCE_GAP_MS, ANNOUNCE_IDLE_MS, COMMON_AP_CHANNELS, FOLLOW_ENABLED,
+    LEGACY_CANDIDATES, N_CHANNELS, PROBATION_MS, RENDEZVOUS_CHANNEL, SETTLE_MS,
+};
+
+fn frame(node_id: u8, epoch: u32, channel: u8, gateway: u8) -> wire::ElectFrame {
+    wire::ElectFrame { node_id, epoch, channel, gateway, w: [0u8; N_CHANNELS] }
+}
+
+/// The whole point of the CSA shape: leaves learn the target while the crown is still reachable,
+/// and again from the far side. Both bursts carry the SAME epoch, so a late pre-move frame is
+/// byte-identical to a post-move one and has nothing to override.
+pub fn announces_before_and_after_the_move() {
+    let mut a = Announcer::new();
+    assert_eq!(a.phase(), Phase::Idle, "boot: nothing to announce");
+    assert!(!a.due(0), "an idle announcer never emits");
+
+    let t0 = 10_000u64;
+    assert!(a.decide(11, t0), "a real channel decision arms the pre-move burst");
+    assert_eq!(a.epoch(), 1, "first decision is epoch 1");
+    assert_eq!(a.phase(), Phase::Pre);
+    let pre_epoch = a.epoch();
+
+    for i in 0..ANNOUNCE_BURST {
+        let t = t0 + u64::from(i) * ANNOUNCE_GAP_MS;
+        assert!(a.due(t), "pre-move frame {i} is due at {t}");
+        assert!(!a.due(t), "a frame is consumed once, not twice");
+        assert!(!a.clear_to_move() || i == ANNOUNCE_BURST - 1, "no move mid-burst");
+    }
+    assert!(a.clear_to_move(), "pre-move burst drained → the caller may retune");
+    assert!(!a.due(t0 + 10 * ANNOUNCE_GAP_MS), "a drained burst stops emitting");
+
+    let t1 = t0 + 5_000;
+    a.moved(t1);
+    assert_eq!(a.phase(), Phase::Post);
+    assert_eq!(a.epoch(), pre_epoch, "the post-move burst carries the SAME epoch");
+    assert!(!a.settled(), "the post burst has not drained yet");
+    for i in 0..ANNOUNCE_BURST {
+        assert!(a.due(t1 + u64::from(i) * ANNOUNCE_GAP_MS), "post-move frame {i} is due");
+    }
+    assert!(a.settled(), "migration over once both bursts have drained");
+
+    let d = a.decision(8);
+    assert_eq!(d, Decision { channel: 11, epoch: 1, gateway: 8 }, "the announced decision");
+}
+
+/// Driving `decide` from an OBSERVED channel means it gets called every tick with the same value.
+/// Burning an epoch per call would make every announcement out-rank the last and defeat
+/// `supersedes` entirely, so a redundant decision must be a no-op.
+pub fn a_redundant_decision_does_not_burn_an_epoch() {
+    let mut a = Announcer::new();
+    assert!(a.decide(6, 0));
+    assert_eq!(a.epoch(), 1);
+    for t in 0..50u64 {
+        assert!(!a.decide(6, t * 100), "re-deciding the same channel changes nothing");
+    }
+    assert_eq!(a.epoch(), 1, "epoch is spent on real moves only");
+    assert!(a.decide(11, 5_000), "a genuinely new channel does advance it");
+    assert_eq!(a.epoch(), 2);
+}
+
+/// A corrupt or unknown channel must never reach the air — the frame builder would encode it and
+/// every leaf that honoured it would tune to nothing.
+pub fn refuses_an_out_of_range_channel() {
+    let mut a = Announcer::new();
+    for bad in [0u8, 14, 99, 255] {
+        assert!(!a.decide(bad, 0), "ch{bad} is not a 2.4 GHz channel");
+        assert_eq!(a.epoch(), 0, "a rejected decision does not advance the epoch");
+        assert_eq!(a.phase(), Phase::Idle);
+    }
+}
+
+/// Epoch orders announcements; a replay of an older one is inert. Critically it must ALSO not look
+/// like liveness — a replayed frame resetting the probation clock would let an attacker (or a stuck
+/// repeater) hold the fleet on a dead epoch forever with no new information.
+pub fn orders_by_epoch_and_ignores_replay() {
+    let mut f = Follower::new();
+    assert_eq!(f.accepted(), 0, "boot: nothing heard");
+    assert_eq!(f.decision(), Decision::bootstrap());
+
+    assert_eq!(f.observe(&frame(8, 3, 11, 8), 1_000, 6), Follow::Move(11), "newer epoch → move");
+    assert_eq!(f.decision().epoch, 3);
+    assert_eq!(f.accepted(), 1);
+
+    assert_eq!(f.observe(&frame(8, 3, 11, 8), 2_000, 11), Follow::Stale, "same epoch is not newer");
+    assert_eq!(f.observe(&frame(9, 1, 1, 9), 3_000, 11), Follow::Stale, "an older epoch is a replay");
+    assert_eq!(f.accepted(), 1, "a rejected frame is not counted as heard");
+    assert_eq!(f.decision().channel, 11, "a replay cannot drag the fleet back");
+
+    assert_eq!(f.observe(&frame(8, 4, 11, 8), 4_000, 11), Follow::Confirmed, "already on ch11");
+    assert_eq!(f.accepted(), 2);
+}
+
+/// `m` is the number the canary roll reads, and it is NOT `n`. In the steady state every leaf is
+/// co-channel with the crown (ESP-NOW is per-channel — a leaf elsewhere hears nothing), so `n`
+/// only ever proves the beacon works. `m` counts announcements naming a different channel, which
+/// is the crown's PRE-move burst being caught — the one hard-to-hit part of the design.
+pub fn counts_would_be_moves_separately_from_hearings() {
+    let mut f = Follower::new();
+    assert_eq!((f.accepted(), f.moves()), (0, 0));
+
+    // Steady state on ch6: heard, but nothing to act on.
+    for (i, ep) in (1..=5u32).enumerate() {
+        assert_eq!(f.observe(&frame(8, ep, 6, 8), 1_000 * (i as u64 + 1), 6), Follow::Confirmed);
+    }
+    assert_eq!((f.accepted(), f.moves()), (5, 0), "beacon proven, no move seen");
+
+    // The crown's pre-move burst, heard on the OLD channel: this is the observation that matters.
+    assert_eq!(f.observe(&frame(8, 6, 11, 8), 10_000, 6), Follow::Move(11));
+    assert_eq!((f.accepted(), f.moves()), (6, 1), "one would-be move");
+
+    // Post-move repeats from the new channel are confirmations, not further moves.
+    assert_eq!(f.observe(&frame(8, 7, 11, 8), 11_000, 11), Follow::Confirmed);
+    assert_eq!((f.accepted(), f.moves()), (7, 1), "a confirmation is not a second move");
+}
+
+/// The anti-flap gate on the OBSERVED channel. A crown reads its channel off the radio every
+/// subtick; an AP that oscillates must not burn an epoch per oscillation, because epoch is the
+/// total order and every announcement would then out-rank the last.
+pub fn an_observed_channel_must_settle_before_it_costs_an_epoch() {
+    let mut a = Announcer::new();
+
+    // Cold start commits IMMEDIATELY — no incumbent to protect, and a booting crown must not sit
+    // silent for SETTLE_MS in exactly the window leaves are looking hardest.
+    assert!(a.observe_channel(6, 0), "the first channel commits at once");
+    assert_eq!((a.epoch(), a.channel()), (1, 6));
+
+    // A challenger appears and must hold its lead.
+    let t = 100_000u64;
+    assert!(!a.observe_channel(11, t), "a new candidate does not commit on sight");
+    assert!(!a.observe_channel(11, t + SETTLE_MS - 1), "not until the window closes");
+    assert_eq!(a.epoch(), 1, "and it has cost nothing yet");
+    assert!(a.observe_channel(11, t + SETTLE_MS), "held its lead → commit");
+    assert_eq!((a.epoch(), a.channel()), (2, 11));
+
+    // A FLAP: the candidate keeps changing, so nothing ever holds long enough.
+    let mut a = Announcer::new();
+    assert!(a.observe_channel(6, 0));
+    for i in 0..200u64 {
+        let ch = if i % 2 == 0 { 1 } else { 11 };
+        assert!(!a.observe_channel(ch, i * SETTLE_MS), "flapping never commits (i={i})");
+    }
+    assert_eq!(a.epoch(), 1, "200 oscillations, zero epochs spent");
+
+    // Returning to the committed channel withdraws the candidate rather than half-arming it.
+    let mut a = Announcer::new();
+    assert!(a.observe_channel(6, 0));
+    assert!(!a.observe_channel(11, 1_000));
+    assert!(!a.observe_channel(6, 2_000), "back home → no-op");
+    assert!(!a.observe_channel(11, 2_000 + SETTLE_MS), "the candidate's clock restarted");
+    assert_eq!(a.epoch(), 1);
+}
+
+/// The steady-state repeat is what makes the frame observable on a fleet that is not migrating —
+/// which is the entire value of the observe-only landing, so it is asserted rather than assumed.
+pub fn beacons_between_migrations() {
+    let mut a = Announcer::new();
+    assert!(!a.beacon_due(u64::MAX), "an idle announcer never beacons");
+
+    // A realistic boot offset, not 0. `decide` back-dates `last_ms` by one gap so the first frame
+    // goes out immediately, and `saturating_sub` floors that at 0 — so at now_ms == 0 exactly, the
+    // first frame waits a gap instead. Harmless on hardware (a crown decides seconds into its
+    // uptime, after association) but it is a real edge and the test should not hide it by only ever
+    // starting at zero.
+    let t0 = 30_000u64;
+    assert!(a.decide(6, t0));
+    assert!(!a.beacon_due(t0 + ANNOUNCE_IDLE_MS * 10), "a LIVE burst is already saying it");
+    for i in 0..ANNOUNCE_BURST {
+        assert!(a.due(t0 + u64::from(i) * ANNOUNCE_GAP_MS));
+    }
+
+    let drained = t0 + u64::from(ANNOUNCE_BURST - 1) * ANNOUNCE_GAP_MS;
+    assert!(!a.beacon_due(drained), "not yet — the burst's last frame was just sent");
+    assert!(a.beacon_due(drained + ANNOUNCE_IDLE_MS), "one repeat per beacon interval");
+    assert!(!a.beacon_due(drained + ANNOUNCE_IDLE_MS), "and exactly one");
+    assert!(a.beacon_due(drained + 2 * ANNOUNCE_IDLE_MS), "then another");
+}
+
+/// The failure mode a monotonic epoch invites: one node with a high persisted epoch out-ranks every
+/// later announcement and wedges the fleet onto a dead channel permanently. Probation is the exit.
+pub fn probation_expires_on_a_dead_epoch() {
+    let mut f = Follower::new();
+    assert!(!f.probation_expired(u64::MAX), "never-heard is not on probation");
+
+    let t = 100_000u64;
+    assert_eq!(f.observe(&frame(8, 9, 11, 8), t, 6), Follow::Move(11));
+    assert!(!f.probation_expired(t), "just heard");
+    assert!(!f.probation_expired(t + PROBATION_MS), "exactly at the window is still inside it");
+    assert!(f.probation_expired(t + PROBATION_MS + 1), "silence past the window → re-elect");
+
+    // A replayed old frame must NOT look like liveness.
+    let stale = t + PROBATION_MS + 1;
+    assert_eq!(f.observe(&frame(8, 2, 1, 8), stale, 11), Follow::Stale);
+    assert!(f.probation_expired(stale), "a replay does not reset probation");
+}
+
+/// The flag is supposed to change NOTHING on a live fleet until it is flipped. This is that claim,
+/// asserted instead of stated: with following off the ladder IS today's blind-scan plan.
+pub fn the_ladder_is_the_legacy_plan_while_following_is_off() {
+    for last_known in [0u8, 1, 6, 11, 3, 13] {
+        let (plan, n) = recovery_ladder(last_known, false);
+        assert_eq!(n, LEGACY_CANDIDATES.len(), "legacy plan length (last_known={last_known})");
+        assert_eq!(&plan[..n], &LEGACY_CANDIDATES[..], "byte-identical to `leaf_scan_tick`'s CANDIDATES");
+    }
+    assert!(!FOLLOW_ENABLED, "and the shipped default IS off — see #278's flip criterion");
+}
+
+/// Best guess first, and never spend a 1500 ms dwell proving the same channel twice.
+pub fn the_ladder_ranks_and_dedupes() {
+    // last-known first, then rendezvous, then the common APs.
+    let (plan, n) = recovery_ladder(3, true);
+    assert_eq!(&plan[..4], &[3, RENDEZVOUS_CHANNEL, COMMON_AP_CHANNELS[0], COMMON_AP_CHANNELS[1]]);
+    assert_eq!(n, N_CHANNELS, "then the rest of the band");
+
+    // last_known == rendezvous: the duplicate is dropped, not dwelled on.
+    let (plan, n) = recovery_ladder(RENDEZVOUS_CHANNEL, true);
+    assert_eq!(plan[0], RENDEZVOUS_CHANNEL);
+    assert_eq!(plan[1], COMMON_AP_CHANNELS[0], "no second dwell on the rendezvous");
+    assert_eq!(n, N_CHANNELS);
+
+    // never knew one → start at the rendezvous.
+    let (plan, n) = recovery_ladder(0, true);
+    assert_eq!(plan[0], RENDEZVOUS_CHANNEL, "no last-known → rendezvous is rung 0");
+    assert_eq!(n, N_CHANNELS);
+
+    // a corrupt last-known is refused, not tuned to.
+    for bad in [14u8, 99, 255] {
+        let (plan, _) = recovery_ladder(bad, true);
+        assert_eq!(plan[0], RENDEZVOUS_CHANNEL, "ch{bad} never enters the plan");
+    }
+}
+
+/// Today's plan can never find a crown outside 1/6/11. The ladder's whole reach argument is that
+/// it eventually probes every channel, exactly once.
+pub fn the_ladder_reaches_the_whole_band() {
+    for last_known in 0..=13u8 {
+        let (plan, n) = recovery_ladder(last_known, true);
+        assert_eq!(n, N_CHANNELS, "every channel is reachable (last_known={last_known})");
+        for ch in 1..=(N_CHANNELS as u8) {
+            assert_eq!(
+                plan[..n].iter().filter(|&&c| c == ch).count(),
+                1,
+                "ch{ch} appears exactly once (last_known={last_known})"
+            );
+        }
+    }
+}
+
+/// A sink that records rather than transmits — and note that implementing this trait is the ONLY
+/// way to observe a `SealedElect`'s bytes at all. That is the invariant, exercised: there is no
+/// accessor to reach for, so a caller that wants the frame must go through the send path.
+struct RecordingSink {
+    last: [u8; wire::ELECT_LEN],
+    dst: [u8; 6],
+    sends: usize,
+}
+
+impl GroupMacSink for RecordingSink {
+    fn send_group_mac(&mut self, dst: &[u8; 6], frame: &[u8]) {
+        assert_eq!(frame.len(), wire::ELECT_LEN, "a sealed frame is always the fixed record");
+        self.last.copy_from_slice(frame);
+        self.dst = *dst;
+        self.sends += 1;
+    }
+}
+
+/// The sealed frame is byte-identical to what the cross-repo encoder produces — sealing must not be
+/// a second, divergent encoder — and it reaches the sink unmodified.
+pub fn sealing_preserves_the_cross_repo_bytes() {
+    let f = frame(5, 42, 11, 8);
+    let mut expect = [0u8; wire::ELECT_LEN];
+    let n = wire::encode(&f, &mut expect).expect("the reference encoder accepts it");
+    assert_eq!(n, wire::ELECT_LEN);
+
+    let mut sink = RecordingSink { last: [0u8; wire::ELECT_LEN], dst: [0u8; 6], sends: 0 };
+    let bcast = [0xffu8; 6];
+    SealedElect::seal(&f).expect("sealable").emit(&mut sink, &bcast);
+
+    assert_eq!(sink.sends, 1, "emit sends exactly once");
+    assert_eq!(sink.dst, bcast);
+    assert_eq!(sink.last, expect, "sealing is the reference encoding, not a second one");
+    assert!(sink.last.starts_with(wire::ELECT_PREFIX), "and it is still a SMOLv1 ELECT frame");
+    assert_eq!(wire::parse(&sink.last), Some(f), "round-trips through the real parser");
+}
+
+/// `seal` inherits `encode`'s rejection, so a malformed decision cannot reach a sink at all.
+pub fn sealing_refuses_a_frame_that_would_strand_a_leaf() {
+    for bad in [0u8, 14, 255] {
+        assert!(SealedElect::seal(&frame(5, 1, bad, 8)).is_none(), "ch{bad} is not sealable");
+    }
+}

--- a/experiments/mesh_elect_verify/src/follow_tests.rs
+++ b/experiments/mesh_elect_verify/src/follow_tests.rs
@@ -5,8 +5,7 @@
 
 use crate::mesh_elect::{
     recovery_ladder, wire, Announcer, Decision, Follow, Follower, GroupMacSink, Phase, SealedElect,
-    ANNOUNCE_BURST, ANNOUNCE_GAP_MS, ANNOUNCE_IDLE_MS, COMMON_AP_CHANNELS, FOLLOW_ENABLED,
-    LEGACY_CANDIDATES, N_CHANNELS, PROBATION_MS, RENDEZVOUS_CHANNEL, SETTLE_MS,
+    ANNOUNCE_BURST, ANNOUNCE_GAP_MS, ANNOUNCE_IDLE_MS, COMMON_AP_CHANNELS, LEGACY_CANDIDATES, N_CHANNELS, PROBATION_MS, RENDEZVOUS_CHANNEL, SETTLE_MS,
 };
 
 fn frame(node_id: u8, epoch: u32, channel: u8, gateway: u8) -> wire::ElectFrame {
@@ -208,7 +207,8 @@ pub fn the_ladder_is_the_legacy_plan_while_following_is_off() {
         assert_eq!(n, LEGACY_CANDIDATES.len(), "legacy plan length (last_known={last_known})");
         assert_eq!(&plan[..n], &LEGACY_CANDIDATES[..], "byte-identical to `leaf_scan_tick`'s CANDIDATES");
     }
-    assert!(!FOLLOW_ENABLED, "and the shipped default IS off — see #278's flip criterion");
+    // (that the shipped default IS off is asserted in `election_verify`, where the flag lives —
+    // it sits beside the MetricWeights it selects, for the cfg reason in its own doc comment.)
 }
 
 /// Best guess first, and never spend a 1500 ms dwell proving the same channel twice.

--- a/experiments/mesh_elect_verify/src/main.rs
+++ b/experiments/mesh_elect_verify/src/main.rs
@@ -13,6 +13,11 @@ mod mesh_elect;
 mod consensus;
 mod wire_tests;
 
+// #278 stage 2, smol-only: the announce schedule / follow state / recovery ladder / send-path seal.
+// Kept OUT of `consensus.rs` + `wire_tests.rs` so those two stay verbatim-diffable against the
+// donor's own suite, the same split the source file itself carries.
+mod follow_tests;
+
 fn main() {
     consensus::weight_saturates_and_floors();
     consensus::partition_merge_is_total_order();
@@ -24,5 +29,20 @@ fn main() {
     wire_tests::rejects_out_of_range_channel();
     wire_tests::encode_refuses_a_short_buffer();
     wire_tests::frame_is_human_readable_in_a_log();
-    println!("mesh_elect_verify: 10 checks passed (2 consensus + 8 wire)");
+
+    follow_tests::announces_before_and_after_the_move();
+    follow_tests::a_redundant_decision_does_not_burn_an_epoch();
+    follow_tests::refuses_an_out_of_range_channel();
+    follow_tests::orders_by_epoch_and_ignores_replay();
+    follow_tests::counts_would_be_moves_separately_from_hearings();
+    follow_tests::an_observed_channel_must_settle_before_it_costs_an_epoch();
+    follow_tests::beacons_between_migrations();
+    follow_tests::probation_expires_on_a_dead_epoch();
+    follow_tests::the_ladder_is_the_legacy_plan_while_following_is_off();
+    follow_tests::the_ladder_ranks_and_dedupes();
+    follow_tests::the_ladder_reaches_the_whole_band();
+    follow_tests::sealing_preserves_the_cross_repo_bytes();
+    follow_tests::sealing_refuses_a_frame_that_would_strand_a_leaf();
+
+    println!("mesh_elect_verify: 23 checks passed (2 consensus + 8 wire + 13 follow/announce)");
 }

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -1077,9 +1077,15 @@ fn main() -> ! {
                     ota::boot_confirm(false); // flips to the good slot + resets — never returns
                 }
             }
-            // #23 stage 2: a LEAF scans 1/6/11 for the elected gateway's HELLO and
-            // locks onto its channel (a no-op on the gateway, which rides its AP ch).
+            // #23 stage 2: a LEAF scans the ranked recovery ladder for the elected gateway's
+            // HELLO and locks onto its channel (a no-op on the gateway, which rides its AP ch).
+            // #278: the ladder is `[1, 6, 11]` verbatim until `mesh_elect::FOLLOW_ENABLED` flips.
             r.leaf_scan_tick(now);
+            // #278/#269: the CROWN announces the mesh rendezvous channel — one repeat per beacon
+            // interval in the steady state, bursts around an actual migration (fired inline by the
+            // reassoc path, which is the only place that knows a move is imminent). Mirror image of
+            // `leaf_scan_tick`: this early-returns on a leaf, that one on a gateway.
+            r.elect_tick(now);
             // #23 fix (oracle #1): a LEAF whose owner has gone silent for a PROLONGED
             // period re-opens the broker election — the ONLY runtime path that takes
             // over a DEAD lowest-id owner (leaves never flush). Cheap: early-returns

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -121,13 +121,15 @@ pub mod coexist;
 // a channel). This module carries and ORDERS the channel the fleet meets on — the value `coexist`
 // takes as its `mesh_ch` argument and that smol still hardcodes as `ESP_NOW_FIXED_CHANNEL`.
 //
-// ⚠️ TEMPORARY, and it must not outlive the next PR: nothing in the firmware calls this yet, so
-// `-D warnings` would fail on dead_code. This is stage 1 of 2 — the frame + its cross-repo test
-// contract land first so they are reviewable on their own; stage 2 adds the `Frame::Elect`
-// dispatch arm in `mode::parse_frame`, the announce/honour paths behind a default-off flag, and
-// re-measures the stack floor for whatever state lands on `RadioManager`. DELETE this allow in
-// that PR; if it is still here afterwards, the wiring silently never happened.
-#[allow(dead_code)]
+// WIRED (stage 2, #278): `mode::parse_frame` dispatches `Frame::Elect`, the crown announces via
+// `RadioManager::elect_tick` and the pre/post bursts in `reassoc_ch6_prefer`, and a leaf tracks
+// every announcement in its `Follower`. The stage-1 `#[allow(dead_code)]` is gone, together with
+// the matching `[unobservable]` entry in `tools/build-matrix.toml` — the module now emits real
+// code in the espnow tier, so that entry's claim became false and the gate said so.
+//
+// ACTING on an announcement is behind `mesh_elect::FOLLOW_ENABLED`, default OFF. Observing is not:
+// a leaf parses, orders and reports every ELECT frame regardless, which is what lets the fleet be
+// measured before it is moved (#278's flip criterion is evidence, not review).
 #[cfg(feature = "espnow")]
 pub mod mesh_elect;
 

--- a/rust/clock/src/net/election.rs
+++ b/rust/clock/src/net/election.rs
@@ -49,19 +49,72 @@ pub struct MetricWeights {
 }
 
 impl MetricWeights {
-    /// The SHIPPED default (JP: "elect the BEST gateway" ⇒ best-gateway is the default behavior,
-    /// team-lead decision 2026-07-20). CO-CHANNEL-DOMINANT: `co_channel` (100) alone outranks the
-    /// maximum of every other signal combined (`rssi` 10·2 + `uptime` 1·2 = 22), so a co-channel
-    /// board ALWAYS beats a stronger OFF-channel board (the id5 ch1-vs-ch6 bug). Absent / empty /
-    /// malformed config falls back to THIS (not to legacy) — best-gateway is on by default.
+    /// CO-CHANNEL-DOMINANT — the #217 rung-3 / id5 disease fix, and the shipped default while
+    /// leaves cannot follow a crown to a new channel. `co_channel` (100) alone outranks the maximum
+    /// of every other signal combined (`rssi` 10·2 + `uptime` 1·2 = 22), so a co-channel board
+    /// ALWAYS beats a stronger OFF-channel board. An off-channel crown is OTA-deaf on a fleet
+    /// pinned to ch6, so this is not a preference — it is a veto, and it has to be.
     ///
-    /// ⚠️ #269 will REBALANCE these. Under channel-follows-the-crown, `co_channel` stops being a
-    /// disease-fix and becomes a channel-change SUPPRESSOR: it would rank a board sitting where the
-    /// mesh already is above a better-internet board elsewhere, by a margin nothing can bridge —
-    /// blocking the migration #269 exists to enable. The fix is to re-scale it from dominant to a
-    /// hysteresis MARGIN, which is also the anti-flap term. Not done here: this commit only removes
-    /// the dead `ntp` input, so the two changes stay separately attributable on a live fleet.
-    pub const DEFAULT: Self = Self { co_channel: 100, rssi: 10, uptime: 1 };
+    /// The veto is delivered by BACKOFF TIER, which is why the magnitude matters and not just the
+    /// ordering: `elect_backoff_ms` normalises the fitness deficit to `MAX_ELECT_TIERS` (2), so with
+    /// `max_fitness` 122 one tier spans ≈ 61 points. `co_channel: 100` pushes any off-channel board
+    /// past a whole tier boundary while a co-channel board's worst deficit is 22 — separation is
+    /// GUARANTEED, not merely likely. Keep that in mind before tuning this down.
+    pub const DOMINANT: Self = Self { co_channel: 100, rssi: 10, uptime: 1 };
+
+    /// CO-CHANNEL AS A HYSTERESIS MARGIN — valid only where leaves can follow a channel migration.
+    ///
+    /// **1. Why 10, derived rather than chosen.** `rssi_score` buckets at −65/−78 dBm weighted 10,
+    /// so ONE BUCKET = 10 points, and one bucket is exactly the jitter amplitude of a board parked
+    /// on a bucket boundary. Setting the margin equal to one bucket makes a one-bucket challenger
+    /// TIE (jitter cannot move the fleet) and a two-bucket challenger WIN (a real gain migrates
+    /// it). It is the floor below which flap returns. Everything after this is context.
+    ///
+    /// **2. Calibration anchor, stated as a DIVERGENCE and not a convergence.** batman-adv exposes
+    /// the same knob as `gw_sel_class`, defaulting to 20 of ~255 TQ ≈ **8%** of its metric range.
+    /// Ours is 10 of a `max_fitness` of 32 ≈ **31%** — roughly 4× stickier. That is deliberate and
+    /// defensible rather than a coincidence to be pleased about: a batman-adv gateway switch makes
+    /// clients re-pick, while a smol channel migration makes **every leaf follow or strand**.
+    /// Higher disruption earns a higher bar.
+    ///
+    /// **3. No claim is made about how batman-adv arrived at 20.** There is no source for it, and a
+    /// wrong reason underneath a right conclusion is the most durable kind of error.
+    ///
+    /// **4. The worked unit error, named so it is not repeated.** `10/122 = 8.2%` looks like a
+    /// beautiful match for batman's 8% and is wrong: 122 is the PRE-re-scale `max_fitness`, which
+    /// still contains the `co_channel: 100` being removed. Post-re-scale the max is **32**.
+    ///
+    /// ⚠️ Margin-to-RANGE is the misleading comparison whenever ranges compress; margin-to-NOISE is
+    /// the invariant, and ours is 1× noise by construction. Do not shave below it — the disruption
+    /// asymmetry forbids a sub-noise margin. It does not demand a super-noise one.
+    ///
+    /// ⚠️ AND THE RE-SCALE CHANGES THE MECHANISM, not only the number — this is the part a reader
+    /// tuning it must not miss. With `max_fitness` 32, one backoff tier spans ≈ 16 points, so a
+    /// 10-point margin is **SUB-TIER**: unlike `DOMINANT`, it does NOT guarantee tier separation,
+    /// and two boards within one tier are resolved by the `node_id·200 ms` sub-tier tiebreak
+    /// instead. So `co_channel` here is a genuine *preference*, not a veto. The anti-flap
+    /// protection for a channel MIGRATION lives elsewhere and deliberately so — `SETTLE_MS` and
+    /// `margin_for` in `net::mesh_elect`, which govern the channel decision rather than the gateway
+    /// one (they are two different elections; see that module's header). Claiming this weight is
+    /// "the anti-flap floor" for the migration would be a comment describing behaviour the binary
+    /// does not have.
+    pub const FOLLOWING: Self = Self { co_channel: 10, rssi: 10, uptime: 1 };
+
+    /// The shipped weights, selected by whether leaves can FOLLOW a channel migration.
+    ///
+    /// This signature is the coupling, and it is a signature rather than a comment on purpose. The
+    /// re-scale and the follow capability cannot ship apart: re-scaling first re-arms exactly the
+    /// disease #217 fixed (a stronger off-channel board wins the crown and a ch6-pinned fleet
+    /// cannot follow it), and a note saying "don't ship these separately" is the kind of guarantee
+    /// this codebase has repeatedly watched fail. There is no way to obtain weights without stating
+    /// which world you are in.
+    pub const fn default_for(follow: bool) -> Self {
+        if follow {
+            Self::FOLLOWING
+        } else {
+            Self::DOMINANT
+        }
+    }
 
     /// Theoretical maximum fitness for these weights — the deficit reference in [`elect_backoff_ms`],
     /// making the tiering scale-invariant to the weight magnitudes. `const` for use at call sites.
@@ -82,6 +135,109 @@ pub enum ElectConfig {
     /// literal payload `legacy` to `smol/mesh/elect`. A genuine 1:1 rollback (no fitness math).
     Legacy,
 }
+
+/// #278/#269 MASTER SWITCH: may a leaf ACT on a `SMOLv1 ELECT` channel announcement?
+///
+/// Default OFF. A leaf still parses, epoch-orders and reports every announcement — observing and
+/// acting are separate, and the observe-only landing is what lets the fleet be measured before it
+/// is moved. #278's closing checklist gates the watch's `ELECT_ENFORCE` on the smol roll showing
+/// ONE clean channel migration first; this is the smol half of that ordering.
+///
+/// ⚠️ It lives HERE, in the gateway-election module, rather than in `net::mesh_elect` where the
+/// following actually happens — and the reason is worth stating because the obvious placement is
+/// the wrong one. `mesh_elect` is `espnow`-gated while `election` is `wifi`-gated, and `espnow`
+/// implies `wifi`, so `election` is visible to strictly more of the tree; a flag in `mesh_elect`
+/// could not be read by `net::wifi`'s config parser at all on a wifi-only build. Putting it beside
+/// the weights it selects also makes the coupling impossible to miss: the same `bool` chooses
+/// `DOMINANT` vs `FOLLOWING` and enables the follow path. Every pure function takes it as a
+/// PARAMETER rather than reading this const, so both host verifiers can exercise both states.
+///
+/// A plain `const` and not a Cargo feature, deliberately: a default-off feature adds an axis to the
+/// build matrix and a fresh exclusions surface, and — worse — the shipped fleet image would then
+/// not CONTAIN the follow path, so the canary roll could not exercise the thing it exists to prove.
+pub const FOLLOW_ENABLED: bool = false;
+
+/// The largest lever weight for which co-channel dominance is still EXPRESSIBLE in a `u8`.
+///
+/// Derived, not chosen: dominance needs `co_channel > rssi·2 + uptime·2`, and `co_channel` is a
+/// `u8`, so the floor `2r + 2u + 1` must fit in 255 ⇒ `r + u ≤ 127`. Capping each at 63 satisfies
+/// that with room (126 ≤ 127). Above this the operator lever could ask for a weighting in which no
+/// legal `co_channel` value dominates at all, and [`parse_elect_config`] would be clamping toward
+/// an invariant it could never reach.
+pub const DOMINANCE_LEVER_CAP: u8 = 63;
+
+/// The smallest `co_channel` for which co-channel capability outranks EVERYTHING else combined.
+#[must_use]
+pub const fn dominance_floor(w: &MetricWeights) -> u8 {
+    let need = w.rssi as u16 * RSSI_SCORE_MAX + w.uptime as u16 * UPTIME_SCORE_MAX + 1;
+    if need > u8::MAX as u16 {
+        u8::MAX
+    } else {
+        need as u8
+    }
+}
+
+/// Does `co_channel` alone strictly outrank the maximum of every other signal combined?
+///
+/// ONE predicate, used in three places — the compile-time assertion on [`MetricWeights::DOMINANT`],
+/// the runtime clamp in [`parse_elect_config`], and the host test. The lever is a SECOND WRITER of
+/// these weights, so an invariant enforced only at compile time binds only half the writers; and
+/// three separate spellings of the same rule is how two of them drift.
+#[must_use]
+pub const fn co_channel_dominates(w: &MetricWeights) -> bool {
+    (w.co_channel as u16) > w.rssi as u16 * RSSI_SCORE_MAX + w.uptime as u16 * UPTIME_SCORE_MAX
+}
+
+/// THE id5 INVARIANT, stated so that it holds in BOTH flag states.
+///
+/// The id5 bug is not "an off-channel board won the crown" — it is "an off-channel crown STRANDS a
+/// fleet that cannot follow it". The stranding is the harm, and inability to follow is its
+/// precondition. So the same predicate covers both worlds: with following OFF the fleet cannot
+/// follow, and only co-channel dominance prevents the harm; with following ON the precondition is
+/// gone and a stronger off-channel gateway is a migration rather than a stranding — which is the
+/// entire point of #269.
+///
+/// Writing the two states as one predicate is what lets `election_verify` assert the id5 case in
+/// both, rather than asserting one thing here and a different thing there and hoping the pair still
+/// means something.
+/// `#[allow(dead_code)]`: this predicate is a STATEMENT of the invariant, not a runtime branch —
+/// the firmware enforces it (the clamp, the const assert) rather than querying it, so nothing calls
+/// it outside a `const` block, which does not count as a use. Deleting it is not an option: it is
+/// the single spelling of the id5 rule that `experiments/election_verify` asserts in BOTH flag
+/// states, and the whole reason the two states can be checked against one property instead of two
+/// unrelated ones. Same shape and same reasoning as `refuse_leaf_lock_off_channel` below.
+#[allow(dead_code)]
+#[must_use]
+pub const fn off_channel_crown_can_strand(w: &MetricWeights, follow: bool) -> bool {
+    !follow && !co_channel_dominates(w)
+}
+
+/// The disease fix, asserted at compile time rather than described. If someone tunes `DOMINANT`
+/// such that a strong off-channel board can out-score a co-channel one, the build stops — which is
+/// the half of the invariant a `const` can carry. The other half (the runtime lever) is
+/// [`parse_elect_config`]'s clamp, because a compile-time assert binds only one of the two writers.
+const _DOMINANT_ACTUALLY_DOMINATES: () = {
+    assert!(co_channel_dominates(&MetricWeights::DOMINANT));
+    assert!(!off_channel_crown_can_strand(&MetricWeights::DOMINANT, false));
+    // And the cap really does keep the floor ATTAINABLE — the arithmetic, not the intent. Written
+    // through `dominance_floor` rather than by re-deriving `2r + 2u + 1` here, so the two cannot
+    // drift apart: if the floor ever saturated, the clamp in `parse_elect_config` would be reaching
+    // for a dominance that no legal `co_channel` value could reach, and would look enforced while
+    // being unenforceable.
+    let at_cap = MetricWeights {
+        co_channel: 0,
+        rssi: DOMINANCE_LEVER_CAP,
+        uptime: DOMINANCE_LEVER_CAP,
+    };
+    let floor = dominance_floor(&at_cap);
+    assert!(floor < u8::MAX, "the floor saturated — DOMINANCE_LEVER_CAP is too high");
+    let clamped_at_cap = MetricWeights {
+        co_channel: floor,
+        rssi: DOMINANCE_LEVER_CAP,
+        uptime: DOMINANCE_LEVER_CAP,
+    };
+    assert!(co_channel_dominates(&clamped_at_cap));
+};
 
 /// Max RSSI bucket value (`rssi_score` ∈ 0..=2).
 const RSSI_SCORE_MAX: u16 = 2;
@@ -219,24 +375,51 @@ pub fn legacy_recovery_backoff_ms(rssi: i8, node_id: u8) -> u64 {
 }
 
 /// Parse the retained `smol/mesh/elect` payload → policy. Panic-free (checked UTF-8, no indexing):
-///   * empty / whitespace / non-UTF-8 / no recognized token ⇒ `BestGateway(DEFAULT)` — best-gateway
-///     is ON by default, and the retain-clear restores it (team-lead decision).
+///   * empty / whitespace / non-UTF-8 / no recognized token ⇒ `BestGateway(default_for(follow))` —
+///     best-gateway is ON by default, and the retain-clear restores it (team-lead decision).
 ///   * `legacy` (case-insensitive) ⇒ `Legacy` (the escape hatch).
-///   * keyed weights `c<n>r<n>n<n>u<n>` (any order, any subset; missing keys inherit `DEFAULT`;
+///   * keyed weights `c<n>r<n>n<n>u<n>` (any order, any subset; missing keys inherit the default;
 ///     values clamp to 255; unknown letters + their digits are ignored) ⇒ `BestGateway(weights)`.
-///     e.g. `c100r10n5u1` = the default; `c0r100` = RSSI-dominant with co-channel off.
-pub fn parse_elect_config(payload: &[u8]) -> ElectConfig {
+///     e.g. `c100r10n5u1` = the following-off default; `c0r100` = RSSI-dominant, co-channel off.
+///
+/// # The clamp: an invariant must bind EVERY writer, not just the compile-time one
+///
+/// This topic is a SECOND WRITER of the weights, and it can re-arm the id5 disease with no code
+/// change at all — `c10r10` demotes co-channel dominance from a retained MQTT payload, and nothing
+/// in the firmware would notice. A `const` assertion on [`MetricWeights::DOMINANT`] binds the
+/// compile-time writer and says nothing whatever about this one.
+///
+/// So while following is off, the parsed weights are clamped back to dominance before they are
+/// returned. Note it is derived from the PARSED weights rather than being a literal: the lever
+/// writes `r` and `u` too, so a hardcoded floor of 22 would be silently invalidated the first time
+/// someone raised `r`. The `r`/`u` cap at [`DOMINANCE_LEVER_CAP`] closes the remaining hole —
+/// without it a payload like `c255r200` asks for a weighting in which NO legal `co_channel` value
+/// dominates, and the clamp would be reaching for an invariant it could never attain.
+///
+/// The result is a property that holds for every possible payload rather than for the ones that
+/// happened to be tested: with `follow == false`, [`co_channel_dominates`] is true of whatever
+/// comes back. `election_verify` asserts exactly that, over a sweep rather than a handful of cases.
+///
+/// # Readback reports APPLIED state
+///
+/// `net::wifi`'s readback logs the weights this function RETURNS, so an operator who publishes
+/// `c10r10` reads back the clamped values and learns immediately that their knob was overruled and
+/// by how much. That is the same rule the `n0` slot already follows: a readback reports what was
+/// applied, never what was sent. Echoing the request would claim an application that never
+/// happened.
+pub fn parse_elect_config(payload: &[u8], follow: bool) -> ElectConfig {
+    let default = MetricWeights::default_for(follow);
     let s = match core::str::from_utf8(payload) {
         Ok(s) => s.trim(),
-        Err(_) => return ElectConfig::BestGateway(MetricWeights::DEFAULT),
+        Err(_) => return ElectConfig::BestGateway(default),
     };
     if s.is_empty() {
-        return ElectConfig::BestGateway(MetricWeights::DEFAULT);
+        return ElectConfig::BestGateway(default);
     }
     if s.eq_ignore_ascii_case("legacy") {
         return ElectConfig::Legacy;
     }
-    let mut w = MetricWeights::DEFAULT;
+    let mut w = default;
     let b = s.as_bytes();
     let mut i = 0;
     while i < b.len() {
@@ -271,6 +454,22 @@ pub fn parse_elect_config(payload: &[u8]) -> ElectConfig {
                 _ => {}
             }
         }
+    }
+    if !follow {
+        // Cap first, so the floor below is always attainable, then raise `c` to it. Order matters:
+        // clamping `c` against an unreachable floor would leave dominance broken while looking like
+        // it had been enforced.
+        if w.rssi > DOMINANCE_LEVER_CAP {
+            w.rssi = DOMINANCE_LEVER_CAP;
+        }
+        if w.uptime > DOMINANCE_LEVER_CAP {
+            w.uptime = DOMINANCE_LEVER_CAP;
+        }
+        let floor = dominance_floor(&w);
+        if w.co_channel < floor {
+            w.co_channel = floor;
+        }
+        debug_assert!(co_channel_dominates(&w));
     }
     ElectConfig::BestGateway(w)
 }

--- a/rust/clock/src/net/mesh_elect.rs
+++ b/rust/clock/src/net/mesh_elect.rs
@@ -476,22 +476,16 @@ pub mod wire {
 // Keeping the split at a single line rather than interleaving is the whole reason a re-sync stays
 // mechanical: diff the top half, ignore the bottom. Add smol-only code HERE, never above.
 
-/// Master switch for **acting** on an announcement. Default OFF, and the default is the entire
-/// point: with it off a leaf still parses, orders and reports every ELECT frame it hears, but never
-/// retunes. That is the same observe-only posture the watch is holding (#278), so both ends of the
-/// pair land in a state where the frame is proven on real hardware before either end moves a
-/// fleet.
-///
-/// It is a plain `const` and not a Cargo feature ON PURPOSE. A default-off feature would add an
-/// axis to the build matrix, a `[tier_exclusive]` row and an exclusions-gate surface, and — worse —
-/// it would make the shipped fleet image *not contain* the follow path, so the canary roll could
-/// not exercise what it is meant to prove. A const keeps every tier's binary identical and makes
-/// the flip a one-line diff a reviewer can see.
-///
-/// ⚠️ Flip criterion is NOT "the code looks right": #278's closing checklist gates the watch's
-/// `ELECT_ENFORCE` on the smol roll showing ONE clean channel migration first. This flag is the
-/// smol half of that ordering.
-pub const FOLLOW_ENABLED: bool = false;
+// The master switch for ACTING on an announcement is `net::election::FOLLOW_ENABLED`, not here.
+//
+// It looks like it belongs in this module, and it does conceptually — but `mesh_elect` is
+// `espnow`-gated while `election` is `wifi`-gated, and `espnow` implies `wifi`, so a flag declared
+// here would be invisible to `net::wifi`'s config parser on a wifi-only build. It also has to sit
+// beside the `MetricWeights` it selects, because the same bool choosing DOMINANT vs FOLLOWING and
+// enabling the follow path IS the structural coupling those two changes needed.
+//
+// Nothing in this file reads it: every function below takes `follow` as a PARAMETER, which is also
+// what lets the host verifier exercise both states without a cfg.
 
 /// Member count carried on every announcement-derived [`Decision`].
 ///

--- a/rust/clock/src/net/mesh_elect.rs
+++ b/rust/clock/src/net/mesh_elect.rs
@@ -32,9 +32,25 @@
 //! |---|---|
 //! | [`wire`] | the frame itself — now an ANNOUNCEMENT of a derived value, not a ballot |
 //! | [`Decision`] + `supersedes` | orders announcements by epoch; rejects stale/replayed ones |
-//! | [`SETTLE_MS`], [`MARGIN_FLOOR`], [`PROBATION_MS`], [`margin_for`] | anti-flap: a challenger must hold its advantage before the fleet moves |
+//! | [`SETTLE_MS`], [`PROBATION_MS`] | anti-flap, and both are WIRED: `Announcer::observe_channel` makes a new channel hold for `SETTLE_MS` before it costs an epoch, and `Follower::probation_expired` is the exit from a wedged high epoch |
+//! | [`MARGIN_FLOOR`], [`margin_for`], [`OBS_STALE_MS`] | retained but **NOT wired** — see below |
 //! | [`RENDEZVOUS_CHANNEL`] | tier 2 of the recovery ladder below |
 //! | [`weight`], [`USABLE_MIN_DBM`] | still populate the frame's `w[13]` honestly — see below |
+//!
+//! ## `MARGIN_FLOOR` / `margin_for` / `OBS_STALE_MS` are retained but NOT wired — deliberately
+//!
+//! Stage 1 listed these alongside `SETTLE_MS` as "anti-flap: a challenger must hold its advantage".
+//! That was aspirational and stage 2 corrected it rather than letting it stand, because a comment
+//! describing behaviour the binary does not have is this codebase's most common defect shape: it
+//! never fails, it just quietly under-delivers.
+//!
+//! The honest statement: all three operate on a **summed weight across peer observations** — the
+//! `Tally`/`Ingest` machinery that was deliberately removed with the `Elector`. `margin_for` takes
+//! an `incumbent_sum` smol never computes; `OBS_STALE_MS` ages observations smol never accumulates.
+//! They are kept because this file is a cross-repo contract and the donor still owns the election:
+//! deleting them would make the next re-sync a merge instead of a diff, and the upstream tests that
+//! pin them run against this exact file. They carry item-scoped `#[allow(dead_code)]` saying so,
+//! rather than a module-wide allow that would also hide a genuinely unwired new feature.
 //!
 //! ## The `w[13]` vector is still filled in, deliberately
 //!
@@ -84,18 +100,26 @@
 //!
 //! # Recovery ladder for a leaf that missed the announcement
 //!
-//! esp-radio 0.18 exposes all-channels or exactly one channel — never a subset
-//! (`channel_bitmap` is hardcoded to 0). A full sweep costs **130-260 ms**
-//! (13 x `Active{min:10,max:20}`); a single-channel probe costs ~10-20 ms. So
-//! recovery is an ordered ladder with early exit, not one expensive sweep:
+//! An ordered ladder with early exit, not one expensive sweep. See [`recovery_ladder`], which is
+//! the implementation and holds the real cost model:
 //!
 //! ```text
 //! 0. heard the announcement        ~0
-//! 1. last-known mesh channel       ~10-20 ms
-//! 2. RENDEZVOUS_CHANNEL (6)        ~10-20 ms
-//! 3. common AP channels (1, 11)    ~10-20 ms each
-//! 4. full sweep                    130-260 ms
+//! 1. last-known mesh channel
+//! 2. RENDEZVOUS_CHANNEL (6)
+//! 3. common AP channels (1, 11)
+//! 4. the rest of the band, ascending
 //! ```
+//!
+//! ⚠️ Stage 1 costed these rungs at 10-20 ms each and a full sweep at 130-260 ms. Those are
+//! `esp-radio`'s **`scan_async`** dwell times and they are the WRONG model for smol, which recovers
+//! by retuning the ESP-NOW PHY and listening for `DWELL_MS` (1500 ms) rather than by scanning. The
+//! numbers are re-derived on [`recovery_ladder`] instead of repeated here — one place to be right.
+//!
+//! What DOES carry over from esp-radio 0.18 is the constraint behind the ladder's shape: it exposes
+//! all-channels or exactly one channel, never a subset (`channel_bitmap` is hardcoded to 0). There
+//! is no "probe these four" primitive to reach for, so a ranked sequence with early exit is not a
+//! design preference, it is the only shape available.
 //!
 //! # What this module does NOT decide
 //!
@@ -139,6 +163,11 @@ pub const WEIGHT_CEIL_DBM: i8 = -35;
 /// this is ~30 missed frames.
 ///
 /// **Must exceed [`SETTLE_MS`] and [`PROBATION_MS`]** — see [`_WINDOW_ORDERING`].
+/// `#[allow(dead_code)]`: operates on a summed weight across peer observations, which smol
+/// does not accumulate (the `Tally`/`Ingest` machinery was cut with the `Elector`). Retained as
+/// the donor's contract surface — see the module header. Item-scoped, so a genuinely unwired
+/// NEW feature still trips `-D warnings` instead of hiding behind a module-wide allow.
+#[allow(dead_code)]
 pub const OBS_STALE_MS: u64 = 60_000;
 
 /// A challenger must hold its lead this long before we spend an epoch on it.
@@ -148,6 +177,11 @@ pub const SETTLE_MS: u64 = 30_000;
 
 /// Floor for the margin a challenger must beat the incumbent by (in summed
 /// weight). See [`margin_for`].
+/// `#[allow(dead_code)]`: operates on a summed weight across peer observations, which smol
+/// does not accumulate (the `Tally`/`Ingest` machinery was cut with the `Elector`). Retained as
+/// the donor's contract surface — see the module header. Item-scoped, so a genuinely unwired
+/// NEW feature still trips `-D warnings` instead of hiding behind a module-wide allow.
+#[allow(dead_code)]
 pub const MARGIN_FLOOR: u32 = 12;
 
 /// After adopting someone else's higher-epoch decision, how long we tolerate
@@ -203,6 +237,11 @@ pub const fn weight(rssi_dbm: i8) -> u32 {
 /// the incumbent keeps the hysteresis meaningful at any fleet size, with a floor
 /// so it is never trivial when scores are small.
 #[must_use]
+/// `#[allow(dead_code)]`: operates on a summed weight across peer observations, which smol
+/// does not accumulate (the `Tally`/`Ingest` machinery was cut with the `Elector`). Retained as
+/// the donor's contract surface — see the module header. Item-scoped, so a genuinely unwired
+/// NEW feature still trips `-D warnings` instead of hiding behind a module-wide allow.
+#[allow(dead_code)]
 pub const fn margin_for(incumbent_sum: u32) -> u32 {
     let scaled = incumbent_sum / 8;
     if scaled > MARGIN_FLOOR {
@@ -421,5 +460,493 @@ pub mod wire {
             gateway,
             w,
         })
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+// SMOL-ONLY WIRING — everything below has NO counterpart in the donor crate.
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+//
+// Everything ABOVE this banner is the vendored cross-repo contract (see the lint-policy note at the
+// top): it must stay byte-diffable against `esp32c6-watch:crates/mesh-elect` so a future re-sync
+// shows only intended divergence. Everything BELOW is smol's own wiring — the announce schedule,
+// the leaf follow state, the recovery ladder, and the send-path seal — and the watch has no
+// equivalent because it is the *observer* in this pairing, not the announcer.
+//
+// Keeping the split at a single line rather than interleaving is the whole reason a re-sync stays
+// mechanical: diff the top half, ignore the bottom. Add smol-only code HERE, never above.
+
+/// Master switch for **acting** on an announcement. Default OFF, and the default is the entire
+/// point: with it off a leaf still parses, orders and reports every ELECT frame it hears, but never
+/// retunes. That is the same observe-only posture the watch is holding (#278), so both ends of the
+/// pair land in a state where the frame is proven on real hardware before either end moves a
+/// fleet.
+///
+/// It is a plain `const` and not a Cargo feature ON PURPOSE. A default-off feature would add an
+/// axis to the build matrix, a `[tier_exclusive]` row and an exclusions-gate surface, and — worse —
+/// it would make the shipped fleet image *not contain* the follow path, so the canary roll could
+/// not exercise what it is meant to prove. A const keeps every tier's binary identical and makes
+/// the flip a one-line diff a reviewer can see.
+///
+/// ⚠️ Flip criterion is NOT "the code looks right": #278's closing checklist gates the watch's
+/// `ELECT_ENFORCE` on the smol roll showing ONE clean channel migration first. This flag is the
+/// smol half of that ordering.
+pub const FOLLOW_ENABLED: bool = false;
+
+/// Member count carried on every announcement-derived [`Decision`].
+///
+/// [`Decision::supersedes`] breaks an epoch tie by member count, because the donor merges
+/// *partitions* that each ran their own election. smol has exactly one announcer — the crown — so
+/// there is no headcount to compare and the arm never discriminates. Pinning it to a constant says
+/// that plainly instead of inventing a number: epoch orders announcements, and the lower-channel
+/// tiebreak resolves the (already pathological) two-crowns-same-epoch case.
+pub const ANNOUNCER_MEMBERS: u8 = 1;
+
+/// Frames per announcement burst. Anchored to the existing `ODEL_BURST` (`net::mode`, #237): the
+/// repeat count smol already uses when a decision must not be missed and the transport will not
+/// acknowledge it. Reusing the number rather than inventing one keeps the two bursts comparable
+/// when someone tunes either.
+pub const ANNOUNCE_BURST: u8 = 6;
+
+/// Spacing between frames of a burst. Anchored to `PREARM_GAP_MS`/`WAKE_GAP_MS` (`net::mode`), the
+/// gap smol already uses for a repeated *broadcast* that a leaf must not miss (the OTAM wake-burst
+/// — the same problem shape: unacked, one in-flight slot, receiver may be busy).
+///
+/// ⚠️ What a burst does and does NOT buy, because the difference decides whether the recovery
+/// ladder below is optional: `ANNOUNCE_BURST × ANNOUNCE_GAP_MS` is 600 ms of coverage against
+/// *collision and queue loss*. It buys nothing at all for a leaf parked on a different channel —
+/// that leaf is deaf for a full `DWELL_MS` (1500 ms) and would miss every frame of the burst. Leaves
+/// in that state are recovered by [`recovery_ladder`], never by repeats. Raising the burst count to
+/// "cover" a parked leaf would be airtime spent on a case it cannot reach.
+pub const ANNOUNCE_GAP_MS: u64 = 120;
+
+/// Steady-state repeat interval, once a burst has drained. Anchored to smol's HELLO cadence
+/// (`main`'s ~2 s "I'm here" advertisement): ELECT is the channel-plane twin of HELLO — one says
+/// *who* is here, the other says *where the fleet meets* — so they beat at the same rate and a
+/// reader tuning one finds the other.
+///
+/// Airtime is not a concern at this rate and the arithmetic should be on the page rather than
+/// assumed: 61 B + the 9 B group-MAC trailer = 70 B every 2 s, from the single crown. That is
+/// ~280 bit/s of a 1 Mbit/s basic rate.
+pub const ANNOUNCE_IDLE_MS: u64 = 2_000;
+
+/// Where a burst is in the announce-then-move sequence.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Phase {
+    /// Nothing to say.
+    Idle,
+    /// Announcing the new channel while still reachable on the OLD one.
+    Pre,
+    /// Announcing from the NEW channel, for leaves that were asleep or parked.
+    Post,
+}
+
+/// The crown's announcement schedule: announce, move, announce again.
+///
+/// This is CSA's shape (see the prior-art section in the module header) — announce the switch
+/// before performing it, then re-announce from the far side. Announcing only *after* guarantees a
+/// window where the crown is deaf to its own fleet; announcing only *before* strands whoever was
+/// asleep. Both bursts carry the SAME epoch, which is stronger than ordering them: a pre-move frame
+/// arriving late is byte-identical to the post-move one, so there is nothing for it to override.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Announcer {
+    epoch: u32,
+    channel: u8,
+    phase: Phase,
+    left: u8,
+    last_ms: u64,
+    /// Settle gate for [`Self::observe_channel`]: a candidate channel and when we first saw it.
+    /// `(0, _)` = nothing pending.
+    pending: (u8, u64),
+}
+
+impl Default for Announcer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Announcer {
+    /// Boot state: nothing decided, nothing to announce.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { epoch: 0, channel: 0, phase: Phase::Idle, left: 0, last_ms: 0, pending: (0, 0) }
+    }
+
+    /// Feed an OBSERVED channel — one read off the radio every tick, which can therefore flap.
+    /// Commits through [`Self::decide`] only once the new value has held for [`SETTLE_MS`].
+    /// Returns true on the tick it commits.
+    ///
+    /// This is the anti-flap half the donor's constants were kept for. Without it a crown whose AP
+    /// oscillates between two channels burns an epoch per oscillation, and since epoch is the total
+    /// order every announcement out-ranks the last — so a flapping AP would not merely be noisy, it
+    /// would make `supersedes` meaningless and drag a following fleet back and forth. Flapping costs
+    /// an association and tears the mesh down; a suboptimal-but-stable channel does not.
+    ///
+    /// The FIRST channel commits immediately (`self.channel == 0`): there is no incumbent to protect
+    /// and no flap to suppress, and making a booting crown sit silent for [`SETTLE_MS`] before
+    /// saying where the fleet meets would be a self-inflicted 30 s hole in exactly the window when
+    /// leaves are looking hardest.
+    pub fn observe_channel(&mut self, channel: u8, now_ms: u64) -> bool {
+        if ch_index(channel).is_none() || channel == self.channel {
+            self.pending = (0, 0); // back on the committed channel → the candidate is withdrawn
+            return false;
+        }
+        if self.channel == 0 {
+            return self.decide(channel, now_ms); // cold start: nothing to protect
+        }
+        if self.pending.0 != channel {
+            self.pending = (channel, now_ms); // a new candidate starts its own clock
+            return false;
+        }
+        if now_ms.saturating_sub(self.pending.1) < SETTLE_MS {
+            return false;
+        }
+        self.pending = (0, 0);
+        self.decide(channel, now_ms)
+    }
+
+    /// The epoch currently being announced.
+    #[must_use]
+    pub const fn epoch(&self) -> u32 {
+        self.epoch
+    }
+
+    /// The channel currently being announced (0 = nothing decided yet).
+    #[must_use]
+    pub const fn channel(&self) -> u8 {
+        self.channel
+    }
+
+    #[must_use]
+    pub const fn phase(&self) -> Phase {
+        self.phase
+    }
+
+    /// A new channel decision: bump the epoch and arm the PRE-move burst. Returns `false` (and
+    /// changes nothing) for an out-of-range channel or a channel we are already announcing, so a
+    /// caller may drive this straight from an observed value without debouncing it — a re-decision
+    /// on the same channel would otherwise burn an epoch per call and defeat `supersedes`.
+    pub fn decide(&mut self, channel: u8, now_ms: u64) -> bool {
+        if ch_index(channel).is_none() || channel == self.channel {
+            return false;
+        }
+        self.epoch = self.epoch.saturating_add(1);
+        self.channel = channel;
+        self.phase = Phase::Pre;
+        self.left = ANNOUNCE_BURST;
+        // Back-date so the first frame of the burst goes out on the very next tick rather than
+        // waiting a gap — the pre-move window is the one where the crown is still reachable.
+        self.last_ms = now_ms.saturating_sub(ANNOUNCE_GAP_MS);
+        true
+    }
+
+    /// True when one frame of the current burst should go out NOW; consumes that repeat.
+    pub fn due(&mut self, now_ms: u64) -> bool {
+        if self.phase == Phase::Idle || self.left == 0 {
+            return false;
+        }
+        if now_ms.saturating_sub(self.last_ms) < ANNOUNCE_GAP_MS {
+            return false;
+        }
+        self.left -= 1;
+        self.last_ms = now_ms;
+        true
+    }
+
+    /// True when a steady-state repeat should go out — the burst has drained and
+    /// [`ANNOUNCE_IDLE_MS`] has passed. Consumes the slot.
+    ///
+    /// The bursts cover a migration; this covers everything else. A leaf that boots, wakes, or
+    /// finally lands on the right channel learns the current decision within one interval instead of
+    /// waiting for the next migration, which on a stable fleet may never come. It is also what makes
+    /// the frame observable at all on a fleet that is not migrating — which is the entire value of
+    /// the observe-only landing, and therefore not optional.
+    pub fn beacon_due(&mut self, now_ms: u64) -> bool {
+        if self.phase == Phase::Idle || self.left > 0 {
+            return false; // idle has nothing to say; a live burst is already saying it
+        }
+        if now_ms.saturating_sub(self.last_ms) < ANNOUNCE_IDLE_MS {
+            return false;
+        }
+        self.last_ms = now_ms;
+        true
+    }
+
+    /// True once the PRE-move burst has drained — the caller may now retune. Kept as a question the
+    /// caller asks rather than a callback, so the move stays where the radio is owned.
+    #[must_use]
+    pub const fn clear_to_move(&self) -> bool {
+        matches!(self.phase, Phase::Pre) && self.left == 0
+    }
+
+    /// Arm the POST-move burst, at the SAME epoch. Call immediately after the retune.
+    pub fn moved(&mut self, now_ms: u64) {
+        self.phase = Phase::Post;
+        self.left = ANNOUNCE_BURST;
+        self.last_ms = now_ms.saturating_sub(ANNOUNCE_GAP_MS);
+    }
+
+    /// True once the POST burst has drained too — the migration is over.
+    #[must_use]
+    pub const fn settled(&self) -> bool {
+        matches!(self.phase, Phase::Post) && self.left == 0
+    }
+
+    /// The decision this announcer is broadcasting, for the frame builder.
+    #[must_use]
+    pub const fn decision(&self, gateway: u8) -> Decision {
+        Decision { channel: self.channel, epoch: self.epoch, gateway }
+    }
+}
+
+/// What a leaf should do with an inbound announcement.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Follow {
+    /// Stale, replayed, or simply not newer — ignore it. Costs nothing and, importantly, does not
+    /// reset the probation clock: a replayed old frame must not look like liveness.
+    Stale,
+    /// Accepted, and it names the channel we are already on. Nothing to do but note we heard it.
+    Confirmed,
+    /// Accepted, and the fleet is moving. The caller retunes to this channel — IFF
+    /// [`FOLLOW_ENABLED`].
+    Move(u8),
+}
+
+/// A leaf's view of the announced channel decision.
+///
+/// Deliberately records what it heard even when [`FOLLOW_ENABLED`] is false. Observation and action
+/// are separate concerns: the observe-only landing is worth having precisely because it lets the
+/// fleet report what it *would* have done — over DIAG, on real hardware, against a real crown —
+/// before anything moves.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Follower {
+    decision: Decision,
+    /// When we last accepted an announcement (0 = never). Drives [`Self::probation_expired`].
+    heard_ms: u64,
+    /// Announcements accepted since boot — a monotonic observability counter, so "did this board
+    /// ever hear the crown" is answerable from a DIAG record instead of a serial console.
+    accepted: u16,
+    /// Accepted announcements that named a DIFFERENT channel than the one we were on — i.e. the
+    /// ones a following leaf would have acted on.
+    ///
+    /// This is the number the canary roll actually needs, and it is not the same as `accepted`.
+    /// In the steady state every leaf is by definition co-channel with the crown (ESP-NOW is
+    /// per-channel — a leaf on another channel hears nothing at all), so `accepted` only ever
+    /// proves the beacon works. `moves` is non-zero exactly when a leaf caught the crown's
+    /// PRE-move burst, which is the one hard-to-hit part of the whole design and the thing
+    /// observe-only exists to measure before anything is allowed to act on it.
+    moves: u16,
+}
+
+impl Default for Follower {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Follower {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { decision: Decision::bootstrap(), heard_ms: 0, accepted: 0, moves: 0 }
+    }
+
+    #[must_use]
+    pub const fn decision(&self) -> Decision {
+        self.decision
+    }
+
+    #[must_use]
+    pub const fn accepted(&self) -> u16 {
+        self.accepted
+    }
+
+    /// See [`Self::moves`] — the count a canary roll reads.
+    #[must_use]
+    pub const fn moves(&self) -> u16 {
+        self.moves
+    }
+
+    /// Ingest one parsed frame. `my_channel` is the channel we are on right now (0 = unknown).
+    ///
+    /// Ordering is [`Decision::supersedes`] verbatim — the donor's total order, so both repos agree
+    /// on which of two announcements wins. Note the boot edge it implies: [`Decision::bootstrap`]
+    /// sits at epoch 0 on [`RENDEZVOUS_CHANNEL`], so an epoch-0 announcement for a LOWER channel
+    /// number supersedes it on the channel tiebreak. That is the donor's rule and it is harmless
+    /// here (a real crown's first `decide` lands on epoch 1), but it is a rule, not an accident, so
+    /// it is written down rather than discovered.
+    pub fn observe(&mut self, f: &wire::ElectFrame, now_ms: u64, my_channel: u8) -> Follow {
+        let d = Decision { channel: f.channel, epoch: f.epoch, gateway: f.gateway };
+        if !d.supersedes(ANNOUNCER_MEMBERS, &self.decision, ANNOUNCER_MEMBERS) {
+            return Follow::Stale;
+        }
+        self.decision = d;
+        self.heard_ms = now_ms;
+        self.accepted = self.accepted.saturating_add(1);
+        if d.channel == my_channel {
+            Follow::Confirmed
+        } else {
+            self.moves = self.moves.saturating_add(1);
+            Follow::Move(d.channel)
+        }
+    }
+
+    /// Has the adopted epoch gone quiet for longer than [`PROBATION_MS`]?
+    ///
+    /// This is the answer to the failure mode a monotonic epoch invites: one node with a high
+    /// persisted epoch can otherwise wedge the entire fleet onto a dead channel permanently, and no
+    /// later announcement can ever out-rank it. After probation the leaf stops treating the adopted
+    /// decision as authoritative and falls back to the [`recovery_ladder`].
+    #[must_use]
+    pub fn probation_expired(&self, now_ms: u64) -> bool {
+        self.heard_ms != 0 && now_ms.saturating_sub(self.heard_ms) > PROBATION_MS
+    }
+}
+
+/// Channels a consumer AP is most likely to sit on, after the rendezvous. 1/6/11 are the three
+/// non-overlapping 2.4 GHz allocations and the only ones most routers auto-select; 6 is already
+/// [`RENDEZVOUS_CHANNEL`], so these are the remaining two.
+pub const COMMON_AP_CHANNELS: [u8; 2] = [1, 11];
+
+/// Upper bound on a ladder: every channel in the band, at most once.
+pub const RECOVERY_MAX: usize = N_CHANNELS;
+
+/// The historical blind-scan plan (`net::mode::leaf_scan_tick`'s `CANDIDATES`, "JP's roam plan").
+/// Named here so [`recovery_ladder`] can *return* it verbatim when following is off — which turns
+/// "the flag changes nothing on a live fleet" from a claim into something a host test asserts.
+pub const LEGACY_CANDIDATES: [u8; 3] = [1, 6, 11];
+
+/// The ordered channel-probe plan for a leaf that has to re-find the mesh, best guess first.
+///
+/// # Cost model — re-derived for smol, NOT inherited
+///
+/// The design record costs this ladder at 10–20 ms per rung and 130–260 ms for a full sweep. Those
+/// numbers are `esp-radio`'s **`scan_async`** dwell times, and smol's leaf recovery does not scan:
+/// `leaf_scan_tick` retunes the ESP-NOW PHY and *listens* for the crown's HELLO for `DWELL_MS`
+/// (1500 ms) before hopping. So the real cost of a rung here is `DWELL_MS`, ~100× the scan figure,
+/// and the real budget is 13 × 1500 ms ≈ 19.5 s to exhaust the band.
+///
+/// That is a much better trade than it looks, and the ranking is what makes it one. Today's plan
+/// probes three channels forever; a crown that moved to ch3 is simply never found. This finds it,
+/// and puts the *likely* answers first: a leaf that still remembers the last channel is back in one
+/// rung, where today it may cycle up to three. Slower worst case, faster common case, and a
+/// reachable band instead of an unreachable one.
+///
+/// (It also does not cost the association, which is the other reason not to reach for a scan: a
+/// scan drops it — `coex_background_scan` is hardcoded false — and a leaf mid-recovery is exactly
+/// who cannot afford that.)
+///
+/// # Rungs
+///
+/// Tier 0 of the design ladder ("heard the announcement") is not a rung: this list is what a leaf
+/// walks *because* tier 0 did not happen. Rungs here are the remaining tiers, in order:
+///
+/// | rung | tier | why |
+/// |---|---|---|
+/// | 0 | 1 | `last_known` — where the mesh was when we last heard it |
+/// | 1 | 2 | [`RENDEZVOUS_CHANNEL`] — the one recovery that cannot fail for timing reasons |
+/// | 2,3 | 3 | [`COMMON_AP_CHANNELS`] — where a consumer AP probably landed |
+/// | 4.. | 4 | the rest of the band ascending — the sweep, degraded into rungs |
+///
+/// Duplicates are dropped, so a leaf whose `last_known` is already the rendezvous does not spend
+/// `DWELL_MS` proving it twice. `last_known == 0` ("never knew one") simply starts at rung 1.
+///
+/// With `follow` false this returns [`LEGACY_CANDIDATES`] unchanged — byte-for-byte today's
+/// behaviour. The ladder is only reachable in a world where the channel can actually move, and
+/// shipping a live behaviour change alongside a flag that is supposed to change nothing is how a
+/// canary roll stops being able to attribute what it sees.
+#[must_use]
+pub fn recovery_ladder(last_known: u8, follow: bool) -> ([u8; RECOVERY_MAX], usize) {
+    let mut out = [0u8; RECOVERY_MAX];
+    let mut n = 0;
+
+    if !follow {
+        for (i, &ch) in LEGACY_CANDIDATES.iter().enumerate() {
+            out[i] = ch;
+            n += 1;
+        }
+        return (out, n);
+    }
+
+    let push = |ch: u8, out: &mut [u8; RECOVERY_MAX], n: &mut usize| {
+        if ch_index(ch).is_none() {
+            return; // 0 = never knew one, or a corrupt value that must not be tuned to
+        }
+        if out[..*n].contains(&ch) {
+            return;
+        }
+        out[*n] = ch;
+        *n += 1;
+    };
+
+    push(last_known, &mut out, &mut n);
+    push(RENDEZVOUS_CHANNEL, &mut out, &mut n);
+    for &ch in COMMON_AP_CHANNELS.iter() {
+        push(ch, &mut out, &mut n);
+    }
+    for ch in 1..=(N_CHANNELS as u8) {
+        push(ch, &mut out, &mut n);
+    }
+    (out, n)
+}
+
+// ── The send path is a SECURITY boundary, so it is a TYPE, not a comment ───────────────────────
+//
+// The module header states the invariant: ELECT must go out via `send_to`, which appends #190's
+// group-MAC trailer, and never via `send_arb_raw`, which does not. A leaf cannot verify an
+// announcement before acting on it — checking costs it the association it would need if the
+// announcement were false — so an unauthenticated ELECT is a remote fleet-stranding primitive.
+//
+// A comment is not a mechanism. Stage A wrote that invariant down in prose and it would have
+// survived any refactor that violated it, silently. So the encoded frame is now a type whose bytes
+// have NO accessor: the only thing you can do with a `SealedElect` is hand it to a `GroupMacSink`,
+// and the only implementation of that trait routes to `send_to`.
+//
+// ⚠️ What this does NOT catch, enumerated rather than assumed — every one of these is covered by
+// `tools/check_elect_send_path.py`, which reads source structure, and NONE of them is covered by
+// the type system alone:
+//   1. Someone rewrites the one-line `GroupMacSink` impl body to call `send_arb_raw`. This is the
+//      LIKELIEST shape by a distance: it is a one-line edit in the direction of "make it compile".
+//   2. Someone adds a SECOND `GroupMacSink` impl that sends raw.
+//   3. Someone calls `wire::encode` directly into a local buffer and sends that, bypassing the seal.
+//   4. Someone hand-builds the frame from the `SMOLv1 ELECT ` literal without touching `encode`.
+//   5. Someone adds a new raw `esp_now.send` call site.
+//   6. Someone changes `should_group_mac` so ELECT stops being MAC'd — the trailer disappears with
+//      the send path untouched. (Pinned by an ELECT case in `experiments/mac_verify`.)
+
+/// A sink that appends the #190 group-MAC trailer to what it sends.
+///
+/// The name is the contract. An implementation that does not append the trailer satisfies the
+/// compiler and breaks the fleet, which is why the single implementation is also checked by
+/// `tools/check_elect_send_path.py` rather than trusted.
+pub trait GroupMacSink {
+    /// Send `frame` to `dst`, appending the group-MAC trailer.
+    fn send_group_mac(&mut self, dst: &[u8; 6], frame: &[u8]);
+}
+
+/// An encoded ELECT frame that can only leave via a [`GroupMacSink`].
+///
+/// The buffer is private and there is no accessor, no `Deref`, no `as_bytes`. [`Self::emit`]
+/// consumes `self`, so a frame cannot be sealed once and sent twice down different paths either.
+pub struct SealedElect {
+    buf: [u8; wire::ELECT_LEN],
+}
+
+impl SealedElect {
+    /// Encode `f`. `None` for an out-of-range channel — the same rejection [`wire::encode`] makes,
+    /// surfaced here so a malformed decision can never reach the air.
+    #[must_use]
+    pub fn seal(f: &wire::ElectFrame) -> Option<Self> {
+        let mut buf = [0u8; wire::ELECT_LEN];
+        let n = wire::encode(f, &mut buf)?;
+        // `encode` writes a fixed-width record or nothing; a short write would mean the layout
+        // constants disagree with the writer, which is a bug, not an input error.
+        debug_assert_eq!(n, wire::ELECT_LEN);
+        Some(Self { buf })
+    }
+
+    /// Hand the frame to the authenticated send path. Consumes `self`.
+    pub fn emit<S: GroupMacSink + ?Sized>(self, sink: &mut S, dst: &[u8; 6]) {
+        sink.send_group_mac(dst, &self.buf);
     }
 }

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -56,6 +56,12 @@ use esp_radio::{
 
 use crate::led::LedState;
 use crate::net::{SmolWifiDevice, WifiPeripherals};
+// #278/#269: the ELECT frame + the announce/follow machinery. Imported as a MODULE rather than
+// glob-imported: its names (`weight`, `Decision`, `Phase`, `Follow`) are generic enough to collide
+// with this file's vocabulary, and `mesh_elect::` at the call site is what tells a reader that the
+// thing being handled is the CHANNEL plane, not the gateway election in `net::election`. Those two
+// are separate concerns that share the word "elect" (see `net::mesh_elect`'s header).
+use crate::net::mesh_elect;
 // #13: the relay-family wire codec + ASCII field helpers live in the PURE, host-testable
 // `net::wire` module (extracted from here, byte-identical). Glob-imported so every call site
 // below (encode_relay, parse_relay[2], *relayack*, encode_dl, write_u5/u10, parse_id/u5/u10,
@@ -656,6 +662,14 @@ enum Frame<'a> {
     /// #57 Mesh Familiar: a decoded FAM frame (heartbeat / handoff / call). Scalar-only
     /// (no borrow) — buffered into the [`FamInbox`] for [`RadioManager::fam_tick`] to ingest.
     Fam(FamFrame),
+    /// #278/#269: the crown's `SMOLv1 ELECT` announcement of the mesh rendezvous channel — a
+    /// decoded, fully length- and digit-checked [`mesh_elect::wire::ElectFrame`]. Scalar-only
+    /// (the fixed 61 B record is copied out by the parser, so nothing borrows the RX buffer).
+    ///
+    /// This is an ANNOUNCEMENT of a derived value, not a ballot: nothing here votes. See
+    /// `net::mesh_elect`'s header for why the channel is a consequence of the gateway election
+    /// rather than an election of its own.
+    Elect(mesh_elect::wire::ElectFrame),
 }
 
 /// #70/#49 observability: a node's own live diag counters, folded into the retained DIAG record
@@ -2148,6 +2162,16 @@ pub struct RadioManager {
     /// still HELLO-scans when it is 0/stale/absent (the proven fallback). Sourced from `rx_control`,
     /// NOT the deliberately-sidestepped `esp_wifi_get_channel`.
     learned_channel: u8,
+    /// #278/#269 CROWN half: the announce schedule for the mesh channel. Only a gateway ever
+    /// advances it (a leaf carries an idle one — 16 B is not worth a `cfg` split that would then
+    /// need re-testing per tier). Pure state; the radio work is in [`RadioManager::elect_tick`].
+    elect_announcer: mesh_elect::Announcer,
+    /// #278/#269 LEAF half: the best channel decision heard so far, plus its freshness.
+    ///
+    /// Maintained REGARDLESS of `mesh_elect::FOLLOW_ENABLED` — observing and acting are separate,
+    /// and observing is the whole value of the observe-only landing: the fleet reports what it
+    /// *would* have done, against a real crown, before anything moves.
+    elect_follower: mesh_elect::Follower,
     /// #13 MESH-TEST rig ONLY: MACs this board pretends it cannot hear. `service()` drops any
     /// inbound frame from a listed source before it touches the roster/parse — a deterministic,
     /// reproducible stand-in for physical RF attenuation that forces a 2-hop topology. Seeded
@@ -2399,6 +2423,8 @@ impl RadioManager {
             scan_locked: false,
             scan_idx: 0,
             learned_channel: 0, // #29: unknown until the first frame is heard
+            elect_announcer: mesh_elect::Announcer::new(), // #278: idle until a channel is known
+            elect_follower: mesh_elect::Follower::new(),   // #278: bootstrap decision until heard
             #[cfg(feature = "mesh-test")]
             deaf: crate::board::DEAF_MACS, // #13 rig: baked per-board deaf-list (empty in prod)
 
@@ -2447,7 +2473,12 @@ impl RadioManager {
     /// roam), it unlocks + resumes scanning. Gateways never scan (they ride their AP
     /// channel via the live association).
     pub fn leaf_scan_tick(&mut self, now: u64) {
-        const CANDIDATES: [u8; 3] = [1, 6, 11]; // JP's roam plan
+        // #278: the probe plan is now RANKED and seeded from the last announcement we accepted —
+        // best guess first, then the rendezvous, then the common APs, then the rest of the band.
+        // With `FOLLOW_ENABLED` off it returns `[1, 6, 11]` verbatim (host-asserted, not claimed),
+        // so this hop loop is byte-identical to the historical blind scan until the flag flips.
+        let (plan, plan_len) = self.scan_plan();
+        let candidates = &plan[..plan_len];
         const DWELL_MS: u64 = 1500; // listen this long per candidate before hopping
         const SCAN_SILENCE_MS: u64 = 6000; // owner silence → assume roam → re-scan
         if self.relay.is_gateway {
@@ -2472,6 +2503,22 @@ impl RadioManager {
             self.scan_locked = false;
             log::info!("smol: leaf lost gateway id{} — re-scanning", self.elected_owner);
         }
+        // #278 PROBATION: the same unlock, for the failure mode a monotonic epoch invites. A node
+        // that persists a high epoch out-ranks every later announcement forever, so a fleet that
+        // adopted it can be wedged onto a dead channel with no way back — `supersedes` is doing
+        // exactly what it was asked to. Probation is the exit: once the adopted epoch has gone
+        // quiet past `PROBATION_MS` we stop treating it as authoritative and walk the ladder again.
+        //
+        // Deliberately a SEPARATE arm from the owner-silence one above, on a separate clock: an
+        // owner can be alive and HELLOing on a channel whose ELECT epoch is long dead, and a dead
+        // epoch can outlive several owners. Folding them would let either mask the other.
+        if self.scan_locked && self.elect_follower.probation_expired(now) {
+            self.scan_locked = false;
+            log::info!(
+                "smol #278: ELECT epoch {} silent past probation — re-scanning from the ladder",
+                self.elect_follower.decision().epoch
+            );
+        }
         if self.scan_locked {
             return;
         }
@@ -2482,7 +2529,7 @@ impl RadioManager {
         // leaf behaves like today's blind scan. `poll` returns Some only on an actual change, so we
         // re-tune the radio exactly as sparsely as the round-robin did (never mid-dwell).
         if self.relay.latch.latched() {
-            if let Some(ch) = self.relay.park.poll(now, &CANDIDATES) {
+            if let Some(ch) = self.relay.park.poll(now, candidates) {
                 let _ = self.esp_now.set_channel(ch);
                 log::info!(
                     "smol #126: latched-leaf channel {} ({})",
@@ -2496,8 +2543,14 @@ impl RadioManager {
         // latch re-bootstraps from a clean hunt.
         self.relay.park.reset();
         if now.saturating_sub(self.last_scan_hop_ms) >= DWELL_MS {
-            self.scan_idx = (self.scan_idx + 1) % CANDIDATES.len();
-            let ch = CANDIDATES[self.scan_idx];
+            // `plan_len` is never 0 (the ladder always yields at least the rendezvous), but modulo
+            // a zero length would panic, and a panic in the leaf recovery path bricks membership
+            // for a board that is already lost. Guard it rather than reason about it.
+            if candidates.is_empty() {
+                return;
+            }
+            self.scan_idx = (self.scan_idx + 1) % candidates.len();
+            let ch = candidates[self.scan_idx];
             let _ = self.esp_now.set_channel(ch);
             self.last_scan_hop_ms = now;
         }
@@ -2883,6 +2936,112 @@ impl RadioManager {
         let mut msg = [0u8; 16];
         let len = encode_id_frame(HELLO_PREFIX, self.id, &mut msg);
         self.send_to(&BROADCAST_ADDRESS, &msg[..len]);
+    }
+
+    // ── #278/#269 the ELECT announcement path ─────────────────────────────────────────────────
+
+    /// The mesh channel as a DERIVED value (#269): wherever this crown's single radio actually is.
+    ///
+    /// Preference order is "measured, then commanded, then historical", which is the order of how
+    /// much each one can be wrong by. `learned_channel` is `rx_control`'s view — what peers are
+    /// genuinely reaching us on. `my_ap_channel` is what we last *asked* the STA for, true a moment
+    /// sooner but a moment less reliable. `ESP_NOW_FIXED_CHANNEL` is the historical constant, and
+    /// falling back to it means a crown that has heard nothing announces the rendezvous, which is
+    /// exactly where a fleet with no other information should meet.
+    fn elect_channel(&self) -> u8 {
+        for ch in [self.learned_channel, self.my_ap_channel] {
+            if mesh_elect::ch_index(ch).is_some() {
+                return ch;
+            }
+        }
+        ESP_NOW_FIXED_CHANNEL
+    }
+
+    /// Broadcast one `SMOLv1 ELECT` announcement of the current decision.
+    ///
+    /// The `w[13]` weight vector is filled in HONESTLY, which here means mostly zeros. smol does not
+    /// run per-channel scans on the announce path (that would cost the association — see the module
+    /// header), so the only channel we can truthfully weigh is the one our own AP is on. Every other
+    /// slot is a measured zero, not a guess. The watch still runs its own election over these
+    /// observations in observe-only mode, and feeding it invented numbers would be worse than
+    /// feeding it few.
+    fn broadcast_elect(&mut self) {
+        // Same abdication rule as HELLO: a demoted ex-crown must not keep asserting a channel
+        // decision any more than it keeps asserting its presence.
+        if self.silent_until_relock {
+            return;
+        }
+        let mut w = [0u8; mesh_elect::N_CHANNELS];
+        if let Some(ix) = mesh_elect::ch_index(self.my_ap_channel) {
+            // `weight` saturates at both ends and returns 0 below USABLE_MIN_DBM, so an unusable AP
+            // contributes nothing rather than a small lie.
+            w[ix] = mesh_elect::weight(self.my_rssi_to_ap) as u8;
+        }
+        let d = self.elect_announcer.decision(self.id);
+        let f = mesh_elect::wire::ElectFrame {
+            node_id: self.id,
+            epoch: d.epoch,
+            channel: d.channel,
+            gateway: d.gateway,
+            w,
+        };
+        let Some(sealed) = mesh_elect::SealedElect::seal(&f) else {
+            // Unreachable via `Announcer::decide`, which range-checks before it ever stores a
+            // channel. Refuse loudly rather than silently: an out-of-range announcement acted on by
+            // a following fleet tunes every leaf to nothing.
+            log::warn!("smol #278: refusing to announce ch{} — out of range", d.channel);
+            return;
+        };
+        // The ONLY way a sealed frame reaches the air. `emit` consumes it, and `SealedElect` has no
+        // byte accessor, so there is no second path to take by accident.
+        sealed.emit(self, &BROADCAST_ADDRESS);
+    }
+
+    /// Drive the crown's announcement schedule. Call every subtick from `main` (cheap: a leaf
+    /// early-returns on the first line).
+    ///
+    /// Announcing is ON by default; only *acting* on an announcement is behind
+    /// `mesh_elect::FOLLOW_ENABLED`. That asymmetry is the point of the observe-only landing — a
+    /// frame nobody emits cannot be proven on hardware, and #278's flip criterion is evidence from
+    /// a real fleet, not a code review.
+    pub fn elect_tick(&mut self, now: u64) {
+        if !self.relay.is_gateway {
+            return; // the mesh channel is the CROWN's channel; a leaf has nothing to announce
+        }
+        let ch = self.elect_channel();
+        // SETTLE-gated, unlike the reassoc path below: this reads an OBSERVED value every subtick,
+        // and an AP that oscillates would otherwise burn one epoch per oscillation. Since epoch is
+        // the total order, that would not merely be noisy — every announcement would out-rank the
+        // last and `supersedes` would stop meaning anything.
+        if self.elect_announcer.observe_channel(ch, now) {
+            log::info!(
+                "smol #278: mesh channel decision → ch{} epoch {} (announcing before the move)",
+                ch,
+                self.elect_announcer.epoch()
+            );
+        }
+        // The pre/post BURSTS around an actual retune are fired inline by `reassoc_ch6_prefer`,
+        // which is the only place that knows a move is about to happen and is still reachable on
+        // the old channel. This tick covers the steady state: one repeat per beacon interval, so a
+        // leaf that boots, wakes, or finally lands on the right channel learns the current decision
+        // without waiting for a migration that may never come.
+        if self.elect_announcer.due(now) || self.elect_announcer.beacon_due(now) {
+            self.broadcast_elect();
+        }
+    }
+
+    /// The ordered channel-probe plan a leaf walks to re-find the mesh, seeded from the last
+    /// announcement it accepted.
+    ///
+    /// Single source of truth for BOTH `leaf_scan_tick` (which hops it) and `current_channel`
+    /// (which reports where in it we are). Those two carried separate `[1, 6, 11]` literals joined
+    /// by a `// must match the scan plan above` comment — a prose contract between two constants,
+    /// which is the shape that rots. Now there is one plan and no claim to keep true.
+    fn scan_plan(&self) -> ([u8; mesh_elect::RECOVERY_MAX], usize) {
+        mesh_elect::recovery_ladder(
+            self.elect_follower.decision().channel,
+            mesh_elect::FOLLOW_ENABLED,
+        )
     }
 
     /// #164: advance every peer's link-quality (ETX) register by one HELLO interval. Call once
@@ -3367,6 +3526,35 @@ impl RadioManager {
             | CrownApDecision::OffChannelFallback { bssid, ch } => (Some(bssid), Some(ch)),
             CrownApDecision::NoAp => (None, None),
         };
+        // #278/#269 ANNOUNCE BEFORE THE MOVE. This is the last instant the crown is still reachable
+        // by the fleet it is about to leave: `disconnect_async` is on the next line. 802.11 solves
+        // this with a Channel Switch Announcement in the beacon and ESP-WIFI-MESH propagates CSA
+        // elements the same way; this is that mechanism on an ESP-NOW carrier.
+        //
+        // Inline and blocking, mirroring `run_crown_delegate`'s ODEL burst — the in-repo precedent
+        // for "unacked frames that must not be missed, fired immediately before a disruptive
+        // action". A tick-driven burst cannot work here: the reassociation below is synchronous, so
+        // the main loop will not run again until the move is already over.
+        //
+        // Cost is `ANNOUNCE_BURST × ANNOUNCE_GAP_MS` = 600 ms, on a path that already blocks for a
+        // 16-AP `scan_async` plus a disconnect and a connect. It is NOT gated on FOLLOW_ENABLED:
+        // announcing is safe for a fleet that ignores announcements, and a frame nobody emits
+        // cannot be proven on hardware — which is what #278's flip criterion asks for.
+        if let Some(new_ch) = chan {
+            if self.elect_announcer.decide(new_ch, now_ms()) {
+                log::warn!(
+                    "smol #278: crown moving to ch{} — announcing epoch {} before the switch",
+                    new_ch,
+                    self.elect_announcer.epoch()
+                );
+                while !self.elect_announcer.clear_to_move() {
+                    let t = now_ms();
+                    if self.elect_announcer.due(t) {
+                        self.broadcast_elect();
+                    }
+                }
+            }
+        }
         let _ = block_on(self.controller.disconnect_async());
         // #233: StationConfig has private fields — build via BuilderLite setters. 0.18's
         // with_bssid/with_channel take the INNER value (wrapping in Some), so only call them
@@ -3394,6 +3582,25 @@ impl RadioManager {
             self.my_ap_channel,
             ESP_NOW_FIXED_CHANNEL
         );
+        // #278/#269 ANNOUNCE AFTER THE MOVE, from the new channel, at the SAME epoch.
+        //
+        // Announcing only before would strand anyone who was asleep or parked on another channel;
+        // announcing only after guarantees a window where the crown is deaf to its own fleet. Both,
+        // asymmetric, is the shape ESP-WIFI-MESH ships — and IDF is explicit that even then the
+        // migration is not atomic ("a temporary channel discrepancy"), which is why the
+        // migration-window guard in `note_crown_ap` stays.
+        //
+        // Same epoch on both bursts is stronger than ordering them: a pre-move frame that arrives
+        // late is byte-identical to a post-move one, so there is nothing for it to override.
+        if matches!(self.elect_announcer.phase(), mesh_elect::Phase::Pre) {
+            self.elect_announcer.moved(now_ms());
+            while !self.elect_announcer.settled() {
+                let t = now_ms();
+                if self.elect_announcer.due(t) {
+                    self.broadcast_elect();
+                }
+            }
+        }
         decision
     }
 
@@ -3842,7 +4049,7 @@ impl RadioManager {
         // unless it equals this list exactly. Change the appends and you must change this line —
         // which is the point: the prose above rotted precisely because nothing could test it.
         //
-        // SHED-ORDER: sog, cfgq, cdeaf, cc, ap, cfg, io, deaf, lg_core, lg
+        // SHED-ORDER: sog, cfgq, cdeaf, cc, ap, cfg, io, deaf, elect, lg_core, lg
         let mut shed = 0u8;
         {
             let mut room_for = |rec: &mut alloc::string::String, field: alloc::string::String| {
@@ -3981,6 +4188,44 @@ impl RadioManager {
                 room_for(
                     &mut rec,
                     alloc::format!("|deaf={}|ddrops={}", deaf_n, self.diag.ddrops),
+                );
+            }
+            // #278/#269 ELECT observability — the deliverable of the observe-only landing, and the
+            // only way the canary roll can see it. `ESP_LOG` is baked at build time, so a release
+            // image is serial-SILENT: the `WOULD follow …` line in `service` exists for a debug
+            // build and is invisible on the fleet. If it is not in DIAG, it did not happen.
+            //
+            //   `elect=<epoch>c<ch>n<accepted>m<moves><mode>`   e.g. `elect=3c11n42m1o`
+            //
+            // `mode` is `a` on the announcing crown, `o` observe-only on a leaf, `f` following.
+            // `m` is the number that matters: `n` only proves the 2 s beacon works (a leaf on the
+            // wrong channel hears nothing at all, so in the steady state every leaf is co-channel
+            // and every announcement is a `Confirmed`), whereas `m` counts announcements naming a
+            // DIFFERENT channel — i.e. the crown's PRE-move burst being caught, which is the one
+            // hard part of the design and the thing that must be measured before anything acts.
+            //
+            // Offered BEFORE the ledger, per the instruction that block's comment leaves for
+            // exactly this case: a field added later must justify shedding after the ledger or be
+            // appended before it. During a channel-migration roll this is the most operationally
+            // urgent field in the record and the ledger is explicitly the least, so it goes ahead
+            // of it — and behind every #204/#217 coexist field, which keep their priority.
+            {
+                let (ep, ch, mode) = if self.relay.is_gateway {
+                    (self.elect_announcer.epoch(), self.elect_announcer.channel(), 'a')
+                } else {
+                    let d = self.elect_follower.decision();
+                    (d.epoch, d.channel, if mesh_elect::FOLLOW_ENABLED { 'f' } else { 'o' })
+                };
+                room_for(
+                    &mut rec,
+                    alloc::format!(
+                        "|elect={}c{}n{}m{}{}",
+                        ep,
+                        ch,
+                        self.elect_follower.accepted(),
+                        self.elect_follower.moves(),
+                        mode
+                    ),
                 );
             }
             // ── #181 ledger readout: OFFERED LAST, therefore SHED FIRST. That ordering is a
@@ -4231,13 +4476,21 @@ impl RadioManager {
     /// 0 until the first frame). `0` ⇒ advisory-only: HA/leaves treat the `<ch>` field as absent
     /// and fall back (no roam-flag / HELLO-scan), so this never ships a false positive.
     fn current_channel(&self) -> u8 {
-        const CANDIDATES: [u8; 3] = [1, 6, 11]; // must match the scan plan above
         if self.relay.is_gateway {
             self.learned_channel // #29: real gateway channel from rx_control (0 until learned)
         } else if !self.scan_locked {
             0
         } else {
-            CANDIDATES[self.scan_idx % CANDIDATES.len()]
+            // #278: reads the SAME plan `leaf_scan_tick` hops. This used to be a second `[1, 6, 11]`
+            // literal held in agreement by a `// must match the scan plan above` comment — a prose
+            // contract between two constants, which is the shape that rots. There is now one plan
+            // and nothing to keep true.
+            let (plan, plan_len) = self.scan_plan();
+            if plan_len == 0 {
+                0 // advisory-only field; 0 means "absent" to every consumer
+            } else {
+                plan[self.scan_idx % plan_len]
+            }
         }
     }
 
@@ -6269,6 +6522,62 @@ impl RadioManager {
                     self.ensure_peer(src, now);
                     label = Some(alloc::format!("bench seq {}", seq));
                 }
+                Some(Frame::Elect(f)) => {
+                    // The announcement arrives on the AUTHENTICATED path: `service` verifies and
+                    // strips the #190 group-MAC before `parse_frame` ever sees these bytes, so a
+                    // forged "everybody move to channel N" never reaches this arm.
+                    //
+                    // Treat it as crown liveness too — it is a crown-only frame, so hearing one is
+                    // the same evidence a HELLO is, and a leaf that hears ELECT but is between
+                    // HELLOs should not be re-electing.
+                    self.peers.last_hello_ms = now;
+                    self.roster.heard(src, Some(f.node_id), rssi, now);
+                    // `learned_channel` was set from THIS frame's `rx_control` a few lines above,
+                    // so it is the most accurate answer to "what channel am I on" available here —
+                    // more so than `current_channel`, which reports a leaf's *planned* rung.
+                    let mine = self.learned_channel;
+                    let verdict = self.elect_follower.observe(&f, now, mine);
+                    match verdict {
+                        mesh_elect::Follow::Stale => {
+                            // Not newer. Deliberately silent and deliberately not counted as
+                            // liveness for probation — a replayed old frame must not look like a
+                            // crown that is still talking.
+                        }
+                        mesh_elect::Follow::Confirmed => {
+                            label = Some(alloc::format!("elect e{} ch{}", f.epoch, f.channel));
+                        }
+                        mesh_elect::Follow::Move(ch) => {
+                            // A crown does not follow: it IS the channel authority, and a gateway
+                            // retuning away from its own AP would strand the fleet it is serving.
+                            // An active OTA session holds its channel too — the precedent is
+                            // `leaf_scan_tick`'s `#3b` hold, for the same reason (hopping
+                            // mid-transfer drops chunks).
+                            let may_move = mesh_elect::FOLLOW_ENABLED
+                                && !self.relay.is_gateway
+                                && !self.ota_leaf.is_active();
+                            if may_move {
+                                let _ = self.esp_now.set_channel(ch);
+                                // Re-acquire on the new channel: the owner we were locked to is by
+                                // definition not where we were listening any more.
+                                self.scan_locked = false;
+                                self.last_scan_hop_ms = now;
+                                log::info!(
+                                    "smol #278: following crown id{} to ch{} (epoch {})",
+                                    f.gateway, ch, f.epoch
+                                );
+                            } else {
+                                // The observe-only report. This line IS the deliverable of the
+                                // default-off landing: it says what the board would have done,
+                                // from a real fleet, before any board moves.
+                                log::info!(
+                                    "smol #278: observe-only — WOULD follow crown id{} to ch{} (epoch {}, from ch{})",
+                                    f.gateway, ch, f.epoch, mine
+                                );
+                            }
+                            label = Some(alloc::format!("elect e{} ->ch{}", f.epoch, ch));
+                        }
+                    }
+                }
                 Some(Frame::Time { id, unix, synced_at }) => {
                     // Buffer the FRESHEST offer (highest synced_at) seen since
                     // `main` last took one, so a burst of frames collapses to the
@@ -6944,6 +7253,31 @@ fn encode_time(id: u8, unix: u32, synced_at: u32, out: &mut [u8]) -> usize {
 }
 
 /// Parse an inbound payload into a [`Frame`], or `None` if it isn't ours.
+/// #278/#269 SECURITY BOUNDARY — the one route an ELECT announcement may take to the air.
+///
+/// A leaf cannot verify a channel announcement before acting on it: `coex_background_scan` is
+/// hardcoded `false` in esp-radio 0.18, so peeking at another channel costs the very association it
+/// would need if the announcement turned out to be a lie. It must TRUST the frame. That makes an
+/// unauthenticated ELECT a remote fleet-stranding primitive — "everybody move to channel N", with no
+/// cheap way for a leaf to detect it — so #190's group-MAC trailer is not a bonus here, it is the
+/// thing that makes trusting the frame safe.
+///
+/// [`Self::send_to`] is the choke that appends that trailer (`should_group_mac` admits any
+/// non-OTA-family `SMOLv1 ` frame that fits the MTU, and `SMOLv1 ELECT ` is 61 B + 9 B = 70 B).
+/// `send_arb_raw` deliberately does NOT append it — correct for the #237 OTA arbitration frames it
+/// exists for, catastrophic for this one.
+///
+/// ⚠️ THE REGRESSION THIS INVITES, named so it is not discovered later: this body is one line, and
+/// the one-line edit that breaks the fleet ("just use the other sender") compiles clean, passes every
+/// test, and looks like a simplification. `tools/check_elect_send_path.py` reads this impl and fails
+/// if it names any sender but `send_to`, or if a second implementation appears. Do not delete that
+/// check because this comment exists — the comment is what failed last time.
+impl mesh_elect::GroupMacSink for RadioManager {
+    fn send_group_mac(&mut self, dst: &[u8; 6], frame: &[u8]) {
+        self.send_to(dst, frame);
+    }
+}
+
 fn parse_frame(data: &[u8]) -> Option<Frame<'_>> {
     // MMO-snake frames are the hot path in the game; try them first. `parse_snk`
     // validates prefix/length/ver itself and degrades on unknown ver.
@@ -7048,6 +7382,14 @@ fn parse_frame(data: &[u8]) -> Option<Frame<'_>> {
         // record (to end-of-frame; empty = none). Twin of the DIAG arm.
         let src = parse_id(rest)?;
         return Some(Frame::Scan { src, value: &rest[3..] });
+    }
+    // #278/#269: the crown's channel announcement. `mesh_elect::wire::parse` owns the whole
+    // decode — exact length, every field digit-checked, channel range-checked at the boundary —
+    // because this frame is the one that can RETUNE a leaf's radio, and a leaf cannot verify an
+    // announcement before acting on it. Deliberately last: it is the rarest frame (one crown, one
+    // per beacon interval) and every arm above is a cheaper prefix match.
+    if let Some(f) = mesh_elect::wire::parse(data) {
+        return Some(Frame::Elect(f));
     }
     None
 }

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -4209,6 +4209,19 @@ impl RadioManager {
             // appended before it. During a channel-migration roll this is the most operationally
             // urgent field in the record and the ledger is explicitly the least, so it goes ahead
             // of it — and behind every #204/#217 coexist field, which keep their priority.
+            //
+            // ⚠️ THIS FIELD CAN VANISH SILENTLY, and here the ambiguity is INVERTED — which is worse
+            // than the #183 ledger case and is the reason it is spelled out separately. A missing
+            // `lgt=` merely means "provenance unavailable". A missing `elect=` reads to a canary
+            // watcher as "this board never heard the crown" — the exact opposite of the truth,
+            // because absence means the record was over budget and this field was shed, NOT that
+            // `n` is 0. The two states are indistinguishable from the field alone.
+            //
+            // Read `|shed=<n>`: present ⇒ n field(s) were dropped for budget and this was among the
+            // first in line; absent ⇒ nothing was shed and `elect=`'s absence would be a genuine
+            // bug. Never conclude "the announcement path is dead" from a missing key — that is a
+            // conclusion the record cannot support, and on a roll it is the conclusion that would
+            // stop a good migration.
             {
                 let (ep, ch, mode) = if self.relay.is_gateway {
                     (self.elect_announcer.epoch(), self.elect_announcer.channel(), 'a')

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2168,7 +2168,7 @@ pub struct RadioManager {
     elect_announcer: mesh_elect::Announcer,
     /// #278/#269 LEAF half: the best channel decision heard so far, plus its freshness.
     ///
-    /// Maintained REGARDLESS of `mesh_elect::FOLLOW_ENABLED` — observing and acting are separate,
+    /// Maintained REGARDLESS of `crate::net::election::FOLLOW_ENABLED` — observing and acting are separate,
     /// and observing is the whole value of the observe-only landing: the fleet reports what it
     /// *would* have done, against a real crown, before anything moves.
     elect_follower: mesh_elect::Follower,
@@ -3001,7 +3001,7 @@ impl RadioManager {
     /// early-returns on the first line).
     ///
     /// Announcing is ON by default; only *acting* on an announcement is behind
-    /// `mesh_elect::FOLLOW_ENABLED`. That asymmetry is the point of the observe-only landing — a
+    /// `crate::net::election::FOLLOW_ENABLED`. That asymmetry is the point of the observe-only landing — a
     /// frame nobody emits cannot be proven on hardware, and #278's flip criterion is evidence from
     /// a real fleet, not a code review.
     pub fn elect_tick(&mut self, now: u64) {
@@ -3040,7 +3040,7 @@ impl RadioManager {
     fn scan_plan(&self) -> ([u8; mesh_elect::RECOVERY_MAX], usize) {
         mesh_elect::recovery_ladder(
             self.elect_follower.decision().channel,
-            mesh_elect::FOLLOW_ENABLED,
+            crate::net::election::FOLLOW_ENABLED,
         )
     }
 
@@ -4214,7 +4214,7 @@ impl RadioManager {
                     (self.elect_announcer.epoch(), self.elect_announcer.channel(), 'a')
                 } else {
                     let d = self.elect_follower.decision();
-                    (d.epoch, d.channel, if mesh_elect::FOLLOW_ENABLED { 'f' } else { 'o' })
+                    (d.epoch, d.channel, if crate::net::election::FOLLOW_ENABLED { 'f' } else { 'o' })
                 };
                 room_for(
                     &mut rec,
@@ -6568,7 +6568,7 @@ impl RadioManager {
                             // An active OTA session holds its channel too — the precedent is
                             // `leaf_scan_tick`'s `#3b` hold, for the same reason (hopping
                             // mid-transfer drops chunks).
-                            let may_move = mesh_elect::FOLLOW_ENABLED
+                            let may_move = crate::net::election::FOLLOW_ENABLED
                                 && !self.relay.is_gateway
                                 && !self.ota_leaf.is_active();
                             if may_move {

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -6239,6 +6239,22 @@ impl RadioManager {
     /// Low-level send helper: fire one frame and wait for the TX callback so we
     /// don't overrun the single in-flight ESP-NOW send slot.
     ///
+    /// RAW-SEND-SITES: send_to:1, send_arb_raw:1, run_leaf_ota_relay:3
+    ///
+    /// Every function permitted to call `esp_now.send` directly, with its call COUNT, checked in
+    /// both directions by `tools/check_elect_send_path.py`. Counts and not just names, because
+    /// adding a fourth send inside `run_leaf_ota_relay` would otherwise slip through a name-only
+    /// allowlist — and an already-listed function is exactly where a new send is easiest to add.
+    ///
+    /// Why the list is short and must stay short: this method is the choke that appends #190's
+    /// group-MAC trailer, so every entry here is, by construction, a way for a frame to reach the
+    /// air UNAUTHENTICATED. That is correct and deliberate for the OTA family (`send_arb_raw`'s
+    /// ODEL/ODON and `run_leaf_ota_relay`'s OTAM broadcasts are consumed before the RX
+    /// verify-then-strip, so a trailer would corrupt them, and they carry their own ed25519
+    /// signature instead). It would be catastrophic for `SMOLv1 ELECT `, which a leaf cannot
+    /// verify before acting on. A new entry is therefore a security decision and belongs in a
+    /// diff, not in someone's afternoon.
+    ///
     /// #190 (Fork B / B1): this is the SINGLE TX choke every `broadcast_*`/relay helper funnels
     /// through, so the group-MAC auth trailer is appended HERE — once — for every SMOLv1 frame.
     /// The gate `starts_with(b"SMOLv1 ")` is load-bearing: `send_to` ALSO carries the #25 WLED

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -259,7 +259,9 @@ impl MeshElect {
             // best-gateway is ON by default (team-lead 2026-07-20); the retained smol/mesh/elect topic
             // re-weights or selects `legacy`. Absent/empty/garbage config keeps THIS default.
             elect_cfg: crate::net::election::ElectConfig::BestGateway(
-                crate::net::election::MetricWeights::DEFAULT,
+                crate::net::election::MetricWeights::default_for(
+                    crate::net::election::FOLLOW_ENABLED,
+                ),
             ),
             i_am_owner: false,
             owner_id: my_id,
@@ -3509,7 +3511,10 @@ fn mqtt_session(
                         // election record. Empty/garbage → BestGateway(DEFAULT) (on-by-default);
                         // `legacy` → the escape hatch. The recovery-backoff + empty-MC-deferral arms
                         // dispatch on it. Consumed in THIS burst (no CFG-relay round-trip).
-                        elect.elect_cfg = crate::net::election::parse_elect_config(payload);
+                        elect.elect_cfg = crate::net::election::parse_elect_config(
+                            payload,
+                            crate::net::election::FOLLOW_ENABLED,
+                        );
                         match elect.elect_cfg {
                             crate::net::election::ElectConfig::Legacy => {
                                 log::info!("smol: #gateway-election metric = LEGACY (lowest-id, retained)")

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -165,25 +165,11 @@ hostsim  = "host-only, and covered by the `cargo test` arm in tools/gate.sh"
 # observed fails the gate, because a reason that has quietly stopped applying reads as a
 # considered decision and is worse than no entry.
 [unobservable]
-# ⚠️ TEMPORARY — stage 2 of #278 MUST delete this entry, and the gate is what will notice.
-# `net/mesh_elect.rs` is the ELECT frame + epoch/anti-flap core, ported ahead of its wiring so it
-# could be reviewed on its own. Nothing calls it yet (it carries a matching dated
-# `#[allow(dead_code)]` at its `pub mod` declaration), so the linker strips it and it emits no
-# observable code in ANY tier — which is exactly what this gate flagged: its absence from the
-# non-espnow tiers proves nothing while it is absent from espnow too.
-#
-# This is the `crdt.rs` shape (#371) caught BEFORE it landed rather than by a later audit, and the
-# reason the check works is that it reads SOURCE STRUCTURE: a symbol-absence check has nothing to
-# complain about in a module that emits no symbols.
-#
-# When stage 2 adds the `Frame::Elect` dispatch arm and the announce/honour paths, the module
-# starts emitting code, this claim becomes false, and the gate fails until the entry is removed.
-# That is the intended sequence — do not pre-emptively delete it, and do not let it survive.
-"src/net/mesh_elect.rs" = """\
-unwired pending stage 2 of #278 — declared and cfg-gated on espnow, but no caller exists yet, so \
-it contributes no executable code to any tier and its exclusion elsewhere is unprovable. Paired \
-with the dated `#[allow(dead_code)]` on `pub mod mesh_elect;` in net.rs; BOTH must be deleted by \
-the PR that wires it, and both fail loudly if they are not."""
+# (`src/net/mesh_elect.rs` was here through stage 1 of #278 and is deliberately gone. Stage 2 added
+# the `Frame::Elect` dispatch arm and the announce/follow paths, so the module now emits observable
+# code in the espnow tier and the entry's claim became FALSE — the gate failed on it, which is the
+# designed sequence working. Removed together with the paired `#[allow(dead_code)]` in net.rs; the
+# two-sided marker is why neither could be dropped quietly.)
 
 "src/secrets.rs" = """\
 consts only (WIFI_NETWORK / MQTT_* / WLED_CAST_*) — 0 fn / 0 impl in both secrets.rs and \

--- a/tools/check_elect_send_path.py
+++ b/tools/check_elect_send_path.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""#278/#269: prove the ELECT announcement can only reach the air AUTHENTICATED.
+
+Why this exists, and why a comment was not enough.
+
+A leaf cannot verify a channel-change announcement before acting on it. esp-radio 0.18 hardcodes
+`coex_background_scan: false`, so a scan DROPS the association — checking an announcement costs the
+leaf the very association it would need if the announcement were false. It has to trust the frame.
+That makes an unauthenticated `SMOLv1 ELECT` a remote fleet-stranding primitive: broadcast
+"everybody move to channel N" and the fleet goes, with no cheap way for any leaf to detect the lie.
+
+#190's group-MAC trailer closes it, but ONLY on the `send_to` path. `send_arb_raw` deliberately does
+not append the trailer (correct for the #237 OTA arbitration frames it exists for), so routing ELECT
+that way silently converts a safe channel hop into a remote fleet partition. Stage 1 wrote that down
+as a DESIGN INVARIANT in prose, and prose would have survived any refactor that violated it.
+
+So the invariant is structural first — `SealedElect` has no byte accessor and can only be handed to
+a `GroupMacSink` — and this script covers the shapes the type system cannot see. Each arm exists
+because it was ENUMERATED as a way to satisfy the types and still ship the bug:
+
+  1. impl-body      the one-line `GroupMacSink` body is rewritten to another sender. THE likeliest
+                    shape: a one-line edit, in the direction of "make it compile", that looks like a
+                    simplification and passes every test.
+  2. impl-count     a SECOND `GroupMacSink` impl appears that sends raw.
+  3. no-accessor    `SealedElect` grows an `as_bytes`/`pub` field, and the seal stops sealing.
+  4. one-encoder    `wire::encode` is called somewhere other than `SealedElect::seal`, so a caller
+                    gets the frame bytes without ever touching the seal.
+  5. no-hand-build  the `SMOLv1 ELECT ` literal is written a second time, building the frame by hand
+                    and bypassing the encoder entirely (which arm 4 would not see).
+  6. raw-sends      a new raw `esp_now.send` call site appears. Declared IN THE SOURCE, checked in
+                    BOTH directions with counts, so adding a send to an already-listed function
+                    fails too.
+
+It deliberately does NOT check that `send_to` appends the trailer — that is `should_group_mac`, and
+it is pinned by an ELECT case in `experiments/mac_verify` where the decision is pure and host-tested.
+Two mechanisms, two places, neither able to silence the other.
+
+Every arm FAILS CLOSED: if an anchor cannot be found, this exits 2 rather than passing. A check that
+quietly stops covering anything is how the prose rotted in the first place.
+
+Usage: tools/check_elect_send_path.py [repo-root]   (exit 0 ok, 1 violation, 2 malformed)
+"""
+import re
+import sys
+from pathlib import Path
+
+# The frame's own prefix, spelled here so a rename of the const cannot silently empty arm 5.
+ELECT_LITERAL = 'b"SMOLv1 ELECT "'
+SINK_TRAIT = "GroupMacSink"
+# Senders that must NEVER appear in the sink impl. `send_to` is the required one and is handled
+# separately — this is the deny-list of everything that skips the trailer.
+FORBIDDEN_SENDERS = ("send_arb_raw", "esp_now.send", "esp_now .send")
+DECL = re.compile(r"RAW-SEND-SITES:\s*([A-Za-z0-9_:,\s]+?)\s*(?:\*/|\n|$)")
+
+
+def fail(msg, *extra):
+    print(f"FATAL: {msg}", file=sys.stderr)
+    for line in extra:
+        print(f"  {line}", file=sys.stderr)
+
+
+def rust_sources(src: Path):
+    return sorted(p for p in src.rglob("*.rs") if p.is_file())
+
+
+def enclosing_fn(text: str, idx: int):
+    """Name of the nearest `fn` declared at or above `idx`. None if there isn't one."""
+    best = None
+    for m in re.finditer(r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(?:const\s+)?fn\s+(\w+)", text[:idx], re.M):
+        best = m.group(1)
+    return best
+
+
+def block_after(text: str, start: int):
+    """The brace-balanced block that opens at or after `start`. None if unbalanced."""
+    open_at = text.find("{", start)
+    if open_at < 0:
+        return None
+    depth = 0
+    for i in range(open_at, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_at : i + 1]
+    return None
+
+
+def main() -> int:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+    src = root / "rust" / "clock" / "src"
+    if not src.is_dir():
+        fail(f"no firmware source tree at {src}")
+        return 2
+    files = {p: p.read_text(encoding="utf-8") for p in rust_sources(src)}
+    if not files:
+        fail(f"parsed ZERO rust sources under {src}")
+        return 2
+
+    bad = []
+    notes = []
+
+    # ── arms 1 + 2: the sink impl(s) ──────────────────────────────────────────────────────────
+    impls = []
+    for path, text in files.items():
+        for m in re.finditer(rf"impl\s+(?:[\w:]+::)?{SINK_TRAIT}\s+for\s+(\w+)", text):
+            body = block_after(text, m.end())
+            if body is None:
+                fail(f"unbalanced braces after the {SINK_TRAIT} impl in {path.relative_to(root)}")
+                return 2
+            impls.append((path, m.group(1), body))
+
+    if not impls:
+        fail(
+            f"no `impl {SINK_TRAIT} for …` found anywhere in {src.relative_to(root)}.",
+            "The ELECT send path is gone or was renamed. This check cannot prove an absent",
+            "invariant, so it refuses to pass — see this script's docstring.",
+        )
+        return 2
+    if len(impls) > 1:
+        where = ", ".join(f"{p.relative_to(root)}:{t}" for p, t, _ in impls)
+        bad.append(
+            f"arm 2 (impl-count): {len(impls)} `{SINK_TRAIT}` implementations ({where}). "
+            "Exactly one may exist — a second is a second send path, which is the whole thing "
+            "this invariant forbids."
+        )
+
+    for path, target, body in impls:
+        rel = path.relative_to(root)
+        if "send_to" not in body:
+            bad.append(
+                f"arm 1 (impl-body): `{SINK_TRAIT} for {target}` ({rel}) does NOT route to "
+                "`send_to`. That is the ONLY path appending #190's group-MAC trailer; anything "
+                "else emits an unauthenticated ELECT, which is a remote fleet-stranding primitive."
+            )
+        for s in FORBIDDEN_SENDERS:
+            if s in body:
+                bad.append(
+                    f"arm 1 (impl-body): `{SINK_TRAIT} for {target}` ({rel}) names `{s}`, which "
+                    "does not append the group-MAC trailer."
+                )
+    if not bad:
+        notes.append(f"1 `{SINK_TRAIT}` impl, routed through send_to")
+
+    # ── arm 3: SealedElect exposes no way to get at the bytes ─────────────────────────────────
+    sealed_impls = 0
+    for path, text in files.items():
+        for m in re.finditer(r"impl\s+SealedElect\s*\{", text):
+            sealed_impls += 1
+            body = block_after(text, m.end() - 1)
+            if body is None:
+                fail(f"unbalanced braces in `impl SealedElect` ({path.relative_to(root)})")
+                return 2
+            for fm in re.finditer(r"pub\s+(?:const\s+)?fn\s+(\w+)\s*\([^)]*\)\s*->\s*([^{;]+)", body):
+                name, ret = fm.group(1), fm.group(2).strip()
+                leaks = "[u8" in ret or "&[u8]" in ret or "str" in ret
+                if leaks:
+                    bad.append(
+                        f"arm 3 (no-accessor): `SealedElect::{name}` returns `{ret}` — the sealed "
+                        "bytes must have NO accessor, or the seal is decoration and any sender "
+                        "can be handed the frame."
+                    )
+        for sm in re.finditer(r"pub\s+struct\s+SealedElect\s*\{([^}]*)\}", text):
+            if re.search(r"\bpub\s+\w+\s*:", sm.group(1)):
+                bad.append(
+                    "arm 3 (no-accessor): `SealedElect` has a PUBLIC field — the buffer must be "
+                    "private."
+                )
+    if sealed_impls == 0:
+        fail("no `impl SealedElect` found — the sealed-frame type is gone or renamed.")
+        return 2
+
+    # ── arm 4: exactly one firmware call site of the encoder, and it is the seal ───────────────
+    encode_sites = []
+    for path, text in files.items():
+        for m in re.finditer(r"\bwire::encode\s*\(|(?<![\w:])encode\s*\(\s*f\s*,", text):
+            fn = enclosing_fn(text, m.start())
+            encode_sites.append((path.relative_to(root), fn))
+    if not encode_sites:
+        fail(
+            "found ZERO call sites of the ELECT encoder.",
+            "Either it was renamed or the seal no longer encodes — both leave this arm covering",
+            "nothing, so it fails rather than passes.",
+        )
+        return 2
+    stray = [(p, fn) for p, fn in encode_sites if fn != "seal"]
+    if stray:
+        where = ", ".join(f"{p}:{fn}" for p, fn in stray)
+        bad.append(
+            f"arm 4 (one-encoder): the ELECT encoder is called outside `SealedElect::seal` "
+            f"({where}). A caller that encodes for itself holds raw frame bytes and can send them "
+            "down any path."
+        )
+    else:
+        notes.append(f"{len(encode_sites)} encoder call site(s), all in SealedElect::seal")
+
+    # ── arm 5: the frame prefix is written exactly once ───────────────────────────────────────
+    literal_sites = []
+    for path, text in files.items():
+        for m in re.finditer(re.escape(ELECT_LITERAL), text):
+            literal_sites.append((path.relative_to(root), text.count("\n", 0, m.start()) + 1))
+    if not literal_sites:
+        fail(
+            f"the literal {ELECT_LITERAL} appears NOWHERE.",
+            "The frame prefix was changed or moved; this arm can no longer detect a hand-built",
+            "frame, so it refuses to pass.",
+        )
+        return 2
+    if len(literal_sites) > 1:
+        where = ", ".join(f"{p}:{ln}" for p, ln in literal_sites)
+        bad.append(
+            f"arm 5 (no-hand-build): {ELECT_LITERAL} is written {len(literal_sites)} times "
+            f"({where}). A second spelling means a frame built by hand, which never touches the "
+            "encoder and so is invisible to arm 4."
+        )
+
+    # ── arm 6: every raw esp_now.send site is declared, with its count ─────────────────────────
+    decl_text = None
+    for text in files.values():
+        m = DECL.search(text)
+        if m:
+            decl_text = m.group(1)
+            break
+    if decl_text is None:
+        fail(
+            "no `RAW-SEND-SITES:` declaration found in the firmware source.",
+            "The allowlist of functions permitted to call `esp_now.send` directly must live where",
+            "a machine can check it — see this script's docstring.",
+        )
+        return 2
+    declared = {}
+    for tok in re.split(r"[,\s]+", decl_text):
+        if not tok:
+            continue
+        name, _, count = tok.partition(":")
+        if not count.isdigit():
+            fail(f"malformed RAW-SEND-SITES entry {tok!r} — expected `fn_name:count`.")
+            return 2
+        declared[name] = int(count)
+
+    actual = {}
+    for path, text in files.items():
+        for m in re.finditer(r"esp_now\s*\.\s*send\s*\(", text):
+            fn = enclosing_fn(text, m.start())
+            if fn is None:
+                fail(f"an `esp_now.send` in {path.relative_to(root)} is not inside any fn")
+                return 2
+            actual[fn] = actual.get(fn, 0) + 1
+    if not actual:
+        fail(
+            "found ZERO raw `esp_now.send` call sites — including the `send_to` choke itself.",
+            "That cannot be right; the pattern must have changed, so this arm is blind.",
+        )
+        return 2
+    if actual != declared:
+        added = {k: v for k, v in actual.items() if declared.get(k) != v}
+        gone = {k: v for k, v in declared.items() if k not in actual}
+        if added:
+            bad.append(
+                "arm 6 (raw-sends): undeclared or miscounted raw send sites: "
+                + ", ".join(f"{k}×{v} (declared {declared.get(k, 0)})" for k, v in sorted(added.items()))
+                + ". Every function that bypasses `send_to` must be declared, because every one of "
+                "them is a path an ELECT frame could take unauthenticated."
+            )
+        if gone:
+            bad.append(
+                "arm 6 (raw-sends): declared but ABSENT: "
+                + ", ".join(f"{k}×{v}" for k, v in sorted(gone.items()))
+                + ". A stale allowlist entry reads as a considered decision and is worse than none."
+            )
+    else:
+        total = sum(actual.values())
+        notes.append(f"{total} raw send sites across {len(actual)} declared fns")
+
+    if bad:
+        print("FATAL: the ELECT send-path invariant is violated.", file=sys.stderr)
+        for b in bad:
+            print(f"  - {b}", file=sys.stderr)
+        print(
+            "  A leaf cannot verify an announcement before acting on it (a scan drops the "
+            "association),\n  so an unauthenticated ELECT strands the fleet. See "
+            "net/mesh_elect.rs's security section.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("  elect send path: " + "; ".join(notes))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -162,6 +162,21 @@ if [ "$run_fw" = 1 ]; then
     printf '%s\n' "$out"; bad "verifier wiring"
   fi
 
+  # #278/#269: the `SMOLv1 ELECT` frame can RETUNE a leaf's radio, and a leaf cannot verify an
+  # announcement before acting on it — esp-radio 0.18 hardcodes `coex_background_scan: false`, so
+  # checking costs the association it would need if the announcement were false. An unauthenticated
+  # ELECT is therefore a remote fleet-stranding primitive, and #190's group-MAC trailer is appended
+  # only on the `send_to` path. Stage 1 wrote that down as prose. This reads source STRUCTURE
+  # instead: one sink impl, routed to `send_to`; a sealed frame with no byte accessor; one encoder
+  # call site; one spelling of the prefix; and every raw `esp_now.send` declared WITH ITS COUNT.
+  # `tools/test_check_elect_send_path.sh` proves all of those can fail, plus three fail-closed arms.
+  step "ELECT reaches the air only authenticated (#278)"
+  if out=$("$ROOT/tools/check_elect_send_path.py" "$ROOT" 2>&1); then
+    printf '%s\n' "$out"; ok "elect send path"
+  else
+    printf '%s\n' "$out"; bad "elect send path"
+  fi
+
   # #350: cheap and before any compile, because everything below DERIVES from this manifest —
   # a gate that builds the wrong tier list confidently is worse than one that refuses to start.
   # The arms: the canonical tier matches REPRO_FLEET_FEATURES (the packaging path's own
@@ -423,6 +438,19 @@ if [ "$run_host" = 1 ]; then
     printf '%s\n' "$out" | tail -2; ok "test_check_exclusions"
   else
     printf '%s\n' "$out" | sed 's/^/        /'; bad "test_check_exclusions"
+  fi
+
+  # #278: same discipline for the ELECT send-path checker, and for the same reason as #351 —
+  # every one of its arms is an ABSENCE check ("no second impl", "no stray encoder call", "no
+  # undeclared raw send"), and an absence check that has quietly stopped covering anything prints
+  # exactly the green an intact one does. Each arm mutates a COPY of the firmware tree into a shape
+  # that was enumerated as "satisfies the type system and still strands the fleet", and asserts the
+  # checker goes red for the RIGHT REASON. Three further arms delete an anchor and require exit 2.
+  step "ELECT send-path checker regression suite (#278)"
+  if out=$("$ROOT/tools/test_check_elect_send_path.sh" 2>&1); then
+    printf '%s\n' "$out" | tail -2; ok "test_check_elect_send_path"
+  else
+    printf '%s\n' "$out" | sed 's/^/        /'; bad "test_check_elect_send_path"
   fi
 
   # The merge guard's own self-test. One line, and it is the difference between "the guard HAS a

--- a/tools/test_check_elect_send_path.sh
+++ b/tools/test_check_elect_send_path.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# test_check_elect_send_path.sh — proves tools/check_elect_send_path.py can FAIL (#278/#269).
+#
+# The invariant it guards is not a style rule: a leaf CANNOT verify an ELECT announcement before
+# acting on it (a scan drops the association — `coex_background_scan` is hardcoded false), so an
+# unauthenticated ELECT is a remote fleet-stranding primitive. Stage 1 stated that in prose, and
+# prose would have survived any refactor that broke it.
+#
+# Which means a checker that only ever passes is the same failure wearing a green badge. Every arm
+# below MUTATES A COPY of the firmware tree into one of the specific shapes that was enumerated as
+# "satisfies the type system and still ships the bug", and asserts the checker goes red FOR THE
+# RIGHT REASON — not merely red. A clean baseline must stay green.
+#
+# SAFETY, and it is not boilerplate: every arm works on a copy under mktemp. No git command, no
+# write anywhere inside the repo. Two separate incidents in this repo destroyed uncommitted work
+# through a self-test that operated on the real tree; this one cannot, because it never has the
+# real tree's path in a writable position.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHK="$ROOT/tools/check_elect_send_path.py"
+pass=0; fail=0
+ok(){ pass=$((pass+1)); echo "ok   - $1"; }
+no(){ fail=$((fail+1)); echo "FAIL - $1"; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# A pristine copy of just the firmware sources, laid out at the path the checker expects.
+seed() {
+  rm -rf "$work/tree"
+  mkdir -p "$work/tree/rust/clock"
+  cp -r "$ROOT/rust/clock/src" "$work/tree/rust/clock/src"
+}
+
+# arm <name> <want-rc> <want-substring> <file-rel-to-src> <old>TAB<new>
+arm() {
+  local name="$1" want_rc="$2" want="$3" file="$4" spec="$5"
+  seed
+  python3 - "$work/tree/rust/clock/src/$file" "$spec" <<'PY'
+import sys
+path, spec = sys.argv[1], sys.argv[2]
+old, new = spec.split("\t")
+s = open(path).read()
+if old not in s:
+    sys.exit(f"fixture setup failed: {old!r} not found — this test needs updating")
+open(path, "w").write(s.replace(old, new, 1))
+PY
+  if [ $? -ne 0 ]; then no "$name (fixture setup)"; return; fi
+  local out rc
+  out="$("$CHK" "$work/tree" 2>&1)"; rc=$?
+  if [ "$rc" != "$want_rc" ]; then no "$name: rc $rc, want $want_rc — $out"; return; fi
+  case "$out" in *"$want"*) ok "$name (rc=$rc)" ;; *) no "$name: rc right, WRONG REASON — $out" ;; esac
+}
+
+echo "== baseline: the real tree must satisfy the invariant =="
+out="$("$CHK" "$ROOT" 2>&1)"; rc=$?
+if [ "$rc" = 0 ]; then ok "unmodified tree: $out"; else no "unmodified tree FAILS: $out"; fi
+
+echo "== arm 1: the likeliest regression — the sink body re-routed to the raw sender =="
+arm "impl body calls send_arb_raw" 1 "arm 1 (impl-body)" net/mode.rs \
+  "$(printf 'self.send_to(dst, frame);\tself.send_arb_raw(*dst, frame);')"
+
+echo "== arm 1b: routed to a NEW helper, so send_to disappears without send_arb_raw appearing =="
+arm "impl body routes elsewhere" 1 "does NOT route to" net/mode.rs \
+  "$(printf 'self.send_to(dst, frame);\tself.send_elect_someday(dst, frame);')"
+
+echo "== arm 2: a second sink implementation =="
+arm "two sink impls" 1 "arm 2 (impl-count)" net/mode.rs \
+  "$(printf 'impl mesh_elect::GroupMacSink for RadioManager {\timpl mesh_elect::GroupMacSink for PeerTracker {\n    fn send_group_mac(&mut self, _dst: &[u8; 6], _frame: &[u8]) {}\n}\n\nimpl mesh_elect::GroupMacSink for RadioManager {')"
+
+echo "== arm 3: the seal grows a byte accessor, and stops sealing anything =="
+arm "SealedElect leaks its bytes" 1 "arm 3 (no-accessor)" net/mesh_elect.rs \
+  "$(printf '    /// Hand the frame to the authenticated send path. Consumes `self`.\t    pub fn as_bytes(&self) -> &[u8] { &self.buf }\n\n    /// Hand the frame to the authenticated send path. Consumes `self`.')"
+
+echo "== arm 4: the encoder called outside the seal =="
+arm "stray encoder call site" 1 "arm 4 (one-encoder)" net/mode.rs \
+  "$(printf 'let d = self.elect_announcer.decision(self.id);\tlet mut scratch = [0u8; 61];\n        let _ = mesh_elect::wire::encode(&f, &mut scratch);\n        let d = self.elect_announcer.decision(self.id);')"
+
+echo "== arm 5: the frame hand-built from a second copy of the literal =="
+arm "prefix literal written twice" 1 "arm 5 (no-hand-build)" net/mode.rs \
+  "$(printf 'const HELLO_PREFIX: &[u8] = b"SMOLv1 HELLO ";\tconst HELLO_PREFIX: &[u8] = b"SMOLv1 HELLO ";\nconst HAND_BUILT_ELECT: &[u8] = b"SMOLv1 ELECT ";')"
+
+echo "== arm 6: a NEW raw send site appears =="
+arm "undeclared raw send" 1 "arm 6 (raw-sends)" net/mode.rs \
+  "$(printf 'pub fn broadcast_hello(&mut self) {\tpub fn broadcast_hello(&mut self) {\n        let _ = self.esp_now.send(&BROADCAST_ADDRESS, b"x");')"
+
+echo "== arm 6b: an EXTRA send inside an already-declared fn (counts, not just names) =="
+arm "miscounted raw send" 1 "arm 6 (raw-sends)" net/mode.rs \
+  "$(printf 'match self.esp_now.send(dst, out) {\tlet _ = self.esp_now.send(dst, out);\n        match self.esp_now.send(dst, out) {')"
+
+echo "== fail-closed: the anchors going missing must NOT read as success =="
+arm "sink impl deleted" 2 "no \`impl GroupMacSink" net/mode.rs \
+  "$(printf 'impl mesh_elect::GroupMacSink for RadioManager {\timpl DeletedSink for RadioManager {')"
+arm "prefix literal renamed away" 2 "appears NOWHERE" net/mesh_elect.rs \
+  "$(printf 'b"SMOLv1 ELECT "\tb"SMOLv1 ELECTX"')"
+arm "declaration deleted" 2 "no \`RAW-SEND-SITES:\` declaration" net/mode.rs \
+  "$(printf 'RAW-SEND-SITES:\tRAW-SEND-SITES-WAS-HERE:')"
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Stage 2 of #278, completing the ELECT announcement path, and the #269 `co_channel` re-scale that is structurally coupled to it. Stage 1 (the frame + its cross-repo test contract) landed in #378.

**Landing posture is OBSERVE-ONLY.** Announcing is on by default; *acting* on an announcement is behind `election::FOLLOW_ENABLED = false`. A leaf parses, epoch-orders and **reports** every announcement regardless. That mirrors the hold the watch is keeping, and it is what makes this issue's flip criterion answerable — #278 gates the watch's `ELECT_ENFORCE` on the smol roll showing one clean migration, which is evidence from a fleet rather than a code review.

With the flag off, nothing a fleet can observe changes except the new beacon: the recovery ladder returns `[1, 6, 11]` byte-for-byte (asserted, not claimed), leaves never retune, and `co_channel: 100` dominance stands.

## The four commits

**1. `324f9f1` — the announcement path.** `Frame::Elect` dispatch delegating the whole decode to `mesh_elect::wire::parse`. `Announcer` announces **before and after** a move at the same epoch (CSA's shape; same-epoch is stronger than ordering the two, since a late pre-move frame is then byte-identical to a post-move one and has nothing to override). The bursts fire inline from `reassoc_ch6_prefer` — the only place that knows a move is imminent and is still reachable on the old channel; a tick-driven burst cannot work there because the reassociation is synchronous. `Follower` uses `supersedes` verbatim, and a replay is inert **and** does not reset probation. Ranked recovery ladder — last-known, rendezvous, common APs, then the rest of the band — which also let me delete both `[1, 6, 11]` literals and the `// must match the scan plan above` prose contract joining them.

**2. `86d7758` — the send-path invariant, machine-checked.** See below.

**3. + 4. `65066cf` — the re-scale and the lever clamp.** See below.

## The security invariant

A leaf **cannot verify a channel announcement before acting on it**: esp-radio 0.18 hardcodes `coex_background_scan: false`, so a scan drops the association and checking costs the leaf the very thing it would need if the announcement were false. It must trust the frame. An unauthenticated ELECT is therefore a remote *"everybody move to channel N"* fleet-stranding primitive, and #190's group-MAC trailer is appended only on the `send_to` path.

Stage 1 wrote that down as prose. It is now enforced two ways:

- **Structurally** — `SealedElect` has private bytes and no accessor, so the only thing you can do with an encoded frame is hand it to a `GroupMacSink`, whose one impl routes to `send_to`.
- **`tools/check_elect_send_path.py`** — six arms, each one *enumerated* as a way to satisfy the type system and still ship the bug: impl-body (the likeliest by a distance — that one-line sink body rewritten to `send_arb_raw`), impl-count, no-accessor, one-encoder, no-hand-build, and raw-sends declared in-source **with counts** (a name-only allowlist would miss a fourth send added inside `run_leaf_ota_relay`, which is exactly where a new one is easiest to add).

All 12 harness arms were watched go red before the check was trusted, three of them fail-closed at exit 2. The one shape the checker structurally cannot see — `should_group_mac` changing so ELECT stops being MAC'd — is pinned separately in `mac_verify` at the real 61 B length. Two mechanisms, neither able to silence the other.

## The re-scale, and why it could not ship alone

`co_channel: 100` is the #217 rung-3 / id5 disease fix. `election_verify` refused the re-scale on its own — its `co-channel id9 must claim before off-channel id3` case fails — and the test is right: re-scaling before leaves can follow re-arms exactly the disease #217 fixed. So the coupling is a **signature**, not a comment: `MetricWeights::default_for(follow)` returns `DOMINANT` or `FOLLOWING`, and there is no way to obtain weights without stating which world you are in. `MetricWeights::DEFAULT` is deleted rather than aliased, so no call site can silently pick one.

The margin (10) is one RSSI bucket = the jitter amplitude at the −65/−78 boundaries: a one-bucket challenger ties, two buckets win. batman-adv's `gw_sel_class` sits beside it as a **calibrated divergence** — ~8% of its range vs our ~31%, ~4× stickier, because a batman gateway switch makes clients re-pick while a smol channel migration makes every leaf follow or strand. No claim is made about how batman arrived at 20; there is no source, and a wrong reason under a right conclusion is the most durable error. The tempting `10/122 = 8.2%` match is recorded as the unit error it is — 122 is the pre-re-scale max, which still contains the 100 being removed. Post-re-scale the max is 32.

⚠️ **The re-scale changes the mechanism, not only the number**, and the comment says so. The veto worked by *backoff tier*: `max_fitness` 122 over 2 tiers means one tier spans ~61 points, so 100 guaranteed separation. At 10, one tier is ~16 points and a 10-point margin is **sub-tier** — the id5 case then resolves on the `node_id·200 ms` tiebreak. So `co_channel` is now a preference, and the anti-flap for a channel migration lives where it belongs, in `mesh_elect`'s `SETTLE_MS`/`margin_for`. Claiming otherwise would be a comment describing behaviour the binary lacks.

That is also how the id5 case passes in **both** flag states, which the numeric assertion cannot: the bug is "an off-channel crown strands a fleet that *cannot follow it*", and inability to follow is precisely what the flag names — so `off_channel_crown_can_strand(w, follow)` is false either way, by the veto with following off and by the follow path with it on.

## The runtime lever

The retained `smol/mesh/elect` topic is a **second writer** of these weights and can re-arm the disease with no code change — `c10r10` does it. A `const` assert binds the compile-time writer and says nothing about this one. While following is off, `parse_elect_config` clamps `c` up to a dominance floor derived from the **parsed** weights, never a literal (the lever writes `r` and `u` too, so a hardcoded 22 would be silently invalidated by a later `r` bump). `r`/`u` cap at 63 first — derived as the largest weight for which the floor `2r + 2u + 1` still fits a `u8` — because `c255r200` otherwise asks for a weighting where no legal `co_channel` dominates, and the clamp would look enforced while being unenforceable.

Result: a property over **every** payload rather than the ones I thought of, asserted across a 288-payload sweep. Verified it can fail — neutering the clamp on a copy of the tree panics on the first case. The readback already prints the weights this returns, so an operator publishing `c10r10` reads back the clamped values (the same `n0` rule: a readback reports what was applied, never what was sent). The topic was confirmed **empty** on the live broker at 2026-08-02 ~01:57 PDT, so this was real-but-unarmed.

## Scope I added beyond the brief, flagged rather than buried

- **A DIAG field**, `|elect=<epoch>c<ch>n<heard>m<moves><mode>`. `ESP_LOG` is baked at build time, so a release image is serial-silent and the `WOULD follow` log line is invisible on the fleet — without DIAG the observe-only landing is unobservable, which is the defect shape this repo keeps catching. Appended before the ledger, which is what that block's own comment instructs for a new field; `SHED-ORDER` updated. **`m` is the number the roll should read**: `n` only proves the 2 s beacon works, because a leaf on the wrong channel hears nothing at all, whereas `m` counts the crown's *pre-move* burst being caught — the one genuinely hard part of the design.
- **`FOLLOW_ENABLED` lives in `election`, not `mesh_elect`.** `mesh_elect` is espnow-gated, `election` is wifi-gated, and espnow implies wifi — a flag declared in `mesh_elect` is invisible to the config parser on a wifi-only build. Beside the weights it selects is also where the coupling is hardest to miss.
- **A plain `const`, not a Cargo feature** — a default-off feature adds a build-matrix axis and an exclusions surface, and the shipped image would then not *contain* the follow path, so the canary roll could not exercise what it exists to prove.

## Two stage-1 claims corrected rather than inherited

1. The header listed `MARGIN_FLOOR`/`margin_for`/`OBS_STALE_MS` as wired anti-flap. They operate on a summed weight across peer observations — the tally machinery deliberately cut with the `Elector` — so they **cannot** be. Now stated, with item-scoped allows.
2. The ladder was costed at 10–20 ms per rung and 130–260 ms per sweep. Those are `scan_async` dwell times; smol does not scan here, it retunes the PHY and listens for `DWELL_MS` (1500 ms), ~100× off. Re-derived at `recovery_ladder`, and the wrong numbers **removed** from the header rather than left standing beside the right ones.

## Verification

- **Gate GREEN, 56 passes.** Stack **106,472 B** vs the 74,208 floor (unmoved — the Elector cut means its 232 B never instantiates, and the added `Announcer`/`Follower` state is small).
- `mesh_elect_verify` 23 checks (2 consensus + 8 wire + 13 new); `election_verify` extended with the both-states id5 invariant, the one-bucket margin, and the 288-payload sweep; `mac_verify` gains the ELECT case.
- Every new check demonstrated red before being trusted, including the pre-existing two-sided rot-marker: re-adding the `[unobservable]` entry produced `FAIL [unobservable] names src/net/mesh_elect.rs, but it WAS observed`.

**Not in scope:** the watch's `ELECT_ENFORCE` flip (#278's closing checklist item, JP-timed), and the crown-side "move the mesh channel to the crown's AP" behaviour itself — nothing moves the channel yet, so the pre/post burst machinery is wired and host-tested but has not been exercised by a real migration on hardware. That is what the roll is for.
