### PR TITLE
feat(fw): #335 Phase 1 — executor beside the superloop (P1.0–P1.3) [HW-CANARY-HELD]

### DIFF
--- a/rust/clock/Cargo.lock
+++ b/rust/clock/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +98,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,7 +118,11 @@ name = "clock"
 version = "0.1.0"
 dependencies = [
  "ed25519-compact",
+ "embassy-executor",
  "embassy-futures",
+ "embassy-net",
+ "embassy-sync 0.7.2",
+ "embassy-time",
  "embedded-graphics",
  "embedded-storage",
  "esp-alloc",
@@ -114,10 +137,12 @@ dependencies = [
  "libm",
  "log",
  "nb 1.1.0",
+ "portable-atomic",
  "sha2",
  "sigil-names",
  "smoltcp",
  "ssd1306",
+ "static_cell",
 ]
 
 [[package]]
@@ -125,6 +150,16 @@ name = "const-default"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
+
+[[package]]
+name = "cordyceps"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9ab7e0ca1d179628fa0172b2b97203c7fa0cd81be2448bd446fb9559ca9261"
+dependencies = [
+ "loom",
+ "tracing",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -162,6 +197,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
@@ -178,6 +223,20 @@ checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core 0.23.0",
  "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -203,6 +262,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -372,6 +442,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-executor"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0d3b15c9d7dc4fec1d8cb77112472fb008b3b28c51ad23838d83587a6d2f1e"
+dependencies = [
+ "cordyceps",
+ "critical-section",
+ "document-features",
+ "embassy-executor-macros",
+ "embassy-executor-timer-queue",
+]
+
+[[package]]
+name = "embassy-executor-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d11a246f53de5f97a387f40ac24726817cd0b6f833e7603baac784f29d6ff276"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "embassy-executor-timer-queue"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc328bf943af66b80b98755db9106bf7e7471b0cf47dc8559cd9a6be504cc9c"
+
+[[package]]
 name = "embassy-futures"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +485,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f10ce10a4dfdf6402d8e9bd63128986b96a736b1a0a6680547ed2ac55d55dba"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "embassy-net"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "347bc855bdbdf50ed9c5a1d80e8204badb0ba149b8732dde38e1e9708ed9d313"
+dependencies = [
+ "document-features",
+ "embassy-net-driver",
+ "embassy-sync 0.8.0",
+ "embassy-time",
+ "embedded-io-async 0.7.0",
+ "embedded-nal-async",
+ "heapless 0.9.3",
+ "log",
+ "managed",
+ "smoltcp",
 ]
 
 [[package]]
@@ -448,6 +567,7 @@ dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "futures-core",
+ "log",
 ]
 
 [[package]]
@@ -457,6 +577,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
 dependencies = [
  "document-features",
+]
+
+[[package]]
+name = "embassy-time-queue-utils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168297bf80aaf114b3c9ad589bf38b01b3009b9af7f97cd18086c5bbf96f5693"
+dependencies = [
+ "embassy-executor-timer-queue",
+ "heapless 0.9.3",
 ]
 
 [[package]]
@@ -567,6 +697,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
 dependencies = [
  "embedded-io 0.7.1",
+]
+
+[[package]]
+name = "embedded-nal"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56a28be191a992f28f178ec338a0bf02f63d7803244add736d026a471e6ed77"
+dependencies = [
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "embedded-nal-async"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5a1bd585135d302f8f6d7de329310938093da6271b37a6c94b8798795c0c6d"
+dependencies = [
+ "embedded-io-async 0.7.0",
+ "embedded-nal",
 ]
 
 [[package]]
@@ -883,7 +1032,10 @@ dependencies = [
  "allocator-api2",
  "cfg-if",
  "document-features",
+ "embassy-executor",
  "embassy-sync 0.8.0",
+ "embassy-time-driver",
+ "embassy-time-queue-utils",
  "esp-alloc",
  "esp-config",
  "esp-hal",
@@ -1094,6 +1246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1309,21 @@ name = "gcd"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
+
+[[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
 
 [[package]]
 name = "generic-array"
@@ -1293,6 +1466,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,10 +1502,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "managed"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "maybe-async-cfg"
@@ -1369,6 +1570,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,6 +1606,12 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "paste"
@@ -1532,6 +1748,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "riscv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,6 +1848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "semihosting"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,8 +1914,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "sigil-names"
 version = "0.1.0"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smoltcp"
@@ -1725,6 +1985,15 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_cell"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0530892bb4fa575ee0da4b86f86c667132a94b74bb72160f58ee5a4afec74c23"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "strsim"
@@ -1816,6 +2085,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,6 +2121,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1886,6 +2225,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1917,6 +2262,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "clock"
 version = "0.1.0"
-edition = "2021"
+# #335 P1.0: edition 2024 (needs rustc ≥ 1.85, so the 1.95 floor below clears it — including on
+# espup's Xtensa fork, which is the lowest toolchain in the matrix).
+edition = "2024"
 # LOWERED 1.96 -> 1.95 by #347 Part 2, because 1.96 was blocking a supported target and had no
 # reason to be there.
 #

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -130,6 +130,7 @@ esp-alloc = { version = "0.10", optional = true }
 esp-rtos = { version = "0.3", optional = true, features = [
     "esp-radio",
     "esp-alloc",
+    "embassy",
     "log-04",
 ] }
 # esp-wifi RENAMED → esp-radio in 0.18. `unstable` unlocks the raw rx/tx tokens

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -135,6 +135,56 @@ esp-rtos = { version = "0.3", optional = true, features = [
     "embassy",
     "log-04",
 ] }
+# --- #335 Phase 1 executor deps ------------------------------------------
+# These three are the executor itself, and they are gated on `wifi` rather than `hw` for one
+# reason: `esp-rtos` — which supplies embassy-time's time DRIVER — is `wifi`-gated on this tree
+# (the reference branch moved it to `hw` in its D1 "executor-first" decision; we did not, because
+# that also makes the no-radio `default` build allocating, superseding the #44 byte-minimal-default
+# invariant for no Phase-1 benefit). embassy-time without a driver is a link error the moment
+# anything calls `Timer::after`, so driver and consumer must share a gate. Consequence, recorded
+# here so P1.3 does not rediscover it: the `Delay` -> `Timer::after` swap in main.rs's splash and
+# superloop is `wifi`-cfg'd, and the `default` tier keeps `Delay`.
+embassy-executor = { version = "0.10", optional = true }
+# `log` mirrors the esp32c6-watch's config and this crate's `log-04` bridge; without it
+# embassy-time's internal diagnostics are silent.
+embassy-time = { version = "0.5", optional = true, features = ["log"] }
+static_cell = { version = "2.1", optional = true }
+# #335 P1.4: the async TCP/IP stack. esp-radio 0.18 exposes an embassy-net-driver `Driver` for
+# `interfaces.station`, so `embassy_net::new(station, …) -> (Stack, Runner)` + a `net_task` running
+# `runner.run().await` gives us a Stack alongside the existing hand-driven smoltcp gateway. Feature
+# list mirrors the watch minus `dns` — smol keeps a hardcoded broker IP (portmap §8).
+# The direct `smoltcp` dep below STAYS for Phase 1: main's `mqtt_session` (~2,000 lines, carrying
+# #21/#56/#153/#309/#324/#217/#188) still drives it, and PORT-SPEC §0.2 is explicit that deleting
+# that gateway is Phases 2-4, not this one. Measured, not assumed: embassy-net 0.9.1 wants the same
+# smoltcp 0.13, so `cargo tree` shows ONE smoltcp v0.13.1 on the espnow tier, not two — the async
+# stack and the hand-driven one share a crate.
+# ⚠️ Sharing it is not free, and this is the only measured cost of the whole step: embassy-net turns
+# on smoltcp's `async` feature (diffed — it is the ONE feature P1.1 adds to smoltcp), which puts a
+# `WakerRegistration` in every socket. That grows `wifi::NTP_SOCK_STORAGE` from 0x540 to 0x580 —
+# +64 B of `.data`, taken straight out of the `.stack` region — with no source change anywhere.
+# [[zero-conflicts-raises-risk]] in miniature: a manifest line that resized a shipping struct.
+embassy-net = { version = "0.9.1", optional = true, features = [
+    "tcp",
+    "udp",
+    "dhcpv4",
+    "medium-ethernet",
+    "log",
+] }
+# #335 P1.5 (declared now, consumed later): the Channel + Signal + CriticalSectionRawMutex behind
+# the DR-H1 mirror atomics and the WIFI_CMD queue.
+embassy-sync = { version = "0.7", optional = true }
+# rv32imc (the C3) has NO native atomics — unlike the C6 watch's rv32imac — so embassy-sync and
+# embassy-net reach for portable-atomic's polyfills. We take NO features, because there is nothing
+# left to ask for: `cargo tree -e features` shows portable-atomic v1.14.0 ALREADY in the device
+# graph with `unsafe-assume-single-core` on, enabled by esp-sync + esp-radio-rtos-driver. This dep
+# line therefore adds no version and no feature to the target build — it only makes the existing
+# edge explicit so the code Phase 1 writes can name the crate.
+# ⚠️ [[smol-portable-atomic-riscv-pin]]: this crate broke every cold firmware build once before,
+# via feature UNIFICATION leaking `unsafe-assume-single-core` into the HOST compile — a leak whose
+# vector was `-Zbuild-std`, not the dep line (see .cargo/config.toml:36-46, where build-std is
+# removed and must stay removed). `wifi`-gating keeps it out of `hostsim` entirely; the host tiers
+# are re-verified on every step of this phase, not assumed.
+portable-atomic = { version = "1", optional = true }
 # esp-wifi RENAMED → esp-radio in 0.18. `unstable` unlocks the raw rx/tx tokens
 # (our smoltcp shim) + the `esp_now` interface. `default-features = false` drops
 # esp-radio's default `esp-alloc` so we re-add it explicitly.
@@ -461,6 +511,14 @@ wifi = [
     "dep:esp-wifi-sys",
     "dep:smoltcp",
     "dep:embassy-futures",
+    # #335 Phase 1. `embassy-futures` above STAYS: `block_on` still drives every radio future
+    # through P1.4 (23 `self.controller` sites in mode.rs), and retiring it is Phase 3 work.
+    "dep:embassy-executor",
+    "dep:embassy-time",
+    "dep:static_cell",
+    "dep:embassy-net",
+    "dep:embassy-sync",
+    "dep:portable-atomic",
     "dep:esp-storage",
     "dep:esp-bootloader-esp-idf",
     "dep:sha2",

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -38,8 +38,10 @@ license = "MIT OR Apache-2.0"
 #
 #   esp-hal          1.1    (esp-radio requires ~1.1.0 — 1.2.0-rc.0 does NOT work)
 #   esp-radio        0.18   (the esp-wifi RENAME; carries esp32c5 too, see #388)
-#   esp-rtos         0.3    (owns the scheduler; the `embassy` executor feature
-#                            is enabled on the #335 phase-1 branch, not here)
+#   esp-rtos         0.3    (owns the scheduler; its `embassy` executor feature
+#                            is ON as of #335 Phase 1 — this note used to say
+#                            "on the phase-1 branch, not here", which stopped
+#                            being true when that branch landed)
 #   esp-alloc        0.10 · esp-storage 0.9 · esp-bootloader-esp-idf 0.5
 #
 # The set moves TOGETHER: esp-radio links against esp-hal internal APIs, so a

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -475,7 +475,17 @@ default = ["esp32c3", "hw"]
 # esp-println / ssd1306) are `optional` so a NON-hardware target (the `hostsim` wasm lib)
 # builds the pure game/render cores without them. `hw` re-bundles them; it is implied by
 # `default` + `wifi` (⊃ espnow/io/cast/wled), so no firmware build changes.
-hw = ["dep:esp-hal", "dep:esp-backtrace", "dep:esp-println", "dep:ssd1306"]
+hw = [
+    "dep:esp-hal", "dep:esp-backtrace", "dep:esp-println", "dep:ssd1306",
+    # #335 P1.2: `embassy-futures` moves up from `wifi`. main's superloop is now an
+    # `async fn run()`, and the no-radio `default`/`hw` build has no executor to drive it
+    # (esp-rtos is `wifi`-gated — see the executor deps above), so its entry point is
+    # `block_on(run())`. embassy-futures is a dependency-free no_std crate and `block_on` is
+    # a poll loop with a noop waker, which is exactly right for a tier whose `run()` contains
+    # no `.await` at all. It costs the default tier ~nothing and it is what lets ONE superloop
+    # body serve every tier instead of two copies that would drift.
+    "dep:embassy-futures",
+]
 
 # #152 web emulator: compile the crate's LIBRARY (src/lib.rs) exposing ONLY the pure
 # plugin/render cores (app contract + snake + clock + input Press + sensors/units host
@@ -510,9 +520,9 @@ wifi = [
     "dep:esp-radio",
     "dep:esp-wifi-sys",
     "dep:smoltcp",
-    "dep:embassy-futures",
-    # #335 Phase 1. `embassy-futures` above STAYS: `block_on` still drives every radio future
-    # through P1.4 (23 `self.controller` sites in mode.rs), and retiring it is Phase 3 work.
+    # #335 P1.2: `dep:embassy-futures` moved to `hw` (it now also drives the default tier's
+    # superloop). It is NOT retired — `block_on` still drives every radio future through P1.4
+    # (23 `self.controller` sites in mode.rs); retiring it is Phase 3 work.
     "dep:embassy-executor",
     "dep:embassy-time",
     "dep:static_cell",

--- a/rust/clock/build.rs
+++ b/rust/clock/build.rs
@@ -130,18 +130,24 @@ fn chip_id() -> u8 {
 
     let from_triple = triple_chip();
     let from_env = std::env::var("SMOL_CHIP").ok().map(|v| v.trim().to_string());
-    if let Some(name) = from_env.as_deref() {
-        if !name.is_empty() && !CHIPS.iter().any(|(n, _)| *n == name) {
-            // Previously an unrecognised name fell through to 0, which failed the build later
-            // with the SELF_CHIP assert — a message about an unknown chip id that says nothing
-            // about the typo that caused it. Fail here, naming the value and the valid set.
-            panic!(
-                "SMOL_CHIP={name:?} is not a chip this tree knows. Valid: {}. \
-                 (It overrides the chip NAME for silicon whose triple is ambiguous; it does not \
-                 need setting when a chip feature is enabled.)",
-                CHIPS.iter().map(|(n, _)| *n).collect::<Vec<_>>().join(" / ")
-            );
-        }
+    // #335 P1.0 (edition 2024): collapsed into a let-chain. src/main.rs defers its 38 sites behind
+    // a crate-level `allow`, but that allow cannot reach here — build.rs is a SEPARATE crate, and
+    // this is the one site in it. Nothing Phase 1 rewrites lives in this file, so there is no
+    // revertibility argument for deferring a two-line collapse; the edition bump is what makes the
+    // let-chain legal in the first place.
+    if let Some(name) = from_env.as_deref()
+        && !name.is_empty()
+        && !CHIPS.iter().any(|(n, _)| *n == name)
+    {
+        // Previously an unrecognised name fell through to 0, which failed the build later
+        // with the SELF_CHIP assert — a message about an unknown chip id that says nothing
+        // about the typo that caused it. Fail here, naming the value and the valid set.
+        panic!(
+            "SMOL_CHIP={name:?} is not a chip this tree knows. Valid: {}. \
+             (It overrides the chip NAME for silicon whose triple is ambiguous; it does not \
+             need setting when a chip feature is enabled.)",
+            CHIPS.iter().map(|(n, _)| *n).collect::<Vec<_>>().join(" / ")
+        );
     }
 
     if let Some((feat_name, feat_id)) = from_feature.first().copied() {

--- a/rust/clock/src/bard/mod.rs
+++ b/rust/clock/src/bard/mod.rs
@@ -12,6 +12,27 @@
 //! This file is the firmware root of the bard tree; `lib.rs` reaches the same three source
 //! files directly via `#[path]` for host tests, so nothing here may be needed by them.
 
+// #335 P1.0 (edition 2024): `unsafe_op_in_unsafe_fn` goes warn-by-default in 2024 — an `unsafe fn`
+// body is no longer implicitly an unsafe block. That is 34 sites across the 9 `unsafe fn`s below,
+// and it is why `clippy -D warnings` went red on the `bard` and `stack-paint` tiers (and ONLY those
+// two: this file is the only one in the tree with that shape). Note the tiers still `cargo check`
+// clean — the lint is a warning, so only the `-D warnings` gate sees it.
+//
+// Allowed at module scope rather than wrapped, for the same reason main.rs defers its 38
+// `collapsible_if` sites: an edition bump should not arrive as a 34-site reflow of a module this
+// phase does not otherwise touch. Two things make that call stronger here than there — every one
+// of these fns is a `static mut` singleton accessor whose SAFETY contract is already stated at the
+// fn level (so per-op marking adds no information a reader lacks), and this is the #300 nano-LLM
+// whose acceptance test is BIT-EXACT against an independent reference implementation. A mechanical
+// 34-site edit through that is a real risk of perturbing a golden result, against no behavioural
+// gain whatsoever.
+//
+// ⚠️ The cost, stated so it is not discovered later: new unsafe ops added inside these fns get no
+// lint. Keep writing explicit `unsafe {}` blocks in new code here anyway.
+// TODO(#335 follow-up): wrap the 34 sites and drop this allow — same cleanup commit as main.rs's
+// `collapsible_if` collapse, which has the same shape and the same reason for waiting.
+#![allow(unsafe_op_in_unsafe_fn)]
+
 pub mod delivery;
 pub mod nano_llm;
 pub mod persona;

--- a/rust/clock/src/lib.rs
+++ b/rust/clock/src/lib.rs
@@ -16,6 +16,10 @@
 //!     emulator drives the `Plugin`s directly and synthesizes `Press` from the keyboard).
 
 #![no_std]
+// #335 P1.0: same edition-2024 let-chain lint as main.rs:39 — see the rationale there. The two
+// crate roots share source files (toast.rs, familiar/), so the allow has to be on both or the
+// hostsim tier reports what the firmware tier suppresses.
+#![allow(clippy::collapsible_if)]
 
 // #348 per-chip memory budgets. The ONE module here that is NOT host-only: it is pure data
 // plus const-eval assertions (no code emitted), and compiling it in both targets means the

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -87,10 +87,22 @@ use esp_hal::{
     clock::CpuClock,
     delay::Delay,
     i2c::master::{BusTimeout, Config as I2cConfig, I2c, SoftwareTimeout},
-    main,
     time::Instant,
     time::Rate,
 };
+// #335 P1.2: the bare-metal `#[main]` entry survives ONLY on the no-radio tier. Under `wifi` the
+// entry is `#[esp_rtos::main]`, which emits its own `#[esp_hal::main] fn main()` wrapper — naming
+// `main` here as well would be an unused import there.
+#[cfg(not(feature = "wifi"))]
+use esp_hal::main;
+// #335 P1.2: the scheduler's two peripherals. Hoisted here from net/wifi.rs and net/mode.rs, which
+// each used to derive them from the `WifiPeripherals` bundle and call `esp_rtos::start` themselves.
+#[cfg(feature = "wifi")]
+use esp_hal::{interrupt::software::SoftwareInterruptControl, timer::timg::TimerGroup};
+// #335 P1.2: `#[esp_rtos::main]` expands to `async fn __embassy_main(spawner: Spawner)`, so the
+// type has to be nameable at this scope even though P1.2 itself does not spawn anything.
+#[cfg(feature = "wifi")]
+use embassy_executor::Spawner;
 use ssd1306::{prelude::*, size::DisplaySize72x40, I2CDisplayInterface, Ssd1306};
 // `DisplayConfig::init` inits the PLAIN Ssd1306 (non-cast builds). Under `feature =
 // "cast"` the display is the `CastOled` tee, whose inherent `init()` forwards to the
@@ -585,8 +597,34 @@ fn millis() -> u64 {
     Instant::now().duration_since_epoch().as_millis()
 }
 
+// -----------------------------------------------------------------------------
+// #335 P1.2 — the entry point, split by tier.
+//
+// The superloop body below is ONE `async fn run()`, unchanged and un-reindented; only how it gets
+// polled differs. Under `wifi`, `#[esp_rtos::main]` builds the esp-rtos thread-mode embassy
+// executor on the main thread and spawns `run()` as its first task — that is what makes a `spawner`
+// available (P1.4) and lets P1.3's `Timer::after` yield to sibling tasks instead of spinning.
+// Without `wifi` there is no esp-rtos (it is `wifi`-gated on this tree, unlike the reference's D1
+// "executor-first" call — see Cargo.toml), so the no-radio build keeps the bare-metal `#[main]` and
+// drives the same future with `block_on`. That future contains no `.await` on this tier, so the
+// poll loop runs it straight through; the two entries are 3 lines each and the body has no fork.
+//
+// ⚠️ `#[esp_rtos::main]` does NOT start the scheduler — it only creates the executor. The single
+// `esp_rtos::start` still has to be called by hand, and lives in `run()` at the radio bring-up
+// (see there for why it is placed exactly where the old two calls used to fire).
+#[cfg(feature = "wifi")]
+#[esp_rtos::main]
+async fn main(_spawner: Spawner) -> ! {
+    run().await
+}
+
+#[cfg(not(feature = "wifi"))]
 #[main]
 fn main() -> ! {
+    embassy_futures::block_on(run())
+}
+
+async fn run() -> ! {
     // #300 bench builds only: paint the free stack BEFORE anything grows a deep call chain, so
     // the high-water report after a story covers the whole run. First statement in `main` on
     // purpose — even HAL init would otherwise go unmeasured. See src/bard/stack_paint.rs for why
@@ -793,6 +831,32 @@ fn main() -> ! {
     let mut grid_cache = grid::GridCache::new();
 
     // --- Radio bring-up (feature-dependent) ----------------------------------
+    // #335 P1.2: the ONE `esp_rtos::start`. It used to be called from two places —
+    // `net/wifi.rs::try_time_sync` and `net/mode.rs::RadioManager::new` — which are the
+    // mutually-exclusive first statements of the two branches immediately below, each deriving
+    // TIMG0 + SW_INTERRUPT from the `WifiPeripherals` bundle it was handed. Both are gone, and
+    // the bundle no longer carries those two peripherals, so the hoist cannot be half-done: a
+    // leftover call site would fail to compile for want of a peripheral to start with.
+    //
+    // Placed HERE, immediately before the branch, rather than at the top of boot next to
+    // `esp_hal::init`, deliberately. This is where the calls fired before, so the hoist changes
+    // WHERE the call is written and not WHEN it runs — the #226 otadata init and the #40
+    // unconfirmed-boot bookkeeping above still complete on a bare-metal context with no scheduler
+    // and no timer driver, exactly as they do on v917. RISKS §R7 is about Phase 1 disturbing the
+    // rollback path by reordering boot; keeping the instant unchanged is how we decline that risk
+    // instead of arguing about it. (RISKS §R11's TIMG0 double-ownership question is unchanged
+    // too: the same timer, claimed at the same moment, by the same call.)
+    //
+    // NON-embassy semantics still hold for the caller: `start` converts THIS context into the
+    // pinned main task and returns, so everything below keeps running as written. What is new is
+    // that "this context" is now an executor task rather than the bare `#[main]` stack.
+    #[cfg(feature = "wifi")]
+    {
+        let timg0 = TimerGroup::new(peripherals.TIMG0);
+        let sw = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+        esp_rtos::start(timg0.timer0, sw.software_interrupt0);
+    }
+
     // Each branch yields `synced` (Option<u32> Unix time at boot). Phase 3 also
     // brings up the blue LED + the live ESP-NOW `radio`.
     #[cfg(not(feature = "wifi"))]
@@ -815,11 +879,9 @@ fn main() -> ! {
             }
         };
         net::try_time_sync(
-            net::WifiPeripherals {
-                timg0: peripherals.TIMG0,
-                sw_int: peripherals.SW_INTERRUPT,
-                wifi: peripherals.WIFI,
-            },
+            // #335 P1.2: TIMG0 + SW_INTERRUPT no longer travel in this bundle — the
+            // scheduler they fed is started once, above.
+            net::WifiPeripherals { wifi: peripherals.WIFI },
             &mut batt_cache,
             &mut grid_cache,
             &mut boot_render,
@@ -869,11 +931,9 @@ fn main() -> ! {
             }
         };
         net::mode::start(
-            net::WifiPeripherals {
-                timg0: peripherals.TIMG0,
-                sw_int: peripherals.SW_INTERRUPT,
-                wifi: peripherals.WIFI,
-            },
+            // #335 P1.2: TIMG0 + SW_INTERRUPT no longer travel in this bundle — the
+            // scheduler they fed is started once, above.
+            net::WifiPeripherals { wifi: peripherals.WIFI },
             // This unit's short id (see NODE_ID) — embedded in HELLO/ACK/BEACON/TIME
             // frames + the single source of truth shared with the node's name. Runtime
             // `node_id()` (NVS, seeded from the baked const) so a shared OTA image never

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -36,6 +36,16 @@
 
 #![no_std]
 #![no_main]
+// #335 P1.0 (edition 2024): let-chains are stable in 2024, so `collapsible_if` can now suggest
+// folding `if a { if let Some(b) = c { … } }` into a single let-chain. It is NOT a pre-existing
+// baseline lint — at edition 2021 clippy could not make the suggestion and the tree was clean.
+// The bump therefore opens 38 fresh sites across 10 files, 23 of them in the two largest files
+// (mode.rs 7.5k lines, wifi.rs 6.2k). Collapsing them here would bury a 4-line edition change in
+// a 38-site reflow of exactly the files Phase 1 P1.2–P1.5 rewrite, and would make this step
+// non-revertible in practice. Allowed crate-wide so the `clippy -D warnings` gate stays green on
+// every tier; the collapse is a separate mechanical cleanup with no Embassy content.
+// TODO(#335 follow-up): collapse the 38 nested ifs and drop this allow.
+#![allow(clippy::collapsible_if)]
 
 // Phase 3 (espnow) stores inbound ESP-NOW messages as owned Strings for display.
 #[cfg(feature = "espnow")]
@@ -62,7 +72,8 @@ esp_bootloader_esp_idf::esp_app_desc!();
 // bootloader auto-reverts too, if it was built with rollback enabled). rc.0 puts
 // `software_reset` in `esp_hal::system`, NOT `esp_hal::reset` (spike-verified).
 #[cfg(feature = "wifi")]
-#[no_mangle]
+// edition 2024: `no_mangle` is now an unsafe attribute (symbol-name control).
+#[unsafe(no_mangle)]
 extern "Rust" fn custom_halt() -> ! {
     // #70 observability: record that THIS reset was a PANIC before we reboot. A panic halts
     // here → software_reset, which the SoC logs as a plain `CoreSw` (same as an intentional

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -760,6 +760,9 @@ async fn run() -> ! {
     draw_splash(&mut display, my_noun, env!("BUILD_NUMBER"), v_noun);
     display.flush().ok();
 
+    // #335 P1.3: still constructed on every tier, but only the no-radio tier still *uses* it —
+    // `subtick` (below `run`) is what the two pacing sites call now. `Delay` is a unit struct, so
+    // holding one the wifi build never reads costs nothing and keeps the two call sites identical.
     let delay = Delay::new();
 
     // --- BOOT button on GPIO9 (debounced short/long) -------------------------
@@ -1136,7 +1139,7 @@ async fn run() -> ! {
     // burst above usually already blew past this (the splash was up throughout);
     // this only adds real wait in the default build, where bring-up is instant.
     while millis().saturating_sub(splash_start) < SPLASH_MIN_MS {
-        delay.delay_millis(SUBTICK_MS);
+        subtick(&delay).await;
     }
 
     log::info!("smol: entering menu");
@@ -2502,8 +2505,40 @@ async fn run() -> ! {
         }
         was_toast = toast_now;
 
-        delay.delay_millis(SUBTICK_MS);
+        subtick(&delay).await;
     }
+}
+
+/// One superloop sub-tick: the ≤20 ms pause at the bottom of the mesh-serving loop, and the same
+/// pause while the boot splash is held (#335 P1.3, porting the reference's `45eea58` / DR-H2).
+///
+/// Under `wifi` this is `embassy_time::Timer::after(…).await`, and the await is the entire point:
+/// a blocking delay never yields, so the executor P1.2 just brought up would never switch to the
+/// tasks P1.4/P1.5 spawn. This is what makes the executor actually *run* something — the
+/// structural half of the deaf-window kill. Without `wifi` there is no time driver (esp-rtos is
+/// `wifi`-gated), so the no-radio tier keeps the blocking `Delay` and this fn simply never awaits.
+///
+/// Pinned to `SUBTICK_MS` = 20 ms, NOT the esp32c6-watch's ~400 ms clamp: the HELLO / TIME /
+/// beacon / diag detectors all look back exactly one `SUBTICK_MS` (see the `now / N !=
+/// (now - SUBTICK_MS) / N` edge tests through the loop), so a longer tick would step over their
+/// boundaries and drop the great majority of mesh broadcasts.
+///
+/// `button.poll` still runs at the TOP of every iteration, so input latency stays ≤20 ms and the
+/// 700 ms long-press gesture is unchanged (DR-M2). The reference deliberately did not add a
+/// `select(Timer, button_edge)` early-wake, and neither do we: it is a latency nicety, not
+/// correctness.
+#[cfg(feature = "wifi")]
+#[inline]
+async fn subtick(_delay: &Delay) {
+    embassy_time::Timer::after(embassy_time::Duration::from_millis(SUBTICK_MS as u64)).await;
+}
+
+/// No-radio tier: no esp-rtos, so no embassy time driver — keep the blocking delay. See the
+/// `wifi` twin above for why the two exist.
+#[cfg(not(feature = "wifi"))]
+#[inline]
+async fn subtick(delay: &Delay) {
+    delay.delay_millis(SUBTICK_MS);
 }
 
 // `draw_clock` moved to `clock.rs` (CLOCK plugin's private render helper, now

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -43,10 +43,10 @@
 extern crate alloc;
 
 use esp_hal::{
-    interrupt::software::SoftwareInterruptControl,
+    // #335 P1.2: SoftwareInterruptControl / TimerGroup are gone from this module —
+    // `esp_rtos::start` and the peripherals it consumes moved to `main`.
     rng::Rng,
     time::Instant,
-    timer::timg::TimerGroup,
 };
 use embassy_futures::block_on;
 use esp_radio::{
@@ -2339,11 +2339,10 @@ impl RadioManager {
         // esp-wifi needs a heap; use the single shared region (see net::init_heap).
         super::init_heap();
 
-        let timg0 = TimerGroup::new(p.timg0);
-        let sw = SoftwareInterruptControl::new(p.sw_int);
-        // #233: start the esp-rtos scheduler that backs esp-radio's os-adapter BEFORE
-        // wifi::new (NON-embassy: start() pins THIS context as the main task and returns).
-        esp_rtos::start(timg0.timer0, sw.software_interrupt0);
+        // #233/#335 P1.2: the esp-rtos scheduler that backs esp-radio's os-adapter must be running
+        // BEFORE wifi::new. It is — `main` calls `esp_rtos::start` once, immediately before
+        // dispatching here, which is the same instant in boot at which this function used to
+        // call it itself.
         // `Rng` is a `Copy` handle (not entropy itself); kept for the SNTP ephemeral-port seed.
         let rng = Rng::new();
         // 0.18: WIFI is 'static → wifi::new returns an owned 'static controller + interfaces

--- a/rust/clock/src/net/target.rs
+++ b/rust/clock/src/net/target.rs
@@ -651,7 +651,8 @@ pub const SELF: TargetId = TargetId {
 /// The bytes are `SELF.encode()` — computed, never transcribed.
 #[cfg(feature = "wifi")]
 #[used]
-#[no_mangle]
+// edition 2024: `no_mangle` is now an unsafe attribute (symbol-name control).
+#[unsafe(no_mangle)]
 pub static SMOL_TARGET_DESC: [u8; DESC_LEN] = SELF.encode();
 
 /// Reads the embedded descriptor back and confirms it decodes to [`SELF`]. Called once on the

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -29,11 +29,11 @@ extern crate alloc;
 use core::net::Ipv4Addr;
 
 use esp_hal::{
-    interrupt::software::SoftwareInterruptControl,
-    peripherals::{SW_INTERRUPT, TIMG0, WIFI},
+    // #335 P1.2: SoftwareInterruptControl / TimerGroup / SW_INTERRUPT / TIMG0 are gone from this
+    // module — `esp_rtos::start` and the peripherals it consumes moved to `main`.
+    peripherals::WIFI,
     rng::Rng,
     time::{Duration, Instant},
-    timer::timg::TimerGroup,
 };
 use esp_radio::wifi::{sta::{ScanMethod, StationConfig}, Config};
 
@@ -461,11 +461,12 @@ pub(crate) const RELAY_FLUSH_BUDGET: Duration = Duration::from_secs(15); // read
 // -------------------------------------------------------------------------
 
 pub struct WifiPeripherals {
-    pub timg0: TIMG0<'static>,
-    // #233: esp-radio 0.18's scheduler (esp-rtos) needs SW_INTERRUPT.software_interrupt0
-    // for context switches. The RNG peripheral is no longer threaded in — esp-hal 1.1's
-    // `Rng::new()` is arg-less and esp-radio pulls entropy internally.
-    pub sw_int: SW_INTERRUPT<'static>,
+    // #233: esp-radio 0.18's scheduler (esp-rtos) needs SW_INTERRUPT.software_interrupt0 for
+    // context switches, and TIMG0 for its timebase. #335 P1.2 moved BOTH out of this bundle:
+    // `esp_rtos::start` is now called once, by `main`, at the same instant in boot that the two
+    // radio-init paths used to call it. The RNG peripheral is not threaded in either — esp-hal
+    // 1.1's `Rng::new()` is arg-less and esp-radio pulls entropy internally. So the bundle is
+    // down to the one peripheral the radio itself consumes.
     pub wifi: WIFI<'static>,
 }
 
@@ -502,12 +503,9 @@ pub fn try_time_sync(
     super::init_heap();
 
     // --- Radio init (#233: esp-radio 0.18 + esp-rtos scheduler) ----------
-    let timg0 = TimerGroup::new(p.timg0);
-    let sw = SoftwareInterruptControl::new(p.sw_int);
-    // esp-radio's os-adapter needs the esp-rtos scheduler running BEFORE wifi::new.
-    // NON-embassy: start() converts THIS context into the pinned main task and returns,
-    // so the blocking superloop below runs unchanged while the radio task preempts in.
-    esp_rtos::start(timg0.timer0, sw.software_interrupt0);
+    // #335 P1.2: `esp_rtos::start` used to be the first statement here. esp-radio's os-adapter
+    // still needs the scheduler running BEFORE `wifi::new`, and it is — `main` starts it
+    // immediately before dispatching to this function, which is the same instant in boot.
     // `Rng` is a `Copy` handle; keep our own copy for the SNTP source-port seed.
     let rng = Rng::new();
     // In 0.18 the WIFI peripheral is 'static, so wifi::new returns an owned 'static


### PR DESCRIPTION
Phase 1 of the #335 Embassy re-platform, executed against today's `main` with `dream/feat-embassy` as a design reference (never rebased). The reference's own order — delete the synchronous stack, then build the async one — is not available on this base, because what it deletes is a hardened, shipping v917 gateway. So this inverts it: **the executor comes up beside the untouched superloop**, and later phases move traffic across. Every step keeps a shipping image and is individually revertible.

## Commits

| step | commit | content |
|---|---|---|
| — | `85546e6` | chore: the Cargo.lock the union probe left out (32 pkgs, 0 removals; landed alone so later lock deltas are attributable) |
| probe | `c00d82d` | esp-rtos `embassy` feature ON — the union (embassy + esp-radio) resolves, compiles, links |
| P1.0 | `455e866` | edition 2021 → 2024, rust-version stays 1.96 |
| P1.1 | `0ad2f8c` | embassy-executor / embassy-time / static_cell / embassy-sync / embassy-net / portable-atomic |
| P1.2 | `40a6a51` | executor ON: `#[esp_rtos::main]` + the single hand `esp_rtos::start` hoisted to `main` |
| P1.3 | `9e86030` | `Timer::after` paces the superloop (3 sites, `SUBTICK_MS = 20` stays the one definition) |

Design call of record (reviewed + approved): the executor rides **`wifi`, not `hw`** — the no-radio default tier is proven byte-identical in all four sections (.data 1904 / .bss 468 / .rodata 19132 / .stack 315388) with zero `esp_rtos`/`embassy_executor` symbols in `nm`, so #44's byte-minimal-default survives.

## ⚠️ Read the .stack trajectory correctly — the P1.3 drop is a MIGRATION, not a loss

| step | .stack | ×floor (74,208) | .bss |
|---|---|---|---|
| baseline | 106,976 | 1.44 | 156,816 |
| P1.0 | 106,976 | 1.44 | 156,816 |
| P1.1 | 106,912 | 1.44 | 156,816 |
| P1.2 | 106,864 | 1.44 | 156,864 |
| **P1.3** | **87,960** | **1.185** | **175,768** |

`nm` names the P1.3 delta: `clock::__main::__embassy_main::POOL` = 18,952 B. Real await points materialise `run()`'s live state as a future in **static task storage** — ~18.9 KB of main's frame (dominated by `RadioManager`) moved out of `.stack` into `.bss`. Real stack demand went **down** while the gate's number reads worse. Corroboration: the wifi-only tier's POOL is 1,184 B (no RadioManager); the default tier has no POOL at all. `ESP32C3_MEASURED_PEAK_BYTES = 55,656` was measured with that frame **on** the stack, so the derived floor is now conservative by ~the POOL size. `budget.rs` is deliberately untouched — re-deriving the peak needs stack-paint under live radio, on a board.

## Gates (every step)

clippy 0 errors on all 10 build-matrix tiers · hostsim suites bard 41 / budget 10 / input 8, 0 failed · `check_verifier_wiring` 19 sound + 1 known phantom · `test_verifier_wiring` 5/5 · `check_elect_send_path`, `check_byte_free`, `check_diag_budget`, `check_shed_order` all green. Also found and filed along the way: #390 (a manifest edit resized `NTP_SOCK_STORAGE` +64 B via smoltcp feature unification — caught only by `nm` A/B).

## What merging requires — this PR is HELD until all four

1. **§R1 on metal:** the `block_on` busy loop inside an executor task is preempted, not deadlocked — `BurstProbe` pre/post on the same board under the same duty (the instrument already ships on main; evidence = the `longest app gap` numbers, not "it boots").
2. **§R11 on metal:** the embassy timebase ticks at wall-clock rate (stopwatch vs the 15 s flush budget).
3. **The #335 round-trip rollback canary:** a Phase-1 image up, then roll *back* and confirm boot + re-election. The 2026-08-02 v917 roll was forward-only; this gate has never been discharged.
4. **The P1.4/P1.5 ownership decision:** `embassy_net::new` needs an owned `interfaces.station`, which the shipping gateway owns on five live borrow paths (`radio_dev.rs` → `mode.rs`); esp-radio 0.18 has one owned station, no Clone/Copy. P1.4 is therefore **absent from this PR by decision, not omission** — it folds into the P1.5 radio-ownership review (`scratch/embassy-port/p15-ownership-proposal.md`, in progress).

Full evidence trail: `scratch/embassy-port/phase1-exec-log.md` (local notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
