### PR TITLE
fix(ota): a deaf leaf's armed install no longer locks the crown out of its own OTA (#381)

### DIFF
--- a/experiments/381_gate_verify/Cargo.toml
+++ b/experiments/381_gate_verify/Cargo.toml
@@ -1,0 +1,15 @@
+# #381 host guard for the crown SELF-OTA gate (net/otagate.rs). The firmware crate is
+# no_std/riscv32imc and cannot host-test, so this `#[path]`-includes the REAL otagate.rs (no drift)
+# and asserts the truth table: the #40 "gateway updates itself LAST" order still holds for a
+# healthy relay, a permanently-deaf leaf's armed install loses its veto over BOTH gates, and the
+# threshold is where it says it is. Permanent guard for #381.
+[package]
+name = "self_ota_gate_verify"
+version = "0.0.0"
+edition = "2021"
+publish = false
+[[bin]]
+name = "self_ota_gate_verify"
+path = "src/main.rs"
+[profile.dev]
+opt-level = 0

--- a/experiments/381_gate_verify/src/main.rs
+++ b/experiments/381_gate_verify/src/main.rs
@@ -1,0 +1,94 @@
+//! #381 crown SELF-OTA gate host guard. `#[path]`-includes the REAL `net/otagate.rs` (no drift)
+//! and pins the bug found live on the 917 roll (2026-08-02): a permanently-deaf leaf's armed
+//! install held BOTH self-install gates on indefinitely, so the crown SKIPPED its own update —
+//! indistinguishable from being up to date, so the roll reported success with the crown on the old
+//! build. `cargo run` — panics on failure.
+//!
+//! The two properties that must not drift apart:
+//!   1. the #40/#3 order survives — a HEALTHY relay still makes the crown wait;
+//!   2. an install that has repeatedly failed BEFORE reaching a leaf stops being a reason to wait.
+//! A change that satisfies only (1) restores the lock; only (2) lets the crown reboot into its own
+//! install mid-relay. Both are asserted here.
+
+#[path = "../../../rust/clock/src/net/otagate.rs"]
+mod otagate;
+
+use otagate::*;
+
+fn main() {
+    // ---- 1. Nothing pending: the ordinary case, the crown installs -----------------------------
+    assert!(
+        crown_may_self_install(false, false, 0),
+        "an idle crown with no leaf install must run its own"
+    );
+
+    // ---- 2. The #40 order survives — a HEALTHY relay still blocks -------------------------------
+    // Below the threshold every combination of the two legacy gates must still suppress. This is
+    // the half that a naive "just release the gate" fix would break, letting the crown reboot into
+    // its own install while a relay it armed is genuinely in flight.
+    for n in 0..LEAF_OTA_SELF_GATE_RETRIES {
+        assert!(
+            !crown_may_self_install(true, false, n),
+            "armed relay (retry={n}) must still suppress the crown's own install"
+        );
+        assert!(
+            !crown_may_self_install(false, true, n),
+            "outstanding retained install (retry={n}) must still suppress"
+        );
+        assert!(
+            !crown_may_self_install(true, true, n),
+            "both gates set (retry={n}) must still suppress"
+        );
+    }
+
+    // ---- 3. #381: a deaf leaf's install loses its veto over BOTH gates ---------------------------
+    // Releasing only the RAM latch is not enough and this asserts why: a deaf leaf pins
+    // `leaf_installs_outstanding` through its RETAINED topic, which is what forced the 2026-08-02
+    // mitigation to clear that topic by hand. Both must release together or the crown stays stuck.
+    assert!(
+        crown_may_self_install(true, true, LEAF_OTA_SELF_GATE_RETRIES),
+        "at the threshold the veto expires and the crown proceeds despite both gates"
+    );
+    assert!(
+        crown_may_self_install(true, true, 35),
+        "the observed id5/id50 state (retry=35) must not hold the crown"
+    );
+    assert!(
+        crown_may_self_install(true, true, u8::MAX),
+        "the saturated counter must not wrap back into suppression"
+    );
+
+    // ---- 4. The threshold is exactly where the constant says --------------------------------------
+    assert!(
+        !leaf_veto_expired(LEAF_OTA_SELF_GATE_RETRIES - 1),
+        "one short of the threshold still vetoes"
+    );
+    assert!(
+        leaf_veto_expired(LEAF_OTA_SELF_GATE_RETRIES),
+        "the threshold itself releases"
+    );
+
+    // ---- 5. The release is monotone in the retry count ------------------------------------------
+    // Guards against a future "window" refactor (release between N and M, suppress again after)
+    // that would make the lock reappear at high retry counts — the precise regime where the bug
+    // was observed. Once released, always released, for every gate combination.
+    for n in LEAF_OTA_SELF_GATE_RETRIES..=u8::MAX {
+        assert!(
+            crown_may_self_install(true, true, n),
+            "retry={n} is past the threshold and must stay released"
+        );
+    }
+
+    // ---- 6. The counter below the threshold is not itself a release ------------------------------
+    // i.e. the escape hatch cannot be reached by the legacy gates alone being clear — that path is
+    // already covered by case 1, but this pins that `leaf_veto_expired` is the ONLY override.
+    assert!(
+        !leaf_veto_expired(0),
+        "a fresh counter must not read as an expired veto"
+    );
+
+    println!(
+        "381_gate_verify: OK — crown self-OTA gate ({} pre-relay retries to veto expiry)",
+        LEAF_OTA_SELF_GATE_RETRIES
+    );
+}

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -1260,8 +1260,15 @@ fn main() -> ! {
             // next leaf lets the gateway self-OTA first, starving the second leaf + inverting the
             // order. Both gates short-circuit BEFORE `take_install_request()` so the gateway's own
             // install command is PRESERVED (fires last, once every leaf's install has cleared).
-            let do_install = !r.leaf_ota_pending()
-                && !r.leaf_installs_outstanding()
+            // #381: both gates above are pinned ON forever by a permanently-deaf leaf — the RAM
+            // latch because `MacUnknown` never produces a terminal outcome, the retained one
+            // because a leaf that never installs never clears its install. The crown then SKIPS
+            // its own update, which is the same quiet non-event as being up to date, so a roll
+            // reports success with the crown on the old build (observed: id5 at `retry=35+` for
+            // deaf id50). The decision moved into `net::otagate` — an armed install that has
+            // repeatedly failed BEFORE ever reaching a leaf loses its veto, while the retained
+            // install and the uncapped pre-relay retry are untouched (#134 / #111 preserved).
+            let do_install = r.crown_may_self_install()
                 && (crate::ota::OTA_AUTO_INSTALL || r.take_install_request());
             if do_install {
                 if let Some(announce) = r.take_ota_offer() {

--- a/rust/clock/src/net.rs
+++ b/rust/clock/src/net.rs
@@ -105,6 +105,15 @@ pub mod wire;
 #[cfg(feature = "espnow")]
 pub mod coexist;
 
+// #381 crown SELF-OTA gating: the pure "may the crown update itself yet" decision, extracted from
+// `main`'s `do_install` after a permanently-deaf leaf's armed install was found pinning BOTH gates
+// on indefinitely — the crown SKIPS its own install, which is indistinguishable from being up to
+// date, so a roll reports success with the crown on the old build. PURE (no esp-hal/esp-radio, no
+// alloc), host-tested by `experiments/381_gate_verify` (`#[path]`-include, like `coexist`);
+// espnow-gated because the relay is the only thing that can arm the gates.
+#[cfg(feature = "espnow")]
+pub mod otagate;
+
 // #278 the `SMOLv1 ELECT` frame + epoch/anti-flap core — PURE (no esp-hal/esp-radio, no alloc),
 // host-tested by `experiments/mesh_elect_verify` (`#[path]`-include, like `coexist`), which runs
 // the esp32c6-watch donor's own tests against this exact file: 10 of them (8 wire + 2 consensus).

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -4059,9 +4059,10 @@ impl RadioManager {
                     shed = shed.saturating_add(1);
                 }
             };
-            // #33 WHY a crown did not self-install, as one octal digit: bit 0 = `leaf_ota_pending`,
-            // bit 1 = `leaf_installs_outstanding`, bit 2 = an install already ARMED in RAM. `1` bits
-            // in 0/1 are suppressing.
+            // #33 WHY a crown did not self-install, as one hex digit: bit 0 = `leaf_ota_pending`,
+            // bit 1 = `leaf_installs_outstanding`, bit 2 = an install already ARMED in RAM,
+            // bit 3 = #381 the armed leaf install has LOST its veto (pre-relay stall). `1` bits in
+            // 0/1 are suppressing — UNLESS bit 3 is set, which overrides both.
             //
             // `main`'s gate is `!leaf_ota_pending && !leaf_installs_outstanding &&
             // take_install_request()`, and the `&&` short-circuits BEFORE the take — so a suppressed
@@ -4072,14 +4073,28 @@ impl RadioManager {
             // means armed and waiting on nothing — i.e. it will fire; `sog=6` means armed but held by
             // an outstanding leaf install.
             //
+            // #381 adds bit 3, and it exists because the FIX is as invisible as the bug was. Once a
+            // deaf leaf's install loses its veto the crown installs with bits 0/1 STILL SET, so
+            // without bit 3 the record would say "held" at the exact moment the crown stopped being
+            // held — the same read-it-backwards trap in the other direction. `sog=f` is the #381
+            // state: armed, both legacy gates set, veto expired, installing anyway.
+            //
             // In the DIAG record rather than the armdiag because `diag_record` already has `&mut self`
             // — the armdiag is built inside `mqtt_session`, which takes disjoint field borrows and
             // would need the value threaded through three signatures and three call sites for the same
             // 7 bytes. Sheddable, so it can never push the record over the publish cliff.
-            let sog = (self.leaf_ota_pending as u8)
-                | ((self.leaf_installs_outstanding as u8) << 1)
-                | ((self.install_requested as u8) << 2);
-            room_for(&mut rec, alloc::format!("|sog={}", sog));
+            // Read through the ACCESSORS, not the raw fields. #381 moved the gate decision out of
+            // `main` into `crown_may_self_install`, which left `leaf_ota_pending()` with no callers
+            // — and a `sog` digit built from raw fields could then drift from the gate it claims to
+            // explain without anything noticing. Same accessors, same answer, and the dead-code
+            // warning stops being a thing to silence.
+            let sog = (self.leaf_ota_pending() as u8)
+                | ((self.leaf_installs_outstanding() as u8) << 1)
+                | ((self.install_requested as u8) << 2)
+                | ((self.leaf_veto_expired() as u8) << 3);
+            // Hex since #381's bit 3 took the value past 7; 0-f is still ONE character, so the
+            // field's width (and its place in the #306 budget) is unchanged.
+            room_for(&mut rec, alloc::format!("|sog={:x}", sog));
             // #21/#56 CROWN-ONLY: the keyed-CFG relay cache as `<used>/<cap>:<dropped>`.
             //
             // This exists because the 2026-07-28 investigation added a drop counter and then could
@@ -4947,6 +4962,14 @@ impl RadioManager {
             self.leaf_ota_fetch_retries = self.leaf_ota_fetch_retries.saturating_add(1);
             (false, self.leaf_ota_fetch_retries)
         } else {
+            // #381: a relay that REACHED the leaf proves the crown's relay path is working right
+            // now, so the pre-relay stall count is stale — reset it. `leaf_ota_fetch_retries` is a
+            // single counter shared across leaves and it releases a single shared gate, so without
+            // this a stale count from deaf leaf A would read as "stalled" while a healthy relay to
+            // leaf B was mid-flight, and the crown would reboot into its own install underneath it.
+            // With it, the counter means "consecutive pre-relay failures with NO successful handoff
+            // in between" — which is the only condition under which holding the crown buys nothing.
+            self.leaf_ota_fetch_retries = 0;
             self.leaf_ota_retries = self.leaf_ota_retries.saturating_add(1);
             let n = self.leaf_ota_retries;
             let exhausted = self.leaf_ota_retries >= LEAF_OTA_MAX_RETRIES;
@@ -4981,6 +5004,29 @@ impl RadioManager {
     /// (`do_install`) on `!leaf_ota_pending()` so a relay is never interrupted.
     pub fn leaf_ota_pending(&self) -> bool {
         self.leaf_ota_pending
+    }
+
+    /// #381: may the crown run its OWN pending install? The whole `do_install` gate, in one call,
+    /// decided by the pure [`crate::net::otagate`] policy (host-tested by
+    /// `experiments/381_gate_verify`).
+    ///
+    /// Supersedes `main` AND-ing `!leaf_ota_pending() && !leaf_installs_outstanding()` inline. Both
+    /// accessors are kept — they still feed the `sog=` DIAG digit — but the DECISION now lives in
+    /// one place, because the bug this fixes was that a permanently-deaf leaf pinned both gates on
+    /// forever and the crown's skip was indistinguishable from being up to date.
+    pub fn crown_may_self_install(&self) -> bool {
+        crate::net::otagate::crown_may_self_install(
+            self.leaf_ota_pending,
+            self.leaf_installs_outstanding,
+            self.leaf_ota_fetch_retries,
+        )
+    }
+
+    /// #381: has the armed leaf install lost its veto over the crown's self-OTA (i.e. did
+    /// [`Self::crown_may_self_install`] return true *despite* a gate being set)? Read only for the
+    /// `sog=` DIAG bit 3, so an operator seeing bits 0/1 set can tell "held" from "released".
+    pub fn leaf_veto_expired(&self) -> bool {
+        crate::net::otagate::leaf_veto_expired(self.leaf_ota_fetch_retries)
     }
 
     /// #3: is ANY leaf still holding a retained OTA install, as of the last TRUSTED gateway flush?

--- a/rust/clock/src/net/otagate.rs
+++ b/rust/clock/src/net/otagate.rs
@@ -1,0 +1,98 @@
+//! #381 crown SELF-OTA gating — the pure decision behind "may the crown update itself yet".
+//!
+//! Extracted from `main`'s `do_install` expression for the same reason `cfgsched` was extracted
+//! from the relay: the failure mode is invisible on the board. A crown that declines its own
+//! install **skips** it — the `&&` short-circuits before `take_install_request()`, so the command
+//! is preserved and nothing fails, logs, or retries. That is byte-for-byte the same non-event as a
+//! crown that is already up to date, which is how a whole fleet roll can report success with the
+//! crown still on the old build.
+//!
+//! # The lock this module exists to break (#381, observed live on the 917 roll, 2026-08-02)
+//!
+//! "The gateway updates itself LAST" is enforced by two gates, and a permanently-deaf leaf pins
+//! both of them ON forever:
+//!
+//! * `leaf_ota_pending` — RAM latch, set when the crown ARMS a relay, cleared only by a terminal
+//!   `record_leaf_ota`. A leaf the crown cannot even address (`MacUnknown`) never produces a
+//!   terminal outcome, so the latch never clears.
+//! * `leaf_installs_outstanding` — derived from the RETAINED install topic. A leaf that never
+//!   installs never clears its retained install, so this never drops either.
+//!
+//! Meanwhile the pre-relay retry (`MacUnknown` / `FetchFailed`, `!reached_leaf()`) is **uncapped
+//! on purpose** — #134: a pre-relay failure is gateway-local and says nothing about the leaf or
+//! the image, so the retained install must survive for the next attempt or the NEXT CROWN
+//! (crown-portable, #111). Capping it re-introduces the #134 bug where a fetch-broken crown burned
+//! an order a healthy successor would have finished. Observed: crown id5 at `retry=35+` for deaf
+//! id50, with its own install silently skipped the whole time.
+//!
+//! # The fix, and what it deliberately does NOT do
+//!
+//! The pre-relay retry keeps running and the retained install is **never** touched here — #134 and
+//! #111 are preserved exactly. What changes is that after [`LEAF_OTA_SELF_GATE_RETRIES`]
+//! consecutive pre-relay failures **with no relay reaching any leaf in between**, that install
+//! stops being allowed to hold the crown's own update hostage. The install stays armed and
+//! retained; only its veto over `do_install` expires.
+//!
+//! This is #195's shape, mirrored. There, a crown whose OWN self-fetch keeps failing stops
+//! re-triggering while deliberately keeping the retained arm (`self_ota_fetch_capped`). Here, a
+//! crown whose RELAY keeps failing pre-handoff stops suppressing itself, while deliberately
+//! keeping the retained install. Both bound a hammer without destroying an order.
+//!
+//! # Why "with no relay reaching any leaf in between" is load-bearing
+//!
+//! `leaf_ota_fetch_retries` is a single counter, not per-leaf, and the latch it releases is a
+//! single bool. If the counter only ever reset on a TERMINAL outcome, a stale count from deaf
+//! leaf A would still read as "stalled" while a perfectly healthy relay to leaf B was mid-flight —
+//! and the crown would reboot into its own install underneath it. `record_leaf_ota` therefore
+//! resets the counter on the post-handoff branch too (`reached_leaf()`), which makes the counter
+//! mean *"consecutive pre-relay failures with no successful handoff in between"* — exactly the
+//! condition under which holding the crown back buys nothing.
+
+/// Consecutive pre-relay failures (`MacUnknown` / `FetchFailed`, no handoff in between) after
+/// which the armed leaf install stops vetoing the crown's own self-OTA.
+///
+/// 3, deliberately the same number as `LEAF_OTA_MAX_RETRIES` (the post-handoff clear cap) and
+/// `SELF_OTA_MAX_RETRIES` (#195's self-fetch cap) — one retry budget across the whole OTA path is
+/// one number for an operator to hold. It is a SEPARATE constant rather than a reuse because it
+/// governs a different thing: those two decide whether to abandon an order, this one only decides
+/// whether an order may keep blocking someone else. At the ~30 s relay-flush cadence this is a
+/// ~90 s grace period before the crown stops waiting — long enough to ride out a transient
+/// roster miss, short enough that it cannot silently outlive a fleet roll.
+pub const LEAF_OTA_SELF_GATE_RETRIES: u8 = 3;
+
+/// Has the currently-armed leaf install failed pre-relay often enough to lose its veto?
+///
+/// Pure predicate over the counter `record_leaf_ota` maintains. `fetch_retries` saturates at
+/// `u8::MAX`, so this stays true once tripped until something resets the counter (a terminal
+/// outcome, or a relay that reaches a leaf).
+#[inline]
+pub fn leaf_veto_expired(fetch_retries: u8) -> bool {
+    fetch_retries >= LEAF_OTA_SELF_GATE_RETRIES
+}
+
+/// May the crown run its OWN pending install?
+///
+/// The ordinary answer is the #40/#3 rule — not while a relay is armed in this session
+/// (`leaf_ota_pending`) and not while any leaf still holds a retained install
+/// (`leaf_installs_outstanding`), so the gateway updates itself LAST. The #381 escape is that a
+/// leaf install which has repeatedly failed *before ever reaching a leaf* no longer counts as a
+/// reason to wait.
+///
+/// Note the escape overrides BOTH gates, not just the RAM latch. That is required, not sloppy: a
+/// deaf leaf pins `leaf_installs_outstanding` through its retained topic, so releasing only the
+/// latch would leave the crown just as stuck — which is precisely the state the 2026-08-02
+/// mitigation had to clear the retained topic by hand to escape.
+#[inline]
+pub fn crown_may_self_install(
+    leaf_ota_pending: bool,
+    leaf_installs_outstanding: bool,
+    fetch_retries: u8,
+) -> bool {
+    leaf_veto_expired(fetch_retries) || (!leaf_ota_pending && !leaf_installs_outstanding)
+}
+
+// No `#[cfg(test)] mod tests` here, deliberately. This module is `espnow`-gated, so it is not in
+// the `hostsim` lib and `cargo test` never compiles it — an in-file test suite would be a suite
+// nothing runs, which is the exact shape #367's verifier-wiring gate exists to catch. The
+// assertions live in `experiments/381_gate_verify/src/main.rs`, which `tools/gate.sh` discovers by
+// glob and runs on every gate.

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -357,6 +357,7 @@ provisioned per tree, so its contents are not a property of the commit at all.""
 # Regenerate with: tools/check_exclusions.py claims --toml
 [tier_exclusive]
 "src/textclip.rs" = "wifi"
+"src/net/otagate.rs" = "espnow"
 "src/bard/delivery.rs" = "bard"
 "src/bard/mod.rs" = "bard"
 "src/bard/nano_llm.rs" = "bard"


### PR DESCRIPTION
Closes #381.

## The failure scenario

A permanently-deaf leaf with an armed install locks the crown out of its **own** OTA, indefinitely.

1. A leaf goes deaf (id50 on the FT roam SSID, 2026-08-02). Its retained install stays armed.
2. Every flush re-surfaces that install. The crown arms a relay → `note_leaf_ota_armed()` sets
   `leaf_ota_pending = 1` → the relay fails **pre-handoff** with `MacUnknown` (the crown cannot
   even address the leaf).
3. A pre-relay failure is **never terminal**, so `record_leaf_ota` never clears the latch. And the
   leaf never installs, so the **retained** gate `leaf_installs_outstanding` never drops either.
4. The crown's self-install gate is `!leaf_ota_pending && !leaf_installs_outstanding`. Both are
   pinned ON. Forever.

The damage is in *how* it fails. `do_install`'s `&&` short-circuits **before**
`take_install_request()`, so the crown's own command is preserved and nothing fails, logs, or
retries — it **skips**. That is byte-for-byte the same non-event as a crown that is already up to
date. **A fleet roll reports success with the crown still on the old build.**

Observed: crown id5 at `mac-unknown retry=35+` for deaf id50, own install silently skipped
throughout. `leaf_ota_pending=1` survived clearing the retained topic by hand, because the latch
is RAM and only a terminal outcome clears it.

## What this does — and what it deliberately does not

**It does not cap the pre-relay retry.** #381's source analysis is explicit that capping it
re-introduces the #134 bug — a fetch-broken crown burning an order a healthy successor would have
finished — and that the retained install must survive for the **next crown** (#111
crown-portability). The retry stays uncapped; the retained install is never touched. What expires
is only that install's **veto** over the crown's own update, after `LEAF_OTA_SELF_GATE_RETRIES = 3`
consecutive pre-relay failures (~90 s at the ~30 s flush cadence).

This is **#195's shape, mirrored**. There, a crown whose *own* self-fetch keeps failing stops
re-triggering while deliberately keeping the retained arm (`self_ota_fetch_capped`). Here, a crown
whose *relay* keeps failing pre-handoff stops suppressing itself, while deliberately keeping the
retained install. Both bound a hammer without destroying an order; both are 3.

**Releasing only the RAM latch would not have worked** — the deaf leaf pins the retained gate too,
which is exactly why the 2026-08-02 mitigation had to clear the topic by hand. Both release
together, and the verifier asserts it, because that is the obvious mistake to make here.

### The subtle half

`record_leaf_ota` now also resets `leaf_ota_fetch_retries` on the **post-handoff** branch. The
counter is shared across leaves and it releases a single shared gate. Had it only reset on a
terminal outcome, a stale count from deaf leaf A would still read as "stalled" while a **healthy
relay to leaf B was mid-flight** — and the crown would reboot into its own install underneath it.
Resetting on `reached_leaf()` makes the counter mean *"consecutive pre-relay failures with no
successful handoff in between"*, which is the only condition under which holding the crown back
buys nothing.

## Shape

The decision moved out of `main`'s expression into a new pure module `net/otagate.rs` — the
`cfgsched` precedent: extracted so the policy can be host-tested, *because the failure mode is
invisible on the board*.

`experiments/381_gate_verify` `#[path]`-includes it and asserts the truth table:

- the #40 order still holds below the threshold (armed relay / outstanding install / both);
- both gates release **at** the threshold, at the observed `retry=35`, and at `u8::MAX`;
- the release is **monotone** to `u8::MAX`, so a future "window" refactor cannot resurrect the
  lock at high retry counts — the exact regime where the bug was observed.

**Mutation-tested in both directions before being trusted** (`[[gate-that-cannot-fail]]`): forcing
the veto to never expire fails at the #381 assertion (`main.rs:48`); forcing it to always expire
fails at the #40-order assertion (`main.rs:30`). Restored source md5 verified identical.

## Observability

`sog=` gains bit 3, and it earns its place: after this fix the crown installs with bits 0/1 **still
set**, so without bit 3 the DIAG record would read "held" at the exact moment the crown stopped
being held — the same read-it-backwards trap the field was added to prevent, in the other
direction. `sog=f` is the #381 state: armed, both legacy gates set, veto expired, installing anyway.

Now formatted hex — 0-f is still **one character**, so the field width and its place in the #306
budget are unchanged (margin 22 B, unchanged). The digit is also built from the accessors rather
than the raw fields now, so it cannot drift from the gate it claims to explain.

## #329 interaction — checked, none

#329 is the own-id order **never arriving** (`install-caught=none`; its own diagnosis explicitly
rules out the `leaf_installs_outstanding` pin, and notes `leaf_ota=0`). #381 is an order that
arrives and is then gated forever (`install-caught=50`). Upstream vs downstream of the same gate;
neither fix affects the other.

## Evidence

Built on `familiar`. Fleet tier `espnow,cast,io`.

| gate | result |
|---|---|
| `cargo clippy --release`, all 10 `build_matrix` tiers | **0 errors**; warning count back to the baseline **3** (local-only `board.rs` `WEATHER_*`, #363) |
| hostsim suites | **bard 41 / budget 10 / input 8**, 0 failed |
| host verifier suites | **19/19 pass**, including the new `381_gate_verify` |
| `check_verifier_wiring.py` | 21 includes / 18 verifiers, **20 SOUND** (was 20/17, 19 sound) — `otagate` is reachable from `main.rs`, i.e. genuinely compiled, not a phantom |
| `test_verifier_wiring.sh` | 5/5 arms proven able to fail |
| `check_elect_send_path` / `check_byte_free` / `check_diag_budget` / `check_shed_order` | all exit 0 |

`readelf -SW`, A/B against an unmodified build of the same base commit:

| section | baseline | this PR | Δ |
|---|---|---|---|
| `.stack` | 106,472 | 106,472 | **0** (1.43× the 74,208 B floor) |
| `.bss` | 157,928 | 157,928 | **0** |
| `.data` | 15,008 | 15,008 | **0** |
| `.rodata` | 68,764 | 68,772 | **+8** (the `{:x}` formatter) |

The fix costs the fleet image eight bytes of `.rodata`.

## Not verified

**No board, no broker, no flash was touched.** The behavioural proof needs a deaf leaf holding an
armed install and a crown with a pending self-install: `sog` should read `3` (held), then `f`
(released) roughly 90 s later, and the crown should install. Ground truth per
`[[smol-ota-ground-truth-hierarchy]]` — an MQTT flip **to a new value**, never a retained topic's
persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
