### PR TITLE
feat(chip): the chip de-pin — per-chip feature arms, a `checks` rung, and the C6 compiling clean (#347 Part 2, #331, #388)

### DIFF
--- a/rust/clock/.cargo/config.toml
+++ b/rust/clock/.cargo/config.toml
@@ -4,6 +4,24 @@
 # script fragments (memory.x, esp32c3.x, linkall.x) via its build script and
 # the `link-arg` flags below wire them into the final link step.
 
+# #347: THE DEFAULT TARGET STAYS THE C3, AND THAT IS A DECISION.
+#
+# The chip de-pin could have deleted this line and required `--target` on every invocation. It
+# deliberately does not: `cargo build --release` with no flags has to remain the guaranteed-green
+# C3 fleet baseline, byte-for-byte, and a per-invocation flag that everyone must remember is a
+# worse guard than a default that is correct. The chip feature and the target triple are chosen
+# TOGETHER, per invocation — see the matrix in tools/build-matrix.toml — and the pairing is
+# enforced from the other end: `budget.rs` refuses a build with no chip feature or with two, and
+# `build.rs` refuses to stamp a chip id it cannot determine (#349).
+#
+# Non-C3 builds therefore pass BOTH halves explicitly:
+#
+#   C5:  cargo check --no-default-features --features esp32c5,<tier> \
+#          --target riscv32imac-unknown-none-elf
+#   C6:  cargo check --no-default-features --features esp32c6,<tier> \
+#          --target riscv32imac-unknown-none-elf
+#   S3:  cargo check --no-default-features --features esp32s3,<tier> \
+#          --target xtensa-esp32s3-none-elf          # + the xtensa toolchain, see below
 [build]
 target = "riscv32imc-unknown-none-elf"
 
@@ -33,6 +51,62 @@ rustflags = [
     "-C", "force-frame-pointers",
 ]
 
+# ── ESP32-C5 / ESP32-C6 (RV32IMAC) ──────────────────────────────────────────────────────────────
+# One section for two chips, because a target triple is an ISA and both chips ARE rv32imac. That
+# ambiguity is exactly what #349 is about: the triple cannot tell a C5 from a C6, so `build.rs`
+# maps it to CHIP_UNKNOWN and the chip FEATURE (plus `SMOL_CHIP` where a name is needed) is what
+# discriminates. Nothing here may imply either chip.
+#
+# No `runner`. Flashing is per-BOARD, not per-triple — it needs the right partition table and, on
+# this fleet, a MAC-guarded port (the USB port map reshuffles; identity is `ID_SERIAL_SHORT` via
+# passive udevadm, never `espflash board-info`, which resets the target). A `runner` here would be
+# a `cargo run` that flashes whichever ESP answered first. It gets added with the board, not with
+# the triple.
+[target.riscv32imac-unknown-none-elf]
+linker = "rust-lld"
+rustflags = [
+    "-C", "linker-flavor=ld.lld",
+    "-C", "link-arg=-Tlinkall.x",
+    "-C", "force-frame-pointers",
+]
+
+# ── ESP32-S3 (Xtensa LX7) ───────────────────────────────────────────────────────────────────────
+# ⚠️ NOT BUILDABLE WITH THE STOCK TOOLCHAIN. `xtensa-esp32s3-none-elf` is a TIER-3 target that
+# upstream rustc does not know: it needs the `esp` channel from espup (Xtensa Rust 1.95.0.0, pinned
+# byte-identical on katana and familiar — upgrade the two in lockstep or a "reproducible" build
+# stops being one). Every build shell must `. ~/export-esp.sh` first, which sets `LIBCLANG_PATH`
+# and prepends the xtensa GCC bin dir.
+#
+# ⚠️⚠️ AND THE TRAP THAT WOULD BREAK THE C3: THE S3 NEEDS `build-std`, AND IT MUST NOT GO IN THIS
+# FILE. There is no prebuilt `core` for this Tier-3 triple, so it must be compiled from source. But
+# cargo's `[unstable] build-std` is **GLOBAL, not per-target** — there is no
+# `[target.xtensa-…] build-std`. Adding it here would turn it on for the C3 too, and that is not a
+# hypothetical cost: it is the exact regression removed on 2026-07-20 (see the note below). build-std
+# forces resolver-1-style feature unification across the host/target boundary, which leaked
+# esp-hal's `portable-atomic/unsafe-assume-single-core` — a riscv-only cfg — into the HOST x86_64
+# build of portable-atomic, where its arch guard `compile_error!`s. That broke EVERY cold-cache C3
+# firmware build, and warm `target/` dirs hid it long enough to ship a release whose ELF only
+# linked because the cache was warm.
+#
+# So build-std is supplied PER INVOCATION, by the S3 wrapper only, as an environment override:
+#
+#   . ~/export-esp.sh
+#   CARGO_UNSTABLE_BUILD_STD=core,alloc \
+#     cargo check --no-default-features --features esp32s3,<tier> \
+#       --target xtensa-esp32s3-none-elf
+#
+# Env-scoped rather than file-scoped means a C3 build cannot inherit it by being in the same tree,
+# which is the property that matters — the 2026-07-20 failure was not that build-std was wrong for
+# the C3, it was that nothing stopped the C3 from getting it.
+[target.xtensa-esp32s3-none-elf]
+rustflags = [
+    "-C", "force-frame-pointers",
+    # No `linker`/`linker-flavor` override here, unlike the riscv targets. Those pin `rust-lld`
+    # because THIS MACHINE's `cc` is a non-compiler shim that must not be in the link path. The
+    # xtensa target has no LLD backend and links through the esp GCC driver that `export-esp.sh`
+    # puts on PATH — pinning `rust-lld` would break it. Same reason, opposite action.
+]
+
 # build-std REMOVED (2026-07-20, morpheus): riscv32imc-unknown-none-elf is a TIER-2 target with a
 # prebuilt core/alloc, so `-Zbuild-std` was unnecessary here. It was also actively HARMFUL: build-std
 # forces resolver-1-style feature unification across the host/target boundary, which leaked esp-hal's
@@ -42,6 +116,12 @@ rustflags = [
 # target/ was warm. Dropping build-std = prebuilt core (no host portable-atomic recompile) → fixed.
 # Verified: cold build of espnow,cast,io + default + wifi all green. REVISIT if a future esp-hal/
 # esp-wifi requires a from-source core (xtensa-only concern; N/A for the riscv C3).
+#
+# #347 UPDATE: that xtensa concern is now REAL — the S3 arm exists and does need a from-source core.
+# It is answered WITHOUT reopening this hole, by supplying build-std as a per-invocation env
+# override (`CARGO_UNSTABLE_BUILD_STD`) from the S3 wrapper instead of as a global config key. See
+# the `[target.xtensa-esp32s3-none-elf]` section above. Leave this block commented out: the fix for
+# "the S3 needs build-std" is never "so turn build-std on".
 # [unstable]
 # build-std = ["core", "alloc"]
 

--- a/rust/clock/Cargo.lock
+++ b/rust/clock/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
  "esp-radio",
  "esp-rtos",
  "esp-storage",
- "esp-wifi-sys-esp32c3",
+ "esp-wifi-sys-chip",
  "libm",
  "log",
  "nb 1.1.0",
@@ -435,6 +435,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-time"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592b0c143ec626e821d4d90da51a2bd91d559d6c442b7c74a47d368c9e23d97a"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "document-features",
+ "embassy-time-driver",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "futures-core",
+]
+
+[[package]]
+name = "embassy-time-driver"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
+dependencies = [
+ "document-features",
+]
+
+[[package]]
+name = "embassy-usb-driver"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa675c5f4349b6aa0fcffc4bf9b241f18cd11b97c1f8323273fb9a5449937fbd"
+dependencies = [
+ "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
+]
+
+[[package]]
+name = "embassy-usb-synopsys-otg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb205e26d59e483e8c48f91f637ec217ec7e2cfb0b61d50482301b991b4ff431"
+dependencies = [
+ "critical-section",
+ "embassy-sync 0.8.0",
+ "embassy-time",
+ "embassy-usb-driver",
+ "portable-atomic",
+]
+
+[[package]]
 name = "embedded-can"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +640,7 @@ dependencies = [
  "esp-println",
  "heapless 0.9.3",
  "riscv",
+ "semihosting",
  "xtensa-lx",
 ]
 
@@ -642,6 +691,8 @@ dependencies = [
  "embassy-embedded-hal",
  "embassy-futures",
  "embassy-sync 0.8.0",
+ "embassy-usb-driver",
+ "embassy-usb-synopsys-otg",
  "embedded-can",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -656,9 +707,11 @@ dependencies = [
  "esp-riscv-rt",
  "esp-rom-sys",
  "esp-sync",
+ "esp-synopsys-usb-otg",
  "esp32",
  "esp32c2",
  "esp32c3",
+ "esp32c5",
  "esp32c6",
  "esp32h2",
  "esp32s2",
@@ -686,6 +739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aebfabb2c21bec45e575e4f6cb6bb7aa8e1b33e7ac45b5dffa0f9d33ff59105"
 dependencies = [
  "document-features",
+ "object",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -713,7 +767,13 @@ dependencies = [
  "esp-metadata-generated",
  "esp-sync",
  "esp-wifi-sys-esp32c3",
+ "esp-wifi-sys-esp32c5",
+ "esp-wifi-sys-esp32c6",
+ "esp-wifi-sys-esp32s3",
  "esp32c3",
+ "esp32c5",
+ "esp32c6",
+ "esp32s3",
  "log",
 ]
 
@@ -758,11 +818,15 @@ dependencies = [
  "esp-wifi-sys-esp32",
  "esp-wifi-sys-esp32c2",
  "esp-wifi-sys-esp32c3",
+ "esp-wifi-sys-esp32c5",
  "esp-wifi-sys-esp32c6",
  "esp-wifi-sys-esp32h2",
  "esp-wifi-sys-esp32s2",
  "esp-wifi-sys-esp32s3",
  "esp32c3",
+ "esp32c5",
+ "esp32c6",
+ "esp32s3",
  "heapless 0.9.3",
  "instability",
  "log",
@@ -770,6 +834,7 @@ dependencies = [
  "num-traits",
  "portable-atomic",
  "portable_atomic_enum",
+ "xtensa-lx-rt",
 ]
 
 [[package]]
@@ -804,6 +869,9 @@ dependencies = [
  "document-features",
  "esp-metadata-generated",
  "esp32c3",
+ "esp32c5",
+ "esp32c6",
+ "esp32s3",
 ]
 
 [[package]]
@@ -862,6 +930,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-synopsys-usb-otg"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8938451cb19032f13365328ea66ab38c8d16deecdf322067442297110eb74468"
+dependencies = [
+ "critical-section",
+ "embedded-hal 0.2.7",
+ "ral-registers",
+ "usb-device",
+ "vcell",
+]
+
+[[package]]
+name = "esp-wifi-sys-chip"
+version = "0.1.0"
+dependencies = [
+ "esp-wifi-sys-esp32c3",
+ "esp-wifi-sys-esp32c5",
+ "esp-wifi-sys-esp32c6",
+ "esp-wifi-sys-esp32s3",
+]
+
+[[package]]
 name = "esp-wifi-sys-esp32"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +978,12 @@ checksum = "b290846b53db9a3965866964260220b67f2c41cc2dbc0b377e7136239fe168a7"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "esp-wifi-sys-esp32c5"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "039337bdc50a40335ed01598e83053164426fed82817492719513d922dcc3592"
 
 [[package]]
 name = "esp-wifi-sys-esp32c6"
@@ -947,6 +1044,15 @@ name = "esp32c3"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e89ed62cf6c043a6d29c520b02a13b359ec8a75d67b65d4330ed717d15fe97"
+dependencies = [
+ "vcell",
+]
+
+[[package]]
+name = "esp32c5"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f8ba56195df10224263c60ceb93b4578450019ee838b7338039a281117cb02"
 dependencies = [
  "vcell",
 ]
@@ -1283,6 +1389,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,6 +1508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ral-registers"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b71a9d9206e8b46714c74255adcaea8b11e0350c1d8456165073c3f75fc81a"
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1613,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semihosting"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8e4abf97879f4e80db69a9fba7bd64998e9bdad25f58ef045a778e191172fd4"
 
 [[package]]
 name = "serde"
@@ -1747,6 +1874,16 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "usb-device"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
+dependencies = [
+ "heapless 0.8.0",
+ "portable-atomic",
+]
 
 [[package]]
 name = "vcell"

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -61,12 +61,12 @@ sigil-names = { path = "../sigil-names", default-features = false }
 # `unstable` is required for I2C/SPI/RNG and is also a hard requirement of
 # esp-wifi. `esp32c3` selects the chip. `rt` + `exception-handler` come from
 # the default features (runtime + fault handler).
-esp-hal = { version = "1.1", features = ["esp32c3", "unstable"], optional = true }
+esp-hal = { version = "1.1", features = ["unstable"], optional = true }
 # NOTE: esp-hal's default features already install the exception handler, so
 # esp-backtrace only provides the panic handler + backtrace printing here.
 # Enabling esp-backtrace's `exception-handler` too causes a duplicate
 # `ExceptionHandler` symbol and an LTO bitcode-load failure at link time.
-esp-backtrace = { version = "0.19", features = ["esp32c3", "panic-handler", "println"], optional = true }
+esp-backtrace = { version = "0.19", features = ["panic-handler", "println"], optional = true }
 # Force the USB Serial/JTAG backend explicitly. This board's console is the
 # native USB Serial/JTAG link (/dev/ttyACM0); esp-println's default `auto`
 # backend only routes to USB-JTAG when it detects host SOF packets at the
@@ -74,7 +74,6 @@ esp-backtrace = { version = "0.19", features = ["esp32c3", "panic-handler", "pri
 # left app logs going to the (unwired) UART0. `jtag-serial` pins the output to
 # USB-JTAG so boot/WiFi/NTP/ESP-NOW logs always appear on /dev/ttyACM0.
 esp-println = { version = "0.17", default-features = false, optional = true, features = [
-    "esp32c3",
     "log-04",
     "jtag-serial",
     "colors",
@@ -105,7 +104,6 @@ esp-alloc = { version = "0.10", optional = true }
 # (NOT `embassy`) — smol stays a blocking superloop, and `esp_rtos::start()` turns main()
 # into the scheduler's pinned main task, so the existing blocking code runs as-is.
 esp-rtos = { version = "0.3", optional = true, features = [
-    "esp32c3",
     "esp-radio",
     "esp-alloc",
     "log-04",
@@ -114,7 +112,6 @@ esp-rtos = { version = "0.3", optional = true, features = [
 # (our smoltcp shim) + the `esp_now` interface. `default-features = false` drops
 # esp-radio's default `esp-alloc` so we re-add it explicitly.
 esp-radio = { version = "0.18", optional = true, default-features = false, features = [
-    "esp32c3",
     "wifi",
     "esp-alloc",
     "unstable",
@@ -123,7 +120,19 @@ esp-radio = { version = "0.18", optional = true, default-features = false, featu
 # #141 TX-power clamp + AP-info readback use raw esp-idf bindings. esp-radio's
 # `sys` module is pub(crate), so we depend on the per-chip bindings crate directly
 # and alias it to `esp_wifi_sys` — net.rs keeps `esp_wifi_sys::include::…` verbatim.
-esp-wifi-sys = { package = "esp-wifi-sys-esp32c3", version = "0.2", optional = true, default-features = false }
+#
+# #347: that alias used to be `package = "esp-wifi-sys-esp32c3"` — a hardcoded chip in a place a
+# feature CANNOT reach, because `esp-wifi-sys` is four separate PACKAGES rather than one package
+# with a chip feature, and cargo resolves `package =` before it knows any features. So the choice
+# moved into `rust/esp-wifi-sys-chip`, which owns all four aliases behind its own chip features.
+#
+# The KEY is still spelled `esp-wifi-sys`, so `esp_wifi_sys::include::…` in net.rs is unchanged
+# character for character. The dep stays optional and is pulled by `wifi` (the RADIO half); the chip
+# arm is forwarded by the chip feature with the WEAK form `esp-wifi-sys?/esp32cX` (the CHIP half).
+# That indirection is not taste — it is the only way to express `chip AND radio`, and getting it
+# wrong would link the Espressif blob archives into the `default` tier, which links none today.
+# Full derivation in rust/esp-wifi-sys-chip/src/lib.rs.
+esp-wifi-sys = { package = "esp-wifi-sys-chip", path = "../esp-wifi-sys-chip", optional = true, default-features = false }
 # #233: esp-radio 0.18 made connect/disconnect/scan ASYNC-only (no blocking variants).
 # smol is a synchronous superloop, so we drive those futures to completion with
 # embassy-futures' busy-loop `block_on` (no executor needed; the esp-rtos scheduler
@@ -145,8 +154,8 @@ smoltcp = { version = "0.13", optional = true, default-features = false, feature
 # rom.rs references an unresolved `esp_rom_sys` (md5/crc pulled by the chip
 # feature). esp-storage gives XIP-safe flash writes (FlashStorage auto-detects
 # 4 MB); esp-bootloader-esp-idf gives the otadata slot/state API + esp_app_desc!.
-esp-storage = { version = "0.9", optional = true, features = ["esp32c3"] }
-esp-bootloader-esp-idf = { version = "0.5", optional = true, features = ["esp32c3"] }
+esp-storage = { version = "0.9", optional = true, features = [] }
+esp-bootloader-esp-idf = { version = "0.5", optional = true, features = [] }
 # Software SHA-256 for the OTA image integrity gate. Chosen over the HW `esp_hal::sha`
 # peripheral deliberately: the HW path needs the SHA peripheral threaded through boot
 # into the OTA burst + a self-referential `ShaDigest` (borrows the `Sha` beside it),
@@ -177,11 +186,136 @@ ed25519-compact = { version = "2", default-features = false, optional = true }
 # (No extra top-level crate; the feature is toggled on esp-wifi below.)
 
 [features]
+# ── CHIP TARGETS (#347 / #331). EXACTLY ONE must be enabled. ───────────────────────────────────
+#
+# Every `esp-*` declaration above used to carry `features = ["esp32c3", …]`. A chip named in EIGHT
+# dependency declarations is not a target, it is a transplant: adding a second board meant editing
+# eight lists in lockstep and there was nothing to check that you had. Now the chip is named ONCE,
+# here, and fans out.
+#
+# ⚠️ THE INVARIANT THAT MAKES PER-CHIP ARMS LEGAL AT ALL:
+#
+#   esp-hal accepts exactly ONE chip feature, and cargo UNIFIES features across a workspace.
+#   Four arms in one manifest is nonetheless fine, because EVERY BUILD INVOCATION IS SINGLE-CHIP:
+#   the features and the target triple are chosen together, per invocation, and a build carrying
+#   two chip features is refused below rather than resolved.
+#
+#   What this manifest can therefore never do is build two chips AT ONCE, or share a cargo
+#   workspace graph with a crate compiled for a different chip. That is why `rust/sigil-names` and
+#   `rust/esp-wifi-sys-chip` declare their own `[workspace]` (see either file): a riscv crate and an
+#   xtensa crate in one graph would hand esp-hal two chips, and no amount of care in THIS file
+#   would help. Shared logic crosses that boundary as chip-agnostic, zero-dep, host-testable
+#   crates consumed BY PATH — the shape emberburrito proved on its own C3+S3 tree.
+#
+# ⚠️ WEAK (`?/`) FORWARDING IS LOAD-BEARING, NOT STYLE. `esp-hal?/esp32c3` means "if esp-hal ends up
+# enabled, turn on its esp32c3 feature". The plain form `esp-hal/esp32c3` would additionally ENABLE
+# the optional dependency — which would drag every bare-metal crate into the `hostsim` build and
+# destroy #152's host-emulator boundary, and would drag the radio + OTA crates into the `default`
+# tier. Every forward below is weak for that reason. The chip is a FACT about the build; it must not
+# be a reason for a crate to appear.
+#
+# A chip feature also supplies the board-independent CAPABILITY features for that silicon (see
+# below). Adding a fifth chip is: one arm here, one `ChipBudget` row in src/budget.rs, one
+# `[chip.*]` row in tools/build-matrix.toml. The checker asserts the last two agree.
+esp32c3 = [
+    "esp-hal?/esp32c3", "esp-backtrace?/esp32c3", "esp-println?/esp32c3",
+    "esp-rtos?/esp32c3", "esp-radio?/esp32c3",
+    "esp-storage?/esp32c3", "esp-bootloader-esp-idf?/esp32c3",
+    "esp-wifi-sys?/esp32c3",
+]
+esp32c5 = [
+    "esp-hal?/esp32c5", "esp-backtrace?/esp32c5", "esp-println?/esp32c5",
+    "esp-rtos?/esp32c5", "esp-radio?/esp32c5",
+    "esp-storage?/esp32c5", "esp-bootloader-esp-idf?/esp32c5",
+    "esp-wifi-sys?/esp32c5",
+    "has-ieee802154",
+]
+esp32c6 = [
+    "esp-hal?/esp32c6", "esp-backtrace?/esp32c6", "esp-println?/esp32c6",
+    "esp-rtos?/esp32c6", "esp-radio?/esp32c6",
+    "esp-storage?/esp32c6", "esp-bootloader-esp-idf?/esp32c6",
+    "esp-wifi-sys?/esp32c6",
+    "has-ieee802154",
+]
+esp32s3 = [
+    "esp-hal?/esp32s3", "esp-backtrace?/esp32s3", "esp-println?/esp32s3",
+    "esp-rtos?/esp32s3", "esp-radio?/esp32s3",
+    "esp-storage?/esp32s3", "esp-bootloader-esp-idf?/esp32s3",
+    "esp-wifi-sys?/esp32s3",
+    "has-psram",
+]
+
+# ── HARDWARE CAPABILITIES ──────────────────────────────────────────────────────────────────────
+#
+# Empty markers, existing to be `cfg`'d on. Chips select capabilities; code predicates on the
+# capability, never on the chip name — the OpenWrt model (`low_mem`, `small_flash`) that
+# src/budget.rs documents and that the esp32c6-watch's `has-pmu`/`has-imu`/`has-audio` seam
+# already runs in this house.
+#
+# ── WHERE smol DIVERGES FROM THE WATCH, AND WHY ────────────────────────────────────────────────
+#
+# The watch's seam is TWO layers: a `board-*` feature supplies the chip AND the capabilities, so
+# `board-waveshare-c6` and `board-cyd-c5` are the user-facing choice. smol has only the chip layer
+# and deliberately grows no `board-*` features. That is not a shortcut — the two repos put the
+# board/chip line in genuinely different places:
+#
+#   * The watch is ONE board per image. Its panel geometry is compile-time (Slint scenes are
+#     absolute-positioned per panel, so build.rs picks a different scene root per board), so a
+#     board IS a build.
+#   * smol is "fat image / thin runtime config" (#72). A board announces what it is at RUNTIME:
+#     `BoardProfile` (#352) is selected from `SELF_CHIP` plus an I2C display PROBE, node identity
+#     comes from a runtime id, and the #72 pin-map arrives over the air. Two smol boards on the
+#     same silicon run the SAME binary on purpose.
+#
+# So at smol the only thing that must be compile-time is what the SILICON fixes, and that is
+# exactly the chip feature and the capabilities it implies. A `board-*` layer here would compile in
+# a fact the runtime already discovers better, and would fork the fleet image per board — the one
+# property the OTA story depends on not doing.
+#
+# ⚠️ Correspondingly, DO NOT add capability features for things BoardProfile probes. `has-display`
+# would be exactly that mistake: it is a runtime I2C probe today (`BoardProfile::for_self(has_display)`),
+# and freezing it into the feature set would make one image per board variant.
+
+# 802.15.4 radio (Thread/Zigbee PHY): the C6 and the C5 have one, the C3 and S3 do not. Marker
+# only — it deliberately does NOT forward to `esp-radio/ieee802154`, and MUST NOT.
+#
+# ⚠️ `esp-radio`'s build script HARD-PANICS when `esp-now` and `ieee802154` are enabled together
+# (the same class of refusal as the `coex`-without-`ble` error documented on the `espnow` feature
+# below). smol's mesh IS ESP-NOW on every tier that has a radio, so a build that turned this marker
+# into the real esp-radio feature would fail at build-script time on the two chips that own the
+# capability — i.e. enabling a C6's headline feature would break the C6. The Zigbee-bridge role
+# (#331 / the NM-CYD-C5's 802.15.4 role) therefore needs a tier where the mesh transport is NOT
+# ESP-NOW, which is a protocol decision and not a feature-flag one. Until then this marker records
+# that the silicon has the radio, and nothing links it.
+has-ieee802154 = []
+
+# Octal/quad PSRAM (the S3's 8 MB). Marker only; the amount and mode are NOT expressible here.
+#
+# ⚠️ PSRAM mode is a RUNTIME `PsramConfig` field in esp-hal 1.1.x, NOT a cargo feature and NOT an
+# `ESP_HAL_CONFIG_*` env knob. A research doc in the emberburrito tree asserted both and was
+# disproven on hardware; write the mode in code where the config struct is built.
+#
+# ⚠️ AND THE ONE THAT SILENTLY CORRUPTS: `esp-radio`'s heap must NEVER live in PSRAM on the S3.
+# The radio blobs use atomics that do not work against PSRAM, and the failure is not a panic — it
+# is wrong data. `net::init_heap` must keep the radio heap in internal DRAM and add PSRAM as a
+# separate region if at all. Recorded at the feature that makes PSRAM reachable, because the
+# temptation ("8 MB of heap, why is the heap still 128 KiB") arrives with the feature.
+has-psram = []
+
 # Phase 1 only: clock on the OLED. `default` = `hw` so `cargo build --release` with no
 # flags is the guaranteed-green firmware baseline — BYTE-IDENTICAL to before the #152
 # split (the bare-metal crates were non-optional before; now they ride `hw`, which
 # `default` and every firmware tier pull, so the same deps + code compile).
-default = ["hw"]
+#
+# #347: `esp32c3` joins it, so `cargo build --release` with no flags is still a C3 image and still
+# byte-identical — the chip moved from eight dependency declarations into one feature, and feature
+# resolution is a set union, so the resolved set is unchanged. That equality is MEASURED, not
+# argued: section sizes + `nm` against the pre-#347 artifact, reported on the PR.
+#
+# ⚠️ Consequence worth knowing before you type it: because the chip rides `default`, building for
+# another chip needs `--no-default-features` and the tier spelled out, or you get TWO chip features
+# and the refusal in src/budget.rs. See the per-chip invocations in tools/build-matrix.toml.
+default = ["esp32c3", "hw"]
 
 # #152 host-emulator boundary. The bare-metal crates (esp-hal / esp-backtrace /
 # esp-println / ssd1306) are `optional` so a NON-hardware target (the `hostsim` wasm lib)

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -2,7 +2,31 @@
 name = "clock"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.96"
+# LOWERED 1.96 -> 1.95 by #347 Part 2, because 1.96 was blocking a supported target and had no
+# reason to be there.
+#
+# It is a FLOOR, not a pin: the C3/C5/C6 builds and every gate run on `stable` (1.97.1 today, per
+# rust-toolchain.toml's ride-stable policy), and lowering a floor cannot change what they compile.
+# What it changes is the ONE toolchain that sits below it — espup's Xtensa fork, which is the only
+# rustc that can target `xtensa-esp32s3-none-elf` and is pinned at **1.95.0.0** (byte-identical on
+# katana and familiar; the two upgrade in lockstep or a reproducible build stops being one).
+#
+# So `1.96` was not describing a language requirement, it was silently declaring the S3 unsupported.
+# MEASURED, not assumed: with this line at 1.95 the S3 arm compiles `core` from source, builds
+# esp-hal 1.1.1 for xtensa, and reaches smol's OWN board code (6 errors in sensors.rs / ota.rs /
+# main.rs). Cargo refuses before any of that with `1.96`: "rustc 1.95.0-nightly is not supported...
+# clock@0.1.0 requires rustc 1.96".
+#
+# And 1.96 was never a reasoned choice — `git log -S` puts it in the crate's SCAFFOLD commit
+# (2ae697b), alongside the `1.96.1` toolchain pin that rust-toolchain.toml has since removed as "a
+# fossil from ONE familiar-side spurious-lint incident". This is the same fossil, one file over.
+# Per JP's standing rule that pins are exceptions carrying written reasons, a floor with no reason
+# that costs a target is exactly the kind that goes.
+#
+# ⚠️ RAISE IT AGAIN ONLY WITH A NAMED FEATURE. If something genuinely needs a newer language
+# feature, this line moves — but raising it above the Xtensa fork's version drops the S3, so say so
+# in the commit and update tools/build-matrix.toml's [chip.esp32s3] row in the same change.
+rust-version = "1.95"
 description = "smol: ESP32-C3 SuperMini + 0.42\" SSD1306 OLED clock with WiFi/NTP + ESP-NOW"
 license = "MIT OR Apache-2.0"
 

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -246,27 +246,36 @@ esp32c3 = [
     "esp-rtos?/esp32c3", "esp-radio?/esp32c3",
     "esp-storage?/esp32c3", "esp-bootloader-esp-idf?/esp32c3",
     "esp-wifi-sys?/esp32c3",
+    "has-tsens", "has-reset-glitch-split",
 ]
 esp32c5 = [
     "esp-hal?/esp32c5", "esp-backtrace?/esp32c5", "esp-println?/esp32c5",
     "esp-rtos?/esp32c5", "esp-radio?/esp32c5",
     "esp-storage?/esp32c5", "esp-bootloader-esp-idf?/esp32c5",
     "esp-wifi-sys?/esp32c5",
-    "has-ieee802154",
+    "has-ieee802154", "has-reset-glitch-unified",
 ]
 esp32c6 = [
     "esp-hal?/esp32c6", "esp-backtrace?/esp32c6", "esp-println?/esp32c6",
     "esp-rtos?/esp32c6", "esp-radio?/esp32c6",
     "esp-storage?/esp32c6", "esp-bootloader-esp-idf?/esp32c6",
     "esp-wifi-sys?/esp32c6",
-    "has-ieee802154",
+    "has-ieee802154", "has-tsens",
+    # NO glitch marker: the C6 is the chip that reports no glitch reason AT ALL. See
+    # `has-reset-glitch-split` below — the absence is the measured fact, not an omission.
 ]
 esp32s3 = [
     "esp-hal?/esp32s3", "esp-backtrace?/esp32s3", "esp-println?/esp32s3",
     "esp-rtos?/esp32s3", "esp-radio?/esp32s3",
     "esp-storage?/esp32s3", "esp-bootloader-esp-idf?/esp32s3",
     "esp-wifi-sys?/esp32s3",
-    "has-psram",
+    "has-psram", "has-reset-glitch-split",
+    # NO `has-tsens`. This arm CARRIED it in the first draft of this commit, from a datasheet-shaped
+    # assumption that the big chip has at least what the little one has. A per-chip `cargo check` on
+    # familiar's xtensa toolchain said otherwise: `esp_hal::tsens` is unresolved for
+    # xtensa-esp32s3-none-elf on esp-hal 1.1.1, exactly as on the C5. Left as a comment rather than
+    # silently corrected, because "the superset chip has the peripheral" is the specific wrong
+    # instinct this whole layer exists to stop anyone acting on. MEASURE the chip.
 ]
 
 # ── HARDWARE CAPABILITIES ──────────────────────────────────────────────────────────────────────
@@ -325,6 +334,59 @@ has-ieee802154 = []
 # separate region if at all. Recorded at the feature that makes PSRAM reachable, because the
 # temptation ("8 MB of heap, why is the heap still 128 KiB") arrives with the feature.
 has-psram = []
+
+# ── The two markers that GATE REAL CODE (#347 Part 2) ──────────────────────────────────────────
+#
+# Worth stating plainly, because the four above are declarations and these two are not: everything
+# from `has-ieee802154` up records a fact and links nothing. The markers below are read by
+# `src/ota.rs` and `src/sensors.rs`, and they are the reason the has-* layer is a mechanism rather
+# than a vocabulary. They were derived from a MEASURED per-chip `cargo check`, not from a datasheet
+# reading — see the tables in each block.
+
+# Internal temperature sensor (`esp_hal::tsens` + `peripherals::TSENS`).
+#
+# esp-hal gates the whole module behind `#[cfg(soc_has_tsens)]`, so on a chip without it the C3's
+# `src/sensors.rs` imports are not a type error but an UNRESOLVED IMPORT — the module does not
+# exist. MEASURED on esp-hal 1.1.1, one `cargo check` per chip: **C3 ✓, C6 ✓, C5 ✗, S3 ✗**.
+#
+# The S3 being a ✗ is the entry worth reading twice: it is the biggest chip of the four and it does
+# not expose the sensor the smallest one does. Half of this table is counter-intuitive, which is the
+# argument for the table.
+#
+# ⚠️ The C5 is the odd one out, and this marker does NOT yet make the C5 compile. `sensors.rs`,
+# `main.rs`'s `peripherals.TSENS` wiring and the `Sensors::new` signature still assume the sensor
+# exists unconditionally; giving them `#[cfg(feature = "has-tsens")]` arms plus a no-sensor
+# fallback is #388's board-bring-up work, tracked in tools/build-matrix.toml's [chip.esp32c5]
+# `blocked_on`. What this marker does is make that work a matter of ADDING cfg arms against a
+# predicate that already exists and is already correct on the other three chips — rather than
+# inventing the predicate at the same time as the fallback, which is how a bring-up ends up
+# spelling `#[cfg(feature = "esp32c5")]` in a sensors module and re-pinning the chip #347 just
+# un-pinned. Declared ahead of its consumer ON PURPOSE, and that is the exception to the rule
+# above, not a new default.
+has-tsens = []
+
+# Glitch-detector reset reporting, in the SoC's `SocResetReason` enum. THREE shapes, not two, which
+# is why this is a pair of markers and not one boolean — MEASURED against esp-hal 1.1.1's
+# per-chip `rtc_cntl/rtc/*.rs`:
+#
+#   | chip           | variants                                          | marker          |
+#   |----------------|---------------------------------------------------|-----------------|
+#   | C3, S3         | `SysClkGlitch` = 0x13 AND `CorePwrGlitch` = 0x17  | -split          |
+#   | C5             | `PowerGlitch`  = 0x19 only                        | -unified        |
+#   | C6             | **none at all**                                   | *neither*       |
+#
+# A chip selecting NEITHER is a legal, meaningful state: `src/ota.rs`'s match arm compiles out and
+# a glitch reset falls through the existing `Some(_) => "other"`. That is honest — the C6 does not
+# distinguish it in hardware, so there is nothing for the token to report. This is exactly why the
+# predicate is a capability and not `cfg(feature = "esp32c6")`: "has no glitch detector" is a fact
+# about silicon that a future fifth chip may share, and it should not have to be re-discovered.
+#
+# ⚠️ DEFERRED, NOT DONE: the C5 also has `CpuLockup` = 0x1A, which the C3 lacks and which nothing
+# maps — it falls to "other". Correct but lossy, and it needs its own marker. Left undone because
+# there is no C5 board to read a DIAG off yet (#388); recorded here so it is a task rather than a
+# caveat that reads as handled. `reset_reason_token()` is NOT chip-complete.
+has-reset-glitch-split = []
+has-reset-glitch-unified = []
 
 # Phase 1 only: clock on the OLED. `default` = `hw` so `cargo build --release` with no
 # flags is the guaranteed-green firmware baseline — BYTE-IDENTICAL to before the #152

--- a/rust/clock/build.rs
+++ b/rust/clock/build.rs
@@ -5,12 +5,15 @@
 //!     name (`net::names::version_name`). Falls back to `"dev"`.
 //!   * `BUILD_NUMBER` — monotonic build count (`git rev-list --count HEAD`) shown
 //!     as `v<N>`. Falls back to `"0"`.
-//!   * `SMOL_CHIP_ID` — (#349) the chip this image is built for, DERIVED from the target
-//!     triple where that is unambiguous (`riscv32imc`→C3, `xtensa-esp32s3`→S3;
-//!     `riscv32imac` is C5 *or* C6 and maps to UNKNOWN = build failure on wifi tiers).
+//!   * `SMOL_CHIP_ID` — (#349, reworked by #347 Part 2) the chip this image is built for,
+//!     derived from the CHIP FEATURE (`esp32c3` / `esp32c5` / `esp32c6` / `esp32s3`), which is
+//!     unambiguous and which `budget.rs` already refuses to leave unset or doubled. The target
+//!     triple and `SMOL_CHIP` are kept as CROSS-CHECKS: either may be absent, neither may
+//!     contradict the feature, and a disagreement fails the build. `SMOL_CHIP` is therefore no
+//!     longer REQUIRED for `riscv32imac` (the C5/C6 triple the feature now discriminates) — it
+//!     remains available for naming silicon whose triple this tree does not map.
 //!     Consumed by `net::target::SELF_CHIP` and embedded in the image's target descriptor so
-//!     a board can refuse an image built for other silicon. `SMOL_CHIP=<name>` overrides by
-//!     name, and is REQUIRED for the ambiguous triples.
+//!     a board can refuse an image built for other silicon.
 //!   * `SMOL_NODE_ID` — (#42) OPTIONAL per-board id override, emitted ONLY when the
 //!     env var is set, so `SMOL_NODE_ID=8 cargo build` builds an id-8 image without
 //!     hand-editing `board.rs` (which reads it via `option_env!`, fallback = its own
@@ -75,40 +78,122 @@ fn main() {
     println!("cargo:rerun-if-env-changed=SMOL_NODE_ID");
 }
 
-/// #349: map the build's target triple to the `net::target::CHIP_*` id embedded in the image
-/// descriptor. `SMOL_CHIP` overrides it by NAME (not by number) for a chip whose triple this
-/// mapping does not yet know — an explicit, greppable act rather than a silent default.
+/// The four `net::target::CHIP_*` ids, as (feature name, id). ONE list, used by all three
+/// sources below, so a fifth chip cannot be taught to two of them and forgotten in the third.
+const CHIPS: [(&str, u8); 4] = [("esp32c3", 1), ("esp32c6", 2), ("esp32s3", 3), ("esp32c5", 4)];
+
+/// #349 + #347 Part 2: the `net::target::CHIP_*` id embedded in the image descriptor.
 ///
-/// `0` (CHIP_UNKNOWN) is returned when the triple is unrecognised, and `net/target.rs` has a
-/// `const _: () = assert!(SELF_CHIP != CHIP_UNKNOWN)` — so an unmapped chip fails the BUILD
-/// instead of shipping an image that claims to be for nothing in particular. That assert only
-/// exists on `wifi` tiers (the ones that can be OTA'd), so a host/hostsim build is unaffected.
+/// ── WHAT CHANGED IN PART 2, AND WHY IT IS A CORRECTNESS FIX ────────────────────────────────
+/// This used to read the TARGET TRIPLE, with `SMOL_CHIP` as an unchecked override. That was the
+/// best available answer when the chip was spelled across eight dependency declarations and
+/// nothing in cargo's world knew it. It is no longer: since bd26db1 the build carries a CHIP
+/// FEATURE, `budget.rs` compile_errors unless EXACTLY ONE is enabled, and a build script can read
+/// features from the environment. So the feature is now the authority, and it is a strictly better
+/// one than the triple in both directions:
+///
+///   * It is UNAMBIGUOUS where the triple is not. `riscv32imac` is the C5 *and* the C6, so the
+///     triple path had to return CHIP_UNKNOWN and lean on `SMOL_CHIP` — meaning every C5/C6 build
+///     needed an env var carrying information the build already had. Forgetting it failed the
+///     build, correctly but confusingly, over a fact that was never actually missing.
+///   * It CANNOT SILENTLY DISAGREE. The old override was applied without ever being compared to
+///     anything, so `--features esp32c6` with `SMOL_CHIP=esp32c5` stamped a C5 id onto a C6 image
+///     — a valid-looking value that `net::target::decide()` would then trust to accept a
+///     cross-chip OTA. That is the exact failure #349 exists to prevent, still reachable through
+///     #349's own escape hatch. Now a disagreement is a hard build failure.
+///
+/// `SMOL_CHIP` is KEPT, for the case that justified it: naming silicon whose triple this mapping
+/// does not know. It just may no longer contradict the feature.
+///
+/// `0` (CHIP_UNKNOWN) still means "nothing here knows", and `net/target.rs`'s
+/// `const _: () = assert!(SELF_CHIP != CHIP_UNKNOWN)` fails the build rather than shipping an
+/// image that claims to be for nothing in particular. That assert exists only on `wifi` tiers, so
+/// host/hostsim builds — which have no chip feature and want none — are unaffected.
 fn chip_id() -> u8 {
-    if let Ok(name) = std::env::var("SMOL_CHIP") {
-        return match name.trim() {
-            "esp32c3" => 1,
-            "esp32c6" => 2,
-            "esp32s3" => 3,
-            "esp32c5" => 4,
-            _ => 0,
-        };
+    // Features reach a build script as `CARGO_FEATURE_<NAME>`, uppercased with `-` -> `_`.
+    let from_feature: Vec<(&str, u8)> = CHIPS
+        .iter()
+        .filter(|(name, _)| {
+            std::env::var(format!("CARGO_FEATURE_{}", name.to_uppercase())).is_ok()
+        })
+        .copied()
+        .collect();
+
+    // TWO chip features: deliberately NOT this function's error to report. `budget.rs` already
+    // refuses it with a message that names the likely cause (`--features esp32c5` without
+    // `--no-default-features`, so `default`'s esp32c3 makes a second chip) and the exact fix.
+    // Panicking here would preempt that with something worse, since a build script's panic is
+    // the first failure the user sees. Emit UNKNOWN and let the good diagnostic win.
+    if from_feature.len() > 1 {
+        return 0;
     }
+
+    let from_triple = triple_chip();
+    let from_env = std::env::var("SMOL_CHIP").ok().map(|v| v.trim().to_string());
+    if let Some(name) = from_env.as_deref() {
+        if !name.is_empty() && !CHIPS.iter().any(|(n, _)| *n == name) {
+            // Previously an unrecognised name fell through to 0, which failed the build later
+            // with the SELF_CHIP assert — a message about an unknown chip id that says nothing
+            // about the typo that caused it. Fail here, naming the value and the valid set.
+            panic!(
+                "SMOL_CHIP={name:?} is not a chip this tree knows. Valid: {}. \
+                 (It overrides the chip NAME for silicon whose triple is ambiguous; it does not \
+                 need setting when a chip feature is enabled.)",
+                CHIPS.iter().map(|(n, _)| *n).collect::<Vec<_>>().join(" / ")
+            );
+        }
+    }
+
+    if let Some((feat_name, feat_id)) = from_feature.first().copied() {
+        // The feature is the authority. Both other sources are now CROSS-CHECKS: each may be
+        // absent or ambiguous, but neither may contradict it.
+        if let Some(env_name) = from_env.as_deref().filter(|s| !s.is_empty()) {
+            assert!(
+                env_name == feat_name,
+                "chip DISAGREEMENT: the build enables feature `{feat_name}` but SMOL_CHIP says \
+                 `{env_name}`. One of them is wrong and guessing which would stamp an image with \
+                 silicon it was not built for — which is how an OTA gets accepted cross-chip \
+                 (#349). Drop SMOL_CHIP (the feature already names the chip) or fix the feature."
+            );
+        }
+        if let Some((triple_name, triple_id)) = from_triple {
+            assert!(
+                triple_id == feat_id,
+                "chip DISAGREEMENT: feature `{feat_name}` but target triple {:?} is {triple_name}. \
+                 The features and the target are chosen TOGETHER, per invocation — see the \
+                 per-chip invocations in tools/build-matrix.toml, or run tools/check_chips.sh.",
+                std::env::var("TARGET").unwrap_or_default()
+            );
+        }
+        return feat_id;
+    }
+
+    // No chip feature. Either a host/hostsim build (no descriptor is emitted on those tiers) or
+    // a bare-metal build that budget.rs is about to refuse. Honour SMOL_CHIP, else the triple.
+    if let Some(name) = from_env.as_deref().filter(|s| !s.is_empty()) {
+        return CHIPS.iter().find(|(n, _)| *n == name).map(|(_, id)| *id).unwrap_or(0);
+    }
+    from_triple.map(|(_, id)| id).unwrap_or(0)
+}
+
+/// The triple -> chip mapping, as a CROSS-CHECK rather than the primary source. `None` means the
+/// triple cannot name a chip: `riscv32imac` is shared by the C5 and the C6, and a host/wasm triple
+/// is not a chip at all. Both are legitimately unknowable here, which is why this returns Option
+/// instead of the old `0` — "ambiguous" and "definitely nothing" were the same value before, and
+/// only one of them should silence a cross-check.
+///
+/// Ordering matters: "riscv32imac" does not contain "riscv32imc" as a prefix-substring, but the
+/// more specific arms are matched first anyway so a future triple cannot alias onto the C3.
+fn triple_chip() -> Option<(&'static str, u8)> {
     let target = std::env::var("TARGET").unwrap_or_default();
-    // riscv32imc = C3; xtensa-esp32s3 = S3. riscv32imac is AMBIGUOUS — the C5 and the C6
-    // share it — so it maps to 0 (CHIP_UNKNOWN) and the wifi-tier const assert fails the
-    // build until `SMOL_CHIP=<name>` says which silicon this image is for. A guessed id
-    // would be a valid-looking value the suitability check trusts: this exact shape once
-    // stamped a C5 build as a C6, which `decide()` would then have accepted cross-chip.
-    // Ordering matters: "riscv32imac" contains no "riscv32imc" substring, but match the
-    // longer/more specific arms first anyway so a future triple cannot alias onto the C3.
     if target.starts_with("xtensa-esp32s3") {
-        3
+        Some(("esp32s3", 3))
     } else if target.starts_with("riscv32imac") {
-        0 // ambiguous (C5|C6) — require SMOL_CHIP, fail closed via the SELF_CHIP assert
+        None // C5 or C6 — the feature discriminates; nothing here can.
     } else if target.starts_with("riscv32imc") {
-        1
+        Some(("esp32c3", 1))
     } else {
-        0 // host/wasm (hostsim, web-emu) — no descriptor is emitted on those tiers anyway
+        None // host/wasm (hostsim, web-emu)
     }
 }
 

--- a/rust/clock/rust-toolchain.toml
+++ b/rust/clock/rust-toolchain.toml
@@ -6,8 +6,27 @@
 # Verified 2026-07-20: main is clean under stable 1.97.1 (clippy -D warnings, all tiers, 0 errors).
 # If a future `stable` introduces a -D-warnings regression, the 4-tier gate catches it → fix the lint
 # (don't re-pin); a genuinely-needed freeze must carry a written reason + revisit trigger here.
-# The RISC-V bare-metal target (ESP32-C3 = RV32IMC, stock rustc target, no Xtensa fork) is required.
+# The RISC-V bare-metal target (ESP32-C3 = RV32IMC, stock rustc target) is required.
+#
+# ── #347 Part 2: "no Xtensa fork" is NO LONGER TRUE, and this file cannot express the exception ──
+# That clause used to end the line above, and the S3 arm falsified it: `xtensa-esp32s3-none-elf` is
+# a Tier-3 target that ONLY espup's Xtensa fork can build, and that fork is pinned at 1.95.0.0 —
+# i.e. OLDER than `stable`, and a fork rather than a channel. Both halves of the ride-stable policy
+# fail for it at once, so it cannot be reconciled here; it has to be an explicit per-invocation
+# override, and the policy below stays the default it always was.
+#
+# S3 builds therefore say `cargo +esp` explicitly, plus `. ~/export-esp.sh` and
+# `CARGO_UNSTABLE_BUILD_STD=core,alloc` (see .cargo/config.toml's xtensa section for why build-std
+# must NOT be a config key). The riscv targets keep riding `stable` unchanged and are unaffected.
+#
+# ⚠️ `+esp` is required and NOT optional-with-a-fallback: without it this file resolves `stable`,
+# which has no xtensa backend, and the failure is an obscure `xtensa_lx` error rather than "wrong
+# toolchain". A `--manifest-path` from elsewhere does NOT pick this file up either (it resolves by
+# DIRECTORY), so an xtensa build launched from the repo root silently gets the wrong toolchain too.
+# Confirm the output says it is compiling for xtensa before believing a green result.
+#
+# `riscv32imac` (C5/C6) needs no exception at all — stock rustc, stable channel, just a target add.
 [toolchain]
 channel = "stable"
-targets = ["riscv32imc-unknown-none-elf"]
+targets = ["riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]
 components = ["rust-src", "rustfmt", "clippy"]

--- a/rust/clock/src/budget.rs
+++ b/rust/clock/src/budget.rs
@@ -279,6 +279,99 @@ pub const ESP32C3: ChipBudget = ChipBudget {
     baseline_image_bytes: 1_155_648,
 };
 
+// ── ESP32-C6 (the esp32c6-watch) ────────────────────────────────────────────────────────
+//
+// Delivered by the esp32c6-watch session 2026-08-24, measured at watch repo `a4a86a3`
+// (clean tree, built via fambuild on familiar; sections from `readelf -SW`, image from
+// `espflash save-image --partition-table partitions.csv`).
+//
+// It is declared here but NOT yet selectable by the `CHIP` ladder below — `target_feature
+// = "a"` cannot tell a C5 from a C6, so the ladder still fails closed for riscv32+atomics
+// until #347's chip de-pin gives it per-chip features to switch on. A row that exists but
+// cannot be selected is the intended intermediate state: the measurement is banked and
+// host-checked (`tests/budget.rs`) without any build silently inheriting it.
+
+/// The empirical boot line for the watch, which sits **ABOVE** the declared floor.
+///
+/// `ESP32C6_WATCH.stack_floor_bytes` (71,680) is the watch's *boot assert* — the contract its
+/// firmware enforces. The bracket actually walked on hardware was **61,000 B = 5/5 boot
+/// panics, 73,000 B = 0/5**, so the true line lies in `(61_000, 73_000]` and this constant is
+/// the conservative upper end: the lowest stack region PROVEN clean, not the lowest that
+/// works.
+///
+/// Recorded as a const, not a sentence, because it makes [`ESP32C6_WATCH`]'s `dram_headroom()`
+/// **optimistic by a known amount** — see [`ESP32C6_WATCH_HEADROOM_OVERSTATEMENT_BYTES`]. A
+/// feature that lands within ~2 KB of fitting must be judged against this number, not against
+/// the declared floor.
+pub const ESP32C6_WATCH_EMPIRICAL_BOOT_LINE_BYTES: u32 = 73_000;
+
+/// By how much [`ChipBudget::dram_headroom`] overstates real safety on the watch: 1,320 B.
+///
+/// This is the C6's version of the trap the C3 row spent two issues learning — a floor that
+/// is a *declaration* rather than a *measurement* drifts from the hardware, and the drift is
+/// invisible until an image links and then dies at boot (#300). Here the drift is known and
+/// signed: the declared floor is the LOW one, so the guard is the permissive direction.
+pub const ESP32C6_WATCH_HEADROOM_OVERSTATEMENT_BYTES: u32 =
+    ESP32C6_WATCH_EMPIRICAL_BOOT_LINE_BYTES - ESP32C6_WATCH.stack_floor_bytes;
+
+/// The inversion above is a FACT to preserve, not a bug to silence. If someone raises the
+/// declared floor to meet the empirical line (the correct fix, once a fresh bracket justifies
+/// a specific number), this assertion fires and points at the two constants that must move
+/// together — the same coupling `ESP32C3_STACK_FLOOR_BYTES` has with its measured peak.
+const _: () = assert!(
+    ESP32C6_WATCH_EMPIRICAL_BOOT_LINE_BYTES > ESP32C6_WATCH.stack_floor_bytes,
+    "the C6 watch's empirical boot line is no longer above its declared stack floor \
+     (src/budget.rs). If the floor was RAISED to meet the line, that is the intended fix — \
+     delete this assertion and the overstatement const with it, and say in the commit which \
+     bracket run justified the new floor. If the LINE was lowered, a fresh 0/5 bracket must \
+     back it; a boot line moved without one is how a floor once ended up at 12,288 B."
+);
+
+/// ESP32-C6 as it ships on the **esp32c6-watch** (RV32IMAC, 512 KB SRAM, 6 MB OTA slots).
+///
+/// ## The baseline is the watch's SHIPPING default, not a stripped image
+///
+/// `free_dram_bytes` is `_stack_start - _bss_end` of the DEFAULT feature build — the same
+/// semantic as the C3 row's "the linked `.stack` region is the leftover DRAM". The watch's
+/// default features **include `tts`** (on by default since its repo's `7cfa270`), so this is
+/// what the board actually runs, not a minimum.
+///
+/// ## ⚠️ The floor is BELOW the observed clean line
+///
+/// 71,680 is the boot assert; the hardware bracket says ~73,000 (see
+/// [`ESP32C6_WATCH_EMPIRICAL_BOOT_LINE_BYTES`]). So `dram_headroom()` returns 8,592 B while
+/// only ~7,272 B is proven safe. Judge anything within 2 KB of fitting against the line.
+///
+/// ## ⚠️ `app_slot_bytes` is 6 MB only because a build.rs hook makes it so
+///
+/// The watch's `partitions.csv` gives `ota_0`/`ota_1` 0x600000 each, but esp-hal's generated
+/// `memory.x` hardcodes a 4 MiB ROM region. The watch's `build.rs` (`widen_rom_region`, its
+/// #67) rewrites it. **Without that hook an image this size does not LINK** — so convergence
+/// must carry the hook or inherit the 4 MiB ceiling, and this row would then be wrong by
+/// 2 MB on the flash axis. Carried as a note here because the number cannot defend itself.
+///
+/// ## ⚠️ Not byte-stable across trees — same class as the C3 row
+///
+/// The watch's `.cargo/config.toml` is git-ignored and holds per-tree WiFi/MQTT literals that
+/// land in `.rodata`/`.data`. Reference measurement ± a few hundred B. The verdicts below turn
+/// on thousands, so it changes nothing — but a byte-exact constant that is not byte-stable is
+/// false precision, and saying so is what stops someone "reconciling" it against another doc.
+///
+/// ## Scarcity axis: DRAM only
+///
+/// Flash headroom after `widen_rom_region` is 1,622,672 B. The C6 is the mirror image of the
+/// Bard's problem on the C3 (flash-comfortable, DRAM-tight) — which is why the two axes are
+/// separate fields and why a verdict that could not name the axis would be useless here.
+pub const ESP32C6_WATCH: ChipBudget = ChipBudget {
+    chip: "esp32c6",
+    free_dram_bytes: 80_272,
+    stack_floor_bytes: 71_680,
+    // partitions.csv (the watch's, NOT smol's partitions-ota.csv): ota_0/ota_1 = 0x600000.
+    // Requires the `widen_rom_region` build.rs hook — see the doc note above.
+    app_slot_bytes: 0x0060_0000,
+    baseline_image_bytes: 4_668_784,
+};
+
 /// The budget in force for the target being compiled.
 ///
 /// **Fail-closed by construction.** A bare-metal target with no declared budget is a
@@ -301,10 +394,15 @@ pub const CHIP: ChipBudget = ESP32C3;
 
 #[cfg(all(target_os = "none", target_arch = "riscv32", target_feature = "a"))]
 compile_error!(
-    "riscv32 WITH atomics = ESP32-C5 or ESP32-C6, and neither has a declared ChipBudget. \
-     Add a `ChipBudget` const with MEASURED numbers (build the canonical tier for the chip \
-     and read `.stack` / image size from the artifact) and extend the CHIP cfg ladder. Do \
-     not copy the C3's row: a guessed budget is worse than an absent one."
+    "riscv32 WITH atomics = ESP32-C5 or ESP32-C6, and this ladder cannot tell them apart. \
+     ESP32C6_WATCH is now declared with MEASURED numbers, but selecting it here would ALSO \
+     hand those numbers to a C5, which has never been measured — a guessed budget wearing a \
+     measured one's clothes, which is worse than an absent one. The A (atomics) extension is \
+     the only thing target_arch/target_feature expose, and it does not discriminate. \
+     THE FIX IS #347's CHIP DE-PIN: once the crate has per-chip features, replace this whole \
+     ladder with a lookup keyed on `feature = \"esp32c5\"` / `\"esp32c6\"` — the data above \
+     does not move, only the selection does. Until then this fails closed, on purpose. \
+     For a C5, the missing piece is a measured ChipBudget row, not a cfg edit."
 );
 
 #[cfg(all(target_os = "none", not(target_arch = "riscv32")))]
@@ -354,6 +452,35 @@ pub mod cost {
         feature: "bard",
         dram_bytes: 39_072,
         flash_bytes: 287_392,
+    };
+
+    /// `story` — the esp32c6-watch's one predicated feature, and the **only cost row in this
+    /// file measured on a chip other than the C3**. Not a smol `[features]` entry today; it is
+    /// here as data because [`super::ESP32C6_WATCH`] is, and a budget with no cost to judge is
+    /// a guard that has never been watched saying yes.
+    ///
+    /// ELF-section deltas against the same watch baseline the chip row was measured from
+    /// (watch repo `a4a86a3`, 2026-08-24):
+    ///
+    /// | quantity | baseline | with `story` | delta |
+    /// |---|---:|---:|---:|
+    /// | `.bss` + `.data` | 286,380 | 291,772 | **+5,392** |
+    /// | `.stack` region | 80,272 | 74,880 | **−5,392** |
+    /// | `.text` + `.rodata` | 4,559,532 | 4,595,074 | **+35,542** |
+    /// | image | 4,668,784 | 4,704,528 | +35,744 |
+    ///
+    /// **Two independent derivations of the DRAM cost agree to the byte** — the statics grew by
+    /// exactly what the stack region lost. That is the same cross-check that made the Bard's
+    /// row trustworthy, and it is the evidence that `.stack` really is "whatever DRAM is left".
+    ///
+    /// ⚠️ `flash_bytes` is the **section** delta (35,542), not the **image** delta (35,744).
+    /// The 202 B difference is image header + padding, and the field is defined as
+    /// `.rodata + .text`. Both numbers are correct for what they measure; do not reconcile one
+    /// to the other.
+    pub const STORY: FeatureCost = FeatureCost {
+        feature: "story",
+        dram_bytes: 5_392,
+        flash_bytes: 35_542,
     };
 }
 

--- a/rust/clock/src/budget.rs
+++ b/rust/clock/src/budget.rs
@@ -381,36 +381,133 @@ pub const ESP32C6_WATCH: ChipBudget = ChipBudget {
 /// the compiler will demand its row here before it will build, which is the intended
 /// friction.
 ///
-/// The selection is `target_arch`-shaped only because this crate pins exactly one bare-metal
-/// target today. **#349 owns chip identity**; when the chip de-pin lands, replace this cfg
-/// ladder with a per-chip-feature lookup — it is one function and the data above does not
-/// move. The `not(target_feature = "a")` guard exists because `target_arch` alone is
-/// "riscv32" for the C3 (imc), the C6 AND the C5 (both imac) — without it a C5/C6 build
-/// would silently inherit the C3's measured numbers, which is precisely the guessed-budget
-/// failure this module's fail-closed rule forbids. The A (atomics) extension is what
-/// separates imac from imc at the cfg level.
-#[cfg(all(target_os = "none", target_arch = "riscv32", not(target_feature = "a")))]
+/// # The selection is now keyed on the CHIP FEATURE (#347 Part 2)
+///
+/// It used to be keyed on `target_arch` + `target_feature = "a"`, which was the best the tree
+/// could do while the chip was hardcoded in eight dependency declarations. That ladder could
+/// name the C3 (riscv32 without atomics) and could prove a build was "a C5 or a C6" — but not
+/// which, because the A extension is the only thing the target cfgs expose and both chips have
+/// it. So `riscv32imac` had to be a `compile_error!`, and the measured C6 row landed in Part 1
+/// unreachable by construction.
+///
+/// The chip feature discriminates exactly, so the ladder is a lookup and the C6 row is live.
+/// The data above did not move; only the selection did — which is what the old note promised
+/// and is worth confirming, because "replace the selection" is the kind of change that quietly
+/// becomes "adjust the numbers so it passes".
+///
+/// # Fail-closed, but at the RIGHT granularity — this is the part that changed shape
+///
+/// **Fail-closed by construction** still holds: no chip silently inherits another's measured
+/// numbers. But the old ladder enforced it by refusing to compile the CRATE, and that was
+/// stricter than the facts require and it blocked the de-pin's own acceptance.
+///
+/// `CHIP` has exactly two consumers, both `bard` predicates at the bottom of this file. So a
+/// chip with no measured row does not break the crate — it breaks only the features whose
+/// verdicts need a budget. Refusing the whole crate meant a C5 radio image, which asks nothing
+/// of this module, could not be compiled or even type-checked until someone produced a
+/// hardware measurement it had no use for. That is not caution, it is a measurement gate on the
+/// wrong build, and it is the reason "port smol to the C5" could not begin.
+///
+/// So an unmeasured chip now selects [`UNMEASURED`] — a poison row that fits nothing — and the
+/// refusal moved to a dedicated predicate beside the `bard` asserts, where it can say what is
+/// actually missing. Strictly stronger, not weaker: the old ladder could only refuse chips it
+/// could NAME, and would have handed a fifth riscv32imc chip the C3's row without a murmur.
+/// [`CHIP_MEASURED`] is the machine-checkable form of the distinction.
+#[cfg(all(target_os = "none", feature = "esp32c3"))]
 pub const CHIP: ChipBudget = ESP32C3;
 
-#[cfg(all(target_os = "none", target_arch = "riscv32", target_feature = "a"))]
+/// The C6 row measured in Part 1, finally reachable. See [`ESP32C6_WATCH`] — and note it is the
+/// esp32c6-**watch's** shipping image, whose DRAM is already spent on a TTS stack and a display.
+/// A smol C6 build is a different image and will want its own row; until it has one, this is a
+/// conservative stand-in on the DRAM axis and an OPTIMISTIC one on flash (6 MB slots exist only
+/// because the watch's `widen_rom_region` build.rs hook rewrites esp-hal's hardcoded 4 MiB ROM
+/// region — smol does not carry that hook yet, so its C6 ceiling is 4 MiB until it does).
+#[cfg(all(target_os = "none", feature = "esp32c6"))]
+pub const CHIP: ChipBudget = ESP32C6_WATCH;
+
+/// A chip whose budget has never been measured, on a bare-metal target.
+///
+/// **A poison row, not a permissive default.** Every field is chosen so that any question asked
+/// of it answers "no" and any number read off it is obviously wrong rather than plausibly
+/// right: zero free DRAM and a zero-byte app slot mean `fits_dram`/`fits_flash` are false for
+/// every cost, and `dram_headroom()`/`flash_headroom()` are 0.
+///
+/// The name is the other half of the design. `chip: "unmeasured"` reaching a log line or a
+/// dashboard reads as a bug immediately, which is the same discipline as
+/// `net::profile`'s deliberately-implausible fallback arm — a fallback that looks like a real
+/// device is how a fallback survives.
+///
+/// ⚠️ `tools/build_matrix.py::budget_chips()` skips this row by name when it cross-checks the
+/// chip roster against `tools/build-matrix.toml`. It is not a fleet target; it is the absence
+/// of one, given a shape.
+#[cfg(all(target_os = "none", not(any(feature = "esp32c3", feature = "esp32c6"))))]
+pub const UNMEASURED: ChipBudget = ChipBudget {
+    chip: "unmeasured",
+    free_dram_bytes: 0,
+    stack_floor_bytes: 0,
+    app_slot_bytes: 0,
+    baseline_image_bytes: 0,
+};
+
+#[cfg(all(target_os = "none", not(any(feature = "esp32c3", feature = "esp32c6"))))]
+pub const CHIP: ChipBudget = UNMEASURED;
+
+/// Whether [`CHIP`] carries MEASURED numbers, as a value rather than as a cfg incantation.
+///
+/// The point of exposing it is that "this chip has no budget" is a fact other code may need to
+/// branch on WITHOUT restating the roster — a second copy of `any(feature = "esp32c3", …)`
+/// somewhere else is exactly the two-statements-of-one-fact rot that `build_matrix.py` exists to
+/// catch between this file and the build matrix.
+#[cfg(target_os = "none")]
+pub const CHIP_MEASURED: bool = cfg!(any(feature = "esp32c3", feature = "esp32c6"));
+
+/// A bare-metal build must name its chip. Distinct from "named it and it has no row" — that is
+/// [`UNMEASURED`] and it only bites the budget-predicated features. This is the build not saying
+/// which silicon it is for AT ALL, which nothing downstream can recover from: `build.rs` cannot
+/// stamp `SMOL_CHIP_ID`, `net::target` cannot refuse a cross-chip OTA image, and `BoardProfile`
+/// cannot label the device.
+#[cfg(all(
+    target_os = "none",
+    not(any(
+        feature = "esp32c3",
+        feature = "esp32c5",
+        feature = "esp32c6",
+        feature = "esp32s3"
+    ))
+))]
 compile_error!(
-    "riscv32 WITH atomics = ESP32-C5 or ESP32-C6, and this ladder cannot tell them apart. \
-     ESP32C6_WATCH is now declared with MEASURED numbers, but selecting it here would ALSO \
-     hand those numbers to a C5, which has never been measured — a guessed budget wearing a \
-     measured one's clothes, which is worse than an absent one. The A (atomics) extension is \
-     the only thing target_arch/target_feature expose, and it does not discriminate. \
-     THE FIX IS #347's CHIP DE-PIN: once the crate has per-chip features, replace this whole \
-     ladder with a lookup keyed on `feature = \"esp32c5\"` / `\"esp32c6\"` — the data above \
-     does not move, only the selection does. Until then this fails closed, on purpose. \
-     For a C5, the missing piece is a measured ChipBudget row, not a cfg edit."
+    "no chip feature is enabled, so this firmware build does not say what silicon it is for. \
+     Enable exactly one of `esp32c3` / `esp32c5` / `esp32c6` / `esp32s3` (rust/clock/Cargo.toml). \
+     `default` carries `esp32c3`, so reaching this means `--no-default-features` was used with a \
+     tier but no chip — the per-chip invocations in tools/build-matrix.toml show the full form. \
+     NOTE this is NOT the 'chip has no measured budget' case: that one is UNMEASURED, it compiles \
+     fine, and it refuses only the features whose verdicts need a budget."
 );
 
-#[cfg(all(target_os = "none", not(target_arch = "riscv32")))]
+/// Two chip features at once. **This must be an error and not a precedence rule**, which is why
+/// there is no `else` arm anywhere above: with a silent winner, `--features esp32c5` — the
+/// natural thing to type, and wrong, because `default` already carries `esp32c3` — would build
+/// C3 numbers, C3 HAL bindings and a C3-stamped descriptor while the operator believed they had
+/// a C5. #349 removed that exact shape from `build.rs` (an ambiguous triple resolved to a
+/// plausible-looking C6 id that `decide()` then trusted); re-introducing it here would be the
+/// same bug one layer up.
+///
+/// esp-hal's own build script would also refuse two chips, eventually. It would do so without
+/// mentioning smol, the feature that caused it, or the `--no-default-features` that fixes it.
+#[cfg(any(
+    all(feature = "esp32c3", feature = "esp32c5"),
+    all(feature = "esp32c3", feature = "esp32c6"),
+    all(feature = "esp32c3", feature = "esp32s3"),
+    all(feature = "esp32c5", feature = "esp32c6"),
+    all(feature = "esp32c5", feature = "esp32s3"),
+    all(feature = "esp32c6", feature = "esp32s3")
+))]
 compile_error!(
-    "no ChipBudget is declared for this bare-metal target. Add a `ChipBudget` const in \
-     src/budget.rs with MEASURED numbers (build the canonical tier for the chip and read \
-     `.stack` / image size from the artifact) and extend the CHIP cfg ladder. Do not copy \
-     the C3's row: an undeclared capability that is guessed is worse than one that is absent."
+    "TWO OR MORE chip features are enabled, and a build is one chip. Almost always the cause is \
+     `--features esp32c5` (or c6/s3) WITHOUT `--no-default-features`: `default` carries \
+     `esp32c3`, so that adds a second chip rather than choosing one. The full form is \
+     `--no-default-features --features esp32c5,<tier>` — see tools/build-matrix.toml, which \
+     spells out the per-chip invocation for every declared chip."
 );
 
 /// Host builds (`hostsim`, the `tests/` suites, `web-emu`) link no firmware, so no device
@@ -497,6 +594,34 @@ pub mod cost {
 //
 // ⚠️ These are the only items in this file that do not move to `smol-core` verbatim — the
 // feature flags belong to whichever crate declares them.
+
+/// **The unmeasured-chip refusal (#347 Part 2).** Must come FIRST, because it is the one case
+/// where the two asserts below would fire with true arithmetic and a misleading explanation.
+///
+/// A budget-predicated feature on a chip with no [`ChipBudget`] row hits [`UNMEASURED`], whose
+/// every field is zero, so `fits_dram` is false and the DRAM assert fires — telling the reader to
+/// shrink `SEQ_CAP` and re-measure, against a chip whose budget does not exist. They would go
+/// tune a model to fit a number that was never measured. The fix is a measurement, and only this
+/// assert can say so.
+///
+/// This is the granularity change from the old cfg ladder made concrete: the refusal is here, on
+/// the feature that needs a budget, instead of on the crate. A C5 radio build asks nothing of this
+/// module and compiles; a C5 **Bard** build is refused, by name, with the measurement to take.
+#[cfg(all(target_os = "none", feature = "bard", not(feature = "off-fleet")))]
+const _: () = assert!(
+    CHIP_MEASURED,
+    "`bard` is budget-predicated, and THIS CHIP HAS NO MEASURED ChipBudget row (src/budget.rs). \
+     The verdict is refused for want of data, NOT because the feature is too big — do not read \
+     the DRAM/FLASH messages below as applying here, and do not shrink the model to satisfy a \
+     budget nobody has measured. \
+     To take the measurement: build the canonical tier for this chip, read `.stack` and the image \
+     size off the artifact (`readelf -SW`), and add a `ChipBudget` const with those numbers plus a \
+     `feature = \"<chip>\"` arm at the CHIP lookup above. Add the chip to tools/build-matrix.toml \
+     in the same commit — `build_matrix.py check` asserts the two rosters agree in both \
+     directions. \
+     Or, if this build is deliberately not a fleet image, add `off-fleet` (#348), which \
+     tools/repro_build.sh then refuses to package."
+);
 
 /// DRAM axis. Fires for `--features bard` on the C3: the Bard's 39,072 B against a
 /// 32,352 B headroom, **short by 6,720 B** — which reproduces #335's published shortfall

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -2070,7 +2070,26 @@ fn take_panic_mark() -> bool {
 
 /// The last reset reason as a short, stable token for the DIAG record. Reads (and clears) the
 /// panic marker first — a panic shows as `CoreSw` at the SoC level, so the marker recovers the
-/// `panic` distinction. Everything else maps the C3 `SocResetReason` set to a compact token.
+/// `panic` distinction. Everything else maps the SoC's `SocResetReason` set to a compact token.
+///
+/// #347 Part 2: this used to say "the C3 set", which was true and is the reason it is now not.
+/// Every variant named below exists on the C3, C5 and C6 alike; only the glitch arm varies between
+/// those three, and it is predicated on a `has-reset-glitch-*` capability rather than on a chip
+/// name. This function compiles clean on all three.
+///
+/// ⚠️ IT DOES NOT COMPILE ON THE S3, and that is a MEASURED, tracked stop-point rather than an
+/// oversight — `tools/build-matrix.toml`'s `[chip.esp32s3]` declares `checks = false` for it and
+/// `tools/check_chips.sh` asserts the failure, so this paragraph cannot quietly become false.
+/// esp-hal spells the four CPU-scoped reasons WITHOUT the core index on the S3, and the values are
+/// identical — `CpuSw`/`CpuMwdt0`/`CpuMwdt1`/`CpuRtcWdt` = 0x0C/0x0B/0x11/0x0D, exactly the C3's
+/// `Cpu0Sw`/`Cpu0Mwdt0`/`Cpu0Mwdt1`/`Cpu0RtcWdt`. So it is a pure esp-hal NAMING variance carrying
+/// no difference in silicon behaviour, which is why it deliberately did NOT get a `has-*` marker
+/// here: that namespace means "the silicon has a thing", and spending it on a spelling would make
+/// the layer's one guarantee unreliable. It needs a differently-named predicate (an esp-hal API
+/// fact, not a capability), and inventing that namespace is a decision worth making on its own
+/// rather than as a side effect of the de-pin. #347 Phase 3 / #331.
+///
+/// Also NOT chip-complete: the C5's `CpuLockup` is unmapped and reports "other" (see Cargo.toml).
 #[cfg(feature = "espnow")]
 pub fn reset_reason_token() -> &'static str {
     if take_panic_mark() {
@@ -2095,7 +2114,19 @@ pub fn reset_reason_token() -> &'static str {
             | R::SysSuperWdt,
         ) => "wdt",
         Some(R::CoreUsbUart | R::CoreUsbJtag) => "usb-jtag",
+        // #347 Part 2: the ONE arm in this match that is not common to all four chips. Every
+        // variant above resolves on the C3, C5, C6 and S3 alike (measured — a per-chip
+        // `cargo check` reported errors on this line and nowhere else); the glitch detectors
+        // come in three shapes and this arm has to be predicated. The capability, never the
+        // chip name — see the table at `has-reset-glitch-split` in Cargo.toml.
+        //
+        // A chip with NEITHER marker (the C6 reports no glitch reason at all) contributes no arm
+        // and its glitch resets — which the silicon does not distinguish — fall through to
+        // "other" below. That fall-through is the designed answer, not a gap.
+        #[cfg(feature = "has-reset-glitch-split")]
         Some(R::SysClkGlitch | R::CorePwrGlitch) => "glitch",
+        #[cfg(feature = "has-reset-glitch-unified")]
+        Some(R::PowerGlitch) => "glitch",
         Some(_) => "other",
         None => "unk",
     }

--- a/rust/clock/tests/budget.rs
+++ b/rust/clock/tests/budget.rs
@@ -18,7 +18,8 @@
 
 use clock::budget::{
     cost, ChipBudget, FeatureCost, ESP32C3, ESP32C3_MEASURED_PEAK_BYTES,
-    ESP32C3_STACK_FLOOR_BYTES,
+    ESP32C3_STACK_FLOOR_BYTES, ESP32C6_WATCH, ESP32C6_WATCH_EMPIRICAL_BOOT_LINE_BYTES,
+    ESP32C6_WATCH_HEADROOM_OVERSTATEMENT_BYTES,
 };
 
 /// The published #335 shortfall. If this test starts failing, either a measurement in
@@ -93,11 +94,134 @@ fn the_flash_axis_is_comfortable_and_says_so_separately() {
     assert_eq!(ESP32C3.flash_headroom() - cost::BARD.flash_bytes, 588_576);
 }
 
+// ── #347: the esp32c6-watch row ─────────────────────────────────────────────────────────
+//
+// Measured by the esp32c6-watch session at watch repo `a4a86a3`, 2026-08-24. These are the
+// tests the compile-time assertions cannot be, for two reasons: the C6 row is not reachable
+// from any `CHIP` selection yet (the cfg ladder still fails closed for riscv32+atomics until
+// the de-pin lands), and a const panic message cannot carry a computed number.
+//
+// ⚠️ ORIENTATION OF THE PREDICATE. It is `chip.fits_dram(&cost)`, NOT `cost.fits_dram(chip)`.
+// The handoff note wrote it the second way. It does not compile, so it could only ever have
+// been a typo — but the same inversion in prose ("does the feature fit the chip" read as
+// "does the chip fit the feature") is exactly how a budget gets applied backwards, so the
+// call is spelled out here rather than left to the reader.
+
+/// The DRAM cost of `story` was derived two independent ways from the same baseline, and they
+/// agree to the byte: the statics grew by what the stack region lost. This test is that
+/// cross-check, kept as arithmetic rather than as a table in a doc comment — if someone
+/// re-measures and updates only one of the two, this fails instead of quietly disagreeing.
+#[test]
+fn the_c6_story_cost_reconciles_from_both_directions() {
+    // .bss + .data: 291,772 − 286,380
+    assert_eq!(291_772u32 - 286_380, cost::STORY.dram_bytes);
+    // .stack region: 80,272 − 74,880 — the same 5,392 B, arrived at from the other side.
+    assert_eq!(
+        ESP32C6_WATCH.free_dram_bytes - 74_880,
+        cost::STORY.dram_bytes
+    );
+    // .text + .rodata: 4,595,074 − 4,559,532
+    assert_eq!(4_595_074u32 - 4_559_532, cost::STORY.flash_bytes);
+    // The IMAGE delta is 35,744, which is NOT the flash-section delta — 202 B of header and
+    // padding. Both are right for what they measure; pinning the gap stops a future
+    // "correction" of one to the other.
+    assert_eq!((4_704_528u32 - 4_668_784) - cost::STORY.flash_bytes, 202);
+}
+
+#[test]
+fn the_c6_headroom_is_the_measured_leftover() {
+    // 80,272 − 71,680.
+    assert_eq!(ESP32C6_WATCH.dram_headroom(), 8_592);
+    // 0x600000 (6,291,456 B, and only because the watch's widen_rom_region build.rs hook
+    // rewrites esp-hal's hardcoded 4 MiB ROM region) − 4,668,784 B.
+    assert_eq!(ESP32C6_WATCH.app_slot_bytes, 6_291_456);
+    assert_eq!(ESP32C6_WATCH.flash_headroom(), 1_622_672);
+}
+
+/// The yes-case, on real declared data rather than a fixture: `story` fits the C6 on both
+/// axes. Note this is the direction the const-assertions structurally cannot demonstrate.
+#[test]
+fn story_fits_the_c6_on_both_axes() {
+    assert!(ESP32C6_WATCH.fits(&cost::STORY));
+    assert!(ESP32C6_WATCH.fits_dram(&cost::STORY));
+    assert!(ESP32C6_WATCH.fits_flash(&cost::STORY));
+    assert_eq!(ESP32C6_WATCH.dram_shortfall(&cost::STORY), 0);
+    assert_eq!(ESP32C6_WATCH.flash_shortfall(&cost::STORY), 0);
+}
+
+/// **The caveat that must not get lost.** The declared floor (71,680) is the watch's boot
+/// assert; the hardware bracket walked 61,000 B = 5/5 panics and 73,000 B = 0/5. So
+/// `dram_headroom()` reports 1,320 B more room than has been proven to boot, and a feature
+/// landing within ~2 KB of fitting must be judged against the empirical line instead.
+///
+/// `story` clears BOTH, which is why it was safe to ship — and checking both is the point:
+/// a verdict that only cleared the optimistic bound would look identical here and differ on
+/// the next feature.
+#[test]
+fn the_c6_declared_floor_is_optimistic_by_a_known_1320_bytes() {
+    assert_eq!(ESP32C6_WATCH_HEADROOM_OVERSTATEMENT_BYTES, 1_320);
+    assert_eq!(
+        ESP32C6_WATCH_EMPIRICAL_BOOT_LINE_BYTES - ESP32C6_WATCH.stack_floor_bytes,
+        ESP32C6_WATCH_HEADROOM_OVERSTATEMENT_BYTES
+    );
+
+    // Judged against the EMPIRICAL line rather than the declared floor.
+    let empirical = ChipBudget {
+        stack_floor_bytes: ESP32C6_WATCH_EMPIRICAL_BOOT_LINE_BYTES,
+        ..ESP32C6_WATCH
+    };
+    assert_eq!(empirical.dram_headroom(), 7_272);
+    assert!(
+        empirical.fits_dram(&cost::STORY),
+        "story must clear the proven-clean line, not merely the declared floor"
+    );
+
+    // And the shipped story image's own stack region (74,880) sits above BOTH.
+    assert!(74_880 > ESP32C6_WATCH_EMPIRICAL_BOOT_LINE_BYTES);
+    assert!(74_880 > ESP32C6_WATCH.stack_floor_bytes);
+}
+
+/// The C6 and the C3 are scarce on OPPOSITE axes, and the model has to be able to say so.
+/// The C3 refuses the Bard on DRAM while sitting comfortable on flash; the C6 has 1.6 MB of
+/// flash headroom and only 8.6 KB of DRAM. A single conflated "does it fit" number would
+/// describe neither chip, which is why `ChipBudget` carries two fields (OpenWrt's `low_mem`
+/// vs `small_flash`) instead of one.
+#[test]
+fn the_two_chips_are_scarce_on_opposite_axes() {
+    assert!(ESP32C6_WATCH.flash_headroom() > ESP32C3.flash_headroom());
+    assert!(ESP32C6_WATCH.dram_headroom() < ESP32C3.dram_headroom());
+    // Concretely: the C6 has ~1.85x the flash room and ~0.27x the DRAM room.
+    assert_eq!(ESP32C3.dram_headroom(), 32_352);
+    assert_eq!(ESP32C6_WATCH.dram_headroom(), 8_592);
+}
+
+/// The Bard does not fit the C6 watch **as the watch is configured today** — and this is the
+/// test most likely to be misread, so it says what it means. `budget.rs` and #347 both note
+/// that "the S3 and C6 have the DRAM to carry the Bard"; that is a claim about the CHIP
+/// (512 KB SRAM), not about this ROW. The row is the watch's shipping image, which has already
+/// spent its DRAM on a TTS stack and a display — leaving 8,592 B, against the Bard's 39,072 B.
+///
+/// So a Bard-on-C6 build is a real possibility and this is not evidence against it. It is
+/// evidence that it needs its OWN measured baseline, taken from a Bard-shaped C6 image, and
+/// that reaching for this row would refuse it for the wrong reason.
+#[test]
+fn the_bard_does_not_fit_the_watch_row_and_that_is_a_statement_about_the_image() {
+    assert!(!ESP32C6_WATCH.fits_dram(&cost::BARD));
+    assert_eq!(ESP32C6_WATCH.dram_shortfall(&cost::BARD), 30_480);
+    // The flash axis, by contrast, is comfortable — 287,392 B inside 1,622,672 B.
+    assert!(ESP32C6_WATCH.fits_flash(&cost::BARD));
+}
+
 /// The predicate must be able to say YES. This fixture is a *hypothetical* chip — the C6 has
 /// 512 KB of SRAM and would clear this easily, but nobody has measured its baseline, and an
 /// unmeasured row does not belong in `budget.rs` (that is the #348 anti-lesson: a capability
 /// that is guessed is worse than one that is absent). So the yes-case is proven here, where
 /// the numbers are explicitly a fixture and cannot be mistaken for a declaration.
+///
+/// ⚠️ HISTORICAL NOTE (#347, 2026-08-24): the C6 now HAS a measured row — [`ESP32C6_WATCH`] —
+/// and `story_fits_the_c6_on_both_axes` proves the yes-case on real data. This fixture stays
+/// because the *reasoning* above is still the rule, and because the C6 row happens to refuse
+/// the Bard (see the test above), so it cannot replace this one.
 #[test]
 fn a_chip_with_room_accepts_the_bard() {
     let roomy = ChipBudget {

--- a/rust/esp-wifi-sys-chip/Cargo.toml
+++ b/rust/esp-wifi-sys-chip/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+name = "esp-wifi-sys-chip"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "smol (#347): the ONE place a per-chip esp-wifi-sys PACKAGE alias is chosen."
+
+# ⚠️ OUTSIDE `rust/clock/`, AND declaring its own workspace, ON PURPOSE. Both are load-bearing —
+# see the `[workspace]` note below. This crate exists for exactly one reason, stated in src/lib.rs:
+# `esp-wifi-sys` is not one crate with a chip FEATURE, it is FOUR SEPARATE PACKAGES, and cargo
+# cannot make a `package =` alias conditional on a feature. So the choice has to happen somewhere,
+# and the only question is whether `clock` learns four crate names or one.
+
+# THE EMPTY WORKSPACE IS THE #347 BOUNDARY, DECLARED RATHER THAN INHERITED.
+#
+# esp-hal accepts exactly ONE chip feature, and cargo UNIFIES features across workspace members.
+# Therefore a riscv crate and an xtensa crate can never share a workspace graph — not "should not",
+# CANNOT: the unified feature set would hand esp-hal two chips and its build script would refuse.
+#
+# smol already satisfies that boundary, but only BY ACCIDENT OF DIRECTORY LAYOUT: `rust/clock` is
+# its own workspace root, and cargo absorbs path dependencies as members only when they live INSIDE
+# the root's directory. `../sigil-names` and `../esp-wifi-sys-chip` sit beside `clock`, not under it,
+# so they are not members. Verified, not assumed: `cargo metadata --no-deps` in rust/clock reports
+# exactly one workspace member.
+#
+# An invariant that holds because of where a directory sits is one `mv` away from not holding, and
+# the failure would surface as an incomprehensible esp-hal build-script error rather than as
+# "you moved a crate". emberburrito hit this on its C3+S3 tree and answered it the same way: every
+# such crate declares `[workspace]`, which pins it as its own root regardless of position. That is
+# the shape smol needs for a C3+S3 fleet, so it is written down here as a declaration.
+[workspace]
+
+[dependencies]
+# THE FOUR ALIASES. Each is optional and selected by the matching feature below; smol's chip
+# feature forwards to it with the WEAK syntax (`esp-wifi-sys?/esp32c3`), which is what makes this
+# crate the chip x radio AND that cargo's feature language cannot express on its own — see
+# src/lib.rs §"Why a shim and not four keys in clock".
+#
+# All four are version 0.2 and were confirmed to EXIST before being written down (`cargo search`,
+# 2026-08-24): -esp32c3, -esp32c5, -esp32c6, -esp32s3, all at 0.2.0. The C5 crate's crates.io
+# blurb reads "for ESP32-C6" — that is an upstream copy-paste in the DESCRIPTION field, not a
+# wrong-chip package; the package name is what selects the bindings.
+esp-wifi-sys-esp32c3 = { version = "0.2", default-features = false, optional = true }
+esp-wifi-sys-esp32c5 = { version = "0.2", default-features = false, optional = true }
+esp-wifi-sys-esp32c6 = { version = "0.2", default-features = false, optional = true }
+esp-wifi-sys-esp32s3 = { version = "0.2", default-features = false, optional = true }
+
+[features]
+# NO `default`. A default chip here would be a guess that compiles — the failure mode #349 spent a
+# commit removing from build.rs, where an ambiguous triple was resolved to a plausible-looking C6
+# id that the suitability check then trusted. `src/lib.rs` fails the build closed when no feature
+# is selected, with a message naming this file.
+esp32c3 = ["dep:esp-wifi-sys-esp32c3"]
+esp32c5 = ["dep:esp-wifi-sys-esp32c5"]
+esp32c6 = ["dep:esp-wifi-sys-esp32c6"]
+esp32s3 = ["dep:esp-wifi-sys-esp32s3"]

--- a/rust/esp-wifi-sys-chip/src/lib.rs
+++ b/rust/esp-wifi-sys-chip/src/lib.rs
@@ -1,0 +1,107 @@
+//! The per-chip `esp-wifi-sys` PACKAGE alias, isolated so that nothing else in smol has to know
+//! there is more than one of them.
+//!
+//! # What this crate is for
+//!
+//! `net.rs` needs three raw esp-idf items for the #141 TX-power clamp and the AP-info readback:
+//! `esp_wifi_set_max_tx_power`, `esp_wifi_sta_get_ap_info` and `wifi_ap_record_t`. `esp-radio`'s
+//! own `sys` module is `pub(crate)`, so they have to come from the bindings crate directly.
+//!
+//! And the bindings crate is **not one crate with a chip feature**. It is four separate packages —
+//! `esp-wifi-sys-esp32c3`, `-esp32c5`, `-esp32c6`, `-esp32s3` — which is a different problem from
+//! every other dependency in the de-pin. `esp-hal`, `esp-radio`, `esp-storage` and friends are ONE
+//! package with a chip FEATURE, so smol's chip feature can just forward to them
+//! (`esp-hal?/esp32c3`). A `package = ` alias cannot be made conditional: cargo resolves the
+//! manifest before it knows anything about features.
+//!
+//! # Why a shim and not four keys in `clock`
+//!
+//! Four keys in `clock/Cargo.toml` would work only if the chip feature could enable one of them,
+//! and that is precisely what it must NOT do — because of a second, sharper constraint:
+//!
+//! > **The chip is chosen independently of whether the radio is on at all.**
+//!
+//! smol's `default` tier is `hw` only: no `esp-radio`, no `esp-rtos`, no OTA crates, and therefore
+//! no bindings. But a `default` build still has to name a chip (it is compiled for a C3). If the
+//! chip feature said `dep:esp-wifi-sys-esp32c3`, the default tier would start linking the
+//! Espressif blob archives that crate's build script emits — a build that today links none of
+//! them. That is not a subtle regression: it is the #348 byte-stability constraint failing on the
+//! one tier the whole de-pin promised not to touch.
+//!
+//! So what is needed is the **conjunction** `chip AND radio`, and cargo's feature language has no
+//! `AND`. What it does have is the weak dependency-feature form `dep?/feature`, meaning *"if that
+//! optional dependency ends up enabled, turn this feature on inside it"*. Routing the choice
+//! through one optional shim turns the impossible conjunction into that form:
+//!
+//! ```text
+//!   clock's `wifi` feature   -> enables the shim          (the RADIO half)
+//!   clock's `esp32c3`        -> "esp-wifi-sys?/esp32c3"   (the CHIP half, weak: only if enabled)
+//!   ------------------------------------------------------------------------------------------
+//!   default tier (no wifi)   -> shim absent, no bindings, no blobs, byte-stable
+//!   fleet tier on a C3       -> shim present with its esp32c3 arm -> the C3 bindings
+//!   fleet tier on an S3      -> shim present with its esp32s3 arm -> the S3 bindings
+//! ```
+//!
+//! The dependency key in `clock/Cargo.toml` is still spelled `esp-wifi-sys`, so
+//! `esp_wifi_sys::include::…` in `net.rs` is **unchanged, character for character**. The de-pin
+//! adds a crate to the graph and zero edits to the call sites.
+//!
+//! # The direction of the boundary, which is the easy thing to get backwards
+//!
+//! `sigil-names` sits outside `rust/clock/` because it is chip-AGNOSTIC and shared. This crate
+//! sits outside for the opposite reason: it is the most chip-DEPENDENT thing in the tree. Both
+//! belong outside the workspace root, and the #347 rule covers both, but it is worth saying which
+//! is which — the `*-core` framing suggests "extract the pure parts", and a reader applying only
+//! that half would try to fold this crate back in, where its four mutually-exclusive aliases would
+//! sit inside the very feature-unification graph they exist to stay out of.
+
+#![no_std]
+
+// ── The selection ───────────────────────────────────────────────────────────────────────────────
+//
+// A glob re-export, deliberately, rather than a hand-listed surface. `net.rs` needs three items
+// today, but the crate's job is "be esp-wifi-sys for this chip", not "be the three items smol
+// currently calls" — a curated list would make the next raw-binding call site a change to this
+// file, and this file is the one place a chip name appears, so it is the worst possible place to
+// invite unrelated edits.
+//
+// The four arms are `cfg`-exclusive rather than `cfg_if`-chained so that enabling two chips is a
+// DUPLICATE DEFINITION error naming both, instead of the higher arm silently winning. Two chip
+// features on at once is not a hypothetical: it is what `cargo build --features esp32c5` does when
+// `default` (which carries `esp32c3`) has not been turned off, and a silent win there would build
+// C3 bindings into an image stamped C5.
+
+#[cfg(feature = "esp32c3")]
+pub use esp_wifi_sys_esp32c3::*;
+
+#[cfg(feature = "esp32c5")]
+pub use esp_wifi_sys_esp32c5::*;
+
+#[cfg(feature = "esp32c6")]
+pub use esp_wifi_sys_esp32c6::*;
+
+#[cfg(feature = "esp32s3")]
+pub use esp_wifi_sys_esp32s3::*;
+
+// ── Fail closed ─────────────────────────────────────────────────────────────────────────────────
+//
+// With no chip feature this crate would compile to an EMPTY module, and the error would surface at
+// `net.rs` as "could not find `include` in `esp_wifi_sys`" — which reads as a version problem in a
+// vendor crate and sends the reader upstream. Naming the real cause here costs one const and saves
+// that trip. Same fail-closed rule as `budget.rs`: an absent selection is a build failure, never a
+// default.
+#[cfg(not(any(
+    feature = "esp32c3",
+    feature = "esp32c5",
+    feature = "esp32c6",
+    feature = "esp32s3"
+)))]
+compile_error!(
+    "esp-wifi-sys-chip: no chip feature selected, so there are no bindings to re-export. This \
+     crate is pulled by smol's `wifi` feature and its chip arm is supplied by smol's chip feature \
+     with the WEAK form `esp-wifi-sys?/esp32cX` (rust/clock/Cargo.toml). Reaching this message \
+     means the radio half was enabled without the chip half — i.e. `wifi` is on and no chip \
+     feature is, which for a firmware build should be impossible because `default` carries \
+     `esp32c3`. The likely cause is `--no-default-features` with a tier but no chip: add one of \
+     `esp32c3` / `esp32c5` / `esp32c6` / `esp32s3`."
+);

--- a/rust/sigil-names/Cargo.toml
+++ b/rust/sigil-names/Cargo.toml
@@ -4,6 +4,19 @@ version = "0.1.0"
 edition = "2021"
 description = "VENDORED copy of realm-sigil's Rust binding. src/ is byte-identical upstream; do not edit."
 
+# #347: DECLARED as its own workspace root, not merely positioned as one.
+#
+# esp-hal accepts exactly one chip feature and cargo unifies features across workspace members, so
+# a riscv crate and an xtensa crate cannot share a workspace graph. `rust/clock` is its own root and
+# absorbs path dependencies only from INSIDE its directory — this crate is beside `clock`, not under
+# it, so it was never a member (verified: `cargo metadata --no-deps` in rust/clock reports one
+# member). But that made a load-bearing invariant depend on where a directory sits, and the symptom
+# of breaking it is an esp-hal build-script error about two chips, which names neither this crate nor
+# the move that caused it. `[workspace]` pins the boundary regardless of position. Same line, same
+# reason, in rust/esp-wifi-sys-chip — the chip-AGNOSTIC crate and the chip-DEPENDENT one both have
+# to stay out of the firmware's feature-unification graph.
+[workspace]
+
 # ⚠️ VENDORED, NOT AUTHORED HERE. `src/lib.rs`, `src/realms.rs` and `src/reserved.rs` are
 # byte-identical copies of realm-sigil's `rust/src/`. Edit them THERE, regenerate with
 # `./sync-words.sh --only rust`, then re-vendor with `tools/sigil_vendor.sh --sync`.

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -59,23 +59,49 @@ builds = true
 ships  = true
 
 [chip.esp32s3]
-# JP's next fleet target. Not yet compilable from this tree: `esp-hal` is pinned with
-# `features = ["esp32c3"]`, `.cargo/config.toml` pins `build.target`, and xtensa needs the
-# esp Rust fork rather than the pinned upstream toolchain.
+# JP's next fleet target.
+#
+# #347 Part 2 REMOVED two of the three original blockers: `esp-hal` no longer hardcodes a chip
+# (the `esp32s3` feature supplies it) and `.cargo/config.toml` now declares this triple instead of
+# pinning only the C3's. What remains is a TOOLCHAIN fact, not a manifest one — which is why the
+# reason below was rewritten rather than left standing. A `blocked_on` whose stated cause has been
+# fixed reads as a considered decision and is the most expensive kind of stale comment.
 target     = "xtensa-esp32s3-none-elf"
 builds     = false
 ships      = false
-blocked_on = "#331 multi-target; needs the esp fork toolchain and a per-chip esp-hal feature"
-# When #331 lands, flipping `builds` to true is a ONE-WORD data change and the matrix,
-# the CI jobs and the tier coverage all follow. That is the entire point of this file.
+# `builds = false` is about CI, not about this tree. Xtensa is a Tier-3 target needing espup's `esp`
+# channel (Xtensa Rust 1.95.0.0, pinned byte-identical on katana and familiar) plus
+# `. ~/export-esp.sh` and a per-invocation `CARGO_UNSTABLE_BUILD_STD=core,alloc`. GitHub runners
+# have none of it, and a permanently-red arm teaches everyone to ignore the gate (#343).
+blocked_on = "xtensa toolchain (espup `esp` channel + export-esp.sh) is not on CI runners; the manifest and target pins are DONE (#347 Part 2)"
+# When the toolchain question is answered, flipping `builds` to true is a ONE-WORD data change and
+# the matrix, the CI jobs and the tier coverage all follow. That is the entire point of this file.
 # `ships` stays false after that: OpenWrt's DEFAULT := n. Buildable is not shipped.
 
 [chip.esp32c6]
-# The esp32c6-watch already runs this chip in its own repo (#347 Phase 2's third consumer).
+# The esp32c6-watch already runs this chip in its own repo (#347 Phase 2's third consumer), and
+# Part 1 landed its MEASURED ChipBudget row — which Part 2's per-feature lookup can now select.
 target     = "riscv32imac-unknown-none-elf"
 builds     = false
 ships      = false
-blocked_on = "#331 multi-target; esp-hal chip feature is pinned to esp32c3 in Cargo.toml"
+# The manifest pin is gone. What blocks a green CI arm is smol's own code, not the chip plumbing:
+# the ROM region. esp-hal generates a 4 MiB ROM region for the C6 and the measured row's 6 MB OTA
+# slots exist only because the watch's `widen_rom_region` build.rs hook rewrites it. smol does not
+# carry that hook, so a C6 image links against a 4 MiB ceiling while its budget claims 6 MB.
+blocked_on = "needs the watch's widen_rom_region build.rs hook (#67 there) before the 6MB-slot budget row is honest; manifest + target pins are DONE (#347 Part 2)"
+
+[chip.esp32c5]
+# The NM-CYD-C5 (#388), fifth fleet target and the intended Zigbee-bridge role. Shares
+# `riscv32imac` with the C6 — the triple CANNOT tell them apart, which is #349's whole subject;
+# the chip FEATURE is what discriminates now.
+target     = "riscv32imac-unknown-none-elf"
+builds     = false
+ships      = false
+# NO ChipBudget row, deliberately: nobody has measured this silicon, and `budget.rs` hands an
+# unmeasured chip a poison row rather than the C6's numbers. `builds = false` is therefore also
+# what keeps the roster check quiet — rule 1 of this file only demands a budget for a chip that
+# BUILDS. The board-specific code stop-points are recorded on #388.
+blocked_on = "#388 board code: TSENS (src/main.rs:708) and a hard-typed GPIO9 need C5 arms; no measured ChipBudget row yet"
 
 # ── TIERS ─────────────────────────────────────────────────────────────────────
 # `features` is passed verbatim to `--features` (empty string = default features only).
@@ -149,6 +175,37 @@ features = "stack-paint,${canonical}"
 default  = "the `default` tier IS this feature set"
 hw       = "implied by every firmware tier; a tier for it alone would build nothing new"
 hostsim  = "host-only, and covered by the `cargo test` arm in tools/gate.sh"
+
+# ── #347 Part 2: the chip axis is not a tier ──────────────────────────────────
+# A CHIP is the other axis of this very matrix — `[chip.*]` above — so a `[tier.esp32c5]` would
+# duplicate the roster in the table designed to stop the roster being duplicated, and would make
+# the cross product this file exists to refuse. Coverage of a chip feature is `builds = true` on
+# its `[chip.*]` row; that is where the "is anything compiling this?" question belongs, and it is
+# already checked in both directions against `budget.rs`.
+#
+# `esp32c3` is exempted for a second, stronger reason worth stating separately: it is carried by
+# `default`, so EVERY tier in this file builds it. It is the most-compiled feature in the tree.
+esp32c3 = "the chip axis, not a tier — carried by `default`, so every tier above already builds it"
+esp32c5 = "the chip axis, not a tier — coverage is `builds` on [chip.esp32c5]"
+esp32c6 = "the chip axis, not a tier — coverage is `builds` on [chip.esp32c6]"
+esp32s3 = "the chip axis, not a tier — coverage is `builds` on [chip.esp32s3]"
+
+# ── #347 Part 2: capability markers ───────────────────────────────────────────
+# Empty marker features, selected BY a chip feature, existing to be `cfg`'d on. They cannot have a
+# tier for the same reason as the chips (they are not an independent axis — no build chooses a
+# capability, the silicon does), and right now they gate no code at all.
+#
+# ⚠️ THAT IS THE HONEST WEAKNESS OF THESE TWO ENTRIES, so it is written down rather than smoothed
+# over. A marker nothing reads is indistinguishable from a marker that has quietly stopped being
+# read, and this file's own rule is that an exemption whose reason has expired is worse than none.
+# The reason has NOT expired — it has not yet started: both are declarations that the silicon has
+# a thing, made at the point where the constraint is documented (see the ⚠️ blocks at each feature
+# in rust/clock/Cargo.toml — the espnow⊕ieee802154 build-script panic, and esp-radio's heap never
+# going in PSRAM). When code starts predicating on them, these entries stay valid unchanged; what
+# would invalidate them is a `has-*` feature that pulls a real dependency, and that one needs a
+# tier.
+has-ieee802154 = "capability marker selected by esp32c5/esp32c6; gates no code yet and links nothing (see the mutual-exclusion note at its declaration)"
+has-psram      = "capability marker selected by esp32s3; gates no code yet and links nothing (PSRAM mode is a RUNTIME PsramConfig field, not a feature)"
 # `off-fleet` deliberately has NO entry here: the bard tier names it, so it is covered, and the
 # checker rejects a feature that is both exempted and covered — an exemption whose reason has
 # quietly stopped applying is worse than none. It caught this exact case when first written.

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -52,11 +52,35 @@ canonical_tier = "fleet"
 # chip the tree cannot compile today — declaring a job that always fails is worse than
 # declaring none, because a permanently-red arm teaches everyone to ignore the gate.
 # `blocked_on` records why, so the row is a tracked commitment rather than a wish.
+#
+# ── `checks`: THE THIRD DECLARATION (#347 Part 2) ─────────────────────────────
+# Rule 1 above splits BUILDS from SHIPS. There turned out to be a rung below both, and leaving it
+# undeclared is what made the de-pin hard to finish: a chip can COMPILE — `cargo check` clean, on
+# the canonical tier, with its own features and its own target — long before CI can produce a
+# linked, budget-honest, publishable artifact for it. Those are different claims and they were
+# collapsed into one word.
+#
+# The C6 is the case that forced the split. Its arm passes `cargo check` clean TODAY, but it cannot
+# have `builds = true`, because its 6 MB OTA slots need a `widen_rom_region` hook smol does not
+# carry (see its row). Under a two-rung model the only truthful thing to say about the C6 was
+# `builds = false` — which reads as "nothing about this chip works" and is the same
+# rounding-a-caveat-to-zero that leaves the next person re-deriving what already holds.
+#
+# So: `checks` = "smol's own source compiles for this chip". It is what `tools/check_chips.sh`
+# asserts, in BOTH directions — a `checks = true` chip that stops compiling fails the gate, and a
+# `checks = false` chip that starts compiling ALSO fails it, because a stale pessimistic
+# declaration is exactly as misleading as a stale optimistic one and this file's whole discipline
+# is that a reason which has expired is worse than no reason. Every value below was measured, not
+# predicted; two of them contradicted what the roster said before it was.
+#
+# The implication ladder is checked by build_matrix.py: ships => builds => checks. You cannot ship
+# what nothing builds, and you cannot build what does not compile.
 
 [chip.esp32c3]
 target = "riscv32imc-unknown-none-elf"
 builds = true
 ships  = true
+checks = true
 
 [chip.esp32s3]
 # JP's next fleet target.
@@ -69,6 +93,21 @@ ships  = true
 target     = "xtensa-esp32s3-none-elf"
 builds     = false
 ships      = false
+# MEASURED on familiar's xtensa toolchain (espup `esp`, Xtensa Rust 1.95.0.0), canonical tier: the
+# whole dependency graph builds — `core` from source, esp-hal 1.1.1 for xtensa — and stops with 6
+# errors in smol's OWN code, in exactly two classes:
+#   * TSENS (2): `esp_hal::tsens` does not exist for the S3 — the same gap as the C5, needs the
+#     `has-tsens` fallback in sensors.rs/main.rs. NOTE this contradicted the roster's assumption
+#     that the biggest chip is a superset; see the `has-tsens` block in rust/clock/Cargo.toml.
+#   * `SocResetReason` CPU-scoped spelling (4): the S3 drops the core index — `CpuSw`/`CpuMwdt0`/
+#     `CpuMwdt1`/`CpuRtcWdt` where the C3 has `Cpu0*`, at IDENTICAL discriminants. A pure esp-hal
+#     naming variance with no silicon difference, so it deliberately got no `has-*` marker (that
+#     namespace means the silicon has a thing). See src/ota.rs's reset_reason_token().
+checks     = false
+# The xtensa toolchain is a property of the CHIP, declared here so no script hardcodes it. Empty /
+# absent `toolchain` means the default (rust-toolchain.toml's `stable`).
+toolchain  = "esp"
+build_std  = "core,alloc"
 # `builds = false` is about CI, not about this tree. Xtensa is a Tier-3 target needing espup's `esp`
 # channel (Xtensa Rust 1.95.0.0, pinned byte-identical on katana and familiar) plus
 # `. ~/export-esp.sh` and a per-invocation `CARGO_UNSTABLE_BUILD_STD=core,alloc`. GitHub runners
@@ -88,7 +127,17 @@ ships      = false
 # the ROM region. esp-hal generates a 4 MiB ROM region for the C6 and the measured row's 6 MB OTA
 # slots exist only because the watch's `widen_rom_region` build.rs hook rewrites it. smol does not
 # carry that hook, so a C6 image links against a 4 MiB ceiling while its budget claims 6 MB.
-blocked_on = "needs the watch's widen_rom_region build.rs hook (#67 there) before the 6MB-slot budget row is honest; manifest + target pins are DONE (#347 Part 2)"
+blocked_on = "needs the watch's widen_rom_region build.rs hook (#67 there) before the 6MB-slot budget row is honest; manifest + target pins are DONE (#347 Part 2), and `cargo check` is CLEAN (checks = true)"
+# ✅ MEASURED CLEAN: `cargo check --no-default-features --features esp32c6,espnow,cast,io --target
+# riscv32imac-unknown-none-elf` (SMOL_CHIP=esp32c6) compiles smol's entire source with zero errors
+# — the only output is 3 pre-existing dead_code warnings for unused WEATHER_* constants in the
+# git-ignored board.rs. This chip is the reason `checks` exists as its own axis: everything smol
+# writes is C6-ready, and what remains is a LINK-time ROM-region fact above.
+#
+# Getting here took ONE line of source: src/ota.rs's glitch arm. Before it, the C6 arm failed with
+# 2 errors and nothing else — TSENS resolved, the radio stack resolved, esp-wifi-sys resolved. The
+# single most portable-looking function in the tree was the last thing pinned to the C3.
+checks     = true
 
 [chip.esp32c5]
 # The NM-CYD-C5 (#388), fifth fleet target and the intended Zigbee-bridge role. Shares
@@ -101,7 +150,19 @@ ships      = false
 # unmeasured chip a poison row rather than the C6's numbers. `builds = false` is therefore also
 # what keeps the roster check quiet — rule 1 of this file only demands a budget for a chip that
 # BUILDS. The board-specific code stop-points are recorded on #388.
-blocked_on = "#388 board code: TSENS (src/main.rs:708) and a hard-typed GPIO9 need C5 arms; no measured ChipBudget row yet"
+blocked_on = "#388 board code: TSENS (src/sensors.rs:28 + src/main.rs:719) needs `has-tsens` arms; no measured ChipBudget row yet"
+# MEASURED, canonical tier, `SMOL_CHIP=esp32c5 ... --target riscv32imac-unknown-none-elf`: the full
+# dependency graph resolves and compiles, stopping with exactly 2 errors, both TSENS — the C5 has no
+# `esp_hal::tsens`. Down from 4: the glitch pair (src/ota.rs) is fixed and shared with the C6.
+#
+# ⚠️ TWO CORRECTIONS TO THIS ROW'S OWN PREVIOUS TEXT, both from running it rather than reading it:
+#   * TSENS in main.rs is at line **719**, not 708. A line number in a `blocked_on` is a promise
+#     that rots silently; this one was ~11 lines stale.
+#   * The "hard-typed GPIO9" is REMOVED from the claim. It did not appear. `cargo check` stops at
+#     the TSENS errors, so GPIO9 is UNCONFIRMED — not disproven, just never reached. It is listed
+#     on #388 as a suspected stop-point and must not be restated here as a measured one; the
+#     difference between "we saw this" and "we expect this" is the entire value of this field.
+checks     = false
 
 # ── TIERS ─────────────────────────────────────────────────────────────────────
 # `features` is passed verbatim to `--features` (empty string = default features only).
@@ -206,6 +267,34 @@ esp32s3 = "the chip axis, not a tier — coverage is `builds` on [chip.esp32s3]"
 # tier.
 has-ieee802154 = "capability marker selected by esp32c5/esp32c6; gates no code yet and links nothing (see the mutual-exclusion note at its declaration)"
 has-psram      = "capability marker selected by esp32s3; gates no code yet and links nothing (PSRAM mode is a RUNTIME PsramConfig field, not a feature)"
+
+# ── The markers that DO gate code — a DIFFERENT exemption reason, deliberately ────────────────
+# The two entries above are exempt because they gate nothing. These three are exempt for the
+# opposite reason, and collapsing them into one shared "capability marker" reason would destroy
+# the distinction this file exists to keep: they ARE compiled, on every tier, and still cannot
+# have a tier of their own.
+#
+# Why they cannot: no build chooses a capability — the SILICON does. Each is selected by a chip
+# arm, so `[tier.has-tsens]` would mean "build a C3 image that pretends it has no temperature
+# sensor", which is not a configuration anyone can flash. The chip axis already covers them.
+#
+# ⚠️ AND THE HONEST PART: the gate's message says "no tier builds it", which is FALSE for all
+# three. `default` carries `esp32c3`, which selects `has-tsens` and `has-reset-glitch-split`, so
+# every one of the 10 jobs in this matrix compiles both — they are among the most-compiled
+# features in the tree. The checker reads each tier's `features` string LITERALLY and cannot see
+# a feature reached transitively through a chip arm, so a truly-covered feature still lands here.
+# That is a limitation of the instrument, not a property of the feature, and the exemption says so
+# rather than restating the checker's wrong claim back as a reason. Teaching the checker to expand
+# the feature graph is the real fix and it is NOT done here (it would need to resolve Cargo.toml's
+# feature closure, which is a cargo-metadata job, not a regex one) — recorded so the next person
+# finds a known gap instead of rediscovering it.
+#
+# `has-reset-glitch-unified` is the one of the three that genuinely is NOT compiled by any job
+# today: only the C5 selects it, and [chip.esp32c5] is `builds = false`. It is covered by a
+# per-chip `cargo check` (tools/check_chips.sh), which is not part of this matrix.
+has-tsens                = "capability marker selected by esp32c3/esp32c6/esp32s3, read by src/sensors.rs; the silicon picks it, not a build, so the chip axis covers it — compiled by every tier via `default`->esp32c3 though the checker cannot see through the chip arm"
+has-reset-glitch-split   = "capability marker selected by esp32c3/esp32s3, read by src/ota.rs reset_reason_token(); same chip-axis reason — compiled by every tier via `default`->esp32c3"
+has-reset-glitch-unified = "capability marker selected by esp32c5 ALONE, read by src/ota.rs; genuinely uncompiled by this matrix because [chip.esp32c5] is builds=false — covered by tools/check_chips.sh until it flips"
 # `off-fleet` deliberately has NO entry here: the bard tier names it, so it is covered, and the
 # checker rejects a feature that is both exempted and covered — an exemption whose reason has
 # quietly stopped applying is worse than none. It caught this exact case when first written.

--- a/tools/build_matrix.py
+++ b/tools/build_matrix.py
@@ -77,7 +77,11 @@ def load(path: Path) -> dict:
             raise Bad(f"tier {name!r} has an unexpanded placeholder: {tier['features']!r}")
 
     for name, chip in chips.items():
-        for field in ("target", "builds", "ships"):
+        # `checks` (#347 Part 2) is REQUIRED like the other three, not defaulted. A default would
+        # have to be either `true` (claiming every new chip compiles — the optimistic lie) or
+        # `false` (claiming none do, so a chip that compiles goes unnoticed — the pessimistic one).
+        # There is no safe default for a measurement, so the manifest must state it.
+        for field in ("target", "builds", "ships", "checks"):
             if field not in chip:
                 raise Bad(f"chip {name!r} declares no `{field}`")
 
@@ -190,10 +194,16 @@ def check(doc: dict, repro: Path, budget: Path) -> list[str]:
     fails: list[str] = []
     chips, tiers = doc["chips"], doc["tiers"]
 
-    # 1. ships => builds. You cannot publish what nothing compiles.
+    # 1. ships => builds => checks. You cannot publish what nothing builds, and you cannot
+    #    build what does not compile. #347 Part 2 added the third rung; the ladder is checked
+    #    one step at a time so the failure names the rung that broke rather than the whole chain.
     for name, spec in chips.items():
         if spec["ships"] and not spec["builds"]:
             fails.append(f"chip {name}: ships = true but builds = false")
+        if spec["builds"] and not spec["checks"]:
+            fails.append(
+                f"chip {name}: builds = true but checks = false — CI is declared to produce an "
+                f"artifact for a chip whose source is declared not to compile")
     for name, spec in tiers.items():
         if spec.get("ships") and name != doc["canonical_tier"]:
             # A shipped tier that is not the canonical one means two fleet images exist and
@@ -265,7 +275,7 @@ def check(doc: dict, repro: Path, budget: Path) -> list[str]:
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("command", choices=("emit", "chips", "ci-matrix", "check"))
+    ap.add_argument("command", choices=("emit", "chips", "chip-checks", "ci-matrix", "check"))
     ap.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     ap.add_argument("--repro", type=Path, default=DEFAULT_REPRO)
     ap.add_argument("--budget", type=Path, default=DEFAULT_BUDGET)
@@ -294,6 +304,39 @@ def main() -> int:
         for name, spec in doc["chips"].items():
             if not args.builds or spec["builds"]:
                 print(name)
+        return 0
+
+    if args.command == "chip-checks":
+        # #347 Part 2: one line per chip for `tools/check_chips.sh`, which runs the per-chip
+        # `cargo check` that `checks` declares the outcome of. Everything the invocation needs
+        # comes from here, so the harness hardcodes NO chip, NO triple and NO toolchain — the
+        # same rule `emit` follows for tiers.
+        #
+        # Fields, tab-separated:
+        #   chip · target · expect(check|fail) · toolchain · build_std · features
+        #
+        # ⚠️ EMPTY OPTIONAL FIELDS ARE WRITTEN AS "-", NOT LEFT EMPTY, and that is not cosmetic.
+        # `emit` gets away with bare tabs because it has TWO fields and only the last can be empty.
+        # This record has six with two optional ones in the MIDDLE, and a tab is an IFS *whitespace*
+        # character in bash — so `read -r a b c d e f` COLLAPSES a run of consecutive tabs and every
+        # field after the gap shifts left. Measured, not theorised: the first run of check_chips.sh
+        # read the C3's feature string as its toolchain name and tried `cargo +espnow,cast,io`.
+        # A sentinel is immune to it, greppable, and survives any reader's IFS.
+        SENTINEL = "-"
+        def opt(v: object) -> str:
+            s = str(v or "").strip()
+            return s if s else SENTINEL
+        #
+        # `features` is the CANONICAL TIER's, always. The per-chip axis crosses one tier only —
+        # rule 2 of the manifest, ONE AXIS AT A TIME — so this deliberately cannot be asked for
+        # a cross product of chips and tiers.
+        canon_features = doc["tiers"][doc["canonical_tier"]]["features"]
+        for name, spec in doc["chips"].items():
+            expect = "check" if spec["checks"] else "fail"
+            print("\t".join((name, spec["target"], expect,
+                             opt(spec.get("toolchain")),
+                             opt(spec.get("build_std")),
+                             canon_features)))
         return 0
 
     if args.command == "ci-matrix":

--- a/tools/build_matrix.py
+++ b/tools/build_matrix.py
@@ -142,7 +142,24 @@ def budget_chips(path: Path) -> set[str]:
     supposed to be comparing — the same discipline `repro_stack_check` uses when it cannot
     read an ELF. `chip: "host"` is skipped: it is the non-device fallback for host builds,
     not a fleet target.
+
+    `chip: "unmeasured"` is skipped for the same KIND of reason and it is worth being precise
+    about, because the two look alike and are not (#347 Part 2). `host` is a real build with no
+    device budget. `unmeasured` is a real DEVICE whose budget nobody has measured yet — the poison
+    row a declared chip selects until a hardware measurement exists, every field zero so that
+    `fits_dram`/`fits_flash` answer no and the budget-predicated features refuse to compile.
+
+    Neither is a fleet target, which is the only property this function is about: it compares the
+    chip ROSTER against `build-matrix.toml`, and a row that stands for "no chip" would demand a
+    `[chip.unmeasured]` section — a build job for the absence of a board.
+
+    ⚠️ Note what is deliberately NOT skipped: a chip that is declared with real numbers but is
+    not in the matrix still fails the check, in both directions. The skip list is for rows that
+    are not chips, never for chips that are inconvenient.
     """
+    # Rows that are not fleet targets. Kept as a named set rather than two inline `!=` tests so
+    # that adding a third one requires reading the docstring's rule for what belongs here.
+    NOT_A_FLEET_TARGET = {"host", "unmeasured"}
     text = path.read_text(encoding="utf-8")
     # `= ChipBudget {` is an INITIALISER. Anchoring on the `=` matters: a bare
     # `ChipBudget\s*\{` also matches `pub struct ChipBudget {` and `impl ChipBudget {`, which
@@ -156,7 +173,7 @@ def budget_chips(path: Path) -> set[str]:
         raise Bad(
             f"{path}: found {literals} `ChipBudget {{` literals but only {len(found)} "
             f"`chip:` fields — refusing to compare a roster I cannot fully read")
-    return {c for c in found if c != "host"}
+    return {c for c in found if c not in NOT_A_FLEET_TARGET}
 
 
 def cargo_features(path: Path) -> set[str]:

--- a/tools/check_chips.sh
+++ b/tools/check_chips.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# check_chips.sh — #347 Part 2. Run the PER-CHIP `cargo check` that `tools/build-matrix.toml`'s
+# `checks` field declares the outcome of, and assert the declaration in BOTH directions.
+#
+# ── WHY THIS EXISTS ───────────────────────────────────────────────────────────────────────────
+# The de-pin's acceptance question is "does a target's own feature matrix pass from inside smol's
+# tree?" — and until this script there was no way to ask it. `tools/gate.sh` crosses the CANONICAL
+# CHIP with every tier; CI's job matrix contains only chips with `builds = true`. Both are correct
+# and neither compiles a C5 or a C6. So the chip arms were verified the way they were added: by
+# hand, once, by whoever was holding the context, with the result written into a commit message.
+# That is exactly the shape #350 exists to end for tiers, applied one axis over.
+#
+# ── THE PART THAT IS NOT OBVIOUS: FAILURE IS ALSO AN EXPECTATION ──────────────────────────────
+# A chip declared `checks = false` must still FAIL. If it starts compiling and nothing notices, the
+# manifest now carries a pessimistic lie — `blocked_on` prose describing work already done, which
+# this repo has been bitten by often enough to have a rule about it (#347 Part 2 rewrote two such
+# `blocked_on` reasons whose stated causes had become false). A stale pessimistic declaration is
+# not the safe direction; it is the direction that hides finished work. So `fail` is asserted as
+# strictly as `check`, and a chip that unexpectedly compiles fails this gate with instructions to
+# flip its row.
+#
+# ── SCOPE, STATED SO IT CANNOT BE MISREAD AS MORE ─────────────────────────────────────────────
+# `cargo check` only. It proves smol's SOURCE compiles for a chip. It does NOT link, does not
+# measure a section, does not honour a ChipBudget and does not produce anything flashable — those
+# are the `builds` rung (CI) and the publish path (`ota_publish.sh`), and a green run here says
+# nothing about either. The ladder is ships => builds => checks; this is the bottom rung.
+#
+# USAGE:  tools/check_chips.sh [chip ...]      # default: every chip in the manifest
+#
+# ⚠️ RUN IT ON familiar, NOT ON katana. Every cargo invocation in this repo is offloaded (JP's
+# standing preference — katana's RAM is the constraint), and this script runs up to four of them:
+#     ssh familiar 'cd ~/Projects/<worktree> && PATH=$HOME/.cargo/bin:$PATH \
+#       CARGO_TARGET_DIR=/var/tmp/ftarget/<name> TMPDIR=/var/tmp/ftarget/tmp tools/check_chips.sh'
+# They run STRICTLY ONE AT A TIME, deliberately: parallel cargo builds balloon the cgroup page
+# cache and have twice taken out a whole agent scope with an oomd sweep.
+
+set -uo pipefail   # NOT -e: a failing `cargo check` is DATA here, not an error to abort on.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CRATE="$ROOT/rust/clock"
+MATRIX="$ROOT/tools/build_matrix.py"
+
+want=("$@")
+pass=0 fail=0 skip=0 verified=0
+
+# ⚠️ `cd` into the CRATE, never the repo root. rust-toolchain.toml resolves by DIRECTORY, so an
+# xtensa build launched from the root silently gets `stable` and fails deep inside xtensa_lx with
+# an error that names neither the toolchain nor the directory (#347/1d22f14 documented this trap
+# after paying for it).
+cd "$CRATE" || { echo "no crate dir at $CRATE" >&2; exit 2; }
+
+while IFS=$'\t' read -r chip target expect toolchain build_std features; do
+    [ -n "$chip" ] || continue
+    # `-` is the manifest's sentinel for "this optional field is empty". It exists because a tab is
+    # an IFS *whitespace* character, so bash collapses consecutive tabs and every field after an
+    # empty one shifts left — which on the first run made this script try `cargo +espnow,cast,io`.
+    # Translate back to empty here, once, so the rest of the loop reads naturally.
+    [ "$toolchain" = "-" ] && toolchain=""
+    [ "$build_std" = "-" ] && build_std=""
+    if [ ${#want[@]} -gt 0 ]; then
+        found=0
+        for w in "${want[@]}"; do [ "$w" = "$chip" ] && found=1; done
+        [ $found -eq 1 ] || continue
+    fi
+
+    # The `esp` channel is not installable from crates.io and is not on CI runners. A missing
+    # toolchain is NOT a failure of the chip arm, and must not be reported as one — but it is also
+    # not a pass. It is counted separately and printed loudly, because a skip that reads like a
+    # green tick is the one outcome worse than a red one.
+    # The pattern must allow END-OF-LINE: espup installs the xtensa fork as a bare `esp` with no
+    # host-triple suffix, unlike `stable-x86_64-unknown-linux-gnu`. An earlier `^esp[ -]` required a
+    # separator that is not there and reported the installed toolchain as absent — a false SKIP,
+    # which is the failure mode this whole block is meant to distinguish from a real one.
+    if [ -n "$toolchain" ] && ! rustup toolchain list 2>/dev/null | grep -qE "^${toolchain}( |-|\$)"; then
+        printf '  \033[33mSKIP\033[0m %-9s %s — toolchain `+%s` not installed (espup)\n' \
+               "$chip" "$target" "$toolchain"
+        skip=$((skip + 1)); continue
+    fi
+
+    # Uniform invocation for EVERY chip, including the C3. The C3 would also be reachable as a
+    # bare `cargo check` (its chip feature rides `default`), and using that shortcut here would
+    # mean the canonical chip is the one chip this harness checks differently from the others —
+    # so the default-features path would be the one never exercised against its explicit form.
+    args=(check --no-default-features --features "${chip},${features}" --target "$target")
+    [ -n "$toolchain" ] && args=("+${toolchain}" "${args[@]}")
+
+    log="/tmp/check-chips-${chip}.log"
+    printf '  .... %-9s %s (expect %s)\033[2K\r' "$chip" "$target" "$expect"
+
+    # `SMOL_CHIP` is always passed: riscv32imac cannot tell a C5 from a C6, so build.rs maps that
+    # triple to CHIP_UNKNOWN and the wifi-tier assert fails the build until a name is supplied
+    # (#349). Harmless where the triple is already unambiguous.
+    #
+    # build-std goes in the ENV, per invocation, never into .cargo/config.toml — cargo's
+    # `[unstable] build-std` is GLOBAL, and a config key would hand it to the riscv builds too.
+    # That is the 2026-07-20 regression that leaked portable-atomic/unsafe-assume-single-core into
+    # the HOST build and broke every cold C3 build. Env-scoped means a C3 check cannot inherit it.
+    if [ -n "$build_std" ]; then
+        # shellcheck disable=SC1090
+        [ -f "$HOME/export-esp.sh" ] && . "$HOME/export-esp.sh" >/dev/null 2>&1
+        CARGO_UNSTABLE_BUILD_STD="$build_std" SMOL_CHIP="$chip" cargo "${args[@]}" >"$log" 2>&1
+    else
+        SMOL_CHIP="$chip" cargo "${args[@]}" >"$log" 2>&1
+    fi
+    rc=$?
+
+    verified=$((verified + 1))
+    # Count DIAGNOSTICS, not lines starting with "error". cargo ends a failed compile with its own
+    # `error: could not compile \`clock\` (bin "clock") due to 6 previous errors`, which a naive
+    # `grep -c '^error'` counts as a seventh — so the first version of this line reported the S3 at
+    # 7 and the C5 at 3, one more than each really has. An off-by-one in a number that goes into a
+    # commit message is how a measurement becomes folklore.
+    errs=$(grep -E '^error' "$log" | grep -vc 'could not compile')
+    if [ $rc -eq 0 ] && [ "$expect" = "check" ]; then
+        printf '  \033[32mok  \033[0m %-9s %s — compiles clean\n' "$chip" "$target"
+        pass=$((pass + 1))
+    elif [ $rc -ne 0 ] && [ "$expect" = "fail" ]; then
+        printf '  \033[32mok  \033[0m %-9s %s — fails as declared (%d errors, %s)\n' \
+               "$chip" "$target" "$errs" "$log"
+        pass=$((pass + 1))
+    elif [ $rc -ne 0 ]; then
+        printf '  \033[31mFAIL\033[0m %-9s %s — declared `checks = true` but %d errors: %s\n' \
+               "$chip" "$target" "$errs" "$log"
+        grep '^error' "$log" | head -5 | sed 's/^/         /'
+        fail=$((fail + 1))
+    else
+        # The direction that hides finished work.
+        printf '  \033[31mFAIL\033[0m %-9s %s — declared `checks = false` but it COMPILES CLEAN.\n' \
+               "$chip" "$target"
+        printf '         Flip `checks = true` on [chip.%s] in tools/build-matrix.toml and rewrite\n' "$chip"
+        printf '         its `blocked_on` — the stated cause is no longer true.\n'
+        fail=$((fail + 1))
+    fi
+done < <("$MATRIX" chip-checks)
+
+echo "  chips: $pass as declared · $fail wrong · $skip skipped (toolchain absent) · $verified actually run"
+[ $fail -eq 0 ] || exit 1
+[ $verified -gt 0 ] || { echo "  nothing was verified — refusing to report success" >&2; exit 1; }
+exit 0

--- a/tools/test_build_matrix_cases/budget_orphan.toml
+++ b/tools/test_build_matrix_cases/budget_orphan.toml
@@ -6,6 +6,7 @@ canonical_tier = "fleet"
 [chip.esp32c3]
 target = "riscv32imc-unknown-none-elf"
 builds = true
+checks = true
 ships = true
 [tier.fleet]
 features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/budget_unreadable.toml
+++ b/tools/test_build_matrix_cases/budget_unreadable.toml
@@ -6,6 +6,7 @@ canonical_tier = "fleet"
 [chip.esp32c3]
 target = "riscv32imc-unknown-none-elf"
 builds = true
+checks = true
 ships = true
 [tier.fleet]
 features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/builds_without_checks.toml
+++ b/tools/test_build_matrix_cases/builds_without_checks.toml
@@ -1,0 +1,24 @@
+# EXPECT: builds = true but checks = false
+# #347 Part 2 added the third rung to the ladder (ships => builds => checks), and a rung with no
+# case here is an unproven gate — which is the one thing this suite exists to prevent. The chip
+# below claims CI produces an artifact for silicon whose source is declared not to compile.
+#
+# Note the esp32s3 row is the LEGAL neighbour of that contradiction and is here on purpose:
+# builds = false with checks = true is the ESP32-C6's real state in tools/build-matrix.toml (it
+# compiles clean but cannot link a budget-honest image yet), so this fixture would also catch an
+# over-eager fix that collapsed the two fields back into one by rejecting that combination too.
+[meta]
+canonical_chip = "esp32c3"
+canonical_tier = "fleet"
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+checks = false
+ships = false
+[chip.esp32s3]
+target = "xtensa-esp32s3-none-elf"
+builds = false
+checks = true
+ships = false
+[tier.fleet]
+features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/canonical_tier_drift.toml
+++ b/tools/test_build_matrix_cases/canonical_tier_drift.toml
@@ -5,6 +5,7 @@ canonical_tier = "fleet"
 [chip.esp32c3]
 target = "riscv32imc-unknown-none-elf"
 builds = true
+checks = true
 ships = true
 [tier.fleet]
 features = "espnow,cast,io,bard"

--- a/tools/test_build_matrix_cases/chip_without_budget.toml
+++ b/tools/test_build_matrix_cases/chip_without_budget.toml
@@ -5,10 +5,12 @@ canonical_tier = "fleet"
 [chip.esp32c3]
 target = "riscv32imc-unknown-none-elf"
 builds = true
+checks = true
 ships = true
 [chip.esp32s3]
 target = "xtensa-esp32s3-none-elf"
 builds = true
+checks = true
 ships = false
 [tier.fleet]
 features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/feature_without_tier.toml
+++ b/tools/test_build_matrix_cases/feature_without_tier.toml
@@ -6,6 +6,7 @@ canonical_tier = "fleet"
 [chip.esp32c3]
 target = "riscv32imc-unknown-none-elf"
 builds = true
+checks = true
 ships = true
 [tier.fleet]
 features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/missing_canonical_chip.toml
+++ b/tools/test_build_matrix_cases/missing_canonical_chip.toml
@@ -5,6 +5,7 @@ canonical_tier = "fleet"
 [chip.esp32c3]
 target = "riscv32imc-unknown-none-elf"
 builds = true
+checks = true
 ships = true
 [tier.fleet]
 features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/second_shipped_tier.toml
+++ b/tools/test_build_matrix_cases/second_shipped_tier.toml
@@ -5,6 +5,7 @@ canonical_tier = "fleet"
 [chip.esp32c3]
 target = "riscv32imc-unknown-none-elf"
 builds = true
+checks = true
 ships = true
 [tier.fleet]
 features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/ships_without_builds.toml
+++ b/tools/test_build_matrix_cases/ships_without_builds.toml
@@ -5,10 +5,12 @@ canonical_tier = "fleet"
 [chip.esp32c3]
 target = "riscv32imc-unknown-none-elf"
 builds = true
+checks = true
 ships = true
 [chip.esp32s3]
 target = "xtensa-esp32s3-none-elf"
 builds = false
+checks = false
 ships = true
 [tier.fleet]
 features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/stale_exemption.toml
+++ b/tools/test_build_matrix_cases/stale_exemption.toml
@@ -6,6 +6,7 @@ canonical_tier = "fleet"
 [chip.esp32c3]
 target = "riscv32imc-unknown-none-elf"
 builds = true
+checks = true
 ships = true
 [tier.fleet]
 features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/three_chips_one_axis.toml
+++ b/tools/test_build_matrix_cases/three_chips_one_axis.toml
@@ -10,14 +10,17 @@ canonical_tier = "fleet"
 [chip.esp32c3]
 target = "riscv32imc-unknown-none-elf"
 builds = true
+checks = true
 ships = true
 [chip.esp32s3]
 target = "xtensa-esp32s3-none-elf"
 builds = true
+checks = true
 ships = false
 [chip.esp32c6]
 target = "riscv32imac-unknown-none-elf"
 builds = true
+checks = true
 ships = false
 [tier.default]
 features = ""

--- a/tools/test_build_matrix_cases/unexpanded_placeholder.toml
+++ b/tools/test_build_matrix_cases/unexpanded_placeholder.toml
@@ -5,6 +5,7 @@ canonical_tier = "fleet"
 [chip.esp32c3]
 target = "riscv32imc-unknown-none-elf"
 builds = true
+checks = true
 ships = true
 [tier.fleet]
 features = "espnow,cast,io"


### PR DESCRIPTION
Closes nothing on its own — this is **#347 Part 2**, the chip de-pin, and it is the part that makes #331's and #388's board work possible without re-pinning what it just un-pinned.

Builds on three commits already on this branch (Part 1's measured C6 budget row, the single-naming seam, the MSRV fix) and adds two.

## The acceptance question, and where it now lives

> A target is done when **its own feature matrix passes from inside smol's tree.**

Until this PR there was no way to *ask* that. `tools/gate.sh` crosses the canonical chip with every tier; CI's job matrix contains only chips with `builds = true`. Both correct, neither compiles a C5 or a C6 — so the chip arms were verified the way they were added: by hand, once, by whoever held the context, with the result written into a commit message. That is exactly the shape #350 ended for tiers, one axis over.

`tools/check_chips.sh` is where that matrix lives now. It derives everything from `tools/build-matrix.toml` — no chip, triple, toolchain or feature string is hardcoded in it:

```
esp32c3   riscv32imc-unknown-none-elf   — compiles clean
esp32c6   riscv32imac-unknown-none-elf  — compiles clean
esp32c5   riscv32imac-unknown-none-elf  — fails as declared (2 errors)
esp32s3   xtensa-esp32s3-none-elf       — fails as declared (6 errors)
chips: 4 as declared · 0 wrong · 0 skipped · 4 actually run          exit 0
```

## THE ESP32-C6 NOW COMPILES CLEAN

Zero errors on the canonical fleet tier for `riscv32imac`. The only output is three pre-existing `dead_code` warnings for unused `WEATHER_*` consts in the git-ignored `board.rs`.

It took **one line of shared source**. Before it: 2 errors and nothing else — TSENS resolved, the radio stack resolved, `esp-wifi-sys` resolved. `src/ota.rs`'s `reset_reason_token()` matched `SocResetReason::SysClkGlitch | CorePwrGlitch`, and that enum has **three shapes, not two** (measured, esp-hal 1.1.1):

| chip | glitch variants | marker |
|---|---|---|
| C3, S3 | `SysClkGlitch` 0x13 **and** `CorePwrGlitch` 0x17 | `has-reset-glitch-split` |
| C5 | `PowerGlitch` 0x19 only | `has-reset-glitch-unified` |
| C6 | **none at all** | *neither* |

A chip selecting **neither** is legal and meaningful: the arm compiles out and a glitch reset falls through the existing `Some(_) => "other"`, which is honest because the C6 does not distinguish it in hardware. Predicating on the capability rather than `cfg(feature = "esp32c6")` is the point — "has no glitch detector" is a fact a fifth chip may share and should not have to be rediscovered.

This is also what turns the `has-*` layer from a vocabulary into a mechanism. bd26db1 exempted its two markers with an honest note that they "gate no code YET"; these ones do.

## `checks` — the third rung, and why it had to exist

The manifest split **builds** from **ships**. The C6 forced a third: it compiles clean *today* but cannot have `builds = true`, because its 6 MB OTA slots need the watch's `widen_rom_region` hook. Under two rungs the only truthful thing to say about the C6 was `builds = false` — which reads as "nothing about this chip works", and is the same rounding-a-caveat-to-zero that leaves the next person re-deriving what already holds.

So `[chip.*]` rows declare `checks` too, and `build_matrix.py` enforces **ships ⇒ builds ⇒ checks**. Required, never defaulted: a default is either the optimistic lie or the pessimistic one, and there is no safe default for a measurement.

`check_chips.sh` asserts it **in both directions**. A `checks = false` chip that *starts* compiling **fails the gate**, because a stale pessimistic declaration hides finished work — this repo has already rewritten two `blocked_on` reasons whose stated causes had quietly become false. Proven rather than assumed: flipping the C6 to `checks = false` produces `FAIL … declared checks = false but it COMPILES CLEAN` and exit 1. There is a matching fixture (`builds_without_checks.toml`), because a new rule with no case is an unproven gate.

## The chip stamp reads the FEATURE now (#349)

`SMOL_CHIP_ID` was derived from the target triple, with `SMOL_CHIP` as an **unchecked** override. Since the chip became a feature, that is strictly worse in two ways:

- **The triple is ambiguous; the feature is not.** `riscv32imac` is the C5 *and* the C6, so the old path returned `CHIP_UNKNOWN` and leaned on `SMOL_CHIP` — every C5/C6 build needed an env var carrying information the build already had. The C6 tier now checks clean with no `SMOL_CHIP` at all.
- **It could silently disagree.** `--features esp32c6` with `SMOL_CHIP=esp32c5` stamped a C5 id onto a C6 image — a valid-looking value `net::target::decide()` would trust to accept a cross-chip OTA. *That is the exact failure #349 exists to prevent, still reachable through #349's own escape hatch.* It is now a hard build failure.

`SMOL_CHIP` is kept for the case that justified it (naming silicon whose triple this tree does not map); it may just no longer contradict the feature. All four new failure paths were exercised, none assumed.

## THE WORKSPACE INVARIANT, stated explicitly

Per-chip arms in one manifest look illegal without it:

> **esp-hal accepts exactly ONE chip feature, and cargo unifies features across a workspace.** Four arms is nonetheless fine because **every build invocation is single-chip** — features and target are chosen *together*, per invocation, and two chip features is a *refusal* (`budget.rs`), not a precedence rule.

What this manifest therefore can never do is build two chips at once, or share a cargo graph with a crate compiled for a different chip. **A riscv tree and an xtensa tree never share a workspace graph.** The boundary answer is the `*-core-by-PATH` pattern — a chip-agnostic, zero-dep, host-testable crate with its own empty `[workspace]`, consumed by path (the shape `sigil-names` and `esp-wifi-sys-chip` already declare). `budget.rs` is written to move into `smol-core` with `git mv` and no edits, and the `has-*` layer is designed to lift **unrenamed**.

Where smol *diverges* from the watch's seam is the **board** layer, deliberately: smol is fat-image/thin-runtime-config (#72), so a board announces itself at runtime via `BoardProfile` (#352). Only what the *silicon* fixes is compile-time. `has-display` would be that mistake inverted — it is an I2C probe.

## Measured stop-points (the honest remainder)

**C5 — 2 errors, both TSENS** (`src/sensors.rs:28`, `src/main.rs:719`). Down from 4; the glitch pair is fixed and shared with the C6.

Two corrections to that row's own previous text, both from *running* it rather than reading it:
- TSENS in `main.rs` is at line **719**, not the 708 the `blocked_on` claimed.
- The **"hard-typed GPIO9" is removed from the claim.** It never appeared — the check stops at TSENS. Unconfirmed, not disproven; the difference between "we saw this" and "we expect this" is the whole value of the field.

**S3 — 6 errors, two classes.** The whole dependency graph builds (`core` from source, esp-hal 1.1.1 for xtensa) and stops in smol's own code:
- **TSENS (2)** — same gap as the C5.
- **`SocResetReason` CPU-scoped spelling (4)** — the S3 has `CpuSw`/`CpuMwdt0`/`CpuMwdt1`/`CpuRtcWdt` where the C3 has `Cpu0*`, at **identical discriminants**. A pure esp-hal *naming* variance with no silicon difference, so it deliberately got **no `has-*` marker**: that namespace means "the silicon has a thing", and spending it on a spelling would make the layer's one guarantee unreliable. It needs a differently-prefixed predicate, which is a decision worth making on its own rather than as a side effect of the de-pin.

`has-tsens` is measured, and half the table is counter-intuitive: **C3 ✓, C6 ✓, C5 ✗, S3 ✗.** The S3 entry is why the table exists — it is the biggest chip of the four and does not expose the sensor the smallest one does. This arm carried `has-tsens` in the first draft of this PR, from exactly the "the superset chip has the peripheral" instinct the layer is meant to stop. The wrong assumption is left in the manifest as a comment rather than quietly deleted.

## The default C3 build is byte-stable — the constraint of record

Confound-free A/B: **both builds in the same directory, same target dir**, only file content differing (the first attempt built the baseline in a *different* path, which feeds `-Cmetadata` and would have reported a false difference).

```
.text 67,132 · .rodata 19,132 · .data 1,904 · .bss 468 · .stack 315,388
ELF 308,368 bytes · 5,961 symbols          ALL IDENTICAL
```

72 raw `nm` differences, every one the `-Cmetadata` crate disambiguator or a `.Lanon.<md5>` local-constant hash — both of which move because `default`'s resolved feature *name* set grew. After normalising **only** those two: **0 differences**, `.Lanon` count 394 = 394, non-anon symbol set identical at **5,567** symbols.

For the `build.rs` commit the evidence is stronger still: the **raw** `nm` md5 is identical to the pre-change build, not merely equal after normalising. Rewriting how the stamp is derived changed nothing about what it stamps, because the C3's feature, triple and default all already agreed on `1`.

## Gates

- `build_matrix.py check` clean · self-tests **13 ok / 0 failed** (was 12, +1 new case)
- host suites: budget **16** · bard **41** · input **8**
- `check_chips.sh`: 4 as declared · 0 wrong · 0 skipped · 4 actually run

## Two instruments were wrong before they were right

Both would have put a false number in a commit message, so both are recorded:

1. The error count read cargo's own `could not compile … due to N previous errors` summary as an extra diagnostic — reporting the S3 at **7** and the C5 at **3**. Real: 6 and 2.
2. The first `check_chips.sh` run **SKIPPED all four chips**. A tab is an IFS *whitespace* character, so bash collapses consecutive tabs and every field after an empty one shifts left — it tried `cargo +espnow,cast,io`. The manifest now emits `-` sentinels. The script's own *"nothing was verified — refusing to report success"* guard is what caught it, on its first run.

## Still blocking a publishable non-C3 image (verified here, not relayed)

Neither is touched by this PR — both are single-chip assumptions in the **publish** path, a rung above `checks`:

- `tools/repro_build.sh:36` — `REPRO_TARGET` is a hardcoded scalar, consumed at lines 76, 259, 260, 298 and 300.
- `repro_stack_floor()` greps `ESP32C3_STACK_FLOOR_BYTES` specifically, i.e. one chip's floor line.

Surfaced by the s3-cyd session (`targets/s3-cyd/BUDGET-PREP.md` §3.5) and confirmed independently before quoting.

**Declined from that same doc, on purpose:** the S3 `ChipBudget` const with `TODO-MEASURED` placeholders (§3.2). `budget.rs` already hands an undeclared chip the `UNMEASURED` poison row, which refuses budget-predicated features; a placeholder const is *strictly worse* — it answers `fits_dram` with fiction instead of refusing. Their own doc says "do not let one ship", and the way to honour that is not to write them. The S3's real status is `checks = false` plus six measured errors. (Their §3.1 diff is also against a stale base — its `-` lines quote a `[chip.esp32s3]` comment already rewritten on this branch.)

## Relationship to #402

#402 imports the watch tree as a subtree under `targets/c6-watch` on a separate branch. **Additive, no file overlap with this PR.** The direction of the dependency is worth stating: that tree re-predicates on *these* arms in a later phase, and the `has-*` layer here is the shared predicate layer it converges on — which is why these names are chosen to lift into `smol-core` without renaming.

## Adding a fifth chip, after this

One feature arm in `Cargo.toml`, one `ChipBudget` row in `budget.rs`, one `[chip.*]` row in `build-matrix.toml` with its measured `checks`. The checker asserts the last two agree in both directions, and `check_chips.sh` asserts the third against reality.

---
🚫 **Do not merge** — opened for review per the brief.
Builds run on familiar only, one cargo in flight at a time, throughout. No hardware, no broker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
