### PR TITLE
feat(chip): the S3 arm — has-tsens fallback + the hal-* namespace; four chips check clean (#398)

### DIFF
--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -270,6 +270,7 @@ esp32s3 = [
     "esp-storage?/esp32s3", "esp-bootloader-esp-idf?/esp32s3",
     "esp-wifi-sys?/esp32s3",
     "has-psram", "has-reset-glitch-split",
+    "hal-cpu-reset-unindexed",
     # NO `has-tsens`. This arm CARRIED it in the first draft of this commit, from a datasheet-shaped
     # assumption that the big chip has at least what the little one has. A per-chip `cargo check` on
     # familiar's xtensa toolchain said otherwise: `esp_hal::tsens` is unresolved for
@@ -387,6 +388,20 @@ has-tsens = []
 # caveat that reads as handled. `reset_reason_token()` is NOT chip-complete.
 has-reset-glitch-split = []
 has-reset-glitch-unified = []
+
+# ── HAL API FACTS — `hal-*`, a DIFFERENT namespace from `has-*`, on purpose ─────────────────────
+#
+# `has-*` means "the silicon has a thing". This namespace means "esp-hal spells a thing
+# differently for this chip" — no silicon difference at all. The first tenant is the S3's
+# CPU-scoped reset reasons: esp-hal drops the core index (`CpuSw`/`CpuMwdt0`/`CpuMwdt1`/
+# `CpuRtcWdt` where the C3/C5/C6 have `Cpu0*`), at IDENTICAL discriminants (0x0C/0x0B/0x11/0x0D).
+# `reset_reason_token()` in src/ota.rs predicates its match arms on this instead of on a chip
+# name. The namespace was deliberately NOT invented during the de-pin (#347 Part 2 left it as a
+# named decision, see the reset_reason_token doc) — it lands here, with the S3 arm that needs it
+# (#398/#331). Spending a `has-*` marker on a spelling would make that layer's one guarantee
+# unreliable; a chip-name cfg in ota.rs would re-pin what #347 just un-pinned. This is the third
+# door.
+hal-cpu-reset-unindexed = []
 
 # Phase 1 only: clock on the OLED. `default` = `hw` so `cargo build --release` with no
 # flags is the guaranteed-green firmware baseline — BYTE-IDENTICAL to before the #152

--- a/rust/clock/src/clock.rs
+++ b/rust/clock/src/clock.rs
@@ -95,9 +95,11 @@ pub(crate) fn draw_clock<D>(
     let reading = sensors.read();
     // #43: temperature unit (°F/°C) per the fleet-global config.
     let sensor_line = sensors::format_sensor_line(&reading, units.temp_f);
+    // `chip_c` is optional-by-silicon (no tsens on the C5/S3) — log the already-formatted
+    // line, which omits the field honestly, rather than inventing a number here.
     log::debug!(
-        "smol: chip {}C, batt {:.2}V (~{}%)",
-        reading.chip_c as i32,
+        "smol: sensors {} (batt {:.2}V ~{}%)",
+        sensor_line.as_str(),
         reading.batt_v,
         reading.batt_pct,
     );

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -158,7 +158,8 @@ mod finder;
 // (needs the radio) → zero code in default/wifi builds (default-build invariant).
 #[cfg(feature = "espnow")]
 mod familiar;
-// On-board sensors: chip die-temp (tsens) + battery ADC on GPIO4. Always on.
+// On-board sensors: battery ADC on GPIO4, always on; chip die-temp only where the
+// silicon has the sensor (`has-tsens` — measured C3 ✓ C6 ✓ C5 ✗ S3 ✗).
 mod sensors;
 // #72 IO/component registry (ESPHome inverted): the digital-`Flex` driver menu +
 // runtime pin-map for the free GPIOs (0/1/3/7/10), configured live over the #56
@@ -715,12 +716,18 @@ fn main() -> ! {
     // --- BOOT button on GPIO9 (debounced short/long) -------------------------
     let mut button = Button::new(peripherals.GPIO9);
 
-    // --- On-board sensors (chip temp + battery ADC on GPIO4) -----------------
+    // --- On-board sensors (battery ADC on GPIO4; die temp where the silicon has one) ---
+    // `peripherals.TSENS` does not EXIST on a no-tsens chip (C5/S3), so the call site is
+    // cfg'd on the capability, matching the two constructors in sensors.rs.
+    #[cfg(feature = "has-tsens")]
     let mut sensors = sensors::Sensors::new(peripherals.TSENS, peripherals.ADC1, peripherals.GPIO4);
+    #[cfg(not(feature = "has-tsens"))]
+    let mut sensors = sensors::Sensors::new(peripherals.ADC1, peripherals.GPIO4);
     log::info!(
-        "smol: sensors up — chip temp + battery ADC on GPIO{} ({}:1 divider)",
+        "smol: sensors up — battery ADC on GPIO{} ({}:1 divider); die-temp: {}",
         sensors::BATT_ADC_GPIO,
         sensors::BATT_DIVIDER as u32,
+        cfg!(feature = "has-tsens"),
     );
 
     // --- #72 IO registry: claim the free GPIOs as runtime-bindable Flex pins --

--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -2077,17 +2077,14 @@ fn take_panic_mark() -> bool {
 /// those three, and it is predicated on a `has-reset-glitch-*` capability rather than on a chip
 /// name. This function compiles clean on all three.
 ///
-/// ⚠️ IT DOES NOT COMPILE ON THE S3, and that is a MEASURED, tracked stop-point rather than an
-/// oversight — `tools/build-matrix.toml`'s `[chip.esp32s3]` declares `checks = false` for it and
-/// `tools/check_chips.sh` asserts the failure, so this paragraph cannot quietly become false.
-/// esp-hal spells the four CPU-scoped reasons WITHOUT the core index on the S3, and the values are
-/// identical — `CpuSw`/`CpuMwdt0`/`CpuMwdt1`/`CpuRtcWdt` = 0x0C/0x0B/0x11/0x0D, exactly the C3's
-/// `Cpu0Sw`/`Cpu0Mwdt0`/`Cpu0Mwdt1`/`Cpu0RtcWdt`. So it is a pure esp-hal NAMING variance carrying
-/// no difference in silicon behaviour, which is why it deliberately did NOT get a `has-*` marker
-/// here: that namespace means "the silicon has a thing", and spending it on a spelling would make
-/// the layer's one guarantee unreliable. It needs a differently-named predicate (an esp-hal API
-/// fact, not a capability), and inventing that namespace is a decision worth making on its own
-/// rather than as a side effect of the de-pin. #347 Phase 3 / #331.
+/// The S3 (#398) compiles via the `hal-cpu-reset-unindexed` predicate: esp-hal spells the four
+/// CPU-scoped reasons WITHOUT the core index on the S3, at identical values — `CpuSw`/`CpuMwdt0`/
+/// `CpuMwdt1`/`CpuRtcWdt` = 0x0C/0x0B/0x11/0x0D, exactly the C3's `Cpu0Sw`/`Cpu0Mwdt0`/
+/// `Cpu0Mwdt1`/`Cpu0RtcWdt`. A pure esp-hal NAMING variance with no silicon difference, which is
+/// why it deliberately did NOT get a `has-*` marker (that namespace means "the silicon has a
+/// thing") — it got the `hal-*` namespace instead, invented for exactly this (see the block in
+/// Cargo.toml). The de-pin (#347 Part 2) left inventing that namespace as a named decision rather
+/// than a side effect; #398's S3 arm made it.
 ///
 /// Also NOT chip-complete: the C5's `CpuLockup` is unmapped and reports "other" (see Cargo.toml).
 #[cfg(feature = "espnow")]
@@ -2100,9 +2097,16 @@ pub fn reset_reason_token() -> &'static str {
     use esp_hal::rtc_cntl::SocResetReason as R;
     match esp_hal::system::reset_reason() {
         Some(R::ChipPowerOn) => "power-on",
+        // The CPU-scoped spellings differ per esp-hal, not per silicon: `Cpu0*` on the
+        // C3/C5/C6, unindexed `Cpu*` on the S3 — identical discriminants. Predicated on
+        // `hal-cpu-reset-unindexed` (see Cargo.toml), never on a chip name.
+        #[cfg(not(feature = "hal-cpu-reset-unindexed"))]
         Some(R::CoreSw) | Some(R::Cpu0Sw) => "sw",
+        #[cfg(feature = "hal-cpu-reset-unindexed")]
+        Some(R::CoreSw) | Some(R::CpuSw) => "sw",
         Some(R::CoreDeepSleep) => "deep-sleep",
         Some(R::SysBrownOut) => "brownout",
+        #[cfg(not(feature = "hal-cpu-reset-unindexed"))]
         Some(
             R::CoreMwdt0
             | R::CoreMwdt1
@@ -2110,6 +2114,17 @@ pub fn reset_reason_token() -> &'static str {
             | R::Cpu0Mwdt1
             | R::CoreRtcWdt
             | R::Cpu0RtcWdt
+            | R::SysRtcWdt
+            | R::SysSuperWdt,
+        ) => "wdt",
+        #[cfg(feature = "hal-cpu-reset-unindexed")]
+        Some(
+            R::CoreMwdt0
+            | R::CoreMwdt1
+            | R::CpuMwdt0
+            | R::CpuMwdt1
+            | R::CoreRtcWdt
+            | R::CpuRtcWdt
             | R::SysRtcWdt
             | R::SysSuperWdt,
         ) => "wdt",

--- a/rust/clock/src/sensors.rs
+++ b/rust/clock/src/sensors.rs
@@ -25,7 +25,15 @@
 #[cfg(feature = "hw")]
 use esp_hal::{
     analog::adc::{Adc, AdcConfig, AdcPin, Attenuation},
-    peripherals::{ADC1, GPIO4, TSENS},
+    peripherals::{ADC1, GPIO4},
+};
+// `has-tsens` is a MEASURED capability, not an assumption: C3 ✓ C6 ✓ C5 ✗ S3 ✗ (the biggest
+// chip lacks the sensor the smallest one has — see the table at `has-tsens` in Cargo.toml).
+// On a chip without it there is no die temperature, and `Reading.chip_c` says so with `None`
+// rather than fabricating a number.
+#[cfg(all(feature = "hw", feature = "has-tsens"))]
+use esp_hal::{
+    peripherals::TSENS,
     tsens::{Config as TsensConfig, TemperatureSensor},
 };
 
@@ -66,8 +74,10 @@ pub const BATT_FULL_V: f32 = 4.2;
 /// A single sensor sample.
 #[derive(Clone, Copy)]
 pub struct Reading {
-    /// Internal chip (die) temperature in °C. NOT ambient.
-    pub chip_c: f32,
+    /// Internal chip (die) temperature in °C. NOT ambient. `None` on silicon with no
+    /// die-temp sensor (`has-tsens` absent: the C5 and S3) — the honest answer, never a
+    /// fabricated number; `format_sensor_line` simply omits the temperature field.
+    pub chip_c: Option<f32>,
     /// Estimated battery voltage in volts (after applying [`BATT_DIVIDER`]).
     /// Meaningless unless a divider is actually wired to [`BATT_ADC_GPIO`].
     pub batt_v: f32,
@@ -80,6 +90,7 @@ pub struct Reading {
 /// [`Reading`] on demand.
 #[cfg(feature = "hw")]
 pub struct Sensors<'d> {
+    #[cfg(feature = "has-tsens")]
     tsens: TemperatureSensor<'d>,
     adc: Adc<'d, ADC1<'d>, esp_hal::Blocking>,
     batt_pin: AdcPin<GPIO4<'d>, ADC1<'d>>,
@@ -103,7 +114,7 @@ impl<'d> Sensors<'d> {
 
     /// A canned sample (24 °C die, 4.05 V ≈ 92 % 1S) — the emulator has no hardware.
     pub fn read(&mut self) -> Reading {
-        Reading { chip_c: 24.0, batt_v: 4.05, batt_pct: 92 }
+        Reading { chip_c: Some(24.0), batt_v: 4.05, batt_pct: 92 }
     }
 }
 
@@ -113,6 +124,9 @@ impl<'d> Sensors<'d> {
     ///
     /// `TSENS`, `ADC1` and `GPIO4` are peripheral singletons handed out by
     /// `esp_hal::init()`; `main` owns that call and passes them in here.
+    /// (On a no-tsens chip there IS no `TSENS` singleton to pass — hence the
+    /// cfg'd second constructor below, and a cfg'd call site in `main`.)
+    #[cfg(feature = "has-tsens")]
     pub fn new(tsens: TSENS<'d>, adc1: ADC1<'d>, gpio4: GPIO4<'d>) -> Self {
         // Temperature sensor: default config (XTAL clock). `new` powers it up;
         // caller should allow a few hundred µs before the first read to settle.
@@ -133,9 +147,25 @@ impl<'d> Sensors<'d> {
         }
     }
 
-    /// Take one temperature + one battery-voltage sample.
+    /// Battery ADC only — the constructor for silicon with no die-temp sensor
+    /// (`has-tsens` absent: C5, S3). Same struct, same `read()` surface; the
+    /// temperature is simply never there to read.
+    #[cfg(not(feature = "has-tsens"))]
+    pub fn new(adc1: ADC1<'d>, gpio4: GPIO4<'d>) -> Self {
+        let mut adc_config = AdcConfig::new();
+        let batt_pin = adc_config.enable_pin(gpio4, Attenuation::_11dB);
+        let adc = Adc::new(adc1, adc_config);
+
+        Self { adc, batt_pin }
+    }
+
+    /// Take one temperature (where the silicon has the sensor) + one
+    /// battery-voltage sample.
     pub fn read(&mut self) -> Reading {
-        let chip_c = self.tsens.get_temperature().to_celsius();
+        #[cfg(feature = "has-tsens")]
+        let chip_c = Some(self.tsens.get_temperature().to_celsius());
+        #[cfg(not(feature = "has-tsens"))]
+        let chip_c = None;
 
         // Blocking oneshot ADC read. `read_oneshot` is non-blocking (returns
         // WouldBlock while converting); `nb::block!` spins until the conversion
@@ -222,11 +252,21 @@ pub fn format_sensor_line(r: &Reading, temp_f: bool) -> LineBuf {
     let mut line = LineBuf::new();
     // #43: chip temp in °F (default) or °C per the fleet-global units, rounded to a whole
     // degree; volts to one decimal. e.g. "73F 3.9V" / "23C 3.9V".
-    if temp_f {
-        let f = r.chip_c * 9.0 / 5.0 + 32.0;
-        let _ = write!(line, "{}F {:.1}V", f as i32, r.batt_v);
-    } else {
-        let _ = write!(line, "{}C {:.1}V", r.chip_c as i32, r.batt_v);
+    //
+    // No die-temp sensor (`chip_c: None`, the C5/S3) → the field is OMITTED, e.g. "3.9V",
+    // never a fabricated 0°/NaN. Consumers of the wire format (#43 canonical °F telemetry)
+    // must treat the temperature field as optional-by-silicon.
+    match (r.chip_c, temp_f) {
+        (Some(c), true) => {
+            let f = c * 9.0 / 5.0 + 32.0;
+            let _ = write!(line, "{}F {:.1}V", f as i32, r.batt_v);
+        }
+        (Some(c), false) => {
+            let _ = write!(line, "{}C {:.1}V", c as i32, r.batt_v);
+        }
+        (None, _) => {
+            let _ = write!(line, "{:.1}V", r.batt_v);
+        }
     }
     line
 }

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -93,17 +93,15 @@ checks = true
 target     = "xtensa-esp32s3-none-elf"
 builds     = false
 ships      = false
-# MEASURED on familiar's xtensa toolchain (espup `esp`, Xtensa Rust 1.95.0.0), canonical tier: the
-# whole dependency graph builds — `core` from source, esp-hal 1.1.1 for xtensa — and stops with 6
-# errors in smol's OWN code, in exactly two classes:
-#   * TSENS (2): `esp_hal::tsens` does not exist for the S3 — the same gap as the C5, needs the
-#     `has-tsens` fallback in sensors.rs/main.rs. NOTE this contradicted the roster's assumption
-#     that the biggest chip is a superset; see the `has-tsens` block in rust/clock/Cargo.toml.
-#   * `SocResetReason` CPU-scoped spelling (4): the S3 drops the core index — `CpuSw`/`CpuMwdt0`/
-#     `CpuMwdt1`/`CpuRtcWdt` where the C3 has `Cpu0*`, at IDENTICAL discriminants. A pure esp-hal
-#     naming variance with no silicon difference, so it deliberately got no `has-*` marker (that
-#     namespace means the silicon has a thing). See src/ota.rs's reset_reason_token().
-checks     = false
+# CHECKS PASS as of #398's S3 arm. The 6 errors this row used to catalogue fell in two moves:
+#   * TSENS (2): the `has-tsens` fallback landed — `sensors.rs` grew cfg'd constructors and
+#     `Reading.chip_c` became `Option<f32>` (a no-tsens chip omits the field, never fabricates).
+#     This was ALSO the C5's named blocker; if the C5 unexpectedly compiles now, this gate will
+#     say so and its row flips too.
+#   * `SocResetReason` CPU-scoped spelling (4): predicated on the new `hal-cpu-reset-unindexed`
+#     feature (the `hal-*` namespace = esp-hal API facts, distinct from `has-*` silicon facts —
+#     see the block in rust/clock/Cargo.toml). See src/ota.rs's reset_reason_token().
+checks     = true
 # The xtensa toolchain is a property of the CHIP, declared here so no script hardcodes it. Empty /
 # absent `toolchain` means the default (rust-toolchain.toml's `stable`).
 toolchain  = "esp"
@@ -150,19 +148,16 @@ ships      = false
 # unmeasured chip a poison row rather than the C6's numbers. `builds = false` is therefore also
 # what keeps the roster check quiet — rule 1 of this file only demands a budget for a chip that
 # BUILDS. The board-specific code stop-points are recorded on #388.
-blocked_on = "#388 board code: TSENS (src/sensors.rs:28 + src/main.rs:719) needs `has-tsens` arms; no measured ChipBudget row yet"
-# MEASURED, canonical tier, `SMOL_CHIP=esp32c5 ... --target riscv32imac-unknown-none-elf`: the full
-# dependency graph resolves and compiles, stopping with exactly 2 errors, both TSENS — the C5 has no
-# `esp_hal::tsens`. Down from 4: the glitch pair (src/ota.rs) is fixed and shared with the C6.
-#
-# ⚠️ TWO CORRECTIONS TO THIS ROW'S OWN PREVIOUS TEXT, both from running it rather than reading it:
-#   * TSENS in main.rs is at line **719**, not 708. A line number in a `blocked_on` is a promise
-#     that rots silently; this one was ~11 lines stale.
-#   * The "hard-typed GPIO9" is REMOVED from the claim. It did not appear. `cargo check` stops at
-#     the TSENS errors, so GPIO9 is UNCONFIRMED — not disproven, just never reached. It is listed
-#     on #388 as a suspected stop-point and must not be restated here as a measured one; the
-#     difference between "we saw this" and "we expect this" is the entire value of this field.
-checks     = false
+blocked_on = "no measured ChipBudget row yet (budget.rs hands an unmeasured chip the poison row); measure on hardware per #388, then flip `builds`"
+# CHECKS PASS as of #398's S3 arm — the `has-tsens` fallback it landed was ALSO this row's last
+# stop-point (sensors.rs cfg'd constructors + `Reading.chip_c: Option<f32>`), and the gate itself
+# demanded this flip: it ran the C5, found it COMPILING CLEAN against a `checks = false`
+# declaration, and refused the stale pessimism — exactly the failure-is-also-an-expectation
+# behaviour this file promises. Two prior suspicions resolved by that run: the TSENS errors are
+# gone (fixed, not moved), and the long-suspected "hard-typed GPIO9" stop-point never existed —
+# the compiler reached the end and found nothing (it had been UNCONFIRMED, never measured; now it
+# is disproven).
+checks     = true
 
 # ── TIERS ─────────────────────────────────────────────────────────────────────
 # `features` is passed verbatim to `--features` (empty string = default features only).
@@ -295,6 +290,11 @@ has-psram      = "capability marker selected by esp32s3; gates no code yet and l
 has-tsens                = "capability marker selected by esp32c3/esp32c6/esp32s3, read by src/sensors.rs; the silicon picks it, not a build, so the chip axis covers it — compiled by every tier via `default`->esp32c3 though the checker cannot see through the chip arm"
 has-reset-glitch-split   = "capability marker selected by esp32c3/esp32s3, read by src/ota.rs reset_reason_token(); same chip-axis reason — compiled by every tier via `default`->esp32c3"
 has-reset-glitch-unified = "capability marker selected by esp32c5 ALONE, read by src/ota.rs; genuinely uncompiled by this matrix because [chip.esp32c5] is builds=false — covered by tools/check_chips.sh until it flips"
+# `hal-*` is the third exemption story: not a silicon capability at all but an esp-hal API fact
+# (see the namespace charter in rust/clock/Cargo.toml). No build chooses a spelling — the HAL
+# does, per chip — so a `[tier.hal-cpu-reset-unindexed]` would mean "build an image that pretends
+# esp-hal names the S3's reset reasons the C3 way", which cannot compile by construction.
+hal-cpu-reset-unindexed  = "esp-hal API-fact marker (hal-* namespace) selected by esp32s3 ALONE, read by src/ota.rs reset_reason_token(); uncompiled by this matrix while [chip.esp32s3] is builds=false — covered by tools/check_chips.sh, same standing as has-reset-glitch-unified"
 # `off-fleet` deliberately has NO entry here: the bard tier names it, so it is covered, and the
 # checker rejects a feature that is both exempted and covered — an exemption whose reason has
 # quietly stopped applying is worse than none. It caught this exact case when first written.


### PR DESCRIPTION
Rides directly on #405's merged de-pin. Fixes the six catalogued S3 errors and flips `[chip.esp32s3]` to `checks = true` — and the gate then demanded the C5 flip too (with the tsens fallback landed, the C5 compiles clean; its declared pessimism went stale mid-PR, exactly the failure-is-also-an-expectation behaviour `check_chips.sh` promises).

## What's in it

- **`has-tsens` fallback** (the 2 TSENS errors, and the C5's named blocker): `sensors.rs` gets cfg'd constructors; `Reading.chip_c` becomes `Option<f32>`. A no-tsens chip (C5, S3 — measured, not datasheet-assumed) omits the temperature honestly: `format_sensor_line` renders `"3.9V"`, never a fabricated `0C`/NaN. ⚠️ Wire note: the #43 canonical telemetry line's temperature field is now optional-by-silicon — the C3 fleet's output is byte-identical to before; only chips that never had the sensor omit it.
- **The `hal-*` namespace** (the 4 `SocResetReason` errors): #405 deliberately left "a differently-named predicate (an esp-hal API fact, not a capability)" as a decision to make on its own. Made here: `hal-cpu-reset-unindexed`, first tenant, with the namespace's charter documented at the declaration. `reset_reason_token()` predicates on it — never a chip name, never a spent `has-*`.
- **Matrix flips**: `esp32s3` → `checks = true`; `esp32c5` → `checks = true` (gate-demanded). The C5's suspected "hard-typed GPIO9" stop-point is now **disproven** — previously unconfirmed-never-reached, the compiler now reaches the end and finds nothing.

## Evidence (all on familiar, exit codes captured directly — never through a pipe)

```
tools/check_chips.sh   → chips: 4 as declared · 0 wrong · 4 actually run
                          esp32c3 ✓  esp32s3 ✓  esp32c6 ✓  esp32c5 ✓  (all compile clean)
clippy -D warnings     → fleet (espnow,cast,io) 0 · default 0 · wifi 0
web-emu cargo check    → 0
```

Routed through the smol session per the agreed lanes (this PR touches `rust/clock`). `builds` stays `false` for both flipped chips — `checks` is the bottom rung; ChipBudget rows remain unmeasured and the poison-row semantics are untouched.

Refs #398 #388 #347 #331 · rides #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)