### PR TITLE
fix(chip): the xtensa arm never included linkall.x — found by the first link ever attempted (#398)

### DIFF
--- a/rust/clock/.cargo/config.toml
+++ b/rust/clock/.cargo/config.toml
@@ -101,6 +101,11 @@ rustflags = [
 [target.xtensa-esp32s3-none-elf]
 rustflags = [
     "-C", "force-frame-pointers",
+    # The linker script, same as both riscv arms. Its absence was found by the first LINK ever
+    # attempted for this target (#398's probe, 2026-08-25): `checks` passes without it — cargo
+    # check never links — and then `ld` emits 129 undefined references (_bss_start, __exception,
+    # the whole S3 vector table), every one a linkall.x symbol. With the line: 129 → 0.
+    "-C", "link-arg=-Tlinkall.x",
     # No `linker`/`linker-flavor` override here, unlike the riscv targets. Those pin `rust-lld`
     # because THIS MACHINE's `cc` is a non-compiler shim that must not be in the link path. The
     # xtensa target has no LLD backend and links through the esp GCC driver that `export-esp.sh`

--- a/rust/clock/src/budget.rs
+++ b/rust/clock/src/budget.rs
@@ -633,7 +633,8 @@ const _: () = assert!(
      (.bss + .data) is larger than free_dram_bytes - stack_floor_bytes, so the linker would \
      take the difference out of the runtime stack and shrink it below the floor SILENTLY — \
      the image would link and then die on hardware (#300, #335, #347). \
-     Options: build it for a chip whose row has the room (#331 — the S3 and C6 do); shrink \
+     Options: build it for a chip with a declared row that has the room (the C6's is measured; \
+     the S3 has NO row yet — #398 — despite what an older revision of this message claimed); shrink \
      the cost (`SEQ_CAP` in src/bard/nano_llm.rs is the lever) and re-measure BOTH the cost \
      and the budget; or, if this build is deliberately not the C3 fleet image, add the \
      `off-fleet` feature — which tools/repro_build.sh then refuses to package."


### PR DESCRIPTION
Two stacked commits — the second's proof requires the first, so they ship as one PR.

**1. `d6e5815` — the xtensa arm never included `-Tlinkall.x`** (found by the S3's first-ever link attempt; `checks` structurally cannot see it — cargo check never links). 129 undefined linker-script symbols → 0. Plus `budget.rs`'s DRAM-assert message contradiction fixed.

**2. `9ba06eb` — per-chip `opt_level` on the matrix seam** (BUDGET-PREP §6.1's measured escape from the fat-LTO Xtensa scavenger crash): the S3 row gets `opt_level = "2"` marked **TOOLCHAIN-BUG WORKAROUND** with the LLVM error quoted (the row reverts when upstream fixes it), threaded as `CARGO_PROFILE_RELEASE_OPT_LEVEL` per invocation through `build_matrix.py chip-checks` → `check_chips.sh`. All other chips untouched — the global profile is what every C3 measurement on record was taken against. The three review conditions are in: the #32 comment's moved-condition note (measured: `double_scalarmult_vartime` = 43,475 B at opt=2 — protection holds, premise not re-derived), the first-flash unproven-silicon caveat in the S3 row itself, and the upstream draft tracked at `docs/upstream/xtensa-fat-lto-scavenger.md` with repo-unverified + no-minimal-reproducer caveats in its header (JP decides if it files).

**Evidence on the true tip (`9ba06eb`), exit codes captured directly:**
```
build_matrix.py check                → rc=0 (10 jobs, roster agrees)
check_chips.sh (all four)            → 4 as declared · 0 wrong  (through the new threading)
S3 FLEET tier, fat LTO, cu=1, opt=2  → LINKS, rc=0, 1,447,584 B  ← the first canonical S3 image ever linked
```

Routed through the smol session per lanes. Refs #398 #347 · evidence: BUDGET-PREP §6/§6.1 (committed 8b749e2, 44ae571)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
