### PR TITLE
feat(chip): per-chip opt_level — the S3's fat-LTO workaround on the matrix seam (#398)

### DIFF
--- a/docs/upstream/xtensa-fat-lto-scavenger.md
+++ b/docs/upstream/xtensa-fat-lto-scavenger.md
@@ -1,0 +1,50 @@
+# Upstream report DRAFT — Xtensa fat-LTO register-scavenger crash
+
+**Status: DRAFT ONLY — NOT FILED. JP decides whether/where to post.**
+
+Two caveats govern this document (both from the discovering run, BUDGET-PREP §6.1, 2026-08-25):
+
+- ⚠️ **Repo choice unverified.** Best guess `esp-rs/rust` (the failing compiler is its `esp`
+  channel), expecting triage onward to `espressif/llvm-project` if confirmed as a backend bug —
+  but nobody has checked which repo accepts codegen bugs, and **no duplicate search has been
+  done**.
+- ⚠️ **No minimal reproducer exists.** The current reproduction is "a whole firmware", which is
+  not a bug report. `cargo-bisect-rustc` likely does not apply (the fork is not a rustc channel);
+  bracketing by esp-hal version may be the practical substitute. Reduce before filing.
+
+smol itself is unblocked (per-chip `opt_level = 2` workaround, `tools/build-matrix.toml`
+`[chip.esp32s3]`), so this files whenever it files — the workaround row reverts when upstream
+fixes it, which is the reason to file at all.
+
+---
+
+## The report body (draft)
+
+**Title.** `LLVM ERROR: Incomplete scavenging after 2nd pass on xtensa-esp32s3-none-elf at
+opt-level=s with fat LTO`
+
+**Environment.** Xtensa Rust fork **1.95.0.0** (`cargo 1.95.0-nightly (f2d3ce0bd 2026-03-21)`),
+espup-installed `esp` toolchain, host x86_64-linux. Target `xtensa-esp32s3-none-elf`,
+`-Zbuild-std=core,alloc`. esp-hal 1.1.2 / esp-radio 0.18.0 / esp-rtos 0.3.0.
+
+**Reproduce.** A large `no_std` binary crate; `-C opt-level=s -C lto=fat -C codegen-units=1`.
+Fails during codegen of the final binary.
+
+**Observed matrix** (the useful part — it brackets the trigger):
+
+| opt | lto | cu | result |
+|---|---|---|---|
+| s | fat | 1 | `Incomplete scavenging after 2nd pass` |
+| s | fat | 2 | same |
+| z | fat | 1 | `Error while trying to spill A8 from class AR: Cannot scavenge register without an emergency spill slot!` (in `compiler_builtins`) |
+| 2 | fat | 1 | **OK** |
+| 3 | fat | 1 | **OK** |
+| s | thin | 1 | **OK** |
+
+So: size-optimising levels + fat LTO only. Both messages come from the register scavenger
+(**inferred** from the messages — standard reading, not proven).
+
+**Separately worth reporting** (different bug, surfaced by the same matrix run): at
+`codegen-units = 4` and `16` the build fails earlier with `error: invalid operand for
+instruction` on `rsr a3, LBEG` in inline asm from a dependency — an assembler/subtarget-feature
+issue, not a scavenger one. Observed, not diagnosed.

--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -580,6 +580,14 @@ overflow-checks = false
 # (0x1F0000). opt="z" collapses it 32× (~93 KB) → production image ~37% of slot. Per-PACKAGE
 # only: the global stays opt="s" (the radio blobs' required timing). Verify runs once per OTA
 # (~ms) on PUBLIC data, so size-over-speed here is free (constant-time not a concern).
+#
+# ⚠️ THE CONDITION MOVED (2026-08-25, #398): the hazard above is stated for opt="s"+fat-LTO,
+# and the S3 builds at opt-level 2 (a per-chip TOOLCHAIN-BUG workaround — see
+# tools/build-matrix.toml [chip.esp32s3]), which is OUTSIDE those stated conditions. Measured
+# at opt=2/fat on the S3: `double_scalarmult_vartime` = 43,475 B — this per-package opt="z" is
+# independent of the global and still in force, so the PROTECTION holds; but that measurement
+# is evidence the gate works, NOT a re-derivation of the premise. If opt-level ever changes
+# again (any chip), re-measure the symbol — do not inherit this paragraph.
 [profile.release.package.ed25519-compact]
 opt-level = "z"
 

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -106,6 +106,19 @@ checks     = true
 # absent `toolchain` means the default (rust-toolchain.toml's `stable`).
 toolchain  = "esp"
 build_std  = "core,alloc"
+# ⚠️ TOOLCHAIN-BUG WORKAROUND, not a preference — this row REVERTS when upstream fixes it.
+# The shipping profile (opt-level = "s", lto = "fat") crashes the Xtensa LLVM backend on this
+# chip's fleet-tier codegen:
+#     rustc-LLVM ERROR: Incomplete scavenging after 2nd pass
+# (opt = "z" crashes the same scavenger differently; 2 and 3 both link; matrix + upstream draft:
+# targets/s3-cyd/BUDGET-PREP.md §6.1 and docs/upstream/xtensa-fat-lto-scavenger.md.) Threaded as
+# CARGO_PROFILE_RELEASE_OPT_LEVEL for THIS CHIP ONLY — the global profile is shared with the C3
+# and every C3 measurement on record (stack floors, #32 symbol sizes, byte-reproducibility)
+# depends on it staying untouched.
+# ⚠️ FIRST-FLASH CAVEAT, for whoever flashes the first S3 fleet image: a compiler that
+# demonstrably mishandled this code at opt="s" merely LINKING at opt=2 is escape, not proof of
+# correct codegen. Treat that flash as unproven silicon — not routine bring-up.
+opt_level  = "2"
 # `builds = false` is about CI, not about this tree. Xtensa is a Tier-3 target needing espup's `esp`
 # channel (Xtensa Rust 1.95.0.0, pinned byte-identical on katana and familiar) plus
 # `. ~/export-esp.sh` and a per-invocation `CARGO_UNSTABLE_BUILD_STD=core,alloc`. GitHub runners

--- a/tools/build_matrix.py
+++ b/tools/build_matrix.py
@@ -313,7 +313,14 @@ def main() -> int:
         # same rule `emit` follows for tiers.
         #
         # Fields, tab-separated:
-        #   chip · target · expect(check|fail) · toolchain · build_std · features
+        #   chip · target · expect(check|fail) · toolchain · build_std · opt_level · features
+        #
+        # `opt_level` (#398): a per-chip release-profile override, threaded as
+        # CARGO_PROFILE_RELEASE_OPT_LEVEL by the consumer. Exists for toolchain-bug workarounds
+        # (the S3's fat-LTO Xtensa crash) — the global profile is shared with the canonical chip
+        # and must never carry a per-chip deviation. Inert for `cargo check` (no codegen), carried
+        # anyway so every consumer of this record — including future build rungs — gets it from
+        # ONE place.
         #
         # ⚠️ EMPTY OPTIONAL FIELDS ARE WRITTEN AS "-", NOT LEFT EMPTY, and that is not cosmetic.
         # `emit` gets away with bare tabs because it has TWO fields and only the last can be empty.
@@ -336,6 +343,7 @@ def main() -> int:
             print("\t".join((name, spec["target"], expect,
                              opt(spec.get("toolchain")),
                              opt(spec.get("build_std")),
+                             opt(spec.get("opt_level")),
                              canon_features)))
         return 0
 

--- a/tools/check_chips.sh
+++ b/tools/check_chips.sh
@@ -49,7 +49,7 @@ pass=0 fail=0 skip=0 verified=0
 # after paying for it).
 cd "$CRATE" || { echo "no crate dir at $CRATE" >&2; exit 2; }
 
-while IFS=$'\t' read -r chip target expect toolchain build_std features; do
+while IFS=$'\t' read -r chip target expect toolchain build_std opt_level features; do
     [ -n "$chip" ] || continue
     # `-` is the manifest's sentinel for "this optional field is empty". It exists because a tab is
     # an IFS *whitespace* character, so bash collapses consecutive tabs and every field after an
@@ -57,6 +57,7 @@ while IFS=$'\t' read -r chip target expect toolchain build_std features; do
     # Translate back to empty here, once, so the rest of the loop reads naturally.
     [ "$toolchain" = "-" ] && toolchain=""
     [ "$build_std" = "-" ] && build_std=""
+    [ "$opt_level" = "-" ] && opt_level=""
     if [ ${#want[@]} -gt 0 ]; then
         found=0
         for w in "${want[@]}"; do [ "$w" = "$chip" ] && found=1; done
@@ -95,13 +96,19 @@ while IFS=$'\t' read -r chip target expect toolchain build_std features; do
     # `[unstable] build-std` is GLOBAL, and a config key would hand it to the riscv builds too.
     # That is the 2026-07-20 regression that leaked portable-atomic/unsafe-assume-single-core into
     # the HOST build and broke every cold C3 build. Env-scoped means a C3 check cannot inherit it.
+    # `opt_level` (#398): a per-chip release-profile override — a TOOLCHAIN-BUG workaround seam,
+    # env-scoped for the same reason build-std is: a config key would hand it to every chip, and
+    # the global profile is what all the C3's recorded measurements were taken against. Inert for
+    # `cargo check` (dev profile, no codegen); threaded so the invocation this script models is
+    # the SAME one a future build rung will make, sourced from ONE manifest field.
+    run_env=(SMOL_CHIP="$chip")
+    [ -n "$opt_level" ] && run_env+=(CARGO_PROFILE_RELEASE_OPT_LEVEL="$opt_level")
     if [ -n "$build_std" ]; then
         # shellcheck disable=SC1090
         [ -f "$HOME/export-esp.sh" ] && . "$HOME/export-esp.sh" >/dev/null 2>&1
-        CARGO_UNSTABLE_BUILD_STD="$build_std" SMOL_CHIP="$chip" cargo "${args[@]}" >"$log" 2>&1
-    else
-        SMOL_CHIP="$chip" cargo "${args[@]}" >"$log" 2>&1
+        run_env+=(CARGO_UNSTABLE_BUILD_STD="$build_std")
     fi
+    env "${run_env[@]}" cargo "${args[@]}" >"$log" 2>&1
     rc=$?
 
     verified=$((verified + 1))


### PR DESCRIPTION
The measured escape from BUDGET-PREP §6.1's fat-LTO Xtensa scavenger crash, as a manifest field on the seam that already carries `toolchain`/`build_std`: `[chip.esp32s3] opt_level = "2"`, marked **TOOLCHAIN-BUG WORKAROUND** with the LLVM error quoted (the row reverts when upstream fixes it), threaded as `CARGO_PROFILE_RELEASE_OPT_LEVEL` per invocation via `build_matrix.py chip-checks` → `check_chips.sh`. Every other chip untouched — the global profile is what every C3 measurement on record was taken against.

The three review conditions, all in: the #32 gate's moved-condition note in `Cargo.toml` (measured 43,475 B at opt=2 — protection holds, premise not re-derived); the first-flash **unproven-silicon** caveat in the S3 row itself; the upstream draft tracked at `docs/upstream/xtensa-fat-lto-scavenger.md` (repo-unverified + no-minimal-reproducer caveats in the header — JP decides if it files).

Evidence (re-verified on THIS branch off current main, exit codes captured directly):
```
build_matrix.py check         → rc=0
check_chips.sh (all four)     → 4 as declared · 0 wrong  (through the new threading)
S3 FLEET tier, fat/cu=1/opt=2 → LINKS, rc=0, 1,447,584 B  (proven on the linkall base, ba314ea now on main)
```

Record note: this work transiently rode #408's branch after its squash had merged — unwound there; this PR is its correct home. Refs #398 #347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)