### PR TITLE
test(elect): assert the smol half of the ELECT tag-collision claim, scanned not listed (#328)

### DIFF
--- a/experiments/mesh_elect_verify/src/main.rs
+++ b/experiments/mesh_elect_verify/src/main.rs
@@ -18,6 +18,12 @@ mod wire_tests;
 // donor's own suite, the same split the source file itself carries.
 mod follow_tests;
 
+// #328, smol-only: the donor's `tag_does_not_collide_with_existing_frames` is verbatim and carries
+// the donor's tag list, which omits nine real smol tags while listing three watch-only ones. This
+// asserts the smol half of that cross-repo claim from smol's OWN prefixes, scanned from source so
+// the list cannot rot silently the way the donor's did.
+mod smol_wire_compat;
+
 fn main() {
     consensus::weight_saturates_and_floors();
     consensus::partition_merge_is_total_order();
@@ -44,5 +50,12 @@ fn main() {
     follow_tests::sealing_preserves_the_cross_repo_bytes();
     follow_tests::sealing_refuses_a_frame_that_would_strand_a_leaf();
 
-    println!("mesh_elect_verify: 23 checks passed (2 consensus + 8 wire + 13 follow/announce)");
+    smol_wire_compat::elect_tag_is_free_in_smol();
+    smol_wire_compat::no_smol_prefix_nests_with_elect();
+    smol_wire_compat::elect_parser_rejects_every_other_smol_frame();
+
+    println!(
+        "mesh_elect_verify: 26 checks passed \
+         (2 consensus + 8 wire + 13 follow/announce + 3 smol-side collision)"
+    );
 }

--- a/experiments/mesh_elect_verify/src/smol_wire_compat.rs
+++ b/experiments/mesh_elect_verify/src/smol_wire_compat.rs
@@ -1,0 +1,163 @@
+//! SMOL-SIDE tag-collision guard for the ELECT frame (#328). Additive and smol-only: it does not
+//! touch the wire format, and it is kept out of `wire_tests.rs` / `consensus.rs` so those two stay
+//! verbatim-diffable against `esp32c6-watch:crates/mesh-elect/tests/` — the same split
+//! `follow_tests.rs` already uses.
+//!
+//! # Why this exists, given `wire_tests::tag_does_not_collide_with_existing_frames` already runs
+//!
+//! That test is the DONOR's, and it is verbatim by design — which means smol also inherited its
+//! blind spot. Its comment claims it covers *"Every tag in use across both repos today."* On this
+//! repo that sentence is false, and has been since it was ported:
+//!
+//! - it lists 15 tags, **three of which smol does not have** (`PING`, `PINGACK`, `SAY` are
+//!   watch-only), and
+//! - it **misses nine real smol tags** — `FAM`, `SNK`, `LDBG`, `ODEL`, `ODON`, `OTAD`, `OTAM`,
+//!   `OTAN` — plus the versioned `BATT2` / `GRID2` / `UP2` / `RELAYACK2`.
+//!
+//! The conclusion it draws (byte 7 `b'E'` is free) is still TRUE — verified below against smol's
+//! real tag set, not assumed. But a claim that holds by luck is not a guard. smol owns the smol
+//! half of a cross-repo claim, so it is asserted here from smol's own prefixes.
+//!
+//! # Why the list is SCANNED and not written down
+//!
+//! The thing that actually went wrong was not the missing tags — it was that a hardcoded list
+//! stopped describing the codebase and **nothing said so**. Re-typing a fresh list here would rot
+//! exactly the same way, one new frame tag from now, and would be the same defect with a newer
+//! date on it. (Concretely: the list this guard was first drafted from still carried a bare
+//! `SMOLv1 UP `, which no longer exists on `main` — it had already rotted before it was ported.)
+//!
+//! So the prefix set is derived from the firmware source at run time, and the assertions are made
+//! against whatever is there today. A new `SMOLv1 <TAG> ` frame is picked up automatically; if it
+//! ever collides with `ELECT`, this fails the gate on the commit that introduces it rather than in
+//! a partition six months later.
+//!
+//! `tools/gate.sh` already made this argument about its own verifier discovery, and it is the same
+//! argument one level in:
+//!
+//! > *Discovered by GLOB, not by a hardcoded list: a new verifier is picked up automatically, which
+//! > is the whole point — the last list-shaped gate silently stopped covering what was added after
+//! > it.*
+
+use crate::mesh_elect::wire::ELECT_PREFIX;
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+/// Firmware source root — `rust/clock/src`, resolved from this crate rather than from the process
+/// CWD so the guard behaves the same under `cargo run` and under `tools/gate.sh`.
+fn clock_src() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../rust/clock/src")
+}
+
+/// Every `.rs` file under `rust/clock/src`, recursively.
+fn rust_sources(dir: &PathBuf, out: &mut Vec<PathBuf>) {
+    let entries = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("cannot read firmware source dir {}: {e}", dir.display()));
+    for entry in entries {
+        let path = entry.expect("cannot stat a firmware source entry").path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Scan the firmware for every `SMOLv1` frame prefix it emits or decodes.
+///
+/// Matches the BYTE-LITERAL form `b"SMOLv1 <TAG> "` only. That is deliberate and it is the reason
+/// this scan is trustworthy: prose mentions the string too (`secrets.rs.example` says *"Every
+/// SMOLv1 ESP-NOW frame carries a truncated…"*), and a looser grep reads `ESP` as a frame tag and
+/// invents a byte-7 collision with `ELECT` that does not exist. Only the literal that a parser can
+/// actually dispatch on counts.
+fn scan_smol_prefixes() -> BTreeSet<String> {
+    let mut files = Vec::new();
+    rust_sources(&clock_src(), &mut files);
+    assert!(!files.is_empty(), "scanned no firmware sources — the guard would vacuously pass");
+
+    let mut found = BTreeSet::new();
+    for path in &files {
+        let text = std::fs::read_to_string(path).unwrap_or_default();
+        for (idx, _) in text.match_indices("b\"SMOLv1 ") {
+            let rest = &text[idx + 2..]; // past the `b"`
+            let Some(end) = rest.find('"') else { continue };
+            let literal = &rest[..end];
+            // A dispatchable prefix is `SMOLv1 <TAG> ` — uppercase/digit tag, one trailing space.
+            let Some(tag) = literal.strip_prefix("SMOLv1 ").and_then(|t| t.strip_suffix(' ')) else {
+                continue;
+            };
+            if !tag.is_empty() && tag.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit()) {
+                found.insert(literal.to_string());
+            }
+        }
+    }
+    assert!(
+        found.len() >= 20,
+        "scanned only {} SMOLv1 prefixes — the scanner has probably broken, and a guard that \
+         silently stops finding things is the defect this file exists to prevent",
+        found.len()
+    );
+    found
+}
+
+/// Byte 7 is the tag's first character — what `parse_frame` keys on after the shared `SMOLv1 `
+/// header, and what a human scanning a serial log keys on too. No smol frame may share it with
+/// `ELECT`, or an old node misparses an announcement instead of ignoring it.
+pub fn elect_tag_is_free_in_smol() {
+    assert_eq!(ELECT_PREFIX[7], b'E');
+    let elect = std::str::from_utf8(ELECT_PREFIX).expect("ELECT_PREFIX is ASCII");
+
+    let mut checked = 0usize;
+    for prefix in scan_smol_prefixes() {
+        if prefix == elect {
+            continue;
+        }
+        let byte7 = prefix.as_bytes()[7];
+        assert_ne!(
+            byte7, ELECT_PREFIX[7],
+            "tag collision: {prefix:?} shares byte 7 ({:?}) with {elect:?}",
+            byte7 as char
+        );
+        checked += 1;
+    }
+    assert!(checked > 0, "no non-ELECT prefixes were checked");
+    println!("  smol_wire_compat: byte 7 'E' is free across {checked} live smol prefixes");
+}
+
+/// The stronger statement, and the one that actually protects the parsers: no smol frame prefix and
+/// `ELECT` may be a prefix of one another. Byte 7 differing implies this today, but the tags are
+/// variable-length (`RELAY` / `RELAYACK` / `RELAYACK2` already nest), so the property worth pinning
+/// is the one about dispatch, not the one about a single byte.
+pub fn no_smol_prefix_nests_with_elect() {
+    let elect = std::str::from_utf8(ELECT_PREFIX).expect("ELECT_PREFIX is ASCII");
+    for prefix in scan_smol_prefixes() {
+        if prefix == elect {
+            continue;
+        }
+        assert!(
+            !prefix.starts_with(elect) && !elect.starts_with(&prefix),
+            "prefix nesting between {prefix:?} and {elect:?} — one parser would shadow the other"
+        );
+    }
+}
+
+/// `ELECT`'s own parser must reject every other smol frame outright. `wire_tests` proves it rejects
+/// malformed ELECT frames; this proves it rejects well-formed frames of a DIFFERENT type, which is
+/// what actually arrives on a shared broadcast channel.
+pub fn elect_parser_rejects_every_other_smol_frame() {
+    use crate::mesh_elect::wire::parse;
+    let elect = std::str::from_utf8(ELECT_PREFIX).expect("ELECT_PREFIX is ASCII");
+    for prefix in scan_smol_prefixes() {
+        if prefix == elect {
+            continue;
+        }
+        // Prefix + plausible payload, padded well past ELECT_LEN so length alone is not the reason
+        // it is rejected.
+        let mut frame = prefix.clone().into_bytes();
+        frame.extend(std::iter::repeat_n(b'0', 64));
+        assert!(
+            parse(&frame).is_none(),
+            "ELECT parse() accepted a {prefix:?} frame — it would feed a foreign frame into the \
+             channel announcement path"
+        );
+    }
+}


### PR DESCRIPTION
Closes part of #328.

## What this is

`experiments/mesh_elect_verify` runs the esp32c6-watch donor's suite **verbatim** — deliberately, so `consensus.rs` and `wire_tests.rs` stay byte-diffable against `crates/mesh-elect/tests/`. The cost of verbatim is that smol inherited the donor's blind spot along with its coverage.

`wire_tests::tag_does_not_collide_with_existing_frames` says:

> `// Every tag in use across both repos today.`

On this repo that sentence is **false**, and has been since the port. It lists 15 tags — three of them watch-only (`PING`, `PINGACK`, `SAY`) — and misses nine real smol tags: `FAM`, `SNK`, `LDBG`, `ODEL`, `ODON`, `OTAD`, `OTAM`, `OTAN`, plus the versioned `BATT2` / `GRID2` / `UP2` / `RELAYACK2`.

**No live bug.** The conclusion it draws — byte 7 `'E'` is free — is still true. I verified that against smol's actual tag set rather than inheriting it. But a claim that holds by luck is not a guard, and this is the repo's own documented defect shape: a correct-sounding comment describing coverage the binary does not have.

## Why scanned, not listed

The failure mode was never the missing tags. It was that **a hardcoded list stopped describing the codebase and nothing said so**. Re-typing a fresh list would rot the same way, one new frame tag from now.

That is not hypothetical — the list I first drafted this from (the `feat/mesh-elect-consensus` branch's `smol_wire_compat.rs`, written 2026-07-29) still carried a bare `SMOLv1 UP `, which no longer exists on `main`. It had already rotted before it could be ported.

So the prefix set is derived from `rust/clock/src` at run time. A new `SMOLv1 <TAG> ` frame is picked up automatically, and if it ever collides with `ELECT` this fails on the commit that introduces it rather than in a partition six months later. `tools/gate.sh` already makes exactly this argument one level out:

> *Discovered by GLOB, not by a hardcoded list: a new verifier is picked up automatically, which is the whole point — the last list-shaped gate silently stopped covering what was added after it.*

## Scanner precision is load-bearing

It matches only the byte-literal form `b"SMOLv1 <TAG> "`. Prose mentions the string too — `secrets.rs.example` says *"Every SMOLv1 ESP-NOW frame carries a truncated…"* — and a looser match reads `ESP` as a frame tag and reports a byte-7 collision with `ELECT` that does not exist. I hit exactly that false positive while investigating and had to walk it back; the narrow match is the fix, and the scan asserts a floor of 20 prefixes so a broken scanner fails instead of vacuously passing.

## Three checks added

1. `elect_tag_is_free_in_smol` — byte 7 free across every live smol prefix.
2. `no_smol_prefix_nests_with_elect` — no prefix nesting either direction (tags are variable-length; `RELAY`/`RELAYACK`/`RELAYACK2` already nest).
3. `elect_parser_rejects_every_other_smol_frame` — `parse()` rejects a *well-formed* frame of every other type, which is what actually arrives on a shared broadcast channel. `wire_tests` only covers malformed ELECT frames.

## Verification

Built and run on familiar (never locally, per lane rules):

```
smol_wire_compat: byte 7 'E' is free across 24 live smol prefixes
mesh_elect_verify: 26 checks passed (2 consensus + 8 wire + 13 follow/announce + 3 smol-side collision)
```

**Proven able to fail.** Appending `b"SMOLv1 ECHO "` to `net/wire.rs`:

```
thread 'main' panicked at src/smol_wire_compat.rs:115:9:
assertion `left != right` failed: tag collision: "SMOLv1 ECHO " shares byte 7 ('E') with "SMOLv1 ELECT "
EXIT=101
```

Restored, green again. Picked up by `tools/gate.sh host` automatically — the verifier loop globs `experiments/*_verify`, so no gate wiring was needed.

## Notes for review

- **No wire-format change, no firmware change.** Additive host test only.
- `wire_tests.rs` / `consensus.rs` deliberately **untouched** — fixing the donor's list in place would break the verbatim-diffability contract the crate's own docs establish. The right place for a smol-side claim is a smol-side file, which is the `follow_tests.rs` precedent.
- Pre-existing and **not** touched by this PR: `cargo clippy -D warnings` on this crate is already red on `main` at `consensus.rs:24` (empty line after doc comment) and `wire_tests.rs:42` (assertion on a constant). Both are in the donor-verbatim files. `gate.sh` clippies only the `rust/clock` tiers, not `experiments/`, which is why they survive unnoticed. Flagging rather than fixing — one of them is the donor's and silencing it is a cross-repo decision, not a cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
