### PR TITLE
feat(display): the S3 arm — smol's screens on the ES3C28P (#398)

### DIFF
--- a/rust/clock/Cargo.toml
+++ b/rust/clock/Cargo.toml
@@ -123,6 +123,12 @@ libm = { version = "0.2", optional = true, default-features = false }
 # firmware AND the #152 host/wasm emulator draw through it.
 ssd1306 = { version = "=0.10.0", optional = true }
 embedded-graphics = "=0.8.2"
+# #398 S3 display arm: the ILI9341V driver + the SPI device wrapper. Optional, pulled
+# ONLY by the esp32s3 chip arm — no other chip's dependency graph changes by one byte.
+# mipidsi is EXACT-pinned: s3_oled's ORIENTATION reasoning is tied to 0.10's MADCTL
+# mapping (the 0x28/0x68 story at board_s3::MADCTL_LANDSCAPE).
+mipidsi = { version = "=0.10.0", optional = true }
+embedded-hal-bus = { version = "0.3.0", optional = true }
 
 # --- WiFi / NTP + radio (Phase 2, feature = "wifi") ----------------------
 esp-alloc = { version = "0.10", optional = true }
@@ -326,6 +332,10 @@ esp32s3 = [
     "esp-wifi-sys?/esp32s3",
     "has-psram", "has-reset-glitch-split",
     "hal-cpu-reset-unindexed",
+    # #398 display arm: the S3's panel stack rides the CHIP arm (the chip implies the
+    # board class today; when a second S3 board exists, #396's variant axis — runtime,
+    # never a feature — still won't move these: they are chip-level driver deps).
+    "dep:mipidsi", "dep:embedded-hal-bus",
     # NO `has-tsens`. This arm CARRIED it in the first draft of this commit, from a datasheet-shaped
     # assumption that the big chip has at least what the little one has. A per-chip `cargo check` on
     # familiar's xtensa toolchain said otherwise: `esp_hal::tsens` is unresolved for

--- a/rust/clock/src/app.rs
+++ b/rust/clock/src/app.rs
@@ -16,13 +16,13 @@ use crate::input::Press;
 // Only the plain (hw, non-cast) `Oled` alias below names these; under `feature = "cast"`
 // the alias is `CastOled`, and under `feature = "hostsim"` (#152) it is the canvas
 // display, so these ssd1306 imports would be unused / unavailable there.
-#[cfg(all(feature = "hw", not(feature = "cast")))]
+#[cfg(all(feature = "hw", not(feature = "cast"), not(feature = "esp32s3")))]
 use ssd1306::mode::BufferedGraphicsMode;
-#[cfg(all(feature = "hw", not(feature = "cast")))]
+#[cfg(all(feature = "hw", not(feature = "cast"), not(feature = "esp32s3")))]
 use ssd1306::prelude::I2CInterface;
-#[cfg(all(feature = "hw", not(feature = "cast")))]
+#[cfg(all(feature = "hw", not(feature = "cast"), not(feature = "esp32s3")))]
 use ssd1306::size::DisplaySize72x40;
-#[cfg(all(feature = "hw", not(feature = "cast")))]
+#[cfg(all(feature = "hw", not(feature = "cast"), not(feature = "esp32s3")))]
 use ssd1306::Ssd1306;
 
 /// The one concrete OLED type in the firmware. `Ctx` holds this CONCRETELY (not a
@@ -30,12 +30,20 @@ use ssd1306::Ssd1306;
 /// and `flush` lives on `Ssd1306`, not the `DrawTarget` trait. The generic draw
 /// helpers (`draw_clock`, …) still take `&mut impl DrawTarget`; a plugin passes
 /// `ctx.display` (which coerces) and flushes it itself.
-#[cfg(all(feature = "hw", not(feature = "cast")))]
+#[cfg(all(feature = "hw", not(feature = "cast"), not(feature = "esp32s3")))]
 pub type Oled = Ssd1306<
     I2CInterface<esp_hal::i2c::master::I2c<'static, esp_hal::Blocking>>,
     DisplaySize72x40,
     BufferedGraphicsMode<DisplaySize72x40>,
 >;
+
+/// #398: the S3 (ES3C28P) backend — the FOURTH repetition of this alias, not new
+/// architecture. Logical 72×40 exactly like the other three (every screen renders
+/// unchanged — the #152 "zero forked render code" gate, applied again); the 4× scaling
+/// to the 320×240 panel happens entirely below this seam, at flush. See `s3_oled.rs`
+/// for why it stores 360 bytes and not a 92 KB image.
+#[cfg(all(feature = "hw", not(feature = "cast"), feature = "esp32s3"))]
+pub type Oled = crate::s3_oled::S3Oled;
 
 /// #152 host emulator: under `feature = "hostsim"` the one concrete `Oled` becomes a
 /// canvas-backed 72×40 framebuffer that impls the SAME `DrawTarget<Color = BinaryColor>`

--- a/rust/clock/src/bard/stack_paint.rs
+++ b/rust/clock/src/bard/stack_paint.rs
@@ -38,6 +38,17 @@ pub fn untouched_bytes(painted: &[u32]) -> usize {
 mod device {
     use super::{untouched_bytes, MARGIN, SENTINEL};
 
+    // ⛔ #398: THIS INSTRUMENT IS INVALID ON THE S3, measured three ways on real
+    // hardware (2026-08-25): (1) 59,504 of 72,004 B read "used" one statement after
+    // paint(), at boot — something in the boot path writes deep inside `.stack` on this
+    // chip; (2) re-painting after esp_hal::init crashed the box into a 99-boot
+    // exception loop — whatever writes there is LIVE; (3) the plausible fix was tested
+    // and disproven: `_stack_end_cpu0`/`_stack_start_cpu0` ALIAS the whole-region
+    // symbols (readelf), so a CPU-slice rebinding changes nothing. The S3's ChipBudget
+    // floor therefore uses the observed-sufficient-region semantics instead
+    // (src/budget.rs ESP32S3_CYD), and porting this instrument to Xtensa — identifying
+    // the writer first — is follow-up on #398. Numbers this module prints on an S3 are
+    // artifacts; the C3's derivation history is unaffected.
     unsafe extern "C" {
         /// Low address of the stack region (it grows DOWN from `_stack_start`).
         static _stack_end: u8;

--- a/rust/clock/src/board_s3.rs
+++ b/rust/clock/src/board_s3.rs
@@ -1,0 +1,613 @@
+//! Board module — **LCDWIKI/QDtech ES3C28P** ("Hosyond 2.8in ESP32-S3 Touchscreen"),
+//! smol fleet node **162**.
+//!
+//! STAGING DRAFT for the smol#398 phase-2 intake PR. Pure constants + provenance: no
+//! `esp-hal` types, no imports, so it compiles anywhere and can be lifted into whatever
+//! module layout the intake PR chooses. Where a real driver wants a typed value
+//! (`PsramMode`, `ColorInversion`, `Orientation`), the raw value is given here with the
+//! construction named in the doc comment — the type stays on the consuming side.
+//!
+//! # Discipline this file follows
+//!
+//! Transposed from `cyd-c5/watch-port/src/board.rs` (the C5 CYD's L3 layer):
+//!
+//! 1. **Every `pub const` carries a source citation** in its doc comment.
+//! 2. **Hazards live AT the constant**, not in a README nobody re-reads at the call site.
+//! 3. **Unmeasured values are labelled `PLACEHOLDER`** with the procedure that settles
+//!    them named — never a plausible-looking number with no provenance.
+//!
+//! # Provenance chain
+//!
+//! Facts here are triple-sourced unless marked otherwise, in this order of authority:
+//!
+//! 1. **Vendor schematic** — `ES3C28P_Schematic.pdf`, fetched 2026-08-01 from lcdwiki,
+//!    archived at `ember.realm.watch/docs/vendor/`. Settles electrical questions
+//!    (`docs/vendor/README.md`).
+//! 2. **emberboy** — `retro-go/components/retro-go/targets/ember-s3/config.h`. A working
+//!    C firmware; authoritative on pins, *not* on MADCTL (see [`MADCTL_LANDSCAPE`]).
+//! 3. **ESPHome** — `ember.realm.watch/esphome/ember-satellite.yaml`. Live on the same
+//!    board class for months.
+//! 4. **Rust on glass** — `emberburrito/burrito-fw`. Proves the values work through
+//!    `esp-hal 1.1.x` + `mipidsi 0.10`, which is the stack smol will use.
+//! 5. **Spike M1 on THIS unit** — flashed 2026-08-24 23:2x, serial heartbeat verified live
+//!    (`targets/s3-cyd/spike/README.md:14`).
+//!
+//! Distilled in `targets/s3-cyd/BOARD.md`; recon in
+//! `~/.claude/projects/-home-jp/scratch/s3-cyd-target/explore-ember.md`.
+//!
+//! # ⚠️ Verification tiers — glass-verified vs board-class-verified
+//!
+//! These are **not** the same claim and the file marks which is which:
+//!
+//! * **UNIT-VERIFIED** on `14:C1:9F:D1:C8:10` (spike M1): boot, console, octal PSRAM maps
+//!   (`8388608` bytes), panel paints, button reads, chip rev v0.2 / efuse block v1.4 /
+//!   crystal 40 MHz. **Panel ORIENTATION is still awaiting a human eyeball on the glass**
+//!   — see [`MADCTL_LANDSCAPE`].
+//! * **BOARD-CLASS-VERIFIED**: everything else — proven on sibling ES3C28P units (Ember,
+//!   ember-mobile, ember-dad, emberburrito, emberboy), not on this one. Same model, same
+//!   schematic. That is strong, and it is still one inference step away from this PCB.
+//! * **SCHEMATIC-ONLY / INFERRED**: called out individually. [`FREE_GPIOS`] is the big one.
+//!
+//! # ⛔ Serial safety — byte-exact matching only
+//!
+//! Five other ES3C28P boards share this bench and **four are live family services**.
+//! reliquary's sealed board is `14:C1:9F:D1:C3:C8` — it differs from this unit only in the
+//! last two octets, and it also contains `C8`. Never prefix-match a serial here; the flash
+//! guard (`targets/s3-cyd/spike/flash.sh:88-95`) says the same thing at more length.
+
+#![allow(dead_code)]
+
+// ===========================================================================
+// Identity
+// ===========================================================================
+
+/// Human board name. `BOARD.md` "Identity".
+pub const BOARD_NAME: &str = "ES3C28P";
+
+/// Module part number: ESP32-S3 **N16R8** — 16 MB flash, 8 MB octal PSRAM, Xtensa LX7
+/// dual-core, 2.4 GHz WiFi + BLE 5.0, **no 802.15.4**. `BOARD.md` "Identity".
+pub const MODULE: &str = "ESP32-S3-N16R8";
+
+/// Rust target triple. **Tier 3** — mainline rustup has no Xtensa; needs the espup fork
+/// (`channel = "esp"`) plus `build-std = ["core", "alloc"]`, and every build shell must
+/// `source ~/export-esp.sh` first or the link fails with ``linker `xtensa-esp32s3-elf-gcc`
+/// not found`` (`reliquary/reliquary-fw/flash.sh:40-47`), which reads like a broken
+/// toolchain rather than an unsourced shell.
+pub const TARGET_TRIPLE: &str = "xtensa-esp32s3-none-elf";
+
+/// Flash size in bytes — 16 MB. `BOARD.md` "Identity"; vendor spec.
+pub const FLASH_BYTES: u32 = 16 * 1024 * 1024;
+
+/// PSRAM size in bytes — 8 MB octal (OPI). **UNIT-VERIFIED**: this board reported exactly
+/// `8388608` at spike M1.
+///
+/// ⚠️ **Assert the SIZE, never the mapping ADDRESS.** The base is image-dependent, not a
+/// board constant: burrito-fw saw `0x3c020000`, this spike sees `0x3c060000`, because
+/// flash-mapped segments shift it. A test pinned to the address passes on one firmware and
+/// fails on the next for no hardware reason. (`BOARD.md` "Identity".)
+pub const PSRAM_BYTES: u32 = 8 * 1024 * 1024;
+
+/// This unit's base MAC = its USB `ID_SERIAL_SHORT` (native USB-Serial/JTAG, `303a:1001`,
+/// CDC-ACM). **The flash guard's allow-list value.**
+///
+/// ⛔ See the module header: `14:C1:9F:D1:C3:C8` (reliquary, SEALED) differs only in the
+/// last two octets. Byte-exact comparison, never a prefix.
+pub const UNIT_SERIAL: &str = "14:C1:9F:D1:C8:10";
+
+/// Silicon revision **v0.2**, efuse block rev **v1.4**, crystal **40 MHz** — captured from
+/// this unit's first flash log 2026-08-25 (`BOARD.md` "Identity"), closing a gap no repo
+/// had recorded. **UNIT-VERIFIED.**
+pub const CHIP_REV: &str = "v0.2";
+
+// ===========================================================================
+// Display — ILI9341V on SPI2
+// ===========================================================================
+//
+// `BOARD.md` "Pin map"; emberboy `config.h`; ESPHome `ember-satellite.yaml`; running in
+// `burrito-fw/src/main.rs:7` ("SPI2 @ 40 MHz, CLK=12 MOSI=11 CS=10 DC=46").
+
+/// SPI2 clock. `BOARD.md` GPIO 12 (`LCD_CLK`).
+pub const PIN_LCD_SCK: u8 = 12;
+
+/// SPI2 MOSI. `BOARD.md` GPIO 11 (`LCD_MOSI`).
+pub const PIN_LCD_MOSI: u8 = 11;
+
+/// SPI2 MISO — **unused**: the panel is write-only and nothing else sits on this bus.
+///
+/// Recorded rather than omitted so a future port does not reuse the pin believing it free.
+/// Unlike the C5 CYD, this board has **no shared SPI bus**: no XPT2046, no SD slot (see
+/// [`HAS_SD_CARD`]). The whole `SharedSpiBus` / chip-select-interleave hazard class from
+/// `cyd-c5/watch-port/src/drivers/spi_bus.rs` **does not exist here**.
+pub const PIN_LCD_MISO: u8 = 13;
+
+/// Display chip select. `BOARD.md` GPIO 10 (`LCD_CS`).
+pub const PIN_LCD_CS: u8 = 10;
+
+/// Display data/command select. `BOARD.md` GPIO 46 (`LCD_DC`).
+///
+/// A strapping pin, but harmless as a runtime output — straps latch at reset, long before
+/// firmware configures anything.
+pub const PIN_LCD_DC: u8 = 46;
+
+/// Backlight, **active-HIGH** through a BSS138 gate. `BOARD.md` GPIO 45 (`LCD_BL`).
+///
+/// ⚠️ GPIO45 is also the **VDD_SPI strapping pin**, which normally makes it a pin to fear:
+/// strapped high it selects a 1.8 V flash rail and browns the module out. **Safe here, for
+/// a schematic reason** — `R32` (10 K to GND) hard-wires the strap LOW, and the strap
+/// latches at reset while GPIO drivers are still inputs, so R32 always wins. No firmware
+/// setting can cause that brownout on this board. (Vendor schematic; `explore-ember.md` §2.)
+///
+/// burrito-fw drives it high *after* the first full paint, so boot shows a painted panel
+/// rather than a white flash. ESPHome uses LEDC PWM @ 20 kHz for dimming.
+pub const PIN_LCD_BACKLIGHT: u8 = 45;
+
+/// `true` — backlight is asserted by driving the pin HIGH. See [`PIN_LCD_BACKLIGHT`].
+pub const LCD_BACKLIGHT_ACTIVE_HIGH: bool = true;
+
+// ---------------------------------------------------------------------------
+// THERE IS NO DISPLAY RESET GPIO.
+// ---------------------------------------------------------------------------
+// LCD_RST is bonded to CHIP_PU / EN — the module's own reset line (`BOARD.md` pin map,
+// final rows). So the panel is already out of reset whenever firmware runs, and there is
+// no pin to toggle.
+//
+// ⚠️ This must be an EXPLICIT ABSENCE in the driver, not a stubbed dummy pin. mipidsi's
+// builder takes `NoResetPin` (`burrito-fw/src/main.rs:56`) and relies on the software
+// reset inside `init()`. Handing it some unrelated GPIO "because the type wants one"
+// drives an unconnected pad and yields a panel that is never reset — which on glass looks
+// exactly like a wiring fault. The C5 CYD hit precisely this: the vendor's MicroPython
+// demo passes `reset=Pin(0)` purely to satisfy a required argument, and GPIO0 is
+// documented FREE in the same repo (`cyd-c5/watch-port/src/board.rs`, the no-reset block).
+// Same shape, same trap, different board.
+
+/// Named absence: this board exposes **no** LCD reset GPIO. Software `SWRESET` only.
+pub const HAS_LCD_RESET_PIN: bool = false;
+
+/// Display SPI clock in Hz — **40 MHz**, proven on glass by burrito-fw
+/// (`burrito-fw/src/main.rs:7`), Mode 0.
+///
+/// Note this is double the C5 CYD's vendor-proven 20 MHz. Nothing is shared with that
+/// board: dedicated bus, different panel, native IOMUX pins.
+pub const SPI_DISPLAY_HZ: u32 = 40_000_000;
+
+/// SPI mode — 0. `esp-hal`'s `Config::default()` is already `Mode::_0`.
+pub const SPI_DISPLAY_MODE: u8 = 0;
+
+// ===========================================================================
+// Panel geometry & MADCTL
+// ===========================================================================
+
+/// Panel controller. mipidsi model `ILI9341Rgb565` — **not** ST7789.
+///
+/// ⚠️ Worth stating loudly because "2.8 inch CYD-shaped ESP32 board" reads as ST7789 to
+/// everyone: this board is dimensionally drop-in with the classic ESP32-2432S028 CYD
+/// (`ember.realm.watch/docs/enclosure.md` §4) while sharing neither its panel controller
+/// nor its touch controller. Dimensional compatibility is not electrical compatibility.
+pub const PANEL_CONTROLLER: &str = "ILI9341V";
+
+/// Native die geometry: 240×320 portrait.
+pub const PANEL_NATIVE_W: u16 = 240;
+/// See [`PANEL_NATIVE_W`].
+pub const PANEL_NATIVE_H: u16 = 320;
+
+/// Logical width in the shipped orientation (landscape).
+pub const LCD_WIDTH: u16 = 320;
+/// Logical height in the shipped orientation (landscape).
+pub const LCD_HEIGHT: u16 = 240;
+
+/// MADCTL (`0x36`) for landscape: **`0x28`** = `MV | BGR`.
+///
+/// In mipidsi 0.10 this is `Orientation::new().rotate(Deg90).flip_vertical()`.
+///
+/// ⛔ **Do NOT copy retro-go's `ILI9341_CMD(0x36, 0x68)`.** Its comment reads
+/// "(MX|MV|BGR) = landscape", but `0x68` is `0x28` **with MX set — a horizontal mirror**,
+/// which retro-go compensates for in its own framebuffer scan order. A normal renderer
+/// must not. Taking that value at face value **shipped mirror-writing in burrito-fw v0.1**
+/// (2026-08-15, fixed same day). This is landmine **L4** in `BOARD.md`.
+///
+/// Orientation ground truth is ESPHome's `ember-satellite.yaml`, which drives this exact
+/// panel with **no** `transform:` / `mirror_x` / `mirror_y` in native portrait — so the
+/// panel obeys the standard rotation table.
+///
+/// **If the image is upside-down but READABLE**, the fix is [`MADCTL_LANDSCAPE_FLIPPED`].
+/// ⚠️ **Never re-add a mirror bit to correct a rotation** — mirrored and rotated look
+/// similar on a symmetric boot screen and diverge the moment text appears.
+///
+/// **Verification status: BOARD-CLASS-VERIFIED, not unit-verified.** Spike M1 painted this
+/// unit's panel, but orientation is still *"awaiting a human eyeball on the glass"*
+/// (`spike/README.md:14`). Treat as correct-but-unwitnessed here.
+pub const MADCTL_LANDSCAPE: u8 = 0x28;
+
+/// The 180°-opposite landscape: **`0xE8`** = mipidsi `.flip_horizontal()`.
+///
+/// The **only** sanctioned escape hatch if the panel reads upside-down. `0x68` and `0xA8`
+/// are the mirrored values and are never the answer — see [`MADCTL_LANDSCAPE`].
+pub const MADCTL_LANDSCAPE_FLIPPED: u8 = 0xE8;
+
+/// Colour order is **BGR** (the `0x08` bit, already folded into [`MADCTL_LANDSCAPE`]).
+pub const MADCTL_COLOR_ORDER_BGR: bool = true;
+
+/// Display inversion **ON** — mipidsi `ColorInversion::Inverted`, raw command `0x21`.
+///
+/// Stated loudly because it is the *opposite* of the C5 CYD's ST7789 panel, which needs
+/// `INVOFF` (`cyd-c5/watch-port/src/board.rs`, `INVERT_COLORS = false`). Two 2.8" panels
+/// on two boards in the same fleet, opposite answers: never inherit this one across boards.
+pub const INVERT_COLORS: bool = true;
+
+/// GRAM column offset — **zero in every rotation**: a clean full-frame 240×320 die, unlike
+/// the 240×240 / 135×240 variants that carry offsets, and unlike the C6 watch's CO5300
+/// (`col_offset = 22`).
+pub const LCD_COL_OFFSET: u16 = 0;
+/// See [`LCD_COL_OFFSET`].
+pub const LCD_ROW_OFFSET: u16 = 0;
+
+/// The ILI9341 has **no** even-alignment rule on `CASET`/`RASET`; 1×1 windows are legal.
+///
+/// Consequence for a Slint port: the C6 watch vendors a fork of Slint's software renderer
+/// solely to even-align dirty regions for the CO5300's 2×2 restriction. **That restriction
+/// does not exist here.** (The watch keeps the fork on every board anyway — it also carries
+/// the `[POOL]` heap-attribution instrumentation, and even windows are a legal subset:
+/// `esp32c6-watch/src/drivers/panel.rs:25-33`.)
+pub const PANEL_REQUIRES_EVEN_WINDOWS: bool = false;
+
+// ===========================================================================
+// Touch — FT6336U on I²C0
+// ===========================================================================
+
+/// Capacitive touch controller: **FT6336U/G**, reports chip id `100` (`0x64`).
+/// Capacitive, **not** the C5 CYD's resistive XPT2046 — different contract entirely
+/// (contact vs pressure, no calibration span to measure).
+pub const TOUCH_CONTROLLER: &str = "FT6336U";
+
+/// Touch I²C address. `BOARD.md` "Touch".
+pub const I2C_ADDR_TOUCH: u8 = 0x38;
+
+/// Shared I²C0 **SDA**. `BOARD.md` GPIO 16 (`I2C_SDA`).
+pub const PIN_I2C_SDA: u8 = 16;
+
+/// Shared I²C0 **SCL**. `BOARD.md` GPIO 15 (`I2C_SCL`).
+pub const PIN_I2C_SCL: u8 = 15;
+
+/// I²C bus speed — 100 kHz. Shared by touch (`0x38`) and the ES8311 codec (`0x18`).
+pub const I2C_HZ: u32 = 100_000;
+
+/// Touch interrupt (`CTP_INT`). `BOARD.md` GPIO 17.
+///
+/// **Genuinely wired and usable** — ESPHome uses it. burrito-fw instead polls at UI frame
+/// rate, which is a choice, not a limitation. (Contrast the C5 CYD, where the touch IRQ is
+/// wired but *every* vendor config says `IRQ = -1`, so its usability was an inference; here
+/// a shipping config actually uses it.)
+pub const PIN_TOUCH_INT: u8 = 17;
+
+// ---------------------------------------------------------------------------
+// ⛔ GPIO 18 — CTP_RST — NEVER CONFIGURE. Landmine L1.
+// ---------------------------------------------------------------------------
+// Touch reset is physically wired to GPIO18, and **driving it breaks the FT6336**. Both a
+// `reset_pin:` binding and a plain output-high were tested; both kill touch. Left entirely
+// alone, the FT6336 pulls RSTN high internally and works.
+//
+// ⚠️ **The schematic says this pin floats and should be driven.** It is wrong in practice.
+// TESTED BEATS DERIVED — this is the one constant in this file where the primary source
+// loses to an experiment, and it is recorded that way deliberately.
+//
+// The absence of GPIO18 from touch initialisation is THE TRICK, not an oversight. A future
+// reader "completing" the driver by adding the reset line will break working touch and will
+// have every reason to think they fixed something. That is why this is a named constant
+// with a refusal in its name rather than a silent omission.
+
+/// ⛔ **NEVER configure this pin.** See the block above and `BOARD.md` landmine L1.
+/// Named so the prohibition is greppable and survives a refactor.
+pub const PIN_TOUCH_RST_DO_NOT_CONFIGURE: u8 = 18;
+
+/// Landscape touch transform, from retro-go: `swap_xy = true`.
+///
+/// ⚠️ **PLACEHOLDER-GRADE — awaiting real-finger confirmation under Rust.** burrito-fw
+/// flagged the whole triple as unconfirmed on its stack. Being capacitive, there is no
+/// calibration span to measure (unlike the C5's XPT2046) — the transform is either right
+/// or visibly wrong.
+///
+/// **Procedure that settles it:** paint a known corner marker, tap each of the four
+/// corners, log raw + transformed coordinates. Ten seconds, once. Until then expect taps
+/// to land in the right *region* under an unverified axis flip.
+pub const TOUCH_SWAP_XY: bool = true;
+/// See [`TOUCH_SWAP_XY`] — same PLACEHOLDER status and same procedure.
+pub const TOUCH_INVERT_X: bool = false;
+/// See [`TOUCH_SWAP_XY`] — same PLACEHOLDER status and same procedure.
+pub const TOUCH_INVERT_Y: bool = true;
+
+// ===========================================================================
+// Audio — ES8311 codec + SC8002B amp
+// ===========================================================================
+
+/// ES8311 codec I²C address. Shares I²C0 with touch.
+pub const I2C_ADDR_CODEC: u8 = 0x18;
+
+// ---------------------------------------------------------------------------
+// ⚠️ I²S PIN NAMING TRAP — the silkscreen names data pins from the CODEC's side.
+// ---------------------------------------------------------------------------
+// `I2S_DO` is the codec's data OUT, i.e. the ESP's data IN (microphone). `I2S_DI` is the
+// codec's data IN, i.e. the ESP's data OUT (playback). Reading them as ESP-side names
+// swaps record and playback, which presents as silence in both directions.
+//
+// This trap is LIVE, not hypothetical: `BOARD.md` records that GPIO6 "gets dropped from
+// third-party pinouts", and the brief commissioning this very file listed the I²S pins as
+// "4/5/7/8" — omitting GPIO6, the microphone. Corrected here.
+
+/// I²S MCLK. `BOARD.md` GPIO 4.
+///
+/// ⚠️ Physically wired **but the codec is BCLK-derived** — which is exactly what makes
+/// landmine [`ES8311_REG01_BCLK_DERIVED`] look right when it is wrong.
+pub const PIN_I2S_MCLK: u8 = 4;
+
+/// I²S bit clock (codec SCLK/BCLK). `BOARD.md` GPIO 5.
+pub const PIN_I2S_BCLK: u8 = 5;
+
+/// Codec `ASDOUT` → **ESP data IN**. This is the **MICROPHONE** path. `BOARD.md` GPIO 6.
+/// The pin third-party pinouts drop — see the naming-trap block above.
+pub const PIN_I2S_DIN_MIC: u8 = 6;
+
+/// I²S word select (codec LRCK/WS). `BOARD.md` GPIO 7.
+pub const PIN_I2S_WS: u8 = 7;
+
+/// **ESP data OUT** → codec `DSDIN`. This is the **PLAYBACK** path. `BOARD.md` GPIO 8.
+pub const PIN_I2S_DOUT_SPK: u8 = 8;
+
+/// Speaker amplifier (SC8002B, 3 W class-AB) shutdown control. `BOARD.md` GPIO 1.
+///
+/// ⚠️ **ACTIVE LOW: drive LOW to turn the amp ON.** The inverted sense means the safe
+/// power-on default (pin low / undriven) is *amp enabled*, not muted — the opposite of the
+/// intuition. Drive it HIGH to silence.
+pub const PIN_AMP_SHUTDOWN: u8 = 1;
+
+/// `true` — the amp is enabled by driving [`PIN_AMP_SHUTDOWN`] LOW.
+pub const AMP_SHUTDOWN_ACTIVE_LOW: bool = true;
+
+/// ES8311 register `0x01` must be **`0xBF`** (BCLK-derived), **not `0x3F`**. Landmine L5.
+///
+/// ⚠️ MCLK *is* physically wired to GPIO4, which is precisely what makes `0x3F` look
+/// correct — the wrong value is the one the schematic argues for. It **fails as silence,
+/// never as an error**: no bus NACK, no status bit, just no sound.
+///
+/// Two consequences that ride along:
+/// * BCLK-derived mode **refuses sample rates below 22050 Hz**.
+/// * **Init order is load-bearing**: reset (`0x00 = 0x00`) FIRST, power-on
+///   (`0x00 = 0x80`) LAST.
+pub const ES8311_REG01_BCLK_DERIVED: u8 = 0xBF;
+
+/// I²C bring-up order: **codec first, touch second.** Landmine L6.
+///
+/// The codec needs the bus once at boot and never again; touch needs it forever. In that
+/// order the two never contend and **zero bus-sharing machinery is required** — a whole
+/// category of code that exists only if you initialise them the other way round.
+pub const I2C_INIT_CODEC_BEFORE_TOUCH: bool = true;
+
+/// There is **no AEC** and the speaker sits inches from the microphone. Anything doing
+/// simultaneous playback and capture must expect to hear itself.
+pub const HAS_ACOUSTIC_ECHO_CANCELLATION: bool = false;
+
+// ===========================================================================
+// LED, button, battery
+// ===========================================================================
+
+/// WS2812 RGB LED (×1, **GRB** order) driven over RMT. `BOARD.md` GPIO 42.
+///
+/// ⚠️ **`esp-hal-smartled` 0.17 wants esp-hal ~1.0 and is incompatible with 1.1.x**, which
+/// is smol's pin. Drive the RMT peripheral directly (~50 lines) rather than pulling the
+/// crate and being forced to downgrade the HAL for one LED.
+pub const PIN_WS2812: u8 = 42;
+
+/// BOOT button (K2), **active-low**. `BOARD.md` GPIO 0.
+///
+/// ⚠️ **This is the entire hardware input budget** — one button, no rotary, no second key.
+/// smol's `input.rs` `Press` model maps onto it directly, which is convenient; any UI
+/// assuming two buttons does not fit this board. Also a strapping pin, and RTC-capable so
+/// it can serve as a wake source.
+pub const PIN_BOOT_BUTTON: u8 = 0;
+
+/// `true` — [`PIN_BOOT_BUTTON`] reads LOW when pressed.
+pub const BOOT_BUTTON_ACTIVE_LOW: bool = true;
+
+/// Battery sense ADC. `BOARD.md` GPIO 9 (`BAT_ADC`).
+///
+/// Onboard **2:1 divider** (200 K / 200 K, schematic `R14`/`R15`) → multiply the reading by
+/// **2.0**; 12 dB attenuation.
+///
+/// ⚠️ **Floats and reads noise with no cell fitted.** A "battery voltage" from an
+/// unpopulated `JP1` is meaningless, not zero — do not publish it as telemetry without
+/// knowing a cell is present.
+///
+/// ⚠️ **There is NO protection IC on this board.** The 2-pin BAT connector goes straight to
+/// the cell; the only over-discharge floor is the ME6217 LDO's dropout (browns out ~3.4 V),
+/// after which the divider (~9 µA) keeps draining. **Bare cells require an external 1S
+/// protection strip** — JP fits one. (Vendor schematic; `ember.realm.watch` #44.)
+pub const PIN_BAT_ADC: u8 = 9;
+
+/// Battery divider ratio — multiply the ADC reading by this. See [`PIN_BAT_ADC`].
+pub const BAT_ADC_DIVIDER: f32 = 2.0;
+
+// ===========================================================================
+// Reserved / absent
+// ===========================================================================
+
+/// GPIOs **consumed by the octal PSRAM** — 33..=37 inclusive. Do not use, do not probe.
+pub const PSRAM_RESERVED_GPIOS: [u8; 5] = [33, 34, 35, 36, 37];
+
+/// PSRAM octal mode is a **RUNTIME field**, not a build feature. Landmine L2.
+///
+/// In esp-hal 1.1.x: `PsramConfig { mode: PsramMode::OctalSpi, size: PsramSize::AutoDetect,
+/// .. }`. There is **no `psram` cargo feature** and **no `ESP_HAL_CONFIG_PSRAM_MODE`
+/// build-time knob** — both claims were re-verified false on 2026-08-14, so an older doc
+/// asserting either is stale.
+///
+/// ⚠️ **Never leave an N16R8 on `Auto`.** Release builds only.
+pub const PSRAM_MODE_IS_RUNTIME_CONFIG: bool = true;
+
+/// ⛔ **Never place the esp-radio heap in PSRAM.** Landmine L3.
+///
+/// On the S3, atomics in PSRAM are **silently non-atomic** (esp-alloc's own documentation),
+/// and the WiFi driver's internals are full of synchronisation primitives. Spend the 64 KiB
+/// of internal RAM knowingly rather than discovering this as intermittent corruption.
+pub const RADIO_HEAP_MAY_USE_PSRAM: bool = false;
+
+/// **No SD card slot exists on this board.** Use a FAT partition on internal flash if
+/// storage is ever needed. (The classic CYD has one; this board does not — another place
+/// dimensional similarity misleads.)
+pub const HAS_SD_CARD: bool = false;
+
+/// **No LDR** (ambient light sensor). Another classic-CYD feature this board lacks.
+pub const HAS_LDR: bool = false;
+
+/// **No 802.15.4 radio** — WiFi + BLE only. Zigbee/Thread is not reachable from this chip.
+pub const HAS_IEEE802154: bool = false;
+
+/// GPIOs believed free.
+///
+/// ⚠️ **INFERRED, NOT SCHEMATIC-VERIFIED** — derived by subtracting claimed pins from the
+/// package, which cannot see a net that exists but went unrecorded. Treat as a hypothesis:
+/// meter a pin before committing hardware to it. Note **19/20 are the native USB D-/D+**
+/// and are only "free" if USB is not used.
+pub const FREE_GPIOS: [u8; 13] = [2, 3, 14, 19, 20, 21, 38, 39, 40, 41, 43, 44, 47];
+
+// ===========================================================================
+// Fleet identity
+// ===========================================================================
+
+/// smol fleet node id for **this unit**. `docs/protocol.md:87-89` — `160–175` is the S3
+/// board class (ES3C28P family); `160` = Ember, `161` = emberburrito, **`162` = this dev
+/// board**.
+///
+/// ⚠️ **Ids are per-NODE, never per-product.** Three ids in this block are the same model.
+///
+/// Identity lives in **NVS** and **OTA never touches NVS**, so only re-provisioning changes
+/// it. The baked factory default is **7** — always pass `SMOL_NODE_ID=162` when
+/// provisioning, or a fresh board silently lands on 7 alongside whatever else is there.
+pub const NODE_ID: u8 = 162;
+
+/// Fleet sigil name for this board: **`eldritch-insignia`**.
+///
+/// ⚠️ **MAC-derived via the `sigil-id` crate — never derive it by hand.** Two hand
+/// derivations of the C5's sigil were both wrong. Row landed in `esp32c6-watch`
+/// `feat/cyd-c5-target` @ `ba46f74` with the dual-contract test.
+///
+/// ⚠️ **Speech collision (not a protocol problem):** `eldritch-insignia` shares its
+/// adjective with `eldritch-lantern`, JP's primary watch. Full sigils and MQTT topics are
+/// unambiguous, but "the eldritch one" now means two devices — **never identify a board by
+/// adjective when debugging by ear.**
+pub const SIGIL_NAME: &str = "eldritch-insignia";
+
+// ---------------------------------------------------------------------------
+// 🔗 smol#396 — the variant-byte seam. LEAVE IT UNREAD.
+// ---------------------------------------------------------------------------
+// `BoardProfile::ha_device_extras()` matches on `(chip, has_display)`, and its
+// `(CHIP_ESP32S3, _)` arm hard-returns `"smol ESP32-S3 Ember"`. Every S3 in the fleet —
+// Ember, emberburrito, reliquary, this board — is `CHIP_ESP32S3` **with a display**, so
+// `has_display` cannot separate them and all four would announce as Ember.
+//
+// The fix is smol#396's variant axis. Its shape was FROZEN 2026-08-25: an **NVS
+// variant/product byte provisioned beside `SMOL_NODE_ID`**, with `protocol.md`'s table as
+// the human record. It must be NVS rather than a runtime probe because the hardware is
+// genuinely identical — there is nothing to detect. And it is explicitly **not** a cargo
+// feature: #352's standing rule keeps the variant axis at runtime.
+//
+// ⚠️ **RULE FOR THIS FILE, from PORT-SCOPING.md:110-114: leave the seam, do not read the
+// byte yet.** #396 lands with smol-d8's profile.rs lane after depin's PR. A constant here
+// that reads or guesses the variant would have to be unpicked, and would meanwhile ship a
+// second source of truth for board identity — the exact defect #352 was written to remove.
+
+/// Placeholder for the smol#396 NVS variant byte. **Deliberately not read yet** — see the
+/// block above. Present only so the seam is greppable from this file.
+pub const VARIANT_BYTE_NVS_KEY: &str = "smol_variant";
+
+// ===========================================================================
+// Compile-time sanity — these catch a bad edit, not a bad board
+// ===========================================================================
+//
+// Cheap, and they fail at build time rather than as a mystery on glass. They assert
+// INTERNAL CONSISTENCY of this file; they cannot validate a wrong-but-consistent pin.
+
+/// No pin is claimed by two different functions.
+const _: () = {
+    let pins = [
+        PIN_LCD_SCK,
+        PIN_LCD_MOSI,
+        PIN_LCD_MISO,
+        PIN_LCD_CS,
+        PIN_LCD_DC,
+        PIN_LCD_BACKLIGHT,
+        PIN_I2C_SDA,
+        PIN_I2C_SCL,
+        PIN_TOUCH_INT,
+        PIN_TOUCH_RST_DO_NOT_CONFIGURE,
+        PIN_I2S_MCLK,
+        PIN_I2S_BCLK,
+        PIN_I2S_DIN_MIC,
+        PIN_I2S_WS,
+        PIN_I2S_DOUT_SPK,
+        PIN_AMP_SHUTDOWN,
+        PIN_WS2812,
+        PIN_BOOT_BUTTON,
+        PIN_BAT_ADC,
+    ];
+    let mut i = 0;
+    while i < pins.len() {
+        let mut j = i + 1;
+        while j < pins.len() {
+            assert!(pins[i] != pins[j], "two functions claim the same GPIO");
+            j += 1;
+        }
+        i += 1;
+    }
+};
+
+/// No claimed pin collides with the octal-PSRAM reservation (33..=37).
+const _: () = {
+    let pins = [
+        PIN_LCD_SCK,
+        PIN_LCD_MOSI,
+        PIN_LCD_MISO,
+        PIN_LCD_CS,
+        PIN_LCD_DC,
+        PIN_LCD_BACKLIGHT,
+        PIN_I2C_SDA,
+        PIN_I2C_SCL,
+        PIN_TOUCH_INT,
+        PIN_I2S_MCLK,
+        PIN_I2S_BCLK,
+        PIN_I2S_DIN_MIC,
+        PIN_I2S_WS,
+        PIN_I2S_DOUT_SPK,
+        PIN_AMP_SHUTDOWN,
+        PIN_WS2812,
+        PIN_BOOT_BUTTON,
+        PIN_BAT_ADC,
+    ];
+    let mut i = 0;
+    while i < pins.len() {
+        assert!(
+            pins[i] < 33 || pins[i] > 37,
+            "a claimed GPIO lands inside the octal-PSRAM reservation 33..=37"
+        );
+        i += 1;
+    }
+};
+
+/// The landscape MADCTL is not one of the two MIRRORED values.
+///
+/// Same guard shape as `burrito-fw`'s `assert_madctl_matches_upstream()`: `0x68` and `0xA8`
+/// are the mirror-writing values that shipped a bug once already, and `0xE8` (the
+/// legitimate 180° escape hatch) must stay representable.
+const _: () = {
+    assert!(
+        MADCTL_LANDSCAPE != 0x68 && MADCTL_LANDSCAPE != 0xA8,
+        "MADCTL is a MIRRORED value — see MADCTL_LANDSCAPE's retro-go note"
+    );
+    assert!(
+        MADCTL_LANDSCAPE == 0x28 || MADCTL_LANDSCAPE == MADCTL_LANDSCAPE_FLIPPED,
+        "MADCTL is neither of the two canonical ILI9341 landscape values"
+    );
+};
+
+/// Landscape geometry is the native die transposed — catches an edited dimension.
+const _: () = {
+    assert!(LCD_WIDTH == PANEL_NATIVE_H && LCD_HEIGHT == PANEL_NATIVE_W);
+};

--- a/rust/clock/src/budget.rs
+++ b/rust/clock/src/budget.rs
@@ -425,6 +425,38 @@ pub const CHIP: ChipBudget = ESP32C3;
 #[cfg(all(target_os = "none", feature = "esp32c6"))]
 pub const CHIP: ChipBudget = ESP32C6_WATCH;
 
+/// The S3 (ES3C28P, #398) — measured on unit `14:C1:9F:D1:C8:10` ("eldritch-insignia",
+/// node 162), 2026-08-25, the day smol first ran on Xtensa silicon.
+///
+/// **`stack_floor_bytes` is an OBSERVED-SUFFICIENT line, not a high-water derivation,
+/// and the difference is a measured fact about the instrument:** `stack-paint` is
+/// INVALID on this chip as written. Its sentinel is trampled by boot-era machinery that
+/// shares the `.stack` region (59,504 B read "used" one statement after painting, at
+/// boot, before anything deep ran), and re-painting after init crashed the box into a
+/// 99-boot exception loop. The `_stack_*_cpu0` symbols alias the whole-region ones
+/// (readelf-verified), so a CPU-slice port is NOT the fix — understanding what actually
+/// writes there is, and that is follow-up work on #398. Until then, the floor is the
+/// C6's own semantics (`ESP32C6_WATCH_EMPIRICAL_BOOT_LINE_BYTES`): **72,004 B is the
+/// `.stack` region of the heaviest-stack tier ever run on this unit** (`stack-paint` =
+/// bard + canonical: narration + mesh relay + MQTT + the 4× display), which ran clean —
+/// the smallest region PROVEN sufficient, not the smallest that works.
+///
+/// `free_dram_bytes` = the fleet image's `.stack` section (readelf, ELF sha256
+/// `5fd23661885a10b1…`, opt-level 2 per the [chip.esp32s3] toolchain-bug workaround —
+/// opt-level moves sections, so the profile is part of this row's provenance).
+/// `app_slot_bytes`/`baseline_image_bytes`: `targets/s3-cyd/partitions-ota-s3.csv`,
+/// espflash save-image against that CSV = 1,028,656 B (16.35% of the slot).
+pub const ESP32S3_CYD: ChipBudget = ChipBudget {
+    chip: "esp32s3",
+    free_dram_bytes: 116_940,
+    stack_floor_bytes: 72_004,
+    app_slot_bytes: 0x0060_0000,
+    baseline_image_bytes: 1_028_656,
+};
+
+#[cfg(all(target_os = "none", feature = "esp32s3"))]
+pub const CHIP: ChipBudget = ESP32S3_CYD;
+
 /// A chip whose budget has never been measured, on a bare-metal target.
 ///
 /// **A poison row, not a permissive default.** Every field is chosen so that any question asked
@@ -440,7 +472,7 @@ pub const CHIP: ChipBudget = ESP32C6_WATCH;
 /// ⚠️ `tools/build_matrix.py::budget_chips()` skips this row by name when it cross-checks the
 /// chip roster against `tools/build-matrix.toml`. It is not a fleet target; it is the absence
 /// of one, given a shape.
-#[cfg(all(target_os = "none", not(any(feature = "esp32c3", feature = "esp32c6"))))]
+#[cfg(all(target_os = "none", not(any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3"))))]
 pub const UNMEASURED: ChipBudget = ChipBudget {
     chip: "unmeasured",
     free_dram_bytes: 0,
@@ -449,7 +481,7 @@ pub const UNMEASURED: ChipBudget = ChipBudget {
     baseline_image_bytes: 0,
 };
 
-#[cfg(all(target_os = "none", not(any(feature = "esp32c3", feature = "esp32c6"))))]
+#[cfg(all(target_os = "none", not(any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3"))))]
 pub const CHIP: ChipBudget = UNMEASURED;
 
 /// Whether [`CHIP`] carries MEASURED numbers, as a value rather than as a cfg incantation.
@@ -459,7 +491,7 @@ pub const CHIP: ChipBudget = UNMEASURED;
 /// somewhere else is exactly the two-statements-of-one-fact rot that `build_matrix.py` exists to
 /// catch between this file and the build matrix.
 #[cfg(target_os = "none")]
-pub const CHIP_MEASURED: bool = cfg!(any(feature = "esp32c3", feature = "esp32c6"));
+pub const CHIP_MEASURED: bool = cfg!(any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3"));
 
 /// A bare-metal build must name its chip. Distinct from "named it and it has no row" — that is
 /// [`UNMEASURED`] and it only bites the budget-predicated features. This is the build not saying

--- a/rust/clock/src/input.rs
+++ b/rust/clock/src/input.rs
@@ -225,6 +225,12 @@ impl Gesture {
 }
 
 /// Debounced BOOT button with short-tap / long-press classification./// Debounced BOOT button with short-tap / long-press classification.
+/// The chip's BOOT-button pin type — see [`Button::new`].
+#[cfg(all(feature = "hw", not(feature = "esp32s3")))]
+type BootPin<'d> = esp_hal::peripherals::GPIO9<'d>;
+#[cfg(all(feature = "hw", feature = "esp32s3"))]
+type BootPin<'d> = esp_hal::peripherals::GPIO0<'d>;
+
 #[cfg(feature = "hw")]
 pub struct Button {
     pin: Input<'static>,
@@ -233,9 +239,13 @@ pub struct Button {
 
 #[cfg(feature = "hw")]
 impl Button {
-    /// Wrap GPIO9 as a pulled-up active-low input. `main` owns `esp_hal::init()`
+    /// Wrap the BOOT pin as a pulled-up active-low input. `main` owns `esp_hal::init()`
     /// and the pin singleton and passes it in, so the HAL is initialised once.
-    pub fn new(pin: esp_hal::peripherals::GPIO9<'static>) -> Self {
+    ///
+    /// The PIN is a chip fact: GPIO9 on the C3 boards, GPIO0 on the S3/ES3C28P (#398 —
+    /// where GPIO9 is the battery ADC). Both are that chip's boot-strapping pin with the
+    /// same pulled-up active-low behaviour, so only the type changes.
+    pub fn new(pin: BootPin<'static>) -> Self {
         let input = Input::new(pin, InputConfig::default().with_pull(Pull::Up));
         Self {
             pin: input,

--- a/rust/clock/src/io.rs
+++ b/rust/clock/src/io.rs
@@ -40,7 +40,13 @@ use esp_hal::gpio::{Flex, InputConfig, Level, OutputConfig, Pull};
 /// the exposed header is already claimed by an on-board peripheral or is a boot
 /// strapping / USB-serial pin — see [`RESERVED_PINS`]. Slot `i` of a [`PinMap`] owns
 /// the physical pin `FREE_PINS[i]`.
+#[cfg(not(feature = "esp32s3"))]
 pub const FREE_PINS: [u8; 5] = [0, 1, 3, 7, 10];
+/// #398 S3 (ES3C28P): the C3's pool pins are all claimed there (0=BOOT, 1=amp enable,
+/// 7=I2S WS, 10=LCD chip-select). These five come from board_s3::FREE_GPIOS, which is
+/// ⚠️ INFERRED-not-schematic-verified — meter a pin before committing hardware to it.
+#[cfg(feature = "esp32s3")]
+pub const FREE_PINS: [u8; 5] = [21, 38, 39, 40, 41];
 
 /// GPIOs that MUST NEVER be bound: a `G`-key descriptor naming one is rejected and
 /// surfaced in DIAG, never applied. Cited against their real claim sites (NOT
@@ -52,7 +58,18 @@ pub const FREE_PINS: [u8; 5] = [0, 1, 3, 7, 10];
 ///   * `9`     — BOOT button        (`main.rs` `Button::new(GPIO9)`; `input.rs`, strapping)
 ///   * `2`     — boot strapping pin (C3 boot-mode select; #72 pin-budget note)
 ///   * `20`,`21` — USB-serial UART  (log console; #72 pin-budget note)
+#[cfg(not(feature = "esp32s3"))]
 pub const RESERVED_PINS: [u8; 8] = [2, 4, 5, 6, 8, 9, 20, 21];
+/// #398 S3: everything the ES3C28P's peripherals claim (board_s3 has the per-pin story):
+/// 0 BOOT · 1 amp(ACTIVE-LOW) · 4–8 I2S/audio · 9 BAT_ADC · 10–13 LCD SPI ·
+/// 15–17 touch I2C/INT · **18 = the touch-reset NEVER-CONFIGURE pin** · 19/20 USB ·
+/// 33–37 octal PSRAM · 42 WS2812 · 45 backlight/strap · 46 LCD DC.
+#[cfg(feature = "esp32s3")]
+pub const RESERVED_PINS: [u8; 26] = [
+    0, 1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18, 19, 20,
+    33, 34, 35, 36, 37, // octal PSRAM — ALL FIVE (a first draft dropped 36/37; count, don't trust)
+    42, 45, 46,
+];
 
 /// Number of runtime-bindable slots (= free pins). Fixed capacity → no alloc.
 pub const NPIN: usize = FREE_PINS.len();

--- a/rust/clock/src/led.rs
+++ b/rust/clock/src/led.rs
@@ -39,7 +39,13 @@ use esp_hal::gpio::{Level, Output};
 /// Everything else in this module works in *logical* on/off; this const is the
 /// single place that maps logical->physical, so re-targeting a board with the
 /// opposite wiring is a one-line change.
+#[cfg(not(feature = "esp32s3"))]
 pub const LED_ACTIVE_LOW: bool = true;
+/// #398 S3: nominal ACTIVE-HIGH — but on the ES3C28P this drives the WS2812's DIN
+/// (GPIO42), which ignores plain levels entirely (it wants the RMT protocol), so no
+/// light shows either way. The state machine still runs; the RMT driver is follow-up.
+#[cfg(feature = "esp32s3")]
+pub const LED_ACTIVE_LOW: bool = false;
 
 // --- Blink half-periods (milliseconds) -----------------------------------
 // A "half-period" is how long the LED stays on, then off, per blink. The blink

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -83,13 +83,11 @@ extern "Rust" fn custom_halt() -> ! {
     esp_hal::system::software_reset()
 }
 
-use esp_hal::{
-    clock::CpuClock,
-    delay::Delay,
-    i2c::master::{BusTimeout, Config as I2cConfig, I2c, SoftwareTimeout},
-    time::Instant,
-    time::Rate,
-};
+use esp_hal::{clock::CpuClock, delay::Delay, time::Instant, time::Rate};
+// The OLED I2C stack is the C3-family panel path; the S3 (#398) drives an SPI ILI9341V
+// through `s3_oled` instead, so these imports are chip-cfg'd with their consumer.
+#[cfg(not(feature = "esp32s3"))]
+use esp_hal::i2c::master::{BusTimeout, Config as I2cConfig, I2c, SoftwareTimeout};
 // #335 P1.2: the bare-metal `#[main]` entry survives ONLY on the no-radio tier. Under `wifi` the
 // entry is `#[esp_rtos::main]`, which emits its own `#[esp_hal::main] fn main()` wrapper — naming
 // `main` here as well would be an unused import there.
@@ -103,17 +101,24 @@ use esp_hal::{interrupt::software::SoftwareInterruptControl, timer::timg::TimerG
 // type has to be nameable at this scope even though P1.2 itself does not spawn anything.
 #[cfg(feature = "wifi")]
 use embassy_executor::Spawner;
+#[cfg(not(feature = "esp32s3"))]
 use ssd1306::{prelude::*, size::DisplaySize72x40, I2CDisplayInterface, Ssd1306};
 // `DisplayConfig::init` inits the PLAIN Ssd1306 (non-cast builds). Under `feature =
 // "cast"` the display is the `CastOled` tee, whose inherent `init()` forwards to the
 // inner panel (it imports `DisplayConfig` itself), so `main` no longer names the trait.
-#[cfg(not(feature = "cast"))]
+#[cfg(all(not(feature = "cast"), not(feature = "esp32s3")))]
 use ssd1306::mode::DisplayConfig;
 
 // App-plugin framework (issue #7): the `Oled` alias, `Ctx`, `Plugin` trait,
 // `AppKind`/`App` enum + centralized dispatch, and the `REGISTRY` that
 // auto-builds the menu. The dispatch keystone every screen plugs into.
 mod app;
+// #398: the S3 (ES3C28P) board truth + display backend. Chip-cfg'd MODULES, not board
+// features (#352's standing rule) — `esp32s3` is a CHIP feature, which is the allowed axis.
+#[cfg(feature = "esp32s3")]
+mod board_s3;
+#[cfg(feature = "esp32s3")]
+mod s3_oled;
 // #300 The Bard — on-device tiny-LLM storyteller. Radio-free (rides `hw`), so it can ship in
 // every tier; the 277 KB model is `.rodata` (XIP flash) and its scratch is `.bss`.
 #[cfg(feature = "bard")]
@@ -558,6 +563,7 @@ const FLUSH_DEFER_CAP_MS: u64 = 120_000;
 #[cfg(feature = "espnow")]
 const REBOOT_DEBOUNCE_MS: u64 = 10_000;
 
+#[cfg(not(feature = "esp32s3"))] // C3 OLED only; the S3's orientation lives in s3_oled
 /// OLED panel rotation. The pocket-watch case hangs from the USB-C end, so the
 /// display is physically upside-down and must be rotated 180° to read upright.
 ///
@@ -698,7 +704,8 @@ async fn run() -> ! {
     #[cfg(feature = "espnow")]
     ota::capture_boot_diag();
 
-    // --- I2C bus to the OLED -------------------------------------------------
+    // --- Panel bring-up (chip-cfg'd: I2C SSD1306 on the C3s; SPI ILI9341V on the S3) ---
+    #[cfg(not(feature = "esp32s3"))]
     let i2c = I2c::new(
         peripherals.I2C0,
         // esp-hal rc.0→1.1 semantic drift (#387): the I2C `Config` default lost its per-byte
@@ -719,10 +726,31 @@ async fn run() -> ! {
     .with_scl(peripherals.GPIO6);
 
     // --- SSD1306 display -----------------------------------------------------
-    let interface = I2CDisplayInterface::new(i2c);
-    // Rotated 180° (case hangs from the USB-C end) — see DISPLAY_ROTATION.
-    let raw_display = Ssd1306::new(interface, DisplaySize72x40, DISPLAY_ROTATION)
-        .into_buffered_graphics_mode();
+    #[cfg(not(feature = "esp32s3"))]
+    let raw_display = {
+        let interface = I2CDisplayInterface::new(i2c);
+        // Rotated 180° (case hangs from the USB-C end) — see DISPLAY_ROTATION.
+        Ssd1306::new(interface, DisplaySize72x40, DISPLAY_ROTATION).into_buffered_graphics_mode()
+    };
+    // #398 S3: ILI9341V over SPI2, every value from `board_s3` (lineage: burrito-fw on
+    // this glass → backend-staging's type proof → here). No reset pin — LCD_RST is bonded
+    // to CHIP_PU/EN on this board. The backlight goes ON only after the first paint, below.
+    #[cfg(feature = "esp32s3")]
+    let raw_display = {
+        let panel = s3_oled::build_panel(
+            peripherals.SPI2,
+            peripherals.GPIO12,
+            peripherals.GPIO11,
+            peripherals.GPIO10,
+            peripherals.GPIO46,
+            Delay::new(),
+        );
+        let mut d = s3_oled::S3Oled::new(panel);
+        // The 62% of the panel outside the 288×160 image: a deliberate black frame
+        // instead of power-on GRAM garbage. Once, at boot — never per frame.
+        d.paint_letterbox(embedded_graphics::pixelcolor::Rgb565::new(0, 0, 0)).ok();
+        d
+    };
     // #26 cast: wrap the panel in the DrawTarget tee so every draw is mirrored into a
     // shadow framebuffer for the WLED pixel-stream. Byte-identical `Oled` (plain
     // Ssd1306) in every non-cast build — see `app::Oled`.
@@ -737,6 +765,9 @@ async fn run() -> ! {
     // radio/mesh/MQTT stack runs unaffected. The only per-cycle cost is one fast I2C
     // NACK per flush attempt. (Cast still works headless — the tee mirrors the RAM
     // buffer, which draws fill regardless of the panel.)
+    // (#398 S3 note: S3Oled::init() cannot fail — SPI is write-only, absence is
+    // undetectable, and the board class is single-variant WITH a panel — so this branch
+    // is compile-time dead there and HEADLESS stays false, which is the truth.)
     if display.init().is_err() {
         // The NACK is also the board's identity statement (OLED board vs screenless
         // SuperMini) — record it for the HA discovery `model` (see `headless()`).
@@ -760,21 +791,42 @@ async fn run() -> ! {
     draw_splash(&mut display, my_noun, env!("BUILD_NUMBER"), v_noun);
     display.flush().ok();
 
+    // #398 S3: backlight ON only now — after the first full paint — so the panel appears
+    // already-lit instead of fading up from GRAM garbage (burrito-fw's proven ordering).
+    // GPIO45 is also the VDD_SPI strap: safe, R32 hard-wires the strap low at reset (see
+    // board_s3::PIN_LCD_BACKLIGHT). Held for 'main — dropping the Output releases the pin.
+    #[cfg(feature = "esp32s3")]
+    let _backlight = esp_hal::gpio::Output::new(
+        peripherals.GPIO45,
+        esp_hal::gpio::Level::High,
+        esp_hal::gpio::OutputConfig::default(),
+    );
+
     // #335 P1.3: still constructed on every tier, but only the no-radio tier still *uses* it —
     // `subtick` (below `run`) is what the two pacing sites call now. `Delay` is a unit struct, so
     // holding one the wifi build never reads costs nothing and keeps the two call sites identical.
     let delay = Delay::new();
 
-    // --- BOOT button on GPIO9 (debounced short/long) -------------------------
+    // --- BOOT button (debounced short/long); the pin is a chip fact ------------
+    #[cfg(not(feature = "esp32s3"))]
     let mut button = Button::new(peripherals.GPIO9);
+    // #398 S3: BOOT is GPIO0 on the ES3C28P — the board's ENTIRE hardware input budget
+    // (board_s3::PIN_BOOT_BUTTON). GPIO9 there is the battery ADC.
+    #[cfg(feature = "esp32s3")]
+    let mut button = Button::new(peripherals.GPIO0);
 
     // --- On-board sensors (battery ADC on GPIO4; die temp where the silicon has one) ---
     // `peripherals.TSENS` does not EXIST on a no-tsens chip (C5/S3), so the call site is
     // cfg'd on the capability, matching the two constructors in sensors.rs.
     #[cfg(feature = "has-tsens")]
     let mut sensors = sensors::Sensors::new(peripherals.TSENS, peripherals.ADC1, peripherals.GPIO4);
-    #[cfg(not(feature = "has-tsens"))]
+    #[cfg(all(not(feature = "has-tsens"), not(feature = "esp32s3")))]
     let mut sensors = sensors::Sensors::new(peripherals.ADC1, peripherals.GPIO4);
+    // #398 S3: the ES3C28P's battery ADC is GPIO9 (onboard 2:1 divider — matching
+    // sensors::BATT_DIVIDER exactly); GPIO4 on this chip is the codec's I2S MCLK.
+    // Floats and reads noise with no cell fitted — a board fact, not a bug.
+    #[cfg(all(not(feature = "has-tsens"), feature = "esp32s3"))]
+    let mut sensors = sensors::Sensors::new(peripherals.ADC1, peripherals.GPIO9);
     log::info!(
         "smol: sensors up — battery ADC on GPIO{} ({}:1 divider); die-temp: {}",
         sensors::BATT_ADC_GPIO,
@@ -792,12 +844,25 @@ async fn run() -> ! {
     #[cfg(feature = "io")]
     let mut io_pins = {
         use esp_hal::gpio::Flex;
+        #[cfg(not(feature = "esp32s3"))]
         let mut m = io::PinMap::new([
             Flex::new(peripherals.GPIO0),
             Flex::new(peripherals.GPIO1),
             Flex::new(peripherals.GPIO3),
             Flex::new(peripherals.GPIO7),
             Flex::new(peripherals.GPIO10),
+        ]);
+        // #398 S3: the C3's pool pins are all CLAIMED on the ES3C28P (0=BOOT, 1=amp
+        // enable ACTIVE-LOW, 7=I2S WS, 10=LCD chip-select — binding that one fights the
+        // display for its own bus). Pool from board_s3::FREE_GPIOS instead — which is
+        // INFERRED-not-schematic-verified (its own caveat): meter before wiring hardware.
+        #[cfg(feature = "esp32s3")]
+        let mut m = io::PinMap::new([
+            Flex::new(peripherals.GPIO21),
+            Flex::new(peripherals.GPIO38),
+            Flex::new(peripherals.GPIO39),
+            Flex::new(peripherals.GPIO40),
+            Flex::new(peripherals.GPIO41),
         ]);
         io::boot_selftest(&mut m);
         m
@@ -893,9 +958,20 @@ async fn run() -> ! {
 
     // Phase 3: blue status LED on GPIO8, created at logical-OFF (GPIO8 is a
     // strapping pin) then fast-blinked during the WiFi/NTP burst inside start().
-    #[cfg(feature = "espnow")]
+    #[cfg(all(feature = "espnow", not(feature = "esp32s3")))]
     let mut led = led::Led::new(esp_hal::gpio::Output::new(
         peripherals.GPIO8,
+        led::Led::off_level(),
+        esp_hal::gpio::OutputConfig::default(),
+    ));
+    // #398 S3: there is no simple status LED on the ES3C28P — GPIO42 is the WS2812's DIN,
+    // which ignores plain GPIO levels (it wants the RMT protocol), so this drive renders
+    // NOTHING visible. Wired anyway so the peer-state machine runs unchanged; the real
+    // WS2812/RMT driver (~50 lines, esp-hal-smartled is version-incompatible) is follow-up
+    // work on #398. GPIO8 on this chip is I2S playback data — not touched.
+    #[cfg(all(feature = "espnow", feature = "esp32s3"))]
+    let mut led = led::Led::new(esp_hal::gpio::Output::new(
+        peripherals.GPIO42,
         led::Led::off_level(),
         esp_hal::gpio::OutputConfig::default(),
     ));

--- a/rust/clock/src/main.rs
+++ b/rust/clock/src/main.rs
@@ -643,6 +643,18 @@ async fn run() -> ! {
 
     esp_println::logger::init_logger_from_env();
     log::info!("smol booting: unified firmware (menu: Clock / Snake / Bench)");
+    // #398 instrument sanity probe (stack-paint builds): expect ≈0 at boot on a chip
+    // where the instrument is valid. On the S3 it reads ~59.5 KB HERE — the proof the
+    // instrument is invalid there (boot-era machinery writes inside .stack; see the
+    // block note in src/bard/stack_paint.rs for the three measurements, including the
+    // disproven CPU-slice hypothesis). Kept as the cheapest validity check for any
+    // future chip: a big number on THIS line means don't trust any later one.
+    #[cfg(feature = "stack-paint")]
+    log::info!(
+        "smol #398 probe: high-water at boot (expect ~0) = {} of {} B",
+        bard::stack_paint::high_water(),
+        bard::stack_paint::region_bytes(),
+    );
 
     // Identity + provenance, both DERIVED (never on the wire): the node's FLEET
     // name from NODE_ID, and the firmware's FORGE version name seeded from the git

--- a/rust/clock/src/net/cast_oled.rs
+++ b/rust/clock/src/net/cast_oled.rs
@@ -25,19 +25,32 @@
 // `prelude::*` brings the traits (`DrawTarget`, `OriginDimensions`, `Dimensions`),
 // `Size`, `Point`, and `Pixel`; only `BinaryColor` is outside the prelude.
 use embedded_graphics::{pixelcolor::BinaryColor, prelude::*};
+#[cfg(not(feature = "esp32s3"))]
 use ssd1306::mode::{BufferedGraphicsMode, DisplayConfig};
+#[cfg(not(feature = "esp32s3"))]
 use ssd1306::prelude::I2CInterface;
+#[cfg(not(feature = "esp32s3"))]
 use ssd1306::size::DisplaySize72x40;
+#[cfg(not(feature = "esp32s3"))]
 use ssd1306::Ssd1306;
 
 use crate::net::cast::{Mirror, SRC_H, SRC_W};
 
 /// The concrete SSD1306 — byte-identical to the pre-cast `app::Oled` alias.
+#[cfg(not(feature = "esp32s3"))]
 type RawOled = Ssd1306<
     I2CInterface<esp_hal::i2c::master::I2c<'static, esp_hal::Blocking>>,
     DisplaySize72x40,
     BufferedGraphicsMode<DisplaySize72x40>,
 >;
+
+/// #398: on the S3 the tee wraps [`crate::s3_oled::S3Oled`] instead. Everything below is
+/// UNCHANGED for both chips — S3Oled deliberately exposes the same inherent surface
+/// (`init`/`flush`/`set_pixel`) with ONE error type across draws and flush, exactly so
+/// this file's single `Err` projection keeps holding (see the note on S3Oled's
+/// `DrawTarget::Error`).
+#[cfg(feature = "esp32s3")]
+type RawOled = crate::s3_oled::S3Oled;
 
 /// The display's `DrawTarget`/flush error type (`display_interface::DisplayError`),
 /// named through the trait so this file needs no direct `display_interface` dep.

--- a/rust/clock/src/s3_oled.rs
+++ b/rust/clock/src/s3_oled.rs
@@ -1,0 +1,378 @@
+//! [`S3Oled`] — the 4th `app::Oled` backend: smol's logical 72×40 `BinaryColor` screens
+//! on the ES3C28P's 320×240 ILI9341V, scaled 4× at flush time. (#398 phase 2, the
+//! display arm. Board truth: [`crate::board_s3`]. Compiled only under `esp32s3`.)
+//!
+//! # The stack, top to bottom
+//!
+//! ```text
+//! smol screens (menu.rs, clock.rs, snake.rs …)   171 BinaryColor sites, UNCHANGED
+//!         │  DrawTarget<Color = BinaryColor>  +  inherent init/flush
+//!         ▼
+//!   S3Oled                ← this file: a 360-BYTE logical 1-bit framebuffer + dirty rect
+//!         │  flush(): lazy 4× expansion INSIDE the fill_contiguous iterator
+//!         ▼
+//!   mipidsi Display<…, ILI9341Rgb565, NoResetPin>   ← ONE window per flush
+//!         │  SPI2 @ 40 MHz, Mode 0
+//!         ▼
+//!   the glass (320×240; the 288×160 image letterboxed by (16, 40))
+//! ```
+//!
+//! # ⚠️ Why ZERO-buffer, not the staged 92 KB `oled-scale` design
+//!
+//! The staging crate (`targets/s3-cyd/backend-staging`, type-proven) stores the scaled
+//! 288×160 RGB565 image — 92,160 B, const-initialised into `.bss`. That was correct as a
+//! type proof and is WRONG in this binary: on the fleet tier the S3's `.stack` leftover
+//! measured 121,036 B (BUDGET-PREP §6.1), and esp-hal's stack is the gap under RAM top —
+//! **a 92 KB static would shrink it to ~29 KB, far below any plausible radio floor**
+//! (the C6 boot-looped at 61 KB). That is the `stack is not headroom` failure shape,
+//! bought knowingly at design time instead of discovered as a WiFi-RX fault later.
+//!
+//! Storing the LOGICAL frame instead costs `72 × 40 / 8 = 360` bytes. The RGB565 pixels
+//! never exist in RAM: `flush` feeds mipidsi's `fill_contiguous` an iterator that maps
+//! each physical pixel back to its logical bit (`px/4`, `py/4`) on the fly. mipidsi sets
+//! the address window once and streams — wire traffic is byte-identical to the buffered
+//! design; the only added cost is a bit-lookup per pixel, and at 40 MHz the wire
+//! dominates the rasterise ~17× (explore-ember.md §2), so the lookup is noise.
+//!
+//! The SPI/panel construction is transcribed from `emberburrito/burrito-fw` `main.rs`
+//! (proven on glass on this board class) via the staging crate.
+
+use embedded_graphics::{
+    pixelcolor::{raw::RawU16, BinaryColor, Rgb565},
+    prelude::*,
+    primitives::Rectangle,
+};
+use embedded_hal_bus::spi::ExclusiveDevice;
+use esp_hal::{
+    delay::Delay,
+    gpio::{Level, Output, OutputConfig},
+    spi::{
+        master::{Config as SpiConfig, Spi},
+        Mode,
+    },
+    time::Rate,
+};
+use mipidsi::{
+    interface::SpiInterface,
+    models::ILI9341Rgb565,
+    options::{ColorInversion, ColorOrder, Orientation, Rotation},
+    Builder, NoResetPin,
+};
+
+use crate::board_s3 as board;
+
+// ===========================================================================
+// Geometry
+// ===========================================================================
+
+/// smol's logical panel width — every screen in the registry is written for this.
+pub const LOGICAL_W: u32 = 72;
+/// smol's logical panel height.
+pub const LOGICAL_H: u32 = 40;
+
+/// Integer scale factor. 4× is the largest that fits: `72×4 = 288 ≤ 320` and
+/// `40×4 = 160 ≤ 240`; 5× would be 360 wide.
+pub const SCALE: u32 = 4;
+
+/// Scaled image width — 288 px.
+pub const IMAGE_W: u32 = LOGICAL_W * SCALE;
+/// Scaled image height — 160 px.
+pub const IMAGE_H: u32 = LOGICAL_H * SCALE;
+
+/// Horizontal letterbox: `(320 − 288) / 2 = 16` px each side. The offset lives HERE —
+/// the logical layer knows nothing of the panel, which is what keeps the scaling
+/// invisible above the `app::Oled` seam.
+pub const LETTERBOX_X: u32 = (board::LCD_WIDTH as u32 - IMAGE_W) / 2;
+/// Vertical letterbox: `(240 − 160) / 2 = 40` px top and bottom.
+pub const LETTERBOX_Y: u32 = (board::LCD_HEIGHT as u32 - IMAGE_H) / 2;
+
+const _: () = {
+    assert!(IMAGE_W <= board::LCD_WIDTH as u32, "scaled image wider than the panel");
+    assert!(IMAGE_H <= board::LCD_HEIGHT as u32, "scaled image taller than the panel");
+};
+
+/// Foreground (lit) colour — white.
+pub const FG: u16 = rgb565(31, 63, 31);
+/// Background (unlit) colour — black.
+pub const BG: u16 = rgb565(0, 0, 0);
+
+/// Pack 5-6-5 channel values into a raw RGB565 word, in a `const` context.
+///
+/// Exists because `embedded-graphics-core` 0.4's `RgbColor` channel accessors are not
+/// `const` (const traits aren't stable), so a const initialiser cannot decompose an
+/// `Rgb565` — the intake note from `oled-scale`, carried here.
+pub const fn rgb565(r: u16, g: u16, b: u16) -> u16 {
+    ((r & 0x1f) << 11) | ((g & 0x3f) << 5) | (b & 0x1f)
+}
+
+// ===========================================================================
+// Panel type + construction — lifted from backend-staging (type-proven), which
+// transcribed it from burrito-fw (glass-proven)
+// ===========================================================================
+
+/// The concrete panel type, named once.
+pub type Panel = mipidsi::Display<
+    SpiInterface<
+        'static,
+        ExclusiveDevice<Spi<'static, esp_hal::Blocking>, Output<'static>, Delay>,
+        Output<'static>,
+    >,
+    ILI9341Rgb565,
+    NoResetPin,
+>;
+
+/// The panel's `DrawTarget` error, **projected rather than hand-spelled**: the true type
+/// is three layers from three crates (`SpiError<DeviceError<esp_hal::spi::Error, _>, _>`)
+/// and any literal spelling silently encodes today's bus-sharing choice. Found by
+/// compiling, not by reading docs (backend-staging's headline finding).
+pub type PanelError = <Panel as DrawTarget>::Error;
+
+/// Landscape orientation — mipidsi's spelling of MADCTL `0x28` (`MV | BGR`),
+/// human-verified on this unit 2026-08-25 ("readable landscape").
+/// ⛔ Not `0x68`: that is `0x28` plus MX, a horizontal mirror — see
+/// [`board::MADCTL_LANDSCAPE`] for the story it already shipped once.
+pub const ORIENTATION: Orientation = Orientation::new().rotate(Rotation::Deg90).flip_vertical();
+
+/// mipidsi's command/pixel batching scratch. `'static` because [`Panel`] is.
+static mut DISPLAY_BUF: [u8; 4096] = [0; 4096];
+
+/// Build the ILI9341V panel on SPI2 from [`crate::board_s3`]'s constants.
+///
+/// Concrete peripheral types on purpose — the signature IS the type proof.
+///
+/// ⚠️ No `.reset_pin()`: `LCD_RST` is bonded to `CHIP_PU`/`EN` on this board
+/// ([`board::HAS_LCD_RESET_PIN`] is `false`); mipidsi's software reset in `init()` does
+/// the work. Handing it an unrelated GPIO "because the type wants one" yields a panel
+/// that is never reset — on glass, indistinguishable from a wiring fault.
+///
+/// ⚠️ The backlight ([`board::PIN_LCD_BACKLIGHT`]) is NOT touched here — the caller turns
+/// it on **after** the first full paint, so the panel appears already-lit instead of
+/// fading up out of vendor GRAM garbage.
+///
+/// # Safety contract
+/// Takes `&'static mut DISPLAY_BUF` internally — call **once**, at boot, before any
+/// concurrency (the same shape burrito-fw uses).
+pub fn build_panel(
+    spi2: esp_hal::peripherals::SPI2<'static>,
+    sck: esp_hal::peripherals::GPIO12<'static>,
+    mosi: esp_hal::peripherals::GPIO11<'static>,
+    cs: esp_hal::peripherals::GPIO10<'static>,
+    dc: esp_hal::peripherals::GPIO46<'static>,
+    mut delay: Delay,
+) -> Panel {
+    let spi = Spi::new(
+        spi2,
+        SpiConfig::default()
+            .with_frequency(Rate::from_hz(board::SPI_DISPLAY_HZ))
+            .with_mode(Mode::_0),
+    )
+    .expect("spi2 config")
+    .with_sck(sck)
+    .with_mosi(mosi);
+
+    let cs = Output::new(cs, Level::High, OutputConfig::default());
+    let dc = Output::new(dc, Level::Low, OutputConfig::default());
+
+    let spi_dev = ExclusiveDevice::new(spi, cs, delay).expect("spi device");
+
+    // SAFETY: called once at boot, before concurrency; DISPLAY_BUF is touched nowhere else.
+    let di = SpiInterface::new(spi_dev, dc, unsafe {
+        &mut *core::ptr::addr_of_mut!(DISPLAY_BUF)
+    });
+
+    Builder::new(ILI9341Rgb565, di)
+        .display_size(board::PANEL_NATIVE_W, board::PANEL_NATIVE_H)
+        // No .reset_pin() — RST is bonded to EN on this board. See the fn doc.
+        .orientation(ORIENTATION)
+        .color_order(ColorOrder::Bgr)
+        .invert_colors(ColorInversion::Inverted)
+        .init(&mut delay)
+        .expect("ili9341 init")
+}
+
+// ===========================================================================
+// S3Oled — the app::Oled contract over a 360-byte logical framebuffer
+// ===========================================================================
+
+const FB_BYTES: usize = (LOGICAL_W as usize * LOGICAL_H as usize) / 8; // 360
+
+/// The 4th `app::Oled` backend. Satisfies exactly the surface `app.rs` requires
+/// (`DrawTarget<Color = BinaryColor>` + `OriginDimensions` + inherent `init()`/`flush()`,
+/// with `clear()` arriving as `DrawTarget`'s provided method through `fill_solid`).
+pub struct S3Oled {
+    panel: Panel,
+    /// Logical 72×40, one bit per pixel, row-major, bit `x % 8` of byte `(y*72 + x) / 8`.
+    fb: [u8; FB_BYTES],
+    /// Dirty logical rect, inclusive: (x0, y0, x1, y1). `None` = clean.
+    dirty: Option<(u32, u32, u32, u32)>,
+}
+
+impl S3Oled {
+    /// Wrap a built panel. Starts **fully dirty** on purpose: a first flush must push the
+    /// whole (blank) image, or the panel shows power-on GRAM garbage inside the letterbox
+    /// (the lesson `oled-scale`'s test suite pinned).
+    pub fn new(panel: Panel) -> Self {
+        Self {
+            panel,
+            fb: [0; FB_BYTES],
+            dirty: Some((0, 0, LOGICAL_W - 1, LOGICAL_H - 1)),
+        }
+    }
+
+    /// Present for `main`'s uniform boot flow; the panel was initialised in
+    /// [`build_panel`]. Mirrors `CanvasOled::init`'s harmless-no-op shape. Typed
+    /// `PanelError` (though it cannot fail) so the ONE error type serves draws, init
+    /// and flush alike — which is what lets `cast_oled`'s tee keep its single `Err`
+    /// alias and byte-identical body across all backends.
+    pub fn init(&mut self) -> Result<(), PanelError> {
+        Ok(())
+    }
+
+    /// Set one logical pixel — the inherent `Ssd1306::set_pixel` surface the cast tee
+    /// (`net/cast_oled.rs`) writes through. Out-of-range is ignored, as there.
+    pub fn set_pixel(&mut self, x: u32, y: u32, on: bool) {
+        if x < LOGICAL_W && y < LOGICAL_H {
+            self.set_bit(x, y, on);
+        }
+    }
+
+    #[inline]
+    fn bit(&self, x: u32, y: u32) -> bool {
+        let idx = (y * LOGICAL_W + x) as usize;
+        (self.fb[idx / 8] >> (idx % 8)) & 1 != 0
+    }
+
+    #[inline]
+    fn set_bit(&mut self, x: u32, y: u32, on: bool) {
+        let idx = (y * LOGICAL_W + x) as usize;
+        let (byte, mask) = (idx / 8, 1u8 << (idx % 8));
+        let old = self.fb[byte];
+        let new = if on { old | mask } else { old & !mask };
+        if new != old {
+            self.fb[byte] = new;
+            self.widen(x, y);
+        }
+    }
+
+    #[inline]
+    fn widen(&mut self, x: u32, y: u32) {
+        self.dirty = Some(match self.dirty {
+            None => (x, y, x, y),
+            Some((x0, y0, x1, y1)) => (x0.min(x), y0.min(y), x1.max(x), y1.max(y)),
+        });
+    }
+
+    /// Push everything drawn since the last flush, as **one** windowed write.
+    ///
+    /// The dirty LOGICAL rect maps to a physical rect at 4×, offset by the letterbox;
+    /// the RGB565 pixels are produced lazily by the iterator (`px/4, py/4` → bit → FG/BG)
+    /// — they never exist in RAM. One `fill_contiguous` = one address window + one
+    /// stream, mipidsi's fast path (per-pixel `draw_iter` is the measured anti-pattern).
+    /// No traffic when clean.
+    pub fn flush(&mut self) -> Result<(), PanelError> {
+        let Some((x0, y0, x1, y1)) = self.dirty.take() else {
+            return Ok(());
+        };
+
+        let (px0, py0) = (x0 * SCALE, y0 * SCALE);
+        let (pw, ph) = ((x1 - x0 + 1) * SCALE, (y1 - y0 + 1) * SCALE);
+
+        let area = Rectangle::new(
+            Point::new((px0 + LETTERBOX_X) as i32, (py0 + LETTERBOX_Y) as i32),
+            Size::new(pw, ph),
+        );
+
+        // Row-major over the physical rect; each pixel reads its logical bit on the fly.
+        let fb = &self.fb;
+        let colors = (py0..py0 + ph).flat_map(move |py| {
+            let ly = py / SCALE;
+            (px0..px0 + pw).map(move |px| {
+                let lx = px / SCALE;
+                let idx = (ly * LOGICAL_W + lx) as usize;
+                let on = (fb[idx / 8] >> (idx % 8)) & 1 != 0;
+                Rgb565::from(RawU16::new(if on { FG } else { BG }))
+            })
+        });
+
+        self.panel.fill_contiguous(&area, colors)
+    }
+
+    /// Paint the letterbox margin once at boot — a deliberate frame instead of power-on
+    /// GRAM garbage. Separate from [`flush`](Self::flush): it never needs to run again,
+    /// and folding it in would repaint 62 % of the panel every frame.
+    pub fn paint_letterbox(&mut self, color: Rgb565) -> Result<(), PanelError> {
+        use embedded_graphics::primitives::PrimitiveStyle;
+        Rectangle::new(
+            Point::zero(),
+            Size::new(board::LCD_WIDTH as u32, board::LCD_HEIGHT as u32),
+        )
+        .into_styled(PrimitiveStyle::with_fill(color))
+        .draw(&mut self.panel)
+    }
+}
+
+impl OriginDimensions for S3Oled {
+    /// **Logical 72×40** — smol's screens see the panel they were written for; the
+    /// scaling stays invisible above this seam.
+    fn size(&self) -> Size {
+        Size::new(LOGICAL_W, LOGICAL_H)
+    }
+}
+
+impl DrawTarget for S3Oled {
+    type Color = BinaryColor;
+    /// `PanelError`, not `Infallible`, though buffer writes cannot fail: on the other
+    /// backends the DrawTarget error and the flush error are the SAME type, and the
+    /// cast tee's single `Err` projection depends on that. Draws always return `Ok`.
+    type Error = PanelError;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for Pixel(p, c) in pixels {
+            if (0..LOGICAL_W as i32).contains(&p.x) && (0..LOGICAL_H as i32).contains(&p.y) {
+                self.set_bit(p.x as u32, p.y as u32, c.is_on());
+            }
+        }
+        Ok(())
+    }
+
+    /// Fast path for solid fills (`DrawTarget::clear` routes here): byte-agnostic bit
+    /// loop over ≤ 2,880 logical pixels — trivially cheap at this size, and one dirty
+    /// widening per call instead of per pixel.
+    fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
+        let Some(clipped) = area.intersection(&self.bounding_box()).size_nonzero() else {
+            return Ok(());
+        };
+        let (x0, y0) = (clipped.top_left.x as u32, clipped.top_left.y as u32);
+        let (x1, y1) = (x0 + clipped.size.width - 1, y0 + clipped.size.height - 1);
+        for y in y0..=y1 {
+            for x in x0..=x1 {
+                let idx = (y * LOGICAL_W + x) as usize;
+                let (byte, mask) = (idx / 8, 1u8 << (idx % 8));
+                if color.is_on() {
+                    self.fb[byte] |= mask;
+                } else {
+                    self.fb[byte] &= !mask;
+                }
+            }
+        }
+        // One widening for the whole rect — set_bit's change-detection is skipped here,
+        // so a redundant solid fill re-dirties; correct (a flush pushes it) and simple.
+        self.widen(x0, y0);
+        self.widen(x1, y1);
+        Ok(())
+    }
+}
+
+/// `Rectangle::intersection` returns a possibly-zero-sized rect; this names the
+/// empty-check so `fill_solid` reads as the two cases it has.
+trait SizeNonZero {
+    fn size_nonzero(self) -> Option<Rectangle>;
+}
+impl SizeNonZero for Rectangle {
+    fn size_nonzero(self) -> Option<Rectangle> {
+        (self.size.width > 0 && self.size.height > 0).then_some(self)
+    }
+}

--- a/rust/clock/src/sensors.rs
+++ b/rust/clock/src/sensors.rs
@@ -25,8 +25,15 @@
 #[cfg(feature = "hw")]
 use esp_hal::{
     analog::adc::{Adc, AdcConfig, AdcPin, Attenuation},
-    peripherals::{ADC1, GPIO4},
+    peripherals::ADC1,
 };
+// The battery ADC pin is a CHIP fact: GPIO4 on the C3 boards; GPIO9 on the S3/ES3C28P
+// (onboard 2:1 divider — GPIO4 there is the codec's I2S MCLK). One alias, so the struct
+// and both constructors stay chip-agnostic. See BATT_ADC_GPIO.
+#[cfg(all(feature = "hw", not(feature = "esp32s3")))]
+use esp_hal::peripherals::GPIO4 as BattGpio;
+#[cfg(all(feature = "hw", feature = "esp32s3"))]
+use esp_hal::peripherals::GPIO9 as BattGpio;
 // `has-tsens` is a MEASURED capability, not an assumption: C3 ✓ C6 ✓ C5 ✗ S3 ✗ (the biggest
 // chip lacks the sensor the smallest one has — see the table at `has-tsens` in Cargo.toml).
 // On a chip without it there is no die temperature, and `Reading.chip_c` says so with `None`
@@ -48,7 +55,12 @@ use esp_hal::{
 ///
 /// This is documentation only; the pin is bound as `peripherals.GPIO4` in
 /// [`Sensors::new`]. Keep this const and that binding in sync.
+#[cfg(not(feature = "esp32s3"))]
 pub const BATT_ADC_GPIO: u8 = 4;
+/// #398 S3: the ES3C28P's BAT_ADC net is GPIO9, through the board's own 2:1 divider
+/// (board_s3::PIN_BAT_ADC — which matches [`BATT_DIVIDER`] exactly). Floats with no cell.
+#[cfg(feature = "esp32s3")]
+pub const BATT_ADC_GPIO: u8 = 9;
 
 /// External resistor-divider ratio on [`BATT_ADC_GPIO`]: `Vbatt / Vpin`.
 ///
@@ -93,7 +105,7 @@ pub struct Sensors<'d> {
     #[cfg(feature = "has-tsens")]
     tsens: TemperatureSensor<'d>,
     adc: Adc<'d, ADC1<'d>, esp_hal::Blocking>,
-    batt_pin: AdcPin<GPIO4<'d>, ADC1<'d>>,
+    batt_pin: AdcPin<BattGpio<'d>, ADC1<'d>>,
 }
 
 /// #152 host-emulator stub: a `Sensors` with the SAME `read()` surface but no HAL — it
@@ -127,7 +139,7 @@ impl<'d> Sensors<'d> {
     /// (On a no-tsens chip there IS no `TSENS` singleton to pass — hence the
     /// cfg'd second constructor below, and a cfg'd call site in `main`.)
     #[cfg(feature = "has-tsens")]
-    pub fn new(tsens: TSENS<'d>, adc1: ADC1<'d>, gpio4: GPIO4<'d>) -> Self {
+    pub fn new(tsens: TSENS<'d>, adc1: ADC1<'d>, gpio4: BattGpio<'d>) -> Self {
         // Temperature sensor: default config (XTAL clock). `new` powers it up;
         // caller should allow a few hundred µs before the first read to settle.
         let tsens = TemperatureSensor::new(tsens, TsensConfig::default())
@@ -151,7 +163,7 @@ impl<'d> Sensors<'d> {
     /// (`has-tsens` absent: C5, S3). Same struct, same `read()` surface; the
     /// temperature is simply never there to read.
     #[cfg(not(feature = "has-tsens"))]
-    pub fn new(adc1: ADC1<'d>, gpio4: GPIO4<'d>) -> Self {
+    pub fn new(adc1: ADC1<'d>, gpio4: BattGpio<'d>) -> Self {
         let mut adc_config = AdcConfig::new();
         let batt_pin = adc_config.enable_pin(gpio4, Attenuation::_11dB);
         let adc = Adc::new(adc1, adc_config);

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -367,6 +367,11 @@ provisioned per tree, so its contents are not a property of the commit at all.""
 # Regenerate with: tools/check_exclusions.py claims --toml
 [tier_exclusive]
 "src/textclip.rs" = "wifi"
+# #398: chip-exclusive (esp32s3). The gate's contract is BOTH sections: this DECLARATION
+# (so removing the cfg-gate later cannot go unnoticed) plus the [unobservable] excuse
+# below (CI cannot build xtensa to observe them). Learned across three CI rounds.
+"src/board_s3.rs" = "esp32s3"
+"src/s3_oled.rs" = "esp32s3"
 "src/net/otagate.rs" = "espnow"
 "src/bard/delivery.rs" = "bard"
 "src/bard/mod.rs" = "bard"

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -330,6 +330,16 @@ hal-cpu-reset-unindexed  = "esp-hal API-fact marker (hal-* namespace) selected b
 # designed sequence working. Removed together with the paired `#[allow(dead_code)]` in net.rs; the
 # two-sided marker is why neither could be dropped quietly.)
 
+# #398: the FIRST CI-unbuildable exclusives — chip-gated on esp32s3, whose tiers cannot
+# build on CI runners (xtensa toolchain absent; see [chip.esp32s3] blocked_on). Observed
+# LOCALLY instead: tools/check_chips.sh compiles both on the pinned espup 1.95.0.0
+# toolchain (familiar/katana), and both have run on real hardware (unit
+# 14:C1:9F:D1:C8:10 — the board draws through s3_oled). When #413 puts the xtensa
+# toolchain in CI (per-target releases), these two graduate back to observed and the
+# gate will FAIL on these entries — the designed stale-claim sequence; delete them then.
+"src/board_s3.rs" = "esp32s3 tiers cannot build on CI (no espup); observed locally via check_chips.sh + on hardware — graduates when #413 lands xtensa in CI"
+"src/s3_oled.rs" = "esp32s3 tiers cannot build on CI (no espup); observed locally via check_chips.sh + on hardware — graduates when #413 lands xtensa in CI"
+
 "src/secrets.rs" = """\
 consts only (WIFI_NETWORK / MQTT_* / WLED_CAST_*) — 0 fn / 0 impl in both secrets.rs and \
 secrets.rs.example, so it emits .rodata and no line rows. It is also git-ignored and \
@@ -357,10 +367,6 @@ provisioned per tree, so its contents are not a property of the commit at all.""
 # Regenerate with: tools/check_exclusions.py claims --toml
 [tier_exclusive]
 "src/textclip.rs" = "wifi"
-# #398: the S3's board truth + display backend — chip-exclusive, not tier-exclusive in the
-# usual sense; the gate keys on the cfg feature either way, and `esp32s3` is the honest key.
-"src/board_s3.rs" = "esp32s3"
-"src/s3_oled.rs" = "esp32s3"
 "src/net/otagate.rs" = "espnow"
 "src/bard/delivery.rs" = "bard"
 "src/bard/mod.rs" = "bard"

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -357,6 +357,10 @@ provisioned per tree, so its contents are not a property of the commit at all.""
 # Regenerate with: tools/check_exclusions.py claims --toml
 [tier_exclusive]
 "src/textclip.rs" = "wifi"
+# #398: the S3's board truth + display backend — chip-exclusive, not tier-exclusive in the
+# usual sense; the gate keys on the cfg feature either way, and `esp32s3` is the honest key.
+"src/board_s3.rs" = "esp32s3"
+"src/s3_oled.rs" = "esp32s3"
 "src/net/otagate.rs" = "espnow"
 "src/bard/delivery.rs" = "bard"
 "src/bard/mod.rs" = "bard"

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -123,7 +123,7 @@ opt_level  = "2"
 # channel (Xtensa Rust 1.95.0.0, pinned byte-identical on katana and familiar) plus
 # `. ~/export-esp.sh` and a per-invocation `CARGO_UNSTABLE_BUILD_STD=core,alloc`. GitHub runners
 # have none of it, and a permanently-red arm teaches everyone to ignore the gate (#343).
-blocked_on = "xtensa toolchain (espup `esp` channel + export-esp.sh) is not on CI runners; the manifest and target pins are DONE (#347 Part 2)"
+blocked_on = "ONLY the CI-runner toolchain remains (espup `esp` channel + export-esp.sh are not on GitHub runners): the manifest/target pins (#347 Part 2), the linkall+opt_level workaround (#408/#409), the display arm, AND the measured ChipBudget row (budget.rs ESP32S3_CYD, 2026-08-25) are all DONE — the chip builds, boots, meshes and draws on real hardware; only CI cannot compile it yet"
 # When the toolchain question is answered, flipping `builds` to true is a ONE-WORD data change and
 # the matrix, the CI jobs and the tier coverage all follow. That is the entire point of this file.
 # `ships` stays false after that: OpenWrt's DEFAULT := n. Buildable is not shipped.


### PR DESCRIPTION
**Proven on glass**: JP eyeballed the board running this branch's fleet-tier image — smol's screens, live on the S3's 320×240 panel, 4× scaled and letterboxed. Same boot joined the ch6 mesh as leaf 162 (authenticated #190 frames, real GROUP_KEY) and landed in the crown's roster alongside the C6 (236) and C5 (176): **four silicon families on one roster line.**

## What it is
The 4th `app::Oled` backend — zero draw sites change (the #152 gate, third application). The S3 stores the logical 72×40 frame as a **360-byte bitmap** and expands 4× lazily inside one `fill_contiguous` per flush. Deliberately NOT the staged 92 KB buffer: that static would shrink the fleet tier's stack gap to ~29 KB — below the floor that boot-looped the C6 (`stack is not headroom`, bought at design time).

Everything else is pins-are-chip-facts: BOOT=GPIO0 (GPIO9 is the battery ADC there, divider matching `sensors::BATT_DIVIDER`), the io pool moves off the C3's pins (which on this board are BOOT/amp-enable/I2S-WS/**LCD chip-select**), the LED state machine runs against the WS2812 pin knowing it renders nothing (RMT follow-up), `board_s3.rs` = the staging constants lifted verbatim as the single source. The cast tee keeps a byte-identical body (S3Oled exposes the same inherent surface with ONE error type — the tee's `Err` projection depends on it).

## Evidence
```
check_chips.sh          → 4 as declared · 0 wrong  (all four chips, this branch)
C3 fleet clippy -D      → 0   (byte-safety: additions are cfg(esp32s3)-scoped)
S3 fleet image          → LINKS 1,436,928 B (opt=2 fat), BOOTS, no panic on serial
On the mesh             → crown roster: 162,-58,0,6,x · smol/162/# publishing
On the glass            → human-verified by JP ("looks good")
```

Known follow-up (filed on #398, not blocking): the cast mirror publishes blank frames on the S3 while the glass shows content (C3 controls: 583–619 lit px) — an S3-specific tee/mirror path bug. Also follow-ups: WS2812 status light via RMT; flashing with `partitions-ota-s3.csv` + OTA proof; the measured ChipBudget soak now unblocked by this running image.

Routed through the smol session per lanes. Refs #398 #331 #347 · rides #405/#408/#409

🤖 Generated with [Claude Code](https://claude.com/claude-code)