### PR TITLE
chore(tools): keep temp artifacts out of the /tmp tmpfs (project tmp/ instead)

### DIFF
--- a/.github/workflows/fw-gate.yml
+++ b/.github/workflows/fw-gate.yml
@@ -49,6 +49,13 @@ env:
   CARGO_TERM_COLOR: always
   # Keep a runner's memory in bounds: these are LTO release builds of an embedded crate.
   SMOL_GATE_JOBS: 2
+  # Where gate.sh leaves the stack verdict, declared ONCE so the arm that WRITES it and the summary
+  # step that READS it cannot drift. They were two independent `/tmp/gate-stack-report` literals in
+  # two files until 2026-08-25 — and when `tools/gate.sh`'s default moved out of `/tmp` (JP's tmpfs
+  # directive: katana's /tmp is a 16 GB RAM-backed tmpfs), a workflow still reading the old literal
+  # would have reported "stack number unavailable" on every run while every gate stayed green. Set
+  # explicitly rather than relying on the script's default, so this file states what it reads.
+  SMOL_GATE_STACK_REPORT: ${{ github.workspace }}/tmp/gate-stack-report
 
 jobs:
   # Split so a Rust-only breakage is distinguishable at a glance from a host-logic regression,
@@ -95,8 +102,8 @@ jobs:
         run: |
           {
             echo "### Canonical image stack"
-            if [ -s /tmp/gate-stack-report ]; then
-              echo '```'; cat /tmp/gate-stack-report; echo '```'
+            if [ -s "$SMOL_GATE_STACK_REPORT" ]; then
+              echo '```'; cat "$SMOL_GATE_STACK_REPORT"; echo '```'
             else
               echo "_stack number unavailable — the canonical build did not reach the check._"
             fi

--- a/tmp/.gitignore
+++ b/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tools/check_chips.sh
+++ b/tools/check_chips.sh
@@ -40,6 +40,14 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CRATE="$ROOT/rust/clock"
 MATRIX="$ROOT/tools/build_matrix.py"
 
+# Per-chip logs go in the REPO, never /tmp (JP directive 2026-08-25 — katana's /tmp is a 16 GB
+# tmpfs, i.e. RAM). Git-ignored via tmp/.gitignore. Absolute, because this script `cd`s to $CRATE.
+CHIPS_TMP="$ROOT/tmp"
+mkdir -p "$CHIPS_TMP" || { echo "check_chips: cannot create $CHIPS_TMP" >&2; exit 2; }
+# The four cargo invocations below inherit this. On familiar, the documented usage above overrides
+# both this and CARGO_TARGET_DIR to /var/tmp/ftarget/* — that host's /tmp is a 512 MB tmpfs.
+export TMPDIR="$CHIPS_TMP"
+
 want=("$@")
 pass=0 fail=0 skip=0 verified=0
 
@@ -85,7 +93,7 @@ while IFS=$'\t' read -r chip target expect toolchain build_std opt_level feature
     args=(check --no-default-features --features "${chip},${features}" --target "$target")
     [ -n "$toolchain" ] && args=("+${toolchain}" "${args[@]}")
 
-    log="/tmp/check-chips-${chip}.log"
+    log="$CHIPS_TMP/check-chips-${chip}.log"
     printf '  .... %-9s %s (expect %s)\033[2K\r' "$chip" "$target" "$expect"
 
     # `SMOL_CHIP` is always passed: riscv32imac cannot tell a C5 from a C6, so build.rs maps that

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -93,6 +93,21 @@ cd "$(dirname "$0")/.."
 ROOT="$PWD"
 CLOCK="rust/clock"
 
+# ── Temp artifacts live in the REPO, not in /tmp (JP directive 2026-08-25) ─────────────────────
+# katana's `/tmp` is a 16 GB **tmpfs** — RAM+swap, not disk. This gate alone writes a log per tier
+# per arm (checks, clippy, exclusions, host bins, test suites), and on 2026-08-25 accumulated temp
+# artifacts filled 13 GB of that tmpfs and starved the machine. Logs are small; the rule is not
+# about this gate's own footprint but about having ONE place per project where temp output goes, so
+# nobody has to audit which script was the greedy one.
+#
+# `$ROOT/tmp` is git-ignored (`tmp/.gitignore` = `*` + `!.gitignore`) and is created on first need.
+# Overridable so CI (whose `/tmp` is ordinary disk) or a caller with a scratch volume can redirect.
+GATE_TMP="${SMOL_GATE_TMP:-$ROOT/tmp}"
+mkdir -p "$GATE_TMP" || { echo "gate: cannot create $GATE_TMP" >&2; exit 2; }
+# `mktemp` and every child process honour TMPDIR, so this covers the tools this script CALLS as
+# well as its own redirects — which is the point: the callees are where the big artifacts appear.
+export TMPDIR="$GATE_TMP"
+
 # #363 — the root the COMPILING arms build from. `$ROOT` (i.e. your checkout) unless the pristine
 # mirror below is engaged, in which case the tiers are built from a copy whose git-ignored
 # provisioning matches what CI generates. Source-READING arms (shed order, DIAG budget, byte-free
@@ -118,7 +133,7 @@ JOBS=()
 [ -n "${SMOL_GATE_JOBS:-}" ] && JOBS=(-j "$SMOL_GATE_JOBS")
 
 # Where the stack verdict is left for a caller (CI lifts it into the PR job summary).
-STACK_REPORT="${SMOL_GATE_STACK_REPORT:-/tmp/gate-stack-report}"
+STACK_REPORT="${SMOL_GATE_STACK_REPORT:-$GATE_TMP/gate-stack-report}"
 rm -f "$STACK_REPORT"
 
 step() { printf '\n\033[1m── %s\033[0m\n' "$1"; }
@@ -339,10 +354,10 @@ if [ "$run_fw" = 1 ]; then
       printf '   \033[33mSKIP\033[0m %-16s (feature not in Cargo.toml on this branch)\n' "$name"; continue
     fi
     args=(--release "${JOBS[@]}"); [ -n "$feats" ] && args+=(--features "$feats")
-    if (cd "$BUILD_ROOT/$CLOCK" && cargo check "${args[@]}") >/tmp/gate-$name.log 2>&1; then
+    if (cd "$BUILD_ROOT/$CLOCK" && cargo check "${args[@]}") >"$GATE_TMP/gate-$name.log" 2>&1; then
       ok "check $name"
     else
-      bad "check $name"; tail -15 /tmp/gate-$name.log | sed 's/^/        /'
+      bad "check $name"; tail -15 "$GATE_TMP/gate-$name.log" | sed 's/^/        /'
     fi
   done < <("$ROOT/tools/build_matrix.py" emit --for check)
 
@@ -355,18 +370,19 @@ if [ "$run_fw" = 1 ]; then
   # true instead of "every tier someone remembered to add here". The fleet tier is named
   # `fleet` in both loops now — it was `canonical` here and `fleet` above, which is why the
   # two lists could disagree without looking like they did. Log path moves with the name:
-  # /tmp/gate-clippy-fleet.log, was /tmp/gate-clippy-canonical.log.
+  # $GATE_TMP/gate-clippy-fleet.log, was $GATE_TMP/gate-clippy-canonical.log (and both were
+  # under /tmp until the 2026-08-25 tmpfs directive — see the GATE_TMP block at the top).
   step "cargo clippy -D warnings — every tier"
   while IFS=$'\t' read -r name feats; do
     if [ -n "$feats" ] && ! grep -qE "^${feats%%,*} *=" "$BUILD_ROOT/$CLOCK/Cargo.toml"; then
       printf '   \033[33mSKIP\033[0m %-16s (feature not in Cargo.toml on this branch)\n' "$name"; continue
     fi
     args=(--release "${JOBS[@]}"); [ -n "$feats" ] && args+=(--features "$feats")
-    if (cd "$BUILD_ROOT/$CLOCK" && cargo clippy "${args[@]}" -- -D warnings) >/tmp/gate-clippy-$name.log 2>&1; then
+    if (cd "$BUILD_ROOT/$CLOCK" && cargo clippy "${args[@]}" -- -D warnings) >"$GATE_TMP/gate-clippy-$name.log" 2>&1; then
       ok "clippy $name"
     else
       bad "clippy $name"
-      grep -E "^(error|warning)" /tmp/gate-clippy-$name.log | grep -v "could not compile" \
+      grep -E "^(error|warning)" "$GATE_TMP/gate-clippy-$name.log" | grep -v "could not compile" \
         | sort -u | sed 's/^/        /' | head -12
     fi
   done < <("$ROOT/tools/build_matrix.py" emit --for clippy)
@@ -403,7 +419,7 @@ if [ "$run_excl" = 1 ]; then
   # tree (seen 2026-08-02: lucid chased a spurious comp_dir failure to exactly this). Per-
   # worktree dirs keep rebuilds warm per checkout, kill cross-worktree pollution AND remove
   # cross-worktree lock contention; the flock below still serializes same-worktree runs.
-  EXCL="${SMOL_GATE_EXCL_DIR:-/tmp/gate-exclusions-$(printf %s "$ROOT" | cksum | cut -d' ' -f1)}"
+  EXCL="${SMOL_GATE_EXCL_DIR:-$GATE_TMP/gate-exclusions-$(printf %s "$ROOT" | cksum | cut -d' ' -f1)}"
   mkdir -p "$EXCL/elf"
   # Concurrent gates sharing the default $EXCL wipe each other's build tree mid-compile and
   # report failures that have nothing to do with the code (seen 2026-08-02: "Blocking waiting
@@ -421,11 +437,11 @@ if [ "$run_excl" = 1 ]; then
     args=(--release --bin clock "${JOBS[@]}"); [ -n "$feats" ] && args+=(--features "$feats")
     if (cd "$BUILD_ROOT/$CLOCK" && CARGO_TARGET_DIR="$EXCL/target" \
           CARGO_PROFILE_RELEASE_DEBUG=line-tables-only cargo build "${args[@]}") \
-          >/tmp/gate-excl-$name.log 2>&1; then
+          >"$GATE_TMP/gate-excl-$name.log" 2>&1; then
       cp "$EXCL/target/$REPRO_TARGET/release/clock" "$EXCL/elf/$name"
       EXCL_ARGS+=(--elf "$name=$feats=$EXCL/elf/$name")
     else
-      bad "exclusions build $name"; tail -15 /tmp/gate-excl-$name.log | sed 's/^/        /'
+      bad "exclusions build $name"; tail -15 "$GATE_TMP/gate-excl-$name.log" | sed 's/^/        /'
     fi
   done < <("$ROOT/tools/build_matrix.py" emit --for check)
   if [ ${#EXCL_ARGS[@]} -eq 0 ]; then
@@ -447,7 +463,7 @@ if [ "$run_fw" = 1 ]; then
   step "stack floor — canonical ELF vs ${REPRO_STACK_FLOOR:-$(repro_stack_floor || echo unreadable)} B"
   if repro_cargo_args "$BUILD_ROOT/$CLOCK" 2>/dev/null && \
      (cd "$BUILD_ROOT/$CLOCK" && cargo build --release "${JOBS[@]}" --features "$REPRO_FLEET_FEATURES" "${REPRO_CARGO_ARGS[@]}") \
-       >/tmp/gate-stack.log 2>&1; then
+       >"$GATE_TMP/gate-stack.log" 2>&1; then
     ELF="${CARGO_TARGET_DIR:-$BUILD_ROOT/$CLOCK/target}/${REPRO_TARGET}/release/clock"
     # Capture the verdict to a file as well as the console: CI lifts it into the job summary so the
     # number is visible without opening logs. Written on FAILURE too — "the stack broke the floor"
@@ -461,7 +477,7 @@ if [ "$run_fw" = 1 ]; then
   else
     bad "stack floor (canonical build failed)"
     echo "canonical build failed before the stack could be measured" > "$STACK_REPORT"
-    tail -15 /tmp/gate-stack.log | sed 's/^/        /'
+    tail -15 "$GATE_TMP/gate-stack.log" | sed 's/^/        /'
   fi
   # #351 arm (b): CORROBORATION on the ELF the stack step just built — the real, non-debug,
   # shipped-geometry binary. The excluded-module list is DERIVED from the tier's features
@@ -492,10 +508,10 @@ if [ "$run_host" = 1 ]; then
     [ -f "$d/Cargo.toml" ] || continue
     n=$(basename "$d")
     case "$n" in *_verify|relay_compat) ;; *) continue ;; esac
-    if (cd "$d" && cargo run --release -q "${JOBS[@]}") >/tmp/gate-$n.log 2>&1; then
+    if (cd "$d" && cargo run --release -q "${JOBS[@]}") >"$GATE_TMP/gate-$n.log" 2>&1; then
       ok "$n"
     else
-      bad "$n"; tail -10 /tmp/gate-$n.log | sed 's/^/        /'
+      bad "$n"; tail -10 "$GATE_TMP/gate-$n.log" | sed 's/^/        /'
     fi
   done
 
@@ -518,12 +534,12 @@ if [ "$run_host" = 1 ]; then
     [ -f "$t" ] || continue
     n=$(basename "$t" .rs)
     if (cd "$ROOT/$CLOCK" && cargo test --no-default-features --features hostsim \
-          --target "$HOST_TRIPLE" --test "$n" "${JOBS[@]}") >/tmp/gate-test-$n.log 2>&1; then
+          --target "$HOST_TRIPLE" --test "$n" "${JOBS[@]}") >"$GATE_TMP/gate-test-$n.log" 2>&1; then
       # Print the count rather than a bare PASS: "8 passed" is checkable, "ok" is not, and a
       # suite that silently starts running ZERO tests still says ok.
-      ok "test $n — $(grep -Eo '[0-9]+ passed' /tmp/gate-test-$n.log | tail -1)"
+      ok "test $n — $(grep -Eo '[0-9]+ passed' "$GATE_TMP/gate-test-$n.log" | tail -1)"
     else
-      bad "test $n"; tail -12 /tmp/gate-test-$n.log | sed 's/^/        /'
+      bad "test $n"; tail -12 "$GATE_TMP/gate-test-$n.log" | sed 's/^/        /'
     fi
   done
 

--- a/tools/measure_debuginfo_delta.sh
+++ b/tools/measure_debuginfo_delta.sh
@@ -27,12 +27,18 @@
 #
 # Usage: tools/measure_debuginfo_delta.sh [worktree-root] [debug-value]
 #        debug-value defaults to line-tables-only (what gate.sh uses); try `1` or `2` to compare.
-# Cost: three full LTO builds of the fleet tier, ~3 min, into /tmp. Touches no tracked file.
+# Cost: three full LTO builds of the fleet tier, ~3 min, into the repo `tmp/`. Touches no tracked file.
 set -uo pipefail
 export PATH="$HOME/.cargo/bin:$PATH"
 WT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
-O=/tmp/smol-debuginfo-delta
+# Temp output goes in the REPO, never /tmp (JP directive 2026-08-25): katana's /tmp is a 16 GB
+# tmpfs (RAM+swap), and this script is the heaviest offender in tools/ — THREE full LTO target
+# dirs of the fleet tier. Putting those in RAM is how 13 GB of tmpfs vanished on 2026-08-25.
+# `$WT/tmp` is git-ignored (tmp/.gitignore) and disk-backed.
+O="$WT/tmp/smol-debuginfo-delta"
 rm -rf "$O"; mkdir -p "$O"
+# Children (cargo, readelf) inherit this; cargo's own scratch then lands on disk too.
+export TMPDIR="$WT/tmp"
 build() { # build <name> <debugflag-or-empty>
   # `env`, not a bare VAR=x prefix: a prefix assembled by ${2:+...} expansion is a WORD, and
   # bash tries to execute it. First run died `CARGO_PROFILE_RELEASE_DEBUG=…: command not found`.
@@ -44,8 +50,11 @@ build() { # build <name> <debugflag-or-empty>
 build n1 ""
 build d  "${2:-line-tables-only}"
 build n2 ""
-python3 - <<'EOF'
-import subprocess, re, hashlib
+# `O` is EXPORTED into the python below rather than re-spelled there. The heredoc is quoted
+# (`<<'EOF'`) so the shell does not expand it, which is why the path used to appear twice as a
+# literal — two definitions of one path, free to drift, and the reason this fix touches python.
+O="$O" python3 - <<'EOF'
+import subprocess, re, hashlib, os
 def secs(p):
     out = subprocess.run(["readelf","-S","-W",p],capture_output=True,text=True).stdout
     r = {}
@@ -56,7 +65,8 @@ def secs(p):
         if "A" not in f or t == "NOBITS": continue
         r[n] = (int(a,16), int(o,16), int(s,16))
     return r
-P = {k: f"/tmp/smol-debuginfo-delta/t-{k}/riscv32imc-unknown-none-elf/release/clock" for k in ("n1","d","n2")}
+O = os.environ["O"]  # set by the shell above; single definition of the output root
+P = {k: f"{O}/t-{k}/riscv32imc-unknown-none-elf/release/clock" for k in ("n1","d","n2")}
 S = {k: secs(v) for k,v in P.items()}
 B = {k: open(v,'rb').read() for k,v in P.items()}
 def cmp(x,y,label):

--- a/tools/ota_publish.sh
+++ b/tools/ota_publish.sh
@@ -33,6 +33,14 @@ set -euo pipefail
 # ---- config (matches the deployed image host + broker legs) -----------------
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLOCK="$REPO/rust/clock"
+# Staged images and any scratch land in the REPO, never /tmp (JP directive 2026-08-25) — katana's
+# /tmp is a 16 GB tmpfs (RAM+swap), and a staged image is ~1.2 MB that an operator may well want to
+# still exist after the shell that made it. `$REPO/tmp` is git-ignored (tmp/.gitignore) and on disk.
+# NOTE: `die` is defined further down, so this uses a plain exit — the config block runs before
+# the helpers exist.
+SMOL_TMP="$REPO/tmp"
+mkdir -p "$SMOL_TMP" || { echo "ota_publish: cannot create $SMOL_TMP" >&2; exit 1; }
+export TMPDIR="$SMOL_TMP"
 ESPFLASH="${ESPFLASH:-$HOME/.cargo/bin/espflash}"
 # #44: reproducible-build helpers — the release build below goes through repro_build_bin so
 # the announced sha256 is a stable, verifiable (commit) identity (see tools/verify_image.sh).
@@ -302,7 +310,7 @@ BUILD="$(choose_build "$COUNT" "$STAGED" "$BUILD_OVERRIDE")"
 # above: ONE reproducible image, one sha per commit for the whole fleet.
 if [ -z "$BIN" ]; then
   echo "building reproducible espnow release @ $HASH (build $BUILD) ..."
-  BIN="/tmp/smol-${BUILD}.bin"
+  BIN="$SMOL_TMP/smol-${BUILD}.bin"
   # #326: staging IS the release act, so stamp it as one HERE rather than hoping the
   # operator remembered `export SMOL_RELEASE=1`. Before this line the release-vs-dev stamp
   # of a STAGED image depended on the operator's shell: repro_build.sh's comment said "the

--- a/tools/ota_verify.sh
+++ b/tools/ota_verify.sh
@@ -143,6 +143,15 @@
 #     whole window and one agent read another's out of `ps`. It now goes in a private config file.
 set -uo pipefail
 
+# ── Temp default: the REPO, not /tmp (JP directive 2026-08-25) ────────────────────────────────
+# katana's /tmp is a 16 GB tmpfs (RAM+swap). This harness's LOG is the wrong thing to keep there
+# for a second reason beyond size: the trap below deliberately PRESERVES the log on a non-PASS run
+# ("`rm -f` on exit destroyed the first real-fleet capture anyone had"), and a capture worth keeping
+# does not belong in a filesystem that evaporates on reboot. `$REPO/tmp` is git-ignored, on disk.
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export TMPDIR="${TMPDIR:-$REPO/tmp}"
+mkdir -p "$TMPDIR" || { echo "ota_verify: cannot create $TMPDIR" >&2; exit 3; }
+
 ID="${1:?usage: ota_verify.sh <board_id> <target_build> [window_s]}"
 TARGET="${2:?target build number, e.g. 907}"
 # 600 s default, not 360: a real leaf OTA RETRIES. The measured 907→id8 run stalled, logged
@@ -232,7 +241,7 @@ if [ -n "$FIXTURE" ]; then
   # exercised. A harness whose tests cannot express its central concept is not tested.
   [ -f "$FIXTURE" ] || { echo "FATAL: fixture not found: $FIXTURE" >&2; exit 4; }
   BROKER="fixture($(basename "$FIXTURE"))"
-  LOG="$(mktemp "/tmp/ota_verify_fix_${ID}_XXXX.log")"
+  LOG="$(mktemp --tmpdir "ota_verify_fix_${ID}_XXXX.log")"
   (
     t0=$(date +%s)
     while IFS= read -r line; do
@@ -272,9 +281,17 @@ else
   # break other tooling and race every concurrent agent on this host. PW is never exported (so it
   # stays out of /proc/*/environ) and never printed.
   umask 077
+  # ⚠️ THIS ONE STAYS IN /tmp ON PURPOSE — the only deliberate /tmp use left in tools/.
+  # It holds a PLAINTEXT BROKER PASSWORD (`-P <pw>`, umask 077). /tmp being a tmpfs is a FEATURE
+  # here: the credential never touches a disk and cannot outlive a reboot. It is ~30 bytes, so it
+  # is nothing to do with the 2026-08-25 tmpfs exhaustion (13 GB of build artifacts), and the
+  # directive's own carve-out is for small text files. Note the two-layer cleanup below — an
+  # immediate `rm` once mosquitto_sub has read it, plus the EXIT trap — which the comment there
+  # explains exists so a kill -9 cannot strand the password. Moving this to the repo would write a
+  # password to disk inside a working tree, which is strictly worse.
   CFGDIR="$(mktemp -d "/tmp/ota_verify_cfg_${ID}_XXXX")"
   printf -- '-P %s\n' "$PW" > "$CFGDIR/mosquitto_sub"
-  LOG="$(mktemp "/tmp/ota_verify_${ID}_XXXX.log")"
+  LOG="$(mktemp --tmpdir "ota_verify_${ID}_XXXX.log")"
   XDG_CONFIG_HOME="$CFGDIR" mosquitto_sub -h "$BROKER" -p 1883 -u "$MQTT_USER" \
     -i "ota_verify_${ID}_$$" -F '%r\t%t\t%p' \
     -t "smol/$ID/ota/progress" -t "smol/$ID/ota/diag" -t "smol/$ID/ota/state" \


### PR DESCRIPTION
katana's `/tmp` is a **16 GB tmpfs — RAM+swap, not disk**. On 2026-08-25 accumulated temp artifacts filled 13 GB of it and starved the machine. Per JP's directive: work in the project directory, each project gets a git-ignored `tmp/` at its root, and temporaries are cleaned up by the task that made them.

`tmp/.gitignore` (`*` + `!.gitignore`) is the one tracked file in the new directory, so the convention arrives with the checkout instead of being something each operator has to know. It was already in use — the s3-cyd session had put ELFs there hours before this branch existed.

## What moved — the sizes are the point

| script | what was going into RAM |
|---|---|
| `measure_debuginfo_delta.sh` | **three full LTO target dirs** of the fleet tier. By far the heaviest offender in `tools/`; ~3 min of cargo output straight into tmpfs |
| `ota_publish.sh` | the staged **~1.2 MB image** |
| `gate.sh` | **17** log paths (per tier, per arm) → `$GATE_TMP`, default `$ROOT/tmp`, override `SMOL_GATE_TMP` |
| `check_chips.sh` | the four per-chip cargo logs |
| `ota_verify.sh` | the OTA capture log |

Each touched script also exports `TMPDIR` to its project `tmp/` and `mkdir -p`s it, so the tools they **call** inherit it — which is where the big artifacts actually appear. `ota_verify.sh` uses `${TMPDIR:-…}` so familiar can still redirect to `/var/tmp/ftarget` (that host's `/tmp` is a 512 MB tmpfs).

`ota_verify.sh`'s log is the one that isn't about size: its trap deliberately **preserves** the log on a non-PASS run, because "`rm -f` on exit destroyed the first real-fleet capture anyone had". A capture worth keeping shouldn't live in a filesystem that evaporates on reboot.

## Two deliberate non-changes

**`gate.sh`'s #363 pristine mirror stays on `/var/tmp`** — it is a build root, deliberately not `$TMPDIR`, per its own comment. Untouched.

**`ota_verify.sh`'s `CFGDIR` stays in `/tmp`** — the only `/tmp` use left in `tools/`, and it is a security decision rather than an oversight. It holds a **plaintext broker password** (`-P <pw>` under umask 077, written to a config dir specifically to keep the credential out of `argv`, per #313). tmpfs is a *feature* there: the credential never touches a disk and cannot outlive a reboot. It is ~30 bytes, so it has nothing to do with the exhaustion this PR addresses, and the directive's carve-out is for exactly this case. Moving it would write a password to disk inside a working tree — strictly worse. **The reasoning is recorded at the line**, because the next person doing a `/tmp` sweep will otherwise "finish the job".

## Two latent bugs found on the way, both "one path, two definitions"

**1. The CI reader/writer split — the one worth reviewing.** `/tmp/gate-stack-report` was an independent literal in `gate.sh` **and** in `.github/workflows/fw-gate.yml`, where the workflow *reads* what the gate *writes*. Moving only the writer would have made CI print "stack number unavailable" on every run **while every gate stayed green** — a permanent, silent loss of what that workflow's own comment calls "the single highest-value line in this workflow". Now declared once as `SMOL_GATE_STACK_REPORT` in the workflow `env:` block and used by both steps.

**2.** `measure_debuginfo_delta.sh` spelled its output root twice — once in shell, once as a literal inside a *quoted* (`<<'EOF'`) python heredoc, so the shell couldn't expand it and the two were free to drift. The path is now exported into the python and read from `os.environ`.

## A gotcha for the next conversion

`mktemp TEMPLATE` with no slash resolves against the **CWD, not `$TMPDIR`** — only `--tmpdir`/`-t` consult the env var. The obvious fix ("drop the `/tmp/` prefix and let TMPDIR handle it") would have dropped OTA logs into `rust/clock`. The conversions use `--tmpdir`.

Also: `$WT/tmp/…` contains the substring `/tmp/`, so a future `grep -rn '/tmp/'` sweep hits the *correct* repo paths too. Grep `"/tmp/` or `=/tmp` instead.

## Verification

Nothing built on katana; no cargo run.

- `bash -n` clean on all five scripts; the python heredoc `compile()`s; `fw-gate.yml` parses as YAML with all three jobs (`host`, `firmware`, `exclusions`) intact
- `tools/test_ota_publish_guards.sh` — **23 passed · 0 failed**
- `tools/test_ota_verify.sh` — **204 passed · 0 failed** on this branch, matched against **204 passed · 0 failed** on a detached control worktree at the base commit `14e6ddd` with `ota_verify.sh` verified unmodified. Both runs uncontended on an otherwise-idle host.
- `git status` confirms the suite's own output file is unstageable — the new ignore rule demonstrating itself

⚠️ **On that last number, for anyone re-running it.** Earlier runs of this suite reported 200/4, all four in `stall_with_retry_not_death` (an 8-second window; the file's own header flags absence-of-signal assertions as "the racy family"). That was host contention, not this change — but establishing it took four wrong attributions, so the working procedure is worth writing down:

- **One healthy run of this suite is TWO processes in a parent→child chain** (it forks a subshell of itself). Two processes is *not* evidence of two runs; four is.
- A `systemd --user` parent is the signature of a real orphan.
- **A tool timeout kills the wrapper, not the child** — so a timed-out foreground run leaves a live suite behind, and the next run's failures are indistinguishable from a regression in whatever you just changed. Launch with `nohup` and check `ps -eo pid,ppid,args` first.

Credit: morpheus-391 independently spotted the `check_chips.sh` log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
