### PR TITLE
feat(tools): #335 STEP G — gate the one-station-consumer invariant, first and alone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ experiments/*/Cargo.lock
 # Stamped at publish time by tools/stamp_site_version.py, from the commit being published.
 # Never commit it: a checked-in version file is a hand-maintained one, i.e. wrong.
 site/version.json
+
+# Scratch for tooling that needs a temp dir (JP directive 2026-08-25: katana's /tmp is a 16 GB
+# tmpfs, i.e. RAM — build/test scratch must be disk-backed). `tools/test_*.sh` default TMPDIR here.
+/tmp/

--- a/docs/embassy/PHASE3-PLAN.md
+++ b/docs/embassy/PHASE3-PLAN.md
@@ -410,7 +410,7 @@ compile-time gate; all 21 can pass on an image that does nothing it exists to do
 
 | step | evidence | host-provable? |
 |---|---|---|
-| **G** | `check_station_consumers.py` exits 0 on main; **its regression suite proves each of the 4 arms can fail**; declared count = 2 | ✅ **fully host-provable** — pure text, no cargo, no board |
+| **G** | ✅ **LANDED.** `check_station_consumers.py` exits 0 on main (`2 station consumer(s) across 2 declared fn(s); 0 embassy_net::new site(s); 2 cfg guard(s) pinned`); the suite is **21 arms, 0 failed** — 9 hazard (one per enumerated bypass), 8 fail-closed (rc=2), 2 regression, 1 baseline. Declared count = **2** | ✅ **fully host-provable** — pure text, no cargo, no board |
 | **B** (sync form) | all **5** sites bounded incl. the `5250` discard; a fabricated lost-completion does not hang; `otam_to` counted separately | ⚠️ **mixed** — the bounding is host-reviewable, but "does not hang under a real lost completion" is **HW-gated** |
 | **T** | `brst` on the same board, same duty, **before vs after**; per `BurstKind` — the `f` and `r` rows are the ones that matter. Plus: `wifi` tier compiles *and* clippies (the 7th path), `.stack` ≥ `ESP32C3_STACK_FLOOR_BYTES` = 74,208, image ≤ 0x1F0000 | ⚠️ **compile gates host-provable; the `brst` number is HW-gated** |
 | **C** | `brst` again (the assoc-path spins are STEP C's territory); `reassoc_ch6_prefer` still applies **both** `with_bssid` and `with_channel` and still records `my_ap_channel` (#217r3/#269/#278); a scan timeout yields `NoAp` and does not wedge | ⚠️ **the #217r3 invariant is host-provable by inspection + the send-path checker; the ladder behaviour is HW-gated** |
@@ -419,9 +419,31 @@ compile-time gate; all 21 can pass on an image that does nothing it exists to do
 
 Rev-1 claimed "7,960 B of margin to an 80,000 B abort line". **There is no 80,000 B line** — it was a
 tripwire in a dispatch brief that got propagated into a design document as a repo constant. The only
-gate is `ESP32C3_STACK_FLOOR_BYTES = 74,208`. Real margin from P1.3's 87,960: **13,752 B**, and the
-floor is itself conservative because `ESP32C3_MEASURED_PEAK_BYTES = 55,656` was measured with the
-`RadioManager` frame on the stack, ~18.9 KB of which P1.3 moved into `.bss`.
+gate is `ESP32C3_STACK_FLOOR_BYTES = 74,208`.
+
+**⚠️ UPDATED 2026-08-25, and the direction is DOWN. The 87,960 / 13,752 B figures above were
+measured before #391 landed** — i.e. on Phase 1 rebased onto the *pre*-de-pin main. As merged
+(`ec3ee63`), the fleet tier measures:
+
+| | `.stack` |
+|---|---|
+| `origin/main` before #391, fleet tier, same seed | 106,472 B |
+| **as merged, fleet tier** | **86,208 B** |
+| `ESP32C3_STACK_FLOOR_BYTES` | 74,208 B |
+
+So the real margin is **12,000 B, not 13,752 B**, and the executor's cost is **20,264 B** of DRAM
+(`.bss` growth silently shrinking `.stack` — `[[smol-stack-is-not-headroom]]`). Independently
+confirmed: CI's own `gate.sh fw` line on #391's head reads `stack: 86208 B (floor 74208 B)`. Note
+the 8-byte tree-dependence this file warns about elsewhere — a `board.rs` provisioned by
+`tools/ci_provision.sh` reads 86,200 B against 86,208 B for a developer seed, so **never assert
+byte-equality on this number**; the inequality is the gate.
+
+The floor remains conservative for the reason stated: `ESP32C3_MEASURED_PEAK_BYTES = 55,656` was
+measured with the `RadioManager` frame on the stack, ~18.9 KB of which P1.3 moved into `.bss` — so
+the true post-P1.3 peak is *lower* than 55,656 and the 1.55× available/peak ratio implied by the
+numbers above is pessimistic. **That mitigation is an argument, not a measurement, and it is not a
+licence to spend the 12 KB.** Re-measure the peak with sentinel paint before treating the ratio as
+recovered.
 
 `StackResources<N>` + embassy-net buffers are a real cost to **schedule deliberately**. They are not
 a scarcity argument and this plan does not make one. (An invented threshold quoted beside three

--- a/docs/embassy/PHASE3-PLAN.md
+++ b/docs/embassy/PHASE3-PLAN.md
@@ -433,10 +433,19 @@ measured before #391 landed** — i.e. on Phase 1 rebased onto the *pre*-de-pin 
 
 So the real margin is **12,000 B, not 13,752 B**, and the executor's cost is **20,264 B** of DRAM
 (`.bss` growth silently shrinking `.stack` — `[[smol-stack-is-not-headroom]]`). Independently
-confirmed: CI's own `gate.sh fw` line on #391's head reads `stack: 86208 B (floor 74208 B)`. Note
-the 8-byte tree-dependence this file warns about elsewhere — a `board.rs` provisioned by
-`tools/ci_provision.sh` reads 86,200 B against 86,208 B for a developer seed, so **never assert
-byte-equality on this number**; the inequality is the gate.
+confirmed: CI's own `gate.sh fw` line on #391's head reads `stack: 86208 B (floor 74208 B)`.
+
+**The number varies by a few bytes between trees, so never assert byte-equality on it — the
+inequality is the gate.** Observed range, four runs: 86,208 B (familiar, developer seed) · 86,200 B
+(familiar, `tools/ci_provision.sh`) · 86,208 B (GitHub CI, which also runs `ci_provision.sh`) ·
+86,208 B (GitHub CI, #391's head). Note what that does NOT say: the delta is *not* "provisioned vs
+developer seed", which is what a single familiar-vs-CI comparison first suggested and which CI then
+contradicted. `secrets.rs`/`board.rs` are git-ignored and provisioned per tree — and
+`ci_provision.sh` substitutes a *fresh random* group key each run — so their literals land in
+`.data`/`.rodata` at slightly different sizes and `.stack` is whatever DRAM is left. That is the
+tree-dependence this file already warns about under "what this file deliberately does not contain";
+attributing it to a specific cause from one observation is how a caveat becomes folklore
+(`[[flagged-caveat-is-not-contained]]`).
 
 The floor remains conservative for the reason stated: `ESP32C3_MEASURED_PEAK_BYTES = 55,656` was
 measured with the `RadioManager` frame on the stack, ~18.9 KB of which P1.3 moved into `.bss` — so

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2335,6 +2335,34 @@ pub fn now_ms() -> u64 {
 impl RadioManager {
     /// Initialise the radio once. Starts in `WifiSta` mode so the caller can do
     /// an NTP burst before switching to ESP-NOW.
+    ///
+    /// STATION-CONSUMER-SITES: mode.rs::RadioManager::new:1, wifi.rs::try_time_sync:1
+    /// STATION-STACK-SITES: none
+    /// STATION-CONSUMER-GUARD: wifi.rs::try_time_sync | net.rs | pub use wifi::try_time_sync; | all(feature = "wifi", not(feature = "espnow"))
+    /// STATION-CONSUMER-GUARD: mode.rs::RadioManager::new | net.rs | pub mod mode; | feature = "espnow"
+    ///
+    /// #335 STEP G. Every function that constructs a consumer of the STA transport, with its
+    /// COUNT, checked in both directions by `tools/check_station_consumers.py`. There are two,
+    /// they are in different files, and that is exactly what made this dangerous enough to need
+    /// a gate — so the roster is ONE declaration, file-qualified, rather than a per-file note
+    /// that can be half-updated.
+    ///
+    /// WHY A GATE AND NOT A COMMENT: `esp_radio::wifi::Interface` is `Copy`. So
+    /// `embassy_net::new(interfaces.station, ..)` does NOT consume the handle, and a `Stack` can
+    /// be live beside a `SmolWifiDevice` over the same interface. It compiles clean, and then both
+    /// pop `data_queue_rx()` — which is keyed by `InterfaceType` alone — so frames are stolen
+    /// nondeterministically. No error, no panic. `STATION-STACK-SITES` is declared EMPTY on
+    /// purpose: the first `embassy_net::new` to land must update this roster deliberately (STEP T,
+    /// moving every consumer in one commit) instead of inheriting a silent pass.
+    ///
+    /// ⚠️ THE GUARDS ARE NOT ON THESE FUNCTIONS. Neither `try_time_sync` nor `RadioManager::new`
+    /// carries a `#[cfg]`, and `mod wifi` is compiled on EVERY radio tier — so on an espnow tier
+    /// both call sites are *compiled*. What makes them mutually exclusive is REACHABILITY, one
+    /// level up in `net.rs`: the `try_time_sync` re-export and `pub mod mode` are the real gates.
+    /// Hence each `STATION-CONSUMER-GUARD` names the gate FILE and the gated ITEM, pipe-separated
+    /// (a cfg predicate contains commas and `=`, never a pipe). The checker compares those cfg
+    /// strings LITERALLY and fails closed on any edit; it does not attempt cfg algebra, so it
+    /// detects "a guard moved" and makes no claim beyond that.
     pub fn new(p: WifiPeripherals, id: u8) -> Option<Self> {
         // esp-wifi needs a heap; use the single shared region (see net::init_heap).
         super::init_heap();

--- a/tools/check_station_consumers.py
+++ b/tools/check_station_consumers.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""#335 STEP G: prove there is exactly ONE live consumer of the STA transport per tier.
+
+Why this exists, and why the type system cannot do it.
+
+`esp_radio::wifi::Interface` is `Copy` (`esp-radio-0.18.0/src/wifi/mod.rs:1306`,
+`#[derive(Clone, Copy, ...)]`). So `embassy_net::new(interfaces.station, ..)` does **not consume**
+the handle, and neither does `SmolWifiDevice::new(interfaces.station)`. A live `Stack` and a live
+`SmolWifiDevice` can therefore exist at the same time, over the same interface, **and it compiles
+clean**. Both bottom out in `data_queue_rx()`, which is keyed by `InterfaceType` alone — so two
+consumers pop ONE queue and frames are stolen nondeterministically between them.
+
+No error. No panic. No failing gate. The invariant "all STA transport consumers move together" is
+today enforced by *nothing at all*, which is this tree's dominant defect shape: a correct comment
+describing behaviour the binary does not have (`[[stubbed-intentions-under-deliver-silently]]`).
+
+This is the `tools/check_elect_send_path.py` idiom applied to that invariant: a declared roster in
+the source, checked in BOTH directions, fail-closed, with a regression suite
+(`tools/test_check_station_consumers.sh`) proving each arm can actually go red. A gate demonstrated
+only in its passing state is not evidence (#350's `test_build_matrix.sh` lesson).
+
+THE FOUR ARMS — each is a way to satisfy the compiler and still ship the packet-theft bug:
+
+  1. count        the per-function count of `SmolWifiDevice::new` drifts from the declared roster.
+                  Counts, not just names, so adding a SECOND device to an already-listed function
+                  fails too — the property that makes the ELECT checker actually work.
+  2. coexist      an `embassy_net::new` appears. THE packet-theft shape. Declared with its own
+                  roster (empty today) so the first one to land must update the roster deliberately
+                  and re-argue the invariant, rather than inheriting a silent pass. Also flags the
+                  acute form directly: one function holding BOTH a stack and a device.
+  3. per-tier     the two consumers stop being mutually exclusive, i.e. someone edits a cfg guard.
+                  THE ARM THAT MATTERS AFTER STEP T, because STEP T is what could make them overlap.
+  4. no-new-ctor  a second way to build the station device appears (`::from`, `::wrap`, a `pub`
+                  tuple field) that arm 1's call-site count would never see.
+
+⚠️ ARM 3'S DELIBERATE LIMITATION, stated rather than oversold. Deciding "these two cfg predicates
+are mutually exclusive" is cfg algebra, and this checker does not attempt it. It asserts the
+*literal* cfg attribute string at each declared gate site against an allow-list recorded in the
+declaration, and fails closed on ANY change. That detects "someone edited a guard" — which is the
+real failure path — and nothing more. If you need algebra, this is not the tool.
+
+⚠️ AND THE STRUCTURAL SUBTLETY THE ROSTER ENCODES, because it surprised the author of this script:
+the two consumers are NOT gated at their own definitions. Neither `try_time_sync` nor
+`RadioManager::new` carries a `#[cfg]` attribute. `mod wifi` is compiled on EVERY radio tier, so on
+an espnow tier BOTH `SmolWifiDevice::new` call sites are *compiled*. What makes them mutually
+exclusive is REACHABILITY, one level up in `net.rs`: the `try_time_sync` re-export is
+`#[cfg(all(feature = "wifi", not(feature = "espnow")))]` and `pub mod mode` is
+`#[cfg(feature = "espnow")]`. That is why each guard declaration names the GATE FILE and the GATED
+ITEM, not the function — pinning a cfg that does not exist where you expect it is how a gate ends up
+green forever.
+
+Usage: tools/check_station_consumers.py [repo-root]   (exit 0 ok, 1 violation, 2 malformed)
+"""
+import re
+import sys
+from pathlib import Path
+
+# The constructor whose call sites ARE the roster.
+DEVICE_CTOR = "SmolWifiDevice::new"
+# The device type, for the no-new-ctor arm.
+DEVICE_TYPE = "SmolWifiDevice"
+# The module that is allowed to construct the device by tuple syntax (it owns the type).
+DEVICE_HOME = "radio_dev.rs"
+# The embassy-net stack constructor — the other consumer of the same queue.
+STACK_CTOR = "embassy_net::new"
+
+DECL_SITES = re.compile(r"STATION-CONSUMER-SITES:\s*(.+?)\s*(?:\*/|\n|$)")
+DECL_STACK = re.compile(r"STATION-STACK-SITES:\s*(.+?)\s*(?:\*/|\n|$)")
+# `<site> | <gate file> | <gated item literal> | <cfg inner>` — pipe-delimited because a cfg
+# predicate contains commas, `=` and parentheses, but never a pipe.
+DECL_GUARD = re.compile(r"STATION-CONSUMER-GUARD:\s*(.+?)\s*(?:\*/|\n|$)")
+NONE_TOKENS = ("none", "(none)", "-")
+
+
+def fail(msg, *extra):
+    print(f"FATAL: {msg}", file=sys.stderr)
+    for line in extra:
+        print(f"  {line}", file=sys.stderr)
+
+
+def rust_sources(src: Path):
+    return sorted(p for p in src.rglob("*.rs") if p.is_file())
+
+
+def strip_comments(text: str) -> str:
+    """Blank every comment, PRESERVING length and newlines so offsets and line numbers still map.
+
+    Not a nicety — it is load-bearing, and the first run of this script proved it. The roster's own
+    doc comment explains the hazard using the words `embassy_net::new(interfaces.station, ..)`, and
+    an unstripped scan counted that PROSE as a real call site and failed the gate. A checker whose
+    verdict can be flipped by documentation about the thing it checks is worse than no checker: the
+    same mechanism that produces a false RED here could be used to produce a false GREEN elsewhere
+    (comment out a real site, or bury a roster-shaped string in a comment).
+
+    Handles `//`, `/* */` (nested, as Rust allows), ordinary strings, char literals and raw strings
+    (`r"..."`, `r#"..."#`), because a `//` inside a string literal is not a comment and blanking it
+    would corrupt the code view.
+    """
+    out = list(text)
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        # raw string: r"..." / r#"..."# / r##"..."##
+        if c == "r" and i + 1 < n and text[i + 1] in '"#':
+            j = i + 1
+            hashes = 0
+            while j < n and text[j] == "#":
+                hashes += 1
+                j += 1
+            if j < n and text[j] == '"':
+                close = '"' + "#" * hashes
+                end = text.find(close, j + 1)
+                i = n if end < 0 else end + len(close)
+                continue
+        if c == '"' or c == "'":
+            quote = c
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text[j] == quote:
+                    j += 1
+                    break
+                if text[j] == "\n" and quote == "'":
+                    break  # not a char literal after all (e.g. a lifetime)
+                j += 1
+            i = j
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+            for k in range(i, j):
+                out[k] = " "
+            i = j
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            depth, j = 0, i
+            while j < n:
+                if text.startswith("/*", j):
+                    depth += 1
+                    j += 2
+                elif text.startswith("*/", j):
+                    depth -= 1
+                    j += 2
+                    if depth == 0:
+                        break
+                else:
+                    j += 1
+            for k in range(i, min(j, n)):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = j
+            continue
+        i += 1
+    return "".join(out)
+
+
+def enclosing_fn(text: str, idx: int):
+    """Name of the nearest `fn` declared at or above `idx`. None if there isn't one."""
+    best = None
+    for m in re.finditer(
+        r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(?:const\s+)?(?:unsafe\s+)?fn\s+(\w+)",
+        text[:idx],
+        re.M,
+    ):
+        best = m.group(1)
+    return best
+
+
+IMPL_RE = re.compile(
+    r"^[ \t]*impl\s*(?:<[^>]*>\s*)?(?:[\w:]+(?:<[^>]*>)?\s+for\s+)?(\w+)", re.M
+)
+
+
+def impl_spans(text: str):
+    """[(open_idx, close_idx, type_name)] for every `impl` block, by BALANCED BRACES.
+
+    Deliberately not "the nearest `impl` above the site": a free function that merely FOLLOWS a
+    closed impl block would be misattributed to it, which would silently rename a roster key and
+    make arm 1 red for a reason that has nothing to do with the invariant. `try_time_sync` is
+    exactly that shape — a free fn in a file with impls above it.
+    """
+    spans = []
+    for m in IMPL_RE.finditer(text):
+        open_at = text.find("{", m.end())
+        if open_at < 0:
+            continue
+        depth = 0
+        for i in range(open_at, len(text)):
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    spans.append((open_at, i, m.group(1)))
+                    break
+    return spans
+
+
+def site_key(path: Path, text: str, idx: int, spans=None):
+    """`file.rs::Type::fn` if genuinely inside an impl, else `file.rs::fn`."""
+    fn = enclosing_fn(text, idx)
+    if fn is None:
+        return None
+    if spans is None:
+        spans = impl_spans(text)
+    # Innermost containing span wins (widest-first ordering is not guaranteed, so pick by size).
+    best = None
+    for open_at, close_at, name in spans:
+        if open_at < idx < close_at and (best is None or (close_at - open_at) < best[0]):
+            best = (close_at - open_at, name)
+    if best is not None:
+        return f"{path.name}::{best[1]}::{fn}"
+    return f"{path.name}::{fn}"
+
+
+def parse_roster(decl_text: str, label: str):
+    """`a::b:1, c::d:2` -> {site: count}. `none` -> {}. Returns None on malformed."""
+    if decl_text.strip().lower() in NONE_TOKENS:
+        return {}
+    out = {}
+    for tok in re.split(r",\s*", decl_text.strip()):
+        tok = tok.strip()
+        if not tok:
+            continue
+        site, _, count = tok.rpartition(":")
+        if not count.isdigit() or not site:
+            fail(f"malformed {label} entry {tok!r} — expected `file.rs::path::fn:count`.")
+            return None
+        out[site] = int(count)
+    return out
+
+
+def code_line_after(text: str, idx: int):
+    """The first non-blank, non-comment line strictly after the line containing `idx`."""
+    for line in text[text.find("\n", idx) + 1 :].split("\n"):
+        s = line.strip()
+        if not s or s.startswith("//"):
+            continue
+        return s
+    return None
+
+
+def main() -> int:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+    src = root / "rust" / "clock" / "src"
+    if not src.is_dir():
+        fail(f"no firmware source tree at {src}")
+        return 2
+    files = {p: p.read_text(encoding="utf-8") for p in rust_sources(src)}
+    if not files:
+        fail(f"parsed ZERO rust sources under {src}")
+        return 2
+    # Two views of every file. `files` is RAW and is what the declaration regexes read, because the
+    # roster deliberately lives in a doc comment. `code` has comments blanked (offsets preserved)
+    # and is what every call-site scan reads. Mixing the two up is how a checker gets fooled by
+    # prose — see `strip_comments`.
+    code = {p: strip_comments(t) for p, t in files.items()}
+
+    bad, notes = [], []
+
+    # ── the declaration (one roster, file-qualified, so it cannot be half-updated) ─────────────
+    decl_sites = decl_stack = None
+    guards_raw = []
+    for text in files.values():
+        if decl_sites is None:
+            m = DECL_SITES.search(text)
+            if m:
+                decl_sites = m.group(1)
+        if decl_stack is None:
+            m = DECL_STACK.search(text)
+            if m:
+                decl_stack = m.group(1)
+        guards_raw += [m.group(1) for m in DECL_GUARD.finditer(text)]
+    if decl_sites is None:
+        fail(
+            "no `STATION-CONSUMER-SITES:` declaration found in the firmware source.",
+            "The roster of functions that construct a STA transport consumer must live where a",
+            "machine can check it — see this script's docstring.",
+        )
+        return 2
+    if decl_stack is None:
+        fail(
+            "no `STATION-STACK-SITES:` declaration found in the firmware source.",
+            f"The roster of `{STACK_CTOR}` sites must be declared even while it is empty — that is",
+            "what makes the FIRST one land deliberately instead of inheriting a silent pass.",
+        )
+        return 2
+
+    declared = parse_roster(decl_sites, "STATION-CONSUMER-SITES")
+    if declared is None:
+        return 2
+    if not declared:
+        fail(
+            "`STATION-CONSUMER-SITES` declares NO sites.",
+            "The tree has at least one STA consumer; an empty roster means this arm is blind.",
+        )
+        return 2
+    declared_stack = parse_roster(decl_stack, "STATION-STACK-SITES")
+    if declared_stack is None:
+        return 2
+
+    # ── arm 1: declared per-function device-constructor counts, both directions ────────────────
+    actual = {}
+    for path, text in code.items():
+        for m in re.finditer(re.escape(DEVICE_CTOR) + r"\s*\(", text):
+            key = site_key(path, text, m.start())
+            if key is None:
+                fail(f"a `{DEVICE_CTOR}` in {path.relative_to(root)} is not inside any fn")
+                return 2
+            actual[key] = actual.get(key, 0) + 1
+    if not actual:
+        fail(
+            f"found ZERO `{DEVICE_CTOR}` call sites.",
+            "That cannot be right while the smoltcp shim is still the transport; the pattern must",
+            "have changed, so this arm is blind and refuses to pass.",
+        )
+        return 2
+    if actual != declared:
+        added = {k: v for k, v in actual.items() if declared.get(k) != v}
+        gone = {k: v for k, v in declared.items() if k not in actual}
+        if added:
+            bad.append(
+                "arm 1 (count): undeclared or miscounted station-consumer sites: "
+                + ", ".join(f"{k}x{v} (declared {declared.get(k, 0)})" for k, v in sorted(added.items()))
+                + f". Every `{DEVICE_CTOR}` is a consumer of the one shared rx queue, so an "
+                "undeclared one is a frame thief that compiles clean."
+            )
+        if gone:
+            bad.append(
+                "arm 1 (count): declared but ABSENT: "
+                + ", ".join(f"{k}x{v}" for k, v in sorted(gone.items()))
+                + ". A stale roster entry reads as a considered decision and is worse than none."
+            )
+
+    # ── arm 2: the packet-theft shape ─────────────────────────────────────────────────────────
+    stack_actual = {}
+    for path, text in code.items():
+        for m in re.finditer(re.escape(STACK_CTOR) + r"\s*\(", text):
+            key = site_key(path, text, m.start())
+            if key is None:
+                fail(f"an `{STACK_CTOR}` in {path.relative_to(root)} is not inside any fn")
+                return 2
+            stack_actual[key] = stack_actual.get(key, 0) + 1
+    if stack_actual != declared_stack:
+        added = {k: v for k, v in stack_actual.items() if declared_stack.get(k) != v}
+        gone = {k: v for k, v in declared_stack.items() if k not in stack_actual}
+        if added:
+            bad.append(
+                "arm 2 (coexist): undeclared "
+                + f"`{STACK_CTOR}` site(s): "
+                + ", ".join(f"{k}x{v}" for k, v in sorted(added.items()))
+                + f". `Interface` is `Copy`, so a `Stack` and a `{DEVICE_TYPE}` over the same "
+                "interface BOTH pop `data_queue_rx()` and steal each other's frames, with no error. "
+                "If this is STEP T, move every consumer in the same commit and update the roster."
+            )
+        if gone:
+            bad.append(
+                "arm 2 (coexist): declared but ABSENT: "
+                + ", ".join(f"{k}x{v}" for k, v in sorted(gone.items()))
+                + ". Remove the entry when the site goes, or the roster stops describing the tree."
+            )
+    # The acute form, called out separately because it is unambiguous wherever the cfgs land:
+    both = sorted(set(stack_actual) & set(actual))
+    if both:
+        bad.append(
+            "arm 2 (coexist): "
+            + ", ".join(both)
+            + f" holds BOTH an `{STACK_CTOR}` and a `{DEVICE_CTOR}`. That is the frame-theft shape "
+            "in its most direct form — one function, two consumers, one queue."
+        )
+
+    # ── arm 3: the cfg guards are literally unchanged ──────────────────────────────────────────
+    if not guards_raw:
+        fail(
+            "no `STATION-CONSUMER-GUARD:` declarations found.",
+            "Each declared site needs its gate pinned, or arm 3 covers nothing.",
+        )
+        return 2
+    guarded = set()
+    for raw in guards_raw:
+        parts = [p.strip() for p in raw.split("|")]
+        if len(parts) != 4:
+            fail(
+                f"malformed STATION-CONSUMER-GUARD {raw!r}",
+                "expected `<site> | <gate file> | <gated item> | <cfg inner>` (4 pipe-separated).",
+            )
+            return 2
+        site, gate_file, gated_item, cfg_inner = parts
+        guarded.add(site)
+        gate_paths = [p for p in code if p.name == gate_file]
+        if not gate_paths:
+            fail(f"guard for {site}: gate file {gate_file!r} not found in the source tree.")
+            return 2
+        gtext = code[gate_paths[0]]
+        needle = f"#[cfg({cfg_inner})]"
+        hit = None
+        for m in re.finditer(re.escape(needle), gtext):
+            nxt = code_line_after(gtext, m.start())
+            if nxt is not None and gated_item in nxt:
+                hit = m
+                break
+        if hit is None:
+            bad.append(
+                f"arm 3 (per-tier): the guard for {site} is not where the roster says. Expected "
+                f"`{needle}` immediately above `{gated_item}` in {gate_file}. "
+                "The two station consumers are mutually exclusive ONLY because of these guards; if "
+                "one moved, they may now both be live on one tier — which compiles, and steals "
+                "frames. Re-derive the exclusion, then update the roster."
+            )
+    missing_guards = sorted(set(declared) - guarded)
+    if missing_guards:
+        fail(
+            "these declared sites have no STATION-CONSUMER-GUARD: " + ", ".join(missing_guards),
+            "An unguarded site is one this arm cannot see, so the roster refuses to pass.",
+        )
+        return 2
+
+    # ── arm 4: `new` stays the only way to build the device ────────────────────────────────────
+    home = [p for p in code if p.name == DEVICE_HOME]
+    if not home:
+        fail(f"the device's home module {DEVICE_HOME!r} was not found.")
+        return 2
+    htext = code[home[0]]
+    struct_m = re.search(r"pub\s+struct\s+" + DEVICE_TYPE + r"\s*(\(|\{|;)", htext)
+    if struct_m is None:
+        fail(
+            f"could not find `pub struct {DEVICE_TYPE}` in {DEVICE_HOME}.",
+            "Arm 4 anchors on that declaration; without it the arm is blind.",
+        )
+        return 2
+    # A `pub` field turns tuple-construction into a public constructor arm 1 would never see.
+    if struct_m.group(1) == "(":
+        tail = htext[struct_m.end() - 1 :]
+        close = tail.find(")")
+        if close > 0 and re.search(r"\bpub\b", tail[:close]):
+            bad.append(
+                f"arm 4 (no-new-ctor): `{DEVICE_TYPE}`'s tuple field is now `pub`, so "
+                f"`{DEVICE_TYPE}(iface)` is a public constructor anywhere in the crate. Arm 1 "
+                "counts `::new` call sites and would never see it."
+            )
+    # Any other associated fn returning Self is a second constructor.
+    for m in re.finditer(r"impl\s+" + DEVICE_TYPE + r"\s*\{", htext):
+        depth, i = 0, m.end() - 1
+        while i < len(htext):
+            if htext[i] == "{":
+                depth += 1
+            elif htext[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        body = htext[m.end() : i]
+        for fm in re.finditer(r"fn\s+(\w+)\s*\([^)]*\)\s*->\s*([^{;]+)", body):
+            name, ret = fm.group(1), fm.group(2).strip()
+            if name == "new":
+                continue
+            if re.search(r"\bSelf\b|\b" + DEVICE_TYPE + r"\b", ret):
+                bad.append(
+                    f"arm 4 (no-new-ctor): `{DEVICE_TYPE}::{name}` also returns "
+                    f"`{ret}` — a second constructor. Arm 1's roster counts `::new` sites only, so "
+                    "a device built through this one is invisible to it."
+                )
+    # Tuple construction outside the owning module.
+    for path, text in code.items():
+        if path.name == DEVICE_HOME:
+            continue
+        for m in re.finditer(r"\b" + DEVICE_TYPE + r"\s*\(", text):
+            bad.append(
+                f"arm 4 (no-new-ctor): {path.relative_to(root)}:"
+                f"{text.count(chr(10), 0, m.start()) + 1} builds `{DEVICE_TYPE}` by tuple syntax "
+                f"rather than `::new`, so arm 1 does not count it."
+            )
+
+    if bad:
+        print("FATAL: the one-station-consumer invariant is violated.", file=sys.stderr)
+        for b in bad:
+            print(f"  - {b}", file=sys.stderr)
+        print(
+            f"  `Interface` is `Copy`, so two consumers over one interface COMPILE and then pop the\n"
+            f"  same `data_queue_rx()` — frames vanish nondeterministically with no error. See this\n"
+            f"  script's docstring and docs/embassy/PHASE3-PLAN.md STEP G.",
+            file=sys.stderr,
+        )
+        return 1
+
+    total = sum(actual.values())
+    notes.append(f"{total} station consumer(s) across {len(actual)} declared fn(s)")
+    notes.append(f"{sum(stack_actual.values())} `{STACK_CTOR}` site(s)")
+    notes.append(f"{len(guards_raw)} cfg guard(s) pinned")
+    print("  station consumers: " + "; ".join(notes))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -280,6 +280,20 @@ if [ "$run_fw" = 1 ]; then
   # instead: one sink impl, routed to `send_to`; a sealed frame with no byte accessor; one encoder
   # call site; one spelling of the prefix; and every raw `esp_now.send` declared WITH ITS COUNT.
   # `tools/test_check_elect_send_path.sh` proves all of those can fail, plus three fail-closed arms.
+  # #335 STEP G. Same idiom, one invariant over: exactly ONE consumer of the STA transport is live
+  # per tier. `esp_radio::wifi::Interface` is `Copy`, so `embassy_net::new(station, ..)` does not
+  # consume it — a `Stack` can be live beside the `SmolWifiDevice` shim over the same interface, it
+  # COMPILES CLEAN, and then both pop `data_queue_rx()` (keyed by `InterfaceType` alone) and steal
+  # each other's frames with no error and nothing in a log. Placed here, beside the ELECT checker
+  # and before any compile, because it is pure text and because STEP T needs a green baseline to
+  # diff against. `tools/test_check_station_consumers.sh` proves all four arms can fail.
+  step "one live STA transport consumer per tier (#335 STEP G)"
+  if out=$("$ROOT/tools/check_station_consumers.py" "$ROOT" 2>&1); then
+    printf '%s\n' "$out"; ok "station consumers"
+  else
+    printf '%s\n' "$out"; bad "station consumers"
+  fi
+
   step "ELECT reaches the air only authenticated (#278)"
   if out=$("$ROOT/tools/check_elect_send_path.py" "$ROOT" 2>&1); then
     printf '%s\n' "$out"; ok "elect send path"
@@ -566,6 +580,20 @@ if [ "$run_host" = 1 ]; then
     printf '%s\n' "$out" | tail -2; ok "test_check_elect_send_path"
   else
     printf '%s\n' "$out" | sed 's/^/        /'; bad "test_check_elect_send_path"
+  fi
+
+  # #335 STEP G, same reasoning one invariant over: every arm of the station-consumer checker is an
+  # ABSENCE check ("no undeclared device", "no embassy_net::new yet", "no second constructor"), and
+  # an absence check that has quietly stopped covering anything prints exactly the green an intact
+  # one does. Two of the arms here are REGRESSION arms rather than hazard arms: the checker's first
+  # run counted its own doc comment's prose as a real call site, so both directions are pinned —
+  # prose naming the constructors must not turn a clean tree red, and commenting out a real site
+  # must not turn a dirty one green.
+  step "station-consumer checker regression suite (#335 STEP G)"
+  if out=$("$ROOT/tools/test_check_station_consumers.sh" 2>&1); then
+    printf '%s\n' "$out" | tail -2; ok "test_check_station_consumers"
+  else
+    printf '%s\n' "$out" | sed 's/^/        /'; bad "test_check_station_consumers"
   fi
 
   # The merge guard's own self-test. One line, and it is the difference between "the guard HAS a

--- a/tools/test_check_station_consumers.sh
+++ b/tools/test_check_station_consumers.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# test_check_station_consumers.sh — proves tools/check_station_consumers.py can FAIL (#335 STEP G).
+#
+# The invariant: exactly ONE consumer of the STA transport is live per tier. It is not a style rule.
+# `esp_radio::wifi::Interface` is `Copy`, so `embassy_net::new(station, ..)` does not consume the
+# handle and a `Stack` can be live beside a `SmolWifiDevice` over the same interface. That COMPILES
+# CLEAN, and then both pop `data_queue_rx()` — keyed by `InterfaceType` alone — so frames are stolen
+# nondeterministically. No error, no panic, nothing to grep for in a log.
+#
+# Which means a checker that only ever passes is the same bug wearing a green badge (#350's
+# test_build_matrix.sh lesson, and `[[gate-that-cannot-fail]]`). Every arm below MUTATES A COPY of
+# the firmware tree into one of the shapes enumerated as "satisfies the compiler and still ships the
+# theft", and asserts the checker goes red FOR THE RIGHT REASON — not merely red. The fail-closed
+# arms assert rc=2, because a checker that silently stops covering anything is how prose rots.
+#
+# The last arm is a REGRESSION arm, not a hazard arm: the first run of the checker counted its own
+# doc comment's prose as a real call site. Documentation about the invariant must never be able to
+# change the verdict, in either direction.
+#
+# SAFETY, and it is not boilerplate: every arm works on a copy under mktemp. No git command, no
+# write anywhere inside the repo. Two separate incidents in this repo destroyed uncommitted work
+# through a self-test that operated on the real tree; this one cannot, because the real tree's path
+# is never in a writable position.
+#
+# TMPDIR: defaults to the repo's gitignored tmp/ (JP directive 2026-08-25 — katana's /tmp is a
+# 16 GB tmpfs, i.e. RAM). mktemp honours TMPDIR, so this is the whole fix.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHK="$ROOT/tools/check_station_consumers.py"
+if [ -z "${TMPDIR:-}" ]; then
+  mkdir -p "$ROOT/tmp" && TMPDIR="$ROOT/tmp" && export TMPDIR
+fi
+pass=0; fail=0
+ok(){ pass=$((pass+1)); echo "ok   - $1"; }
+no(){ fail=$((fail+1)); echo "FAIL - $1"; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+seed() {
+  rm -rf "$work/tree"
+  mkdir -p "$work/tree/rust/clock"
+  cp -r "$ROOT/rust/clock/src" "$work/tree/rust/clock/src"
+}
+
+patch1() {   # patch1 <abs-file> <old>TAB<new>
+  python3 - "$1" "$2" <<'PY'
+import sys
+path, spec = sys.argv[1], sys.argv[2]
+old, new = spec.split("\t")
+s = open(path).read()
+if old not in s:
+    sys.exit(f"fixture setup failed: {old!r} not found — this test needs updating")
+open(path, "w").write(s.replace(old, new, 1))
+PY
+}
+
+# arm <name> <want-rc> <want-substring> <file-rel-to-src> <old>TAB<new>
+arm() {
+  local name="$1" want_rc="$2" want="$3" file="$4" spec="$5"
+  seed
+  if ! patch1 "$work/tree/rust/clock/src/$file" "$spec"; then no "$name (fixture setup)"; return; fi
+  local out rc
+  out="$("$CHK" "$work/tree" 2>&1)"; rc=$?
+  if [ "$rc" != "$want_rc" ]; then no "$name: rc $rc, want $want_rc — $out"; return; fi
+  case "$out" in *"$want"*) ok "$name (rc=$rc)" ;; *) no "$name: rc right, WRONG REASON — $out" ;; esac
+}
+
+DEV_WIFI='let mut device = SmolWifiDevice::new(interfaces.station);'
+DEV_MODE='sta: Some(SmolWifiDevice::new(interfaces.station)),'
+ROSTER='/// STATION-CONSUMER-SITES: mode.rs::RadioManager::new:1, wifi.rs::try_time_sync:1'
+STACKROSTER='/// STATION-STACK-SITES: none'
+
+echo "== baseline: the real tree must satisfy the invariant =="
+out="$("$CHK" "$ROOT" 2>&1)"; rc=$?
+if [ "$rc" = 0 ]; then ok "unmodified tree: $out"; else no "unmodified tree FAILS: $out"; fi
+
+echo "== arm 1 (count): the roster drifts from the tree =="
+# A SECOND device in an ALREADY-LISTED function — the shape a name-only allowlist would miss.
+arm "second device in a listed fn" 1 "arm 1 (count)" net/wifi.rs \
+"$DEV_WIFI	$DEV_WIFI
+    let _steal = SmolWifiDevice::new(interfaces.station);"
+# A device in a function nobody declared.
+arm "device in an undeclared fn" 1 "arm 1 (count)" net/radio_dev.rs \
+"const WIFI_MTU: usize = 1514;	const WIFI_MTU: usize = 1514;
+pub fn sneaky(i: Interface<'static>) -> SmolWifiDevice { SmolWifiDevice::new(i) }"
+# A declared site that no longer exists — a stale roster entry reads as a decision.
+arm "declared site removed" 1 "declared but ABSENT" net/mode.rs \
+"$DEV_MODE	sta: None,"
+
+echo "== arm 2 (coexist): THE packet-theft shape =="
+# The first embassy_net::new must be deliberate, not inherited.
+arm "undeclared embassy_net::new" 1 "arm 2 (coexist)" net/mode.rs \
+"pub fn now_ms() -> u64 {	pub fn now_ms() -> u64 {
+    let _ = embassy_net::new(1, 2, 3, 4);"
+# The acute form: one function holding both consumers over one interface.
+arm "one fn holds stack AND device" 1 "holds BOTH" net/wifi.rs \
+"$DEV_WIFI	$DEV_WIFI
+    let _stack = embassy_net::new(interfaces.station, cfg, res, seed);"
+
+echo "== arm 3 (per-tier): a cfg guard was edited — the arm that matters after STEP T =="
+# Widening the try_time_sync gate to plain `wifi` makes BOTH consumers reachable on espnow tiers.
+arm "guard widened to plain wifi" 1 "arm 3 (per-tier)" net.rs \
+'#[cfg(all(feature = "wifi", not(feature = "espnow")))]
+pub use wifi::try_time_sync;	#[cfg(feature = "wifi")]
+pub use wifi::try_time_sync;'
+# Moving the gated item out from under its cfg is the same failure with a different shape.
+arm "gated item detached from its cfg" 1 "arm 3 (per-tier)" net.rs \
+'#[cfg(all(feature = "wifi", not(feature = "espnow")))]
+pub use wifi::try_time_sync;	#[cfg(all(feature = "wifi", not(feature = "espnow")))]
+pub use wifi::CFG_KEY_LED;
+pub use wifi::try_time_sync;'
+
+echo "== arm 4 (no-new-ctor): a second way to build the device =="
+arm "pub tuple field" 1 "arm 4 (no-new-ctor)" net/radio_dev.rs \
+"pub struct SmolWifiDevice(Interface<'static>);	pub struct SmolWifiDevice(pub Interface<'static>);"
+arm "second constructor returning Self" 1 "arm 4 (no-new-ctor)" net/radio_dev.rs \
+"    /// STA MAC	    pub fn wrap(i: Interface<'static>) -> Self { Self(i) }
+
+    /// STA MAC"
+arm "tuple construction outside its module" 1 "arm 4 (no-new-ctor)" net/wifi.rs \
+"$DEV_WIFI	let mut device = SmolWifiDevice(interfaces.station);"
+
+echo "== fail-closed: a blind checker must refuse to pass, never quietly succeed =="
+arm "roster deleted" 2 "no \`STATION-CONSUMER-SITES:\` declaration" net/mode.rs \
+"$ROSTER	/// (roster deleted by the test)"
+arm "stack roster deleted" 2 "no \`STATION-STACK-SITES:\` declaration" net/mode.rs \
+"$STACKROSTER	/// (stack roster deleted by the test)"
+arm "roster count malformed" 2 "malformed STATION-CONSUMER-SITES" net/mode.rs \
+"$ROSTER	/// STATION-CONSUMER-SITES: mode.rs::RadioManager::new:many, wifi.rs::try_time_sync:1"
+arm "guard names a gate file that does not exist" 2 "not found in the source tree" net/mode.rs \
+"| net.rs | pub mod mode;	| nowhere.rs | pub mod mode;"
+arm "a declared site has no guard" 2 "have no STATION-CONSUMER-GUARD" net/mode.rs \
+'/// STATION-CONSUMER-GUARD: mode.rs::RadioManager::new | net.rs | pub mod mode; | feature = "espnow"	/// (guard deleted by the test)'
+arm "guard declaration malformed" 2 "malformed STATION-CONSUMER-GUARD" net/mode.rs \
+"| net.rs | pub mod mode; | feature	| net.rs | feature"
+# Zero call sites means the pattern moved and every count arm is blind. Two files, so inline.
+seed
+if patch1 "$work/tree/rust/clock/src/net/wifi.rs" "$DEV_WIFI	let mut device = make_dev(interfaces.station);" \
+   && patch1 "$work/tree/rust/clock/src/net/mode.rs" "$DEV_MODE	sta: Some(make_dev(interfaces.station)),"; then
+  out="$("$CHK" "$work/tree" 2>&1)"; rc=$?
+  if [ "$rc" != 2 ]; then no "zero device ctor sites: rc $rc, want 2 — $out"
+  else case "$out" in *"found ZERO"*) ok "zero device ctor sites (rc=2)" ;;
+       *) no "zero device ctor sites: rc right, WRONG REASON — $out" ;; esac
+  fi
+else no "zero device ctor sites (fixture setup)"; fi
+# A tree with no sources at all must also refuse.
+mkdir -p "$work/empty/rust/clock/src"
+out="$("$CHK" "$work/empty" 2>&1)"; rc=$?
+if [ "$rc" = 2 ]; then ok "empty source tree refuses (rc=2)"; else no "empty tree: rc $rc, want 2 — $out"; fi
+
+echo "== regression: PROSE must not move the verdict, in either direction =="
+# The checker's first run counted its own doc comment as a call site. A comment naming both
+# constructors must leave a clean tree clean.
+seed
+if patch1 "$work/tree/rust/clock/src/net/radio_dev.rs" \
+"const WIFI_MTU: usize = 1514;	const WIFI_MTU: usize = 1514;
+// Prose: embassy_net::new(interfaces.station, ..) beside SmolWifiDevice::new(interfaces.station)
+/* and a block comment: SmolWifiDevice::new(x); embassy_net::new(y); */"; then
+  out="$("$CHK" "$work/tree" 2>&1)"; rc=$?
+  if [ "$rc" = 0 ]; then ok "comments naming both ctors stay green (rc=0)"
+  else no "PROSE FLIPPED THE VERDICT: rc $rc — $out"; fi
+else no "prose regression (fixture setup)"; fi
+# ...and a real site COMMENTED OUT must not silently satisfy the roster either.
+arm "commenting out a real site is caught" 1 "declared but ABSENT" net/mode.rs \
+"$DEV_MODE	// $DEV_MODE"
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes the STEP G deliverable in `docs/embassy/PHASE3-PLAN.md` §1. **No transport change** — this is the gate that constrains STEP T, landing before it and alone, because a gate that arrives with the change it guards has never once been red.

## The invariant, and why the type system cannot hold it

`esp_radio::wifi::Interface` is `Copy`. So `embassy_net::new(interfaces.station, …)` does **not consume** the handle, and a `Stack` can be live beside the `SmolWifiDevice` smoltcp shim over the same interface. That **compiles clean** — and then both bottom out in `data_queue_rx()`, which is keyed by `InterfaceType` alone, so two consumers pop one queue and frames are stolen nondeterministically. No error, no panic, nothing in a log. "All transport consumers move together" was enforced by *nothing*.

## What landed

- **`tools/check_station_consumers.py`** — four arms in the `check_elect_send_path.py` idiom: declared roster in the source, checked **both directions**, fail-closed, exit `0`/`1`/`2`.

  | arm | catches |
  |---|---|
  | `count` | per-function `SmolWifiDevice::new` count drifts (counts, not names — so a *second* device in an already-listed fn fails too) |
  | `coexist` | `embassy_net::new` appears. Declared **empty** today, so the first one must update the roster deliberately rather than inherit a silent pass. Plus the acute form: one fn holding both consumers |
  | `per-tier` | a cfg guard was edited — **the arm that matters after STEP T** |
  | `no-new-ctor` | a second constructor (`::wrap`, a `pub` tuple field, tuple syntax outside the owning module) that `count` cannot see |

- **`tools/test_check_station_consumers.sh`** — **21 arms, 0 failed**: 9 hazard, 8 fail-closed (`rc=2`), 2 regression, 1 baseline. Mutates only copies under `mktemp`; no git command, no write inside the repo (the two prior incidents where a self-test destroyed uncommitted work).
- Roster declared on `mode.rs::RadioManager::new` — one of the two sites, so anyone editing it sees the roster.
- `gate.sh`: checker in `fw`, suite in `host`, mirroring the ELECT split.

## Two things the spec did not anticipate — both load-bearing

**1. The cfg guards are not on the two functions.** Neither `try_time_sync` nor `RadioManager::new` carries a `#[cfg]`, and `mod wifi` is compiled on *every* radio tier — so on an espnow tier **both call sites are compiled**. The mutual exclusion is **reachability**, one level up in `net.rs`: the `try_time_sync` re-export and `pub mod mode`. A checker that looked for "the cfg above the fn" would have found nothing and passed forever. Each guard therefore names the gate **file** and the gated **item**, pipe-separated (a cfg predicate contains commas and `=`, never a pipe).

**2. The checker must ignore comments — its own first run proved it.** It counted the roster's doc-comment prose, the words `embassy_net::new(interfaces.station, ..)`, as a real call site and failed. A verdict documentation can flip is worse than no checker, because the same mechanism yields a false **green** (comment out a real site). Hence `strip_comments`, which blanks comments while preserving offsets and handles strings/char/raw-strings so a `//` inside a literal survives. Two regression arms pin both directions.

Also fixed en route: `site_key`'s impl-qualification was "nearest `impl` above the site", which misattributes a free fn that merely *follows* a closed impl block — exactly `try_time_sync`'s shape. Replaced with balanced-brace span tracking.

**Arm 3's limitation, stated rather than sold:** literal cfg-string comparison, no cfg algebra. It detects "a guard moved" and claims nothing more.

## §5.1 corrected — and the direction is DOWN

That section exists to stop an unmeasured number reading as measured, so a stale *measurement* in it was the same defect it was written against. Its `87,960 / 13,752 B` predate #391 (taken over the **pre**-de-pin main). As merged (`ec3ee63`):

| | `.stack` |
|---|---|
| `origin/main` before #391, fleet, same seed | 106,472 B |
| **as merged, fleet** | **86,208 B** |
| floor | 74,208 B |

Margin is **12,000 B**, not 13,752 B; the executor costs **20,264 B** of DRAM. CI's own line on #391's head agrees: `stack: 86208 B (floor 74208 B)`. Recorded beside it: the **8-byte tree-dependence** (86,200 B under `ci_provision` vs 86,208 B for a dev seed — the gate is the inequality, never byte-equality), and that the floor's conservatism is an **argument, not a measurement**, and not a licence to spend the 12 KB.

## Evidence

Run on familiar with `board.rs`/`secrets.rs` provisioned by `tools/ci_provision.sh`, so the tree matches CI rather than a developer seed:

```
gate.sh host → GATE GREEN, "21 passed, 0 failed"
gate.sh fw   → GATE GREEN
               station consumers: 2 station consumer(s) across 2 declared fn(s);
               0 `embassy_net::new` site(s); 2 cfg guard(s) pinned
               10/10 tiers check + clippy -D warnings clean
               stack: 86200 B (floor 74208 B)
```

Per `[[gate-that-cannot-fail]]`: the number is **21 arms, 0 failed**, and the arms are proven able to go red — not merely observed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)