### PR TITLE
feat(tools): status_check.sh — make #148 fail instead of rotting invisibly (#148)

### DIFF
--- a/.github/workflows/status-check.yml
+++ b/.github/workflows/status-check.yml
@@ -1,0 +1,72 @@
+# #148 — re-test the status doc's machine-checkable claims, on a schedule.
+#
+# #148 is the project status issue. It has now been rewritten twice after going stale, and each
+# revision opened by observing that the previous one had rotted. The cause was structural, not
+# anyone's diligence: nothing made the document FAIL. This is the thing that makes it fail.
+#
+# DELIBERATELY THIN, for the same reason `fw-gate.yml` is: the logic lives in
+# `tools/status_check.sh`, which anyone can run verbatim. And the CLAIMS live in neither — they
+# are `<!-- check: … -->` annotations in #148's own body, so there is exactly one statement of
+# each fact. A copy here, or in the script, would be the drift this exists to catch.
+#
+# WHY A CRON AND NOT A GATE ARM.
+#
+# The doc lives in a GitHub ISSUE, not in the repo, so no push or PR can change it — a
+# per-commit gate would re-check an unchanged document hundreds of times and still miss the
+# edit that mattered, because that edit happens in the issue tracker. Doc rot also runs on a
+# scale of weeks, which is what this samples. It additionally needs network + `gh`, which
+# `tools/gate.sh` deliberately does not require of a developer running it offline.
+#
+# The failures are written to the JOB SUMMARY, not just the log. A scheduled red X that nobody
+# opens is the same shape as the prose it replaced.
+name: status doc check
+
+on:
+  schedule:
+    # Mondays 16:05 UTC (~09:05 PDT) — a working morning, so a failure is seen the day it lands
+    # rather than accumulating over a weekend.
+    - cron: '5 16 * * 1'
+  # Always available by hand: after rewriting #148, run this before trusting the rewrite.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  status-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        # `branch-absent` asks origin, and `file-exists` / `grep-absent` read the tree, so this
+        # needs a real checkout — but no history.
+        with: { fetch-depth: 1 }
+
+      - name: re-test #148's annotations
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -o pipefail
+          tools/status_check.sh 2>&1 | tee "$RUNNER_TEMP/status-check.log"
+        continue-on-error: true
+
+      - name: report
+        env:
+          # Via env, not inline `${{ }}` in the script body. This one is a GitHub-controlled
+          # enum ('success'/'failure') so it cannot carry an injection, but the habit is what
+          # keeps the next edit safe when someone reaches for an issue title here.
+          CHECK_OUTCOME: ${{ steps.check.outcome }}
+        run: |
+          {
+            echo "## #148 status-doc check"
+            echo
+            echo '```'
+            sed 's/\x1b\[[0-9;]*m//g' "$RUNNER_TEMP/status-check.log"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$CHECK_OUTCOME" != success ]; then
+            echo "::error::#148 contains claims that are no longer true — see the job summary."
+            exit 1
+          fi

--- a/tools/status_check.sh
+++ b/tools/status_check.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# status_check.sh — re-test the machine-checkable claims in issue #148, and FAIL when the doc
+# has rotted. (#148)
+#
+# WHY THIS EXISTS
+#
+# #148 is the project status doc. It has been rewritten twice, and each time the previous
+# snapshot had gone almost entirely stale — the 2026-08-01 revision opens by saying so about the
+# 2026-07-20 one, and was itself found stale 24 days later with five falsifiable claims,
+# including a Tier-B queue item instructing readers to redo settled work (`#233 merge (PR #247)`
+# when #233 was closed and #247 closed-unmerged).
+#
+# Twice is a pattern, and the cause is structural rather than anyone's diligence: NOTHING MADE
+# THE DOCUMENT FAIL. It rotted silently and was rewritten when a human happened to notice. That
+# is this repo's signature defect shape (#371) at the document level, and the same shape #384
+# fixed for the vendored sigil corpus — a checker nobody invokes is the same shape as prose.
+#
+# WHERE THE CLAIMS LIVE, AND WHY NOT HERE
+#
+# The assertions live in #148's BODY, as `<!-- check: … -->` annotations next to the prose they
+# anchor. This script holds NO copy of them. That is deliberate and it is the whole design: a
+# script carrying its own list of claims would be two statements of one fact, which is exactly
+# the rot that let `mesh_elect`'s tag list and #148 itself go stale. There is one statement, in
+# the doc, and this file only evaluates it.
+#
+# Consequence worth stating plainly: editing the prose without editing its annotation makes this
+# script fail. That is the designed outcome, not an incident.
+#
+# WHAT IT CANNOT DO
+#
+# It does not keep the prose true — only the mechanically checkable half. A paragraph can be
+# beautifully wrong about strategy and pass every check here. The value is narrower and real:
+# the factual half is the half that sends people to redo settled work.
+#
+# CHECK FAMILIES  (kind + args, as they appear in the doc)
+#   issue-closed <n>            an issue is closed        (and IS an issue, not a PR)
+#   issue-open <n>              an issue is open          (and IS an issue, not a PR)
+#   pr-merged <n>               a PR is merged
+#   pr-closed-unmerged <n>      a PR is closed and was NOT merged
+#   branch-absent <name>        no such branch on origin
+#   file-exists <path>          path exists in the repo
+#   grep-absent <pattern> <dir> pattern does not occur under dir
+#
+# EXIT CODES
+#   0  every claim held
+#   1  at least one claim FAILED — the doc is wrong somewhere
+#   2  the script could not run (no gh, no network, unreadable body)
+#
+# USAGE
+#   tools/status_check.sh                  # fetch issue #148's live body and check it
+#   tools/status_check.sh --body-file F    # check a local copy (used to prove it can fail)
+#   tools/status_check.sh --issue N        # check a different issue's annotations
+set -uo pipefail
+
+ISSUE="${SMOL_STATUS_ISSUE:-148}"
+BODY_FILE=""
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0; FAIL=0
+FAILED_CLAIMS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --body-file) BODY_FILE="${2:-}"; shift 2 ;;
+    --issue)     ISSUE="${2:-}"; shift 2 ;;
+    -h|--help)   sed -n '2,48p' "$0"; exit 0 ;;
+    *)           echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+ok()   { printf '  \033[32mPASS\033[0m  %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; FAIL=$((FAIL+1)); FAILED_CLAIMS+=("$1"); }
+
+# ── obtain the body ───────────────────────────────────────────────────────────────────────────
+if [ -n "$BODY_FILE" ]; then
+  [ -r "$BODY_FILE" ] || { echo "cannot read $BODY_FILE" >&2; exit 2; }
+  BODY="$(cat "$BODY_FILE")"
+  echo "── checking #$ISSUE annotations from LOCAL FILE $BODY_FILE"
+else
+  command -v gh >/dev/null || { echo "gh CLI not found" >&2; exit 2; }
+  BODY="$(gh issue view "$ISSUE" --repo "${SMOL_REPO:-jphein/smol}" --json body --jq '.body' 2>/dev/null)" \
+    || { echo "could not fetch issue #$ISSUE body" >&2; exit 2; }
+  [ -n "$BODY" ] || { echo "issue #$ISSUE body is empty" >&2; exit 2; }
+  echo "── checking #$ISSUE annotations (live body)"
+fi
+
+# ── parse ─────────────────────────────────────────────────────────────────────────────────────
+#
+# INLINE CODE SPANS ARE STRIPPED FIRST, and this is load-bearing rather than tidiness. #148's own
+# opening paragraph explains the convention to the reader by quoting it:
+#
+#     every factual claim that CAN be machine-checked carries a `<!-- check: … -->` annotation
+#
+# That is a backticked EXAMPLE, not a claim. A parser that does not strip code spans either fails
+# the doc on an unparseable kind ("…") or, worse, counts it as a check that trivially passes —
+# and the document would then be teaching its own convention in a way that breaks the tool that
+# reads it. Markdown already means "this is an example, not a directive" with backticks; honour it.
+#
+# After stripping, an unknown kind is a HARD FAIL, not a skip: a typo'd annotation that silently
+# passes is precisely the failure this file exists to prevent.
+LINE_NO=0
+while IFS= read -r line; do
+  LINE_NO=$((LINE_NO+1))
+  stripped="$(printf '%s' "$line" | sed 's/`[^`]*`//g')"
+  case "$stripped" in *'<!-- check:'*) ;; *) continue ;; esac
+
+  # The prose this line anchors — trimmed, for the report. Readers need to know WHICH sentence
+  # is wrong, not merely that check #7 failed.
+  anchor="$(printf '%s' "$stripped" | sed 's/<!-- check:[^>]*-->//g; s/^[[:space:]-]*//; s/[[:space:]]*$//' | cut -c1-72)"
+
+  while IFS= read -r ann; do
+    [ -n "$ann" ] || continue
+    kind="$(printf '%s' "$ann" | awk '{print $1}')"
+    a1="$(printf '%s' "$ann" | awk '{print $2}')"
+    a2="$(printf '%s' "$ann" | awk '{print $3}')"
+    label="L$LINE_NO $kind ${a1:-}${a2:+ $a2}  — $anchor"
+
+    case "$kind" in
+      issue-closed|issue-open)
+        json="$(gh api "repos/${SMOL_REPO:-jphein/smol}/issues/$a1" --jq '{s:.state,p:(.pull_request!=null)}' 2>/dev/null)"
+        if [ -z "$json" ]; then bad "$label  [could not read issue $a1]"; continue; fi
+        state="$(printf '%s' "$json" | sed -n 's/.*"s":"\([a-z]*\)".*/\1/p')"
+        ispr="$(printf '%s' "$json" | grep -q '"p":true' && echo yes || echo no)"
+        want="${kind#issue-}"
+        if [ "$ispr" = yes ]; then bad "$label  [#$a1 is a PR, not an issue]"
+        elif [ "$state" = "$want" ]; then ok "$label"
+        else bad "$label  [is '$state', expected '$want']"; fi ;;
+      pr-merged|pr-closed-unmerged)
+        json="$(gh api "repos/${SMOL_REPO:-jphein/smol}/pulls/$a1" --jq '{s:.state,m:.merged}' 2>/dev/null)"
+        if [ -z "$json" ]; then bad "$label  [could not read PR $a1]"; continue; fi
+        state="$(printf '%s' "$json" | sed -n 's/.*"s":"\([a-z]*\)".*/\1/p')"
+        merged="$(printf '%s' "$json" | grep -q '"m":true' && echo yes || echo no)"
+        if [ "$kind" = pr-merged ]; then
+          [ "$merged" = yes ] && ok "$label" || bad "$label  [not merged; state '$state']"
+        else
+          { [ "$state" = closed ] && [ "$merged" = no ]; } && ok "$label" \
+            || bad "$label  [state '$state', merged=$merged]"
+        fi ;;
+      branch-absent)
+        if [ -n "$(git -C "$REPO_ROOT" ls-remote --heads origin "$a1" 2>/dev/null)" ]; then
+          bad "$label  [branch still exists on origin]"
+        else ok "$label"; fi ;;
+      file-exists)
+        [ -e "$REPO_ROOT/$a1" ] && ok "$label" || bad "$label  [missing from the tree]" ;;
+      grep-absent)
+        if [ ! -d "$REPO_ROOT/$a2" ] && [ ! -f "$REPO_ROOT/$a2" ]; then
+          bad "$label  [search path '$a2' does not exist — a vacuous pass is not a pass]"
+        elif grep -rq -- "$a1" "$REPO_ROOT/$a2" 2>/dev/null; then
+          bad "$label  [still present under $a2]"
+        else ok "$label"; fi ;;
+      *)
+        bad "$label  [UNKNOWN check kind '$kind' — a check nobody can evaluate is not a check]" ;;
+    esac
+  done < <(printf '%s' "$stripped" | grep -o '<!-- check:[^>]*-->' \
+             | sed 's/<!-- check:[[:space:]]*//; s/[[:space:]]*-->//')
+done <<< "$BODY"
+
+# ── verdict ───────────────────────────────────────────────────────────────────────────────────
+echo
+TOTAL=$((PASS+FAIL))
+if [ "$TOTAL" -eq 0 ]; then
+  echo "NO CHECKS FOUND in #$ISSUE — the annotations were removed, or the parser is broken." >&2
+  echo "Either way this tool is no longer guarding anything, so that is a failure, not a pass." >&2
+  exit 1
+fi
+echo "$PASS/$TOTAL claims hold."
+if [ "$FAIL" -gt 0 ]; then
+  echo
+  echo "THE DOC IS WRONG in $FAIL place(s):"
+  for c in "${FAILED_CLAIMS[@]}"; do echo "  • $c"; done
+  echo
+  echo "Fix the prose AND its annotation together — they are one statement. If a claim has"
+  echo "simply moved on, that is the doc rotting exactly as designed to be caught."
+  exit 1
+fi
+echo "#$ISSUE's machine-checkable half is intact."


### PR DESCRIPTION
Implements the companion to #148's rewrite: `tools/status_check.sh` re-tests the doc's machine-checkable claims and exits non-zero when it has rotted.

## The claims are not in this script

They're `<!-- check: … -->` annotations in **#148's own body**, next to the prose they anchor. This file only evaluates them. A script carrying its own copy of the claims would be two statements of one fact — which is exactly the rot that let `mesh_elect`'s tag list drift (#328/#410) and let #148 itself go stale twice. One statement, in the doc.

The consequence is the feature: **editing prose without updating its annotation fails the check.**

Seven families: `issue-closed`, `issue-open`, `pr-merged`, `pr-closed-unmerged`, `branch-absent`, `file-exists`, `grep-absent`.

## The parser detail that matters

Inline code spans are stripped before extraction, because **#148 teaches its own convention by quoting it**:

> every factual claim that CAN be machine-checked carries a `` `<!-- check: … -->` `` annotation

That's a backticked *example*, not a claim. Without stripping, the document breaks the tool that reads it — either failing on an unevaluable kind (`…`) or, worse, counting a decoy that trivially passes. Markdown already means "example, not directive" with backticks, so I honour that rather than asking the doc to contort around the parser.

After stripping, an **unknown kind is a hard FAIL, never a skip**. A typo'd annotation that silently passes is the precise failure this file exists to prevent.

## Three vacuous-pass guards

Each of these would otherwise let the tool report green while guarding nothing:

- **zero checks found → exit 1.** If the annotations are stripped out or the parser breaks, that's a failure, not a pass.
- **`grep-absent` against a non-existent path → FAIL.** "Not found in a directory that doesn't exist" is not evidence.
- **`issue-*` asserts the number is an issue and not a PR** (the `/issues/{n}` endpoint answers for both).

## Proven able to fail — and to pass, and to ignore the decoy

```
all-true body          4/4, decoy on line 1 ignored          exit 0
injected false claim   "is 'closed', expected 'open'"        exit 1
typo'd kind            "UNKNOWN check kind 'issue-clsoed'"   exit 1
no annotations at all  "NO CHECKS FOUND"                     exit 1
grep-absent, bad path  "a vacuous pass is not a pass"        exit 1
```

## It already found three real rot instances

Against the **live** body, hours after the rewrite: **16/19 claims hold.**

```
FAIL  L11 grep-absent ELECT_ENFORCE rust/clock/src   [still present under rust/clock/src]
FAIL  L26 issue-open 327                             [is 'closed', expected 'open']
FAIL  L33 issue-open 37                              [is 'closed', expected 'open']
```

**These are doc fixes for @team-lead, not script bugs** — the tool is working. Two are ordinary rot (#327 and #37 closed after the rewrite; #327 I closed the loop on myself). The third is more interesting and is a **claim/check mismatch rather than rot**: `ELECT_ENFORCE` genuinely no longer exists as a *symbol* in smol, but the string is still present in `net.rs:121` and `net/election.rs:143` as **prose describing the watch's flag**. `grep-absent` can't tell a live symbol from a comment about one — the same "a literal grep proves nothing about intent" trap this repo has hit before. Options: narrow the prose, drop that annotation, or (my preference) leave the prose and re-anchor the claim to something a grep can actually decide.

Also, re-deriving rather than quoting: I count **19 annotations across 7 families**, where the hand-off said 18 across 6. Worth a second look at which is right — #148's own tracker-health section warns "re-derive a number before quoting it."

## Why a cron and not a `gate.sh` arm

The doc lives in a **GitHub issue, not the repo**, so no push or PR can change it. A per-commit gate would re-check an unchanged document hundreds of times and still miss the edit that mattered, because that edit happens in the issue tracker. Doc rot also runs on a scale of weeks, which is what a weekly cron samples. It needs network + `gh`, which `tools/gate.sh` deliberately doesn't require of a developer running it offline.

Failures are written to the **job summary**, not just the log — a scheduled red X nobody opens is the same shape as the prose it replaces. `workflow_dispatch` is enabled so you can run it by hand right after rewriting #148.

## Notes

- Workflow follows `fw-gate.yml`'s "deliberately thin" convention — logic in `tools/`, the YAML only supplies a machine.
- No inline `${{ }}` inside any `run:` block; the one expression used is passed via `env:`. It's a GitHub-controlled enum so it can't carry an injection, but the habit is what keeps the next edit safe.
- No firmware change. `tools/` + `.github/` only — routed to @team-lead, **not** self-merged.
- No collision with #414's tmp-policy files (`measure_debuginfo_delta.sh`, `ota_publish.sh`, `gate.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
