### PR TITLE
feat(dashboard): UNCOVERED — the inverse of DEAD ROWS, so a live board with no card is visible (#356)

### DIFF
--- a/ha/dashboard/build_control_room.py
+++ b/ha/dashboard/build_control_room.py
@@ -1105,7 +1105,7 @@ async def main():
             # The fleet explains the card counts: node boxes are per-node, so "built 33 / live 31"
             # is a node that joined since the last real run, not a mystery.
             report_fleet(nodes, dormant, roster)
-            return report_check(cfg, view, prev, extras, retired, retiring, st)
+            return report_check(cfg, view, prev, extras, retired, retiring, st, nodes)
         if prev:
             if retiring:
                 print(f"  REMOVED {len(retiring)} card(s) listed in RETIRE_LIVE:",
@@ -1429,8 +1429,8 @@ def _dead(sources, st):
     return out
 
 
-def audit_views(cfg, view, prev, extras, st):
-    """#340 — DEAD ROWS for the WHOLE DASHBOARD. Returns (dead, audited).
+def _audit_sources(cfg, view, prev, extras):
+    """#340 — the ONE walk over every view on the dashboard. Returns (sources, audited).
 
     THE THIRD FACE OF #333. The first two were about scope within one view (preserved cards were
     outside it; the check only ran before a change). This one is a level up: `classify()` resolves
@@ -1492,15 +1492,101 @@ def audit_views(cfg, view, prev, extras, st):
     n = len(cfg.get("views") or [])
     assert sum(1 for a in audited if a[3]) == n, \
         f"a view escaped the audit: {sum(1 for a in audited if a[3])} audited of {n}"
+    return sources, audited
+
+
+def audit_views(cfg, view, prev, extras, st):
+    """#340's contract, unchanged: (dead, audited). The walk itself moved to `_audit_sources`
+    so #356's UNCOVERED could ask the inverse question of the SAME walk — see `wired_entities`."""
+    sources, audited = _audit_sources(cfg, view, prev, extras)
     return _dead(sources, st), audited
 
 
-def report_check(cfg, view, prev, extras, retired, retiring, st):
-    """--check output. Exit code: 1 live-only drift · 3 dead rows · 0 clean.
+def wired_by_source(cfg, view, prev, extras):
+    """#356 — {source_tag: {entity, …}} for every card on the dashboard. Union it for 'wired'.
 
-    Precedence when both fire: 1. Live-only is the more structural failure — a card the repo
-    cannot rebuild at all outranks a card it can rebuild but which points somewhere dead. Both
-    sections always print, so the exit code chooses your first action without hiding the rest.
+    Deliberately built from `_audit_sources`, the same walk `audit_views` uses, rather than by a
+    second traversal. The rule this file keeps re-learning is that a second enumeration of one
+    fact drifts from the first: #340 was a confident answer about a subset, and #328 was a tag
+    list that quietly stopped describing the tags. UNCOVERED is the inverse of DEAD ROWS and it
+    must be asked against identical evidence, or the two can disagree about what is on the glass.
+
+    Kept PER SOURCE rather than pre-unioned because the two questions need different grain. The
+    dashboard-wide union answers "is this board anywhere at all", which is the invariant worth an
+    exit code. The per-view breakdown answers "which view is thin", which is what #356 was actually
+    about — `smol-telemetry` wiring a hardcoded 7/8/9 while the fleet moved on. The union alone
+    reports 0 for that, correctly and uselessly, because `smol-control` covers every node."""
+    sources, _ = _audit_sources(cfg, view, prev, extras)
+    out = {}
+    for tag, d in sources:
+        out.setdefault(tag, set()).update(d)
+    return out
+
+
+def nodes_covered_by(entities, nodes):
+    """How many of `nodes` have at least one entity in `entities`. Pure; see uncovered_nodes."""
+    entities = set(entities)
+    return sum(1 for m in nodes or ()
+               if (set(m.get("own") or []) | {e for e in (m.get("fw") or {}).values() if e})
+               & entities)
+
+
+def uncovered_nodes(nodes, wired):
+    """#356 — LIVE fleet members that no card anywhere on the dashboard wires. Returns {id: meta}.
+
+    THE INVERSE OF DEAD ROWS, and it needs its own question because neither existing check can
+    reach it. A dead row is a CARD WIRED TO NO NODE; this is a NODE WIRED TO NO CARD. `_dead`
+    starts from the cards and asks what is missing from HA, so a board with no card contributes
+    nothing to walk and is invisible by construction — the audit's coverage line can honestly read
+    'DEAD ROWS · 0' and '2 of 2 views' while a live board appears nowhere on the glass.
+
+    That is the observed defect, not a hypothetical: `smol-telemetry` builds its tiles from a
+    hardcoded id list (7/8/9), so when the fleet moved on, live boards simply had no row and
+    nothing said so for weeks. #340 made every view visible to the audit; this makes every live
+    NODE visible to it.
+
+    DORMANT NODES ARE NOT A FINDING. A retired board with no tile is the dashboard being correct,
+    and reporting it would make this check cry wolf on exactly the fleet churn it should tolerate.
+    Liveness comes from `discover_fleet`'s heartbeat rule (`meta['on']`), which is deliberately the
+    same rule the dashboard paints green with — so a node this reports as uncovered is never one
+    the glass shows as present, and vice versa.
+
+    TAKES THE CALLER'S LIVE LIST — it does NOT re-derive liveness, and that is the whole of the
+    contract. `main()` builds `nodes` from `live`, which is `meta['on']` PLUS every peer in the
+    current crown's roster PLUS the crown itself by definition, with a "nothing live → show
+    everything" fallback. Re-testing `meta['on']` here would quietly disagree with that: a C6 watch
+    the crown is hearing at −35 dBm has no hand-written heartbeat sensor, so raw `on` reads False
+    for it — the exact wrong-in-both-directions failure #312 removed from `discover_fleet`. One
+    definition of live, owned by the caller, and this asks only "is it on the glass".
+
+    Pure, and separate from the I/O, so the offline test can prove BOTH directions without an HA
+    instance — the same reason `scrub_foreign` is pure in the ha repo's deploy tool. A check whose
+    finding path never runs in a test is indistinguishable from one that cannot find anything."""
+    wired = set(wired)
+    out = {}
+    for meta in nodes or ():
+        ents = set(meta.get("own") or []) | {e for e in (meta.get("fw") or {}).values() if e}
+        if not (ents & wired):
+            out[meta["id"]] = meta
+    return dict(sorted(out.items()))
+
+
+def report_check(cfg, view, prev, extras, retired, retiring, st, nodes=None):
+    """--check output. Exit code: 1 live-only drift · 3 dead rows · 5 uncovered nodes · 0 clean.
+
+    Precedence when several fire: 1, then 3, then 5. Live-only is the most structural failure — a
+    card the repo cannot rebuild at all outranks a card it can rebuild but which points somewhere
+    dead, and both outrank a node the dashboard simply does not mention. The first two say the
+    dashboard is WRONG; the third says it is INCOMPLETE, which is real but never the thing to fix
+    first. Every section always prints, so the exit code chooses your first action without hiding
+    the rest.
+
+    #356 added 5 rather than folding uncovered nodes into 1 or 3, because the remediation is
+    somewhere else entirely: live-only means edit the scaffold, dead rows means repoint a card,
+    uncovered means a view (often one this repo does not build) never enumerated the fleet at all.
+    A shared code would send someone to the wrong file. `tools/ha_deploy.sh` learned this code in
+    the same change — its `case` had a `*)` arm reading "check could not run", and its own comment
+    warns that "mislabelling a real finding as 'couldn't check' is the worse direction of the two".
 
     SCOPE, and #340 changed exactly one thing about it. LIVE-ONLY / RETIRED / RETIRING are about
     the ONE view this repo generates — they compare a scaffold against its own output, and no other
@@ -1511,6 +1597,9 @@ def report_check(cfg, view, prev, extras, retired, retiring, st):
     decide whether a deploy broke a card. A second section it does not grep would have re-created
     #340 inside the consumer: a confident answer about a subset."""
     dead, audited = audit_views(cfg, view, prev, extras, st)   # #340: EVERY view, not just ours
+    by_src = wired_by_source(cfg, view, prev, extras)          # same walk, inverse question
+    wired = {e for ents in by_src.values() for e in ents}
+    uncovered = uncovered_nodes(nodes or (), wired)            # #356: EVERY live node, too
     # Coverage first, and as a list. "DEAD ROWS · 0" is only worth reading if you can see what was
     # looked at, and for two releases the honest rendering of that line was "0, in one of two views".
     on_dash = sum(1 for a in audited if a[3])
@@ -1609,7 +1698,48 @@ def report_check(cfg, view, prev, extras, retired, retiring, st):
         print(f"\nDEAD ROWS · 0 — every wired entity on all {on_dash} view(s) of '{DASH}' "
               f"exists and is actually provided.")
 
-    return 1 if extras else (3 if dead else 0)
+    # #356 — the inverse question. Printed as one `UNCOVERED · N` line for the same reason DEAD
+    # ROWS is: `tools/ha_deploy.sh` greps these headers out of the output, and a per-node section
+    # it does not grep would re-create #340 inside the consumer.
+    live_n = len(nodes or ())
+    if nodes is None:
+        print("\nUNCOVERED · not checked (no fleet passed to report_check)")
+    elif uncovered:
+        print(f"\nUNCOVERED · {len(uncovered)} LIVE node(s) that NO card on '{DASH}' wires "
+              f"— of {live_n} live in the fleet.")
+        print("  The inverse of DEAD ROWS: not a card pointing at nothing, but a board the")
+        print("  dashboard never mentions. Neither of the checks above can see this — they walk")
+        print("  the cards, and a node with no card contributes nothing to walk.")
+        for nid, meta in uncovered.items():
+            print(f"    - id{nid}  {meta.get('name') or '?'}  (fw {meta.get('sw') or '?'})")
+        print("\n  FIX: whichever view is meant to carry per-node tiles must ENUMERATE the fleet")
+        print("       rather than hardcode ids. `smol-telemetry` is built from ~/Projects/ha and")
+        print("       builds its tiles from a fixed id list, which is how this rots (#356): the")
+        print("       fleet moves, the list does not, and nothing says so.")
+        print("       Deriving the tiles the way this script does — discover_fleet() + sigil_of()")
+        print("       — makes both the ids and the names come from the firmware-authored registry,")
+        print("       which is the one source that cannot drift from the boards.")
+    elif live_n:
+        print(f"\nUNCOVERED · 0 — all {live_n} live node(s) are wired by at least one card on "
+              f"'{DASH}'.")
+    else:
+        print("\nUNCOVERED · 0 — no live nodes in the fleet to cover.")
+
+    # PER-SOURCE COVERAGE — informational, and deliberately NOT part of the exit code.
+    #
+    # UNCOVERED above is the invariant: a live board must appear SOMEWHERE. This is the finer
+    # question #356 actually asked — which view is thin. It cannot be a failure, because nothing
+    # in this repo states which views are SUPPOSED to carry per-node tiles: `smol-control` is
+    # generated per-node by design, while `smol-telemetry` is built in ~/Projects/ha and its
+    # intent lives there. Failing on a low number would be this script inventing another repo's
+    # requirements. Printing it makes the thinness visible, which is the whole of #356's
+    # complaint — "a dead-row audit cannot see this by construction".
+    if nodes:
+        print(f"\n  per-source node coverage (informational — of {live_n} live node(s)):")
+        for tag in sorted(by_src):
+            print(f"    {tag:<26} covers {nodes_covered_by(by_src[tag], nodes):>2}")
+
+    return 1 if extras else (3 if dead else (5 if uncovered else 0))
 
 
 def report_fleet(nodes, dormant, roster):

--- a/ha/dashboard/test_uncovered_nodes.py
+++ b/ha/dashboard/test_uncovered_nodes.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""#356 regression test — a live node that no card wires must be reported, and a covered one must not.
+
+    python3 ha/dashboard/test_uncovered_nodes.py        # exit 0 = pass
+
+NO HA INSTANCE, NO TOKEN, NO NETWORK. `uncovered_nodes()` is pure on purpose, and this is the
+payoff: the finding path runs on every invocation instead of only when someone happens to have a
+dashboard in the wrong state. `test_dead_rows.py` needs live HA because it asserts things about
+real entities; this needs nothing, and a check that can only be tested against production is a
+check that mostly is not tested.
+
+WHY THIS FILE EXISTS. `smol-telemetry` builds per-node tiles from a hardcoded id list (7/8/9). The
+fleet moved to other ids and those boards simply had no row — for weeks, with nothing saying so.
+The existing audits could not catch it *by construction*: `report_dead_rows` walks the CARDS and
+asks what HA is missing, so a node with no card contributes nothing to walk. `DEAD ROWS · 0` and
+`VIEWS AUDITED · 2 of 2` were both true and both silent about a live board that was nowhere.
+
+So this asserts BOTH directions, which is the property that actually matters:
+  * an uncovered live node IS reported — the check can fail; and
+  * a covered one is NOT — the check is not merely reporting everything, which would pass
+    direction 1 while being useless.
+
+That second half is not padding. A version of this that returned every node would satisfy "it can
+fail" and would cry wolf on every board, which is the fastest way to get a check ignored — the
+#338 failure mode this repo already has a name for.
+
+DORMANT NODES DO NOT APPEAR HERE, and that is the design rather than a gap: `main()` splits the
+fleet into `nodes` (live) and `dormant` before either is printed, so `uncovered_nodes` is handed
+only the live list and never decides liveness itself. See the fixture note below for what happened
+when an earlier draft of this test assumed otherwise.
+"""
+import os, sys, importlib.util
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# The module reads os.environ["HA_TOKEN"] at import time (line ~58) and would KeyError. Nothing is
+# dialled — no connection is opened unless main() runs, and it does not.
+os.environ.setdefault("HA_TOKEN", "offline-test-not-a-real-token")
+
+FAILURES = []
+
+
+def check(label, got, want):
+    if got == want:
+        print(f"  PASS  {label}")
+    else:
+        print(f"  FAIL  {label}\n          got:  {got}\n          want: {want}")
+        FAILURES.append(label)
+
+
+def load_generator():
+    """Import build_control_room without running it."""
+    spec = importlib.util.spec_from_file_location("bcr", os.path.join(HERE, "build_control_room.py"))
+    m = importlib.util.module_from_spec(spec)
+    argv, sys.argv = sys.argv, ["test"]      # the module inspects sys.argv for --check/--from-worktree
+    try:
+        spec.loader.exec_module(m)
+    finally:
+        sys.argv = argv
+    return m
+
+
+# Shaped like the LIST `main()` passes: one entry per node already judged live, `own` from the
+# entity registry and `fw` the resolved firmware entities.
+#
+# THE LIST IS ALREADY THE LIVE SET. An earlier draft of this test invented a `{id: meta}` dict and
+# had `uncovered_nodes` re-filter on `meta["on"]`, and it passed — the fixture encoded my
+# assumption about the caller rather than the caller. A live run against real HA raised
+# `'list' object has no attribute 'items'` on the first line that touched it. Worse than the crash
+# was what the crash hid: `main()` derives `live` from `on` PLUS the crown's roster PLUS the crown
+# itself, so re-filtering on `on` would have dropped a C6 watch the crown hears at -35 dBm but
+# which owns no hand-written heartbeat sensor. Green test, wrong answer, in the direction #312
+# already fixed once.
+def node(nid, name, own=(), fw=None):
+    return {"id": nid, "name": name, "own": list(own), "fw": fw or {}, "sw": "v922"}
+
+
+def main():
+    bcr = load_generator()
+    u = bcr.uncovered_nodes
+
+    # The real shape of the #356 defect: two live boards, one on a tile and one not.
+    fleet = [node(8,  "Eldritch Jewel", own=["sensor.smol_8_rssi"]),
+             node(51, "Ashen Vigil",    own=["sensor.smol_51_rssi"])]
+    wired = {"sensor.smol_8_rssi"}
+    check("an uncovered live node is reported", sorted(u(fleet, wired)), [51])
+    check("a covered live node is not reported", 8 in u(fleet, wired), False)
+
+    # The cry-wolf guard, expressed the way the caller actually expresses it: a dormant board is
+    # simply ABSENT from this list (`main()` puts it in `dormant`), so the check must never be the
+    # thing deciding liveness. Passing only live nodes, nothing here should be invented.
+    check("a node absent from the live list cannot be reported", u([], set()), {})
+
+    # Coverage may come from either source — `own` (entity registry) or `fw` (resolved firmware
+    # entities). Counting only one would report a board that is plainly on the glass.
+    fleet_fw = [node(50, "Mystic Chalice", fw={"rssi": "sensor.smol_50_rssi"})]
+    check("coverage via the resolved fw entity counts",
+          u(fleet_fw, {"sensor.smol_50_rssi"}), {})
+    check("...and its absence is still caught",
+          sorted(u(fleet_fw, {"sensor.something_else"})), [50])
+
+    # A node with NO entities at all cannot be covered by anything — report it rather than let an
+    # empty intersection read as "fine".
+    check("a live node owning no entities is reported",
+          sorted(u([node(176, "no entities yet")], {"sensor.smol_8_rssi"})), [176])
+
+    # Whole fleet uncovered — the state #356 actually describes.
+    check("every live node uncovered when nothing is wired",
+          sorted(u(fleet, set())), [8, 51])
+
+    # Empty fleet must not invent a finding.
+    check("an empty fleet reports nothing", u([], {"sensor.anything"}), {})
+
+    # Output is id-ordered regardless of input order, because the report prints it verbatim.
+    check("result is sorted by node id",
+          list(u([node(51, "b"), node(8, "a")], set())), [8, 51])
+
+    # `nodes_covered_by` — the per-source counter behind the informational breakdown. This is the
+    # number that actually exposes #356: on live HA it prints `view:smol-telemetry covers 0` while
+    # the dashboard-wide UNCOVERED is a clean 0, because `smol-control` carries every node. Both
+    # facts are true and only the pair of them is informative.
+    c = bcr.nodes_covered_by
+    check("counts only nodes with a wired entity", c({"sensor.smol_8_rssi"}, fleet), 1)
+    check("a source wiring nothing covers 0", c(set(), fleet), 0)
+    check("a source wiring everything covers all",
+          c({"sensor.smol_8_rssi", "sensor.smol_51_rssi"}, fleet), 2)
+    check("unrelated entities cover nothing", c({"sensor.kitchen_light"}, fleet), 0)
+
+    print()
+    if FAILURES:
+        print(f"FAILED: {len(FAILURES)} check(s)")
+        return 1
+    print("test_uncovered_nodes: all checks passed — the inverse audit finds, and does not cry wolf")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ha_deploy.sh
+++ b/tools/ha_deploy.sh
@@ -352,6 +352,13 @@ cmd_dash() { # read-only; prints the generator's report, returns 0 in sync / 1 d
        echo "    into ha/dashboard/smol-control-scaffold.yaml (see #305 for how)." ;;
     3) echo "  → DEAD ROWS: the dashboard is reproducible but wired to entities HA does not have."
        echo "    Repoint or gate them — the card renders 'Entity not found' as it stands." ;;
+    # #356 — the inverse of 3: not a card pointing at nothing, but a live board no card mentions.
+    # Given its own arm for the reason the comment above insists on: the remediation is in a
+    # different file (usually a view this repo does not build), so folding it into 1 or 3 would
+    # send someone to edit a scaffold that has never contained the card.
+    5) echo "  → UNCOVERED NODES: a live board appears on NO card. The dashboard is not wrong,"
+       echo "    it is incomplete — a view is hardcoding node ids instead of enumerating the"
+       echo "    fleet (see #356). The list is above." ;;
     *) echo "  → check could not run (exit $rc); the dashboard is UNVERIFIED, not proven clean." ;;
   esac
   return "$rc"
@@ -769,7 +776,7 @@ cmd_push() {
     local dash_out=""
     dash_out="$(HA_TOKEN="$HA_TOKEN" timeout 180 python3 \
       "$REPO_DIR/ha/dashboard/build_control_room.py" --check 2>&1)" || dash_rc=$?
-    printf '%s\n' "$dash_out" | sed -n '/^LIVE-ONLY/p;/^DEAD ROWS/p;/^  ⚠/p;/^    - /p' | sed 's/^/    /'
+    printf '%s\n' "$dash_out" | sed -n '/^LIVE-ONLY/p;/^DEAD ROWS/p;/^UNCOVERED/p;/^  ⚠/p;/^    - /p' | sed 's/^/    /'
     # #340: that count is DASHBOARD-WIDE — every view, not just `smol-control` — so this warning
     # now covers rows on views this repo does not generate (a push that deletes an entity can kill
     # a card on any of them). The generator deliberately keeps it as ONE `DEAD ROWS · N` line so
@@ -794,6 +801,10 @@ cmd_push() {
     case "$dash_rc" in
       0|3) : ;;   # 3 is already covered by the DEAD ROWS branch above
       1) note "dashboard also reports LIVE-ONLY drift (see #305 — back-port vs retire is a decision)" ;;
+      # #356: a real finding, not a failure to run. Deliberately a `note` and not a ⚠ — an
+      # uncovered node is a pre-existing coverage gap, not damage this push just did, and the
+      # post-deploy question here is "did this push break anything".
+      5) note "dashboard also reports UNCOVERED live node(s) with no card at all (#356)" ;;
       *) echo "  ⚠ post-deploy dashboard check could not run (exit $dash_rc) — run it by hand." >&2 ;;
     esac
   fi


### PR DESCRIPTION
Closes the tractable half of #356: the issue's own "worth considering alongside it" — **a check for the inverse direction, a live fleet member with no tile**.

## The gap, and why nothing could see it

A dead row is a **card wired to no node**. This is a **node wired to no card**. `report_dead_rows` walks the *cards* and asks what HA is missing, so a board with no card contributes nothing to walk — it is invisible *by construction*. `DEAD ROWS · 0` and `VIEWS AUDITED · 2 of 2` were both true, and both silent, while `smol-telemetry` built tiles from a hardcoded 7/8/9 and the fleet moved on. #340 made every **view** visible to the audit; this makes every live **node** visible to it.

## Two grains, and only one deserves an exit code

I want to be straight about this, because the headline number is unexciting:

**UNCOVERED (exit 5)** — the invariant, "a live board must appear *somewhere*". On the current fleet it reports a clean **0**, because `smol-control` generates a box per node. That is the honest result, not a disappointment: dashboard-wide, no board is missing.

**Per-source coverage (informational)** — which view is thin. This is what #356 actually complained about, and it is where the defect is plainly visible:

```
UNCOVERED · 0 — all 5 live node(s) are wired by at least one card on 'smol-mesh'.

  per-source node coverage (informational — of 5 live node(s)):
    built                      covers  5
    live-only                  covers  0
    view:smol-telemetry        covers  0
```

`smol-telemetry` covers **zero of five** live nodes — measured, where the issue previously had to assert it by reading the JSON.

That number is deliberately **not** part of the exit code. Nothing in this repo states which views are *supposed* to carry per-node tiles, and `smol-telemetry` is built in `~/Projects/ha`. Failing on a low count would be this script inventing another repo's requirements — and a check that fails on someone else's design decision is one that gets ignored (#338). Printing it satisfies #356's actual complaint: *"a dead-row audit cannot see this by construction."*

## Compatibility, deliberately

- **`audit_views`'s `(dead, audited)` contract is unchanged.** `test_view_audit.py` unpacks it as a 2-tuple in **eleven** places; my first draft returned a 3-tuple and would have broken every one. The walk moved into `_audit_sources`, so UNCOVERED asks its inverse question of the *same* walk — a second traversal would be exactly the two-statements-of-one-fact drift that produced #340 and #328.
- **Exit 5 is new rather than folded into 1 or 3**, because the remediation is in a different file. `tools/ha_deploy.sh` learned it in the same change: **both** of its `case` arms had a `*)` reading *"check could not run"*, so a real finding would have rendered as a crash — which that file's own comment calls "the worse direction of the two". Its output filter learned `^UNCOVERED`, and the finding is a `note`, not a ⚠, since an uncovered node is a pre-existing gap rather than damage the push just did.

## Liveness is not re-derived, and that is the contract

`main()` builds the live list from `meta["on"]` **plus** the crown's roster **plus** the crown itself. An earlier draft of mine re-filtered on `on` inside the check, which would have dropped a C6 watch the crown hears at −35 dBm but which owns no hand-written heartbeat sensor — wrong in exactly the direction #312 already fixed once. One definition of live, owned by the caller.

## What the live run caught that the test did not

The offline fixture encoded *my assumption* about the caller (`{id: meta}`) rather than the caller (a list). It passed green, and then raised `'list' object has no attribute 'items'` on the first real invocation. Worse than the crash was what it concealed — the liveness bug above. The test now carries that note, because the useful lesson is about fixtures agreeing with callers, not about the typo.

## Tests

- **`test_uncovered_nodes.py` — 13 checks, no HA, no token, no network.** `uncovered_nodes` and `nodes_covered_by` are pure precisely so the finding path runs on every invocation, instead of only when someone happens to have a dashboard in the wrong state. Asserts both directions: an uncovered node *is* reported, and a covered one is *not* — a version that returned everything would satisfy "it can fail" while being useless.
- `test_view_audit.py` — green (the eleven call sites).
- `test_dead_rows.py` — green.
- Live `--check` against HA: exit 1 from **pre-existing** LIVE-ONLY drift, unchanged from the baseline I captured before touching anything.

## Notes

- Not firmware, not `rust/clock`, not `docs/protocol.md`. Touches `ha/dashboard/` + `tools/ha_deploy.sh` (unfrozen now that #414 has merged).
- The larger half of #356 — regenerating `smol-telemetry` from `discover_fleet()`/`sigil_of()` — is cross-repo (`~/Projects/ha`) and stays open. This makes its absence *visible and measured*, which is what the issue said was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
