### PR TITLE
targets/c6-watch refresh: the S3 paints (ILI9341V driver + panel seam)

### DIFF
--- a/src/bin/slint_demo.rs
+++ b/src/bin/slint_demo.rs
@@ -54,6 +54,9 @@ mod board;
 mod drivers {
     pub mod co5300;
     pub mod qspi_bus;
+    // The demo bin re-declares the panel alias (its inline mod tree can't see
+    // the library's) — C6/QSPI only; the demo is a C6 tool.
+    pub type ActivePanel<'d> = co5300::Co5300Display<'d>;
 }
 
 #[path = "../peripherals"]

--- a/src/board/cyd_c5.rs
+++ b/src/board/cyd_c5.rs
@@ -105,3 +105,9 @@ pub const BACKLIGHT_DIMMABLE: bool = false;
 /// PROVISIONAL: boot straps are 26/27/28 and no key is confirmed wired; the
 /// board may be touch-only. Flip only with a measured press on glass.
 pub const HAS_BOOT_KEY: bool = false;
+
+// SPI clocks for the shared display/touch bus (drivers/spi_bus.rs reads
+// these). MEASURED values from the CYD bring-up: ST7789 at 20 MHz, XPT2046 at
+// 2.5 MHz on the same bus with per-select retuning.
+pub const SPI_DISPLAY_HZ: u32 = 20_000_000;
+pub const SPI_TOUCH_HZ: u32 = 2_500_000;

--- a/src/board/esp32s3_cyd.rs
+++ b/src/board/esp32s3_cyd.rs
@@ -95,3 +95,10 @@ pub const HAS_BOOT_KEY: bool = true;
 // This board clocks its panel at 40 MHz (SPI_DISPLAY_HZ in board_es3c28p.rs),
 // so the number is different — measure it during bring-up before treating any
 // row constant as this board's fact (measured, never inherited).
+
+// SPI clock for the display bus (drivers/spi_bus.rs). board_es3c28p.rs:
+// SPI_DISPLAY_HZ = 40 MHz (ESPHome-proven on the board class). SPI_TOUCH_HZ
+// exists only because the shared bus code names it — this board's touch is
+// I2C (FT6336U); nothing selects the SPI touch lane and touch_cs is None.
+pub const SPI_DISPLAY_HZ: u32 = 40_000_000;
+pub const SPI_TOUCH_HZ: u32 = 2_500_000;

--- a/src/drivers/framebuffer.rs
+++ b/src/drivers/framebuffer.rs
@@ -16,7 +16,8 @@ use embedded_graphics_core::prelude::*;
 use embedded_graphics_core::primitives::Rectangle;
 
 use crate::board;
-use crate::drivers::co5300::{Co5300Display, DisplayError};
+use crate::drivers::co5300::DisplayError;
+use crate::drivers::ActivePanel;
 
 use alloc::vec::Vec;
 
@@ -78,7 +79,7 @@ impl Framebuffer {
     /// Flush the whole frame to the panel: expand RGB332 -> RGB565 and
     /// nearest-neighbor upscale 2x (each half-res pixel -> a 2x2 panel block).
     /// Each half-res row feeds two consecutive panel rows.
-    pub fn flush(&mut self, display: &mut Co5300Display) {
+    pub fn flush(&mut self, display: &mut ActivePanel) {
         display.set_addr_window(0, 0, WIDTH as u16, HEIGHT as u16);
         display.bus_mut().begin_pixels();
         for y in 0..HEIGHT {

--- a/src/drivers/ili9341.rs
+++ b/src/drivers/ili9341.rs
@@ -1,0 +1,151 @@
+//! ILI9341V panel driver — the ES3C28P (ESP32-S3 CYD, eldritch-insignia).
+//!
+//! Skeleton and discipline from morpheus's glass-proven `st7789.rs`
+//! (feat/cyd-c5-gating): same [`SharedSpiBus`] underneath, same DCS command
+//! set (CASET/RASET/RAMWR/MADCTL/COLMOD), same no-reset-pin SWRESET story.
+//! The chip-specific difference is deliberate ABSENCE: the ST7789's
+//! voltage/gamma block (PORCTRL/GCTRL/VCOMS/…) is that silicon's register
+//! map, not this one's — the ILI9341V runs its power-on defaults, which is
+//! what mipidsi 0.10 ships and what two sibling units run on glass
+//! (burrito-fw, ember-satellite). If the bench finds the defaults washed
+//! out, gamma tuning is a measured follow-up, not a guessed init line.
+//!
+//! Every panel fact here reads from `board::*`, lifted from smol's
+//! `targets/s3-cyd/board-staging/board_es3c28p.rs` (the single source):
+//! MADCTL 0x28 (human-verified; 0x68 is the mirror trap), BGR order,
+//! INVERSION ON (where the ST7789 wants it OFF), 320x240 landscape with no
+//! GRAM offsets, backlight GPIO45 active-high.
+//!
+//! The inherent surface mirrors `Co5300Display` exactly — `ActivePanel` in
+//! `drivers/mod.rs` aliases one or the other per board, and main.rs compiles
+//! against whichever is selected (the panel.rs structural-satisfaction
+//! contract).
+
+use embedded_graphics::pixelcolor::Rgb565;
+use embedded_graphics::prelude::*;
+use esp_hal::delay::Delay;
+use esp_hal::gpio::Output;
+
+use crate::board;
+use crate::drivers::spi_bus::SharedSpiBus;
+
+const CMD_SWRESET: u8 = 0x01;
+const CMD_SLPOUT: u8 = 0x11;
+const CMD_INVOFF: u8 = 0x20;
+const CMD_INVON: u8 = 0x21;
+const CMD_NORON: u8 = 0x13;
+const CMD_DISPOFF: u8 = 0x28;
+const CMD_DISPON: u8 = 0x29;
+const CMD_CASET: u8 = 0x2A;
+const CMD_RASET: u8 = 0x2B;
+const CMD_MADCTL: u8 = 0x36;
+const CMD_COLMOD: u8 = 0x3A;
+
+/// Datasheet: 5 ms after SWRESET before the next command, 120 ms out of
+/// sleep. The generous values match the proven sibling inits.
+const RST_DELAY_MS: u32 = 150;
+const SLPOUT_DELAY_MS: u32 = 120;
+
+pub struct Ili9341Display<'d> {
+    bus: SharedSpiBus<'d>,
+    /// Plain GPIO until the LEDC driver lands: set_brightness > 0 = ON.
+    /// The §1d slider renders on this board (backlight-dimmable = true is
+    /// the HARDWARE fact); smooth dimming is documented bring-up debt.
+    backlight: Output<'d>,
+    delay: Delay,
+    width: u16,
+    height: u16,
+    col_offset: u16,
+    row_offset: u16,
+}
+
+impl<'d> Ili9341Display<'d> {
+    pub fn new(bus: SharedSpiBus<'d>, backlight: Output<'d>) -> Self {
+        Self {
+            bus,
+            backlight,
+            delay: Delay::new(),
+            width: board::LCD_WIDTH,
+            height: board::LCD_HEIGHT,
+            col_offset: board::LCD_COL_OFFSET,
+            row_offset: board::LCD_ROW_OFFSET,
+        }
+    }
+
+    /// Initialize the panel. No reset line on this board
+    /// (`HAS_LCD_RESET_PIN = false` in the board facts), so SWRESET carries
+    /// the whole reset story — it is not optional.
+    pub fn init(&mut self) {
+        self.bus.write_command(CMD_SWRESET);
+        self.delay.delay_millis(RST_DELAY_MS);
+
+        self.bus.write_command(CMD_SLPOUT);
+        self.delay.delay_millis(SLPOUT_DELAY_MS);
+
+        self.bus.write_c8d8(CMD_COLMOD, 0x55); // 16 bpp RGB565
+        self.bus.write_c8d8(
+            CMD_MADCTL,
+            board::MADCTL_LANDSCAPE
+                | if board::LCD_COLOR_ORDER_BGR { 0x08 } else { 0x00 },
+        );
+        // The ILI9341V wants inversion ON where the ST7789 wants it OFF —
+        // a board fact, not a driver choice.
+        self.bus.write_command(if board::LCD_INVERT_COLORS {
+            CMD_INVON
+        } else {
+            CMD_INVOFF
+        });
+        self.bus.write_command(CMD_NORON);
+        self.bus.write_command(CMD_DISPON);
+        self.delay.delay_millis(20);
+        self.backlight.set_high();
+    }
+
+    pub fn set_addr_window(&mut self, x: u16, y: u16, w: u16, h: u16) {
+        let x0 = x + self.col_offset;
+        let x1 = x0 + w - 1;
+        let y0 = y + self.row_offset;
+        let y1 = y0 + h - 1;
+        self.bus.write_c8d16d16(CMD_CASET, x0, x1);
+        self.bus.write_c8d16d16(CMD_RASET, y0, y1);
+    }
+
+    pub fn fill_screen(&mut self, color: Rgb565) {
+        let w = self.width;
+        let h = self.height;
+        self.write_pixels_area(0, 0, w, h, color);
+    }
+
+    pub fn write_pixels_area(&mut self, x: u16, y: u16, w: u16, h: u16, color: Rgb565) {
+        self.set_addr_window(x, y, w, h);
+        let raw: u16 = embedded_graphics::pixelcolor::raw::RawU16::from(color).into_inner();
+        self.bus.begin_pixels();
+        self.bus.write_repeat(raw, w as u32 * h as u32);
+        self.bus.end_pixels();
+    }
+
+    pub fn bus_mut(&mut self) -> &mut SharedSpiBus<'d> {
+        &mut self.bus
+    }
+
+    /// Backlight is a plain GPIO until the LEDC driver lands: any non-zero
+    /// level = ON. The threshold matches the shell's own `v > 0.5` bool so
+    /// the slider's midpoint behaves predictably.
+    pub fn set_brightness(&mut self, brightness: u8) {
+        if brightness > 0 {
+            self.backlight.set_high();
+        } else {
+            self.backlight.set_low();
+        }
+    }
+
+    pub fn display_on(&mut self) {
+        self.bus.write_command(CMD_DISPON);
+        self.backlight.set_high();
+    }
+
+    pub fn display_off(&mut self) {
+        self.backlight.set_low();
+        self.bus.write_command(CMD_DISPOFF);
+    }
+}

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -2,3 +2,18 @@ pub mod panel;
 pub mod co5300;
 pub mod framebuffer;
 pub mod qspi_bus;
+// The plain-SPI DCS panel stack (CYD-class boards). Not compiled on the C6:
+// its board module deliberately lacks the SPI_*_HZ consts these read.
+#[cfg(not(feature = "board-waveshare-c6"))]
+pub mod spi_bus;
+#[cfg(feature = "board-esp32s3-cyd")]
+pub mod ili9341;
+
+// The board's panel driver, structurally (the panel.rs contract): main.rs and
+// the render/flush seams compile against this alias, and each driver carries
+// the same inherent surface. The C5 aliases co5300 LINK-ONLY until morpheus's
+// st7789 merges — its glass runs his branch's image today.
+#[cfg(any(feature = "board-waveshare-c6", feature = "board-cyd-c5"))]
+pub type ActivePanel<'d> = co5300::Co5300Display<'d>;
+#[cfg(feature = "board-esp32s3-cyd")]
+pub type ActivePanel<'d> = ili9341::Ili9341Display<'d>;

--- a/src/drivers/spi_bus.rs
+++ b/src/drivers/spi_bus.rs
@@ -1,0 +1,441 @@
+//! ⚠️ LIFTED from feat/cyd-c5-gating @ a5f39e2 (morpheus's lane) so the S3
+//! panel driver can ship from main before that branch merges. His branch
+//! stays authoritative for this file until then — the merge unifies; do not
+//! let a conflict resolve AGAINST his copy.
+//! Shared classic-SPI bus for the NM-CYD-C5: ST7789 panel + XPT2046 touch on
+//! one SPI2 (FSPI) peripheral.
+//!
+//! # Why this exists, and why its method names look like the watch's
+//!
+//! This is the CYD's answer to the watch's `drivers::qspi_bus::QspiBus`. The
+//! public surface is deliberately name- and signature-compatible
+//! (`write_command`, `write_c8d8`, `write_c8d16d16`, `begin_pixels`,
+//! `stream_pixels`, `end_pixels`, `write_pixels`, `write_repeat`) so that
+//! [`crate::drivers::st7789::St7789Display`] can be a line-for-line analogue of
+//! `Co5300Display`, and so the watch's `ui::slint_platform::TwoLineFlusher` —
+//! whose entire hardware contact is
+//!
+//! ```text
+//! display.set_addr_window(x0, y_even, w, 2);
+//! display.bus_mut().write_pixels(&scratch[..w * 2]);
+//! ```
+//!
+//! — compiles against this stack with a type swap and nothing else.
+//!
+//! # Three differences from `QspiBus`, all forced by the hardware
+//!
+//! 1. **Framing.** The CO5300 is QSPI: a command is opcode `0x02` plus a 24-bit
+//!    register address, pixels are opcode `0x32` plus address `0x003C00`, all
+//!    on four data lines. The ST7789 is classic 4-wire SPI: a **DC pin** low
+//!    for command bytes, high for data bytes, one data line. So every
+//!    `write_c*` here lowers DC, ships one byte, raises DC, ships the payload.
+//!
+//! 2. **Two devices, two clock rates.** The panel wants 20 MHz and the XPT2046
+//!    wants <= ~2 MHz for a settled conversion (see [`crate::board`] for the
+//!    vendor citations). Running the touch chip at display speed does not
+//!    error — it returns *plausible* garbage, the worst failure mode there is.
+//!    [`SharedSpiBus`] therefore owns both chip selects and reapplies the SPI
+//!    `Config` whenever the active device changes, skipping the reconfigure
+//!    when it would be a no-op (the display path never pays for it).
+//!
+//! 3. **Blocking, not deferred.** `QspiBus` hand-rolls a non-blocking DMA kick
+//!    so the CPU can render the next strip while the previous one is in flight
+//!    — that was the fix for "render starves touch" on the watch. Here the bus
+//!    is genuinely shared with the touch controller, so a transfer that is left
+//!    in flight with CS low is a transfer that blocks touch polling anyway; the
+//!    deferred trick buys nothing and costs a CS-ownership hazard. This driver
+//!    uses `SpiDmaBus` (DMA'd, but synchronous). Revisit only if profiling on
+//!    glass shows the strip flush dominating, and only with a plan for who owns
+//!    CS during the overlap.
+//!
+//! # ⚠️ The invariant that makes DC framing safe — do not break it
+//!
+//! Every `write_c*` here raises DC immediately after shipping the opcode byte.
+//! That is only correct because `SpiDmaBus::write` is **fully synchronous down
+//! to the last clock edge**: it ends each chunk with `wait_for_idle()`, whose
+//! `is_done()` checks `driver().busy()` — the SPI peripheral's own busy flag —
+//! *before* looking at the DMA channel (esp-hal 1.1.2,
+//! `src/spi/master/dma.rs:343-369`). So when `write` returns, the byte has been
+//! clocked out, not merely handed to the DMA.
+//!
+//! If anyone later swaps this for a deferred/non-blocking flush (the
+//! `QspiBus::write_pixels` trick), **DC and CS transitions must move behind an
+//! explicit completion wait**. Raising DC while the opcode's final bits are
+//! still on the wire makes the panel read them as pixel data: the failure looks
+//! like intermittent colour corruption under load, not like a framing bug, and
+//! it will not reproduce at low frame rates.
+//!
+//! Also audited for the esp-hal 1.1 "defaults are not 1.0-rc.0's defaults"
+//! hazard called out in `PORT-SCOPING.md`: `spi::master::Config::default()` is
+//! 1 MHz / `Mode::_0` / MSB-first on both directions
+//! (`src/spi/master/mod.rs:478-490`). Frequency and mode are set explicitly
+//! below; MSB-first is what both the ST7789 and the XPT2046 want, so no default
+//! is being silently inherited here.
+
+use esp_hal::gpio::Output;
+use esp_hal::spi::master::{Config as SpiConfig, SpiDmaBus};
+use esp_hal::time::Rate;
+use esp_hal::Blocking;
+
+use crate::board;
+
+/// Bytes staged per DMA write.
+///
+/// Sized to exactly one watch-style two-line strip: `LCD_WIDTH * 2 lines * 2 B`
+/// = 1280 B, so the hot path is a single staged copy and a single DMA. (The
+/// watch's equivalent strip is 1640 B because its panel is 410 px wide; its
+/// `DMA_CHUNK` is 2048, the next power of two above that.)
+///
+/// `SpiDmaBus::write` already re-chunks anything longer than the DMA TX buffer,
+/// so this constant bounds the *staging* array, i.e. `.bss`. Bigger would only
+/// help `write_repeat`, which is not on any latency-critical path.
+///
+/// # PSRAM: internal RAM is a preference here, not a requirement
+///
+/// ⚠️ **CORRECTED 2026-08-25. An earlier version of this comment claimed "DMA
+/// cannot reach PSRAM on the ESP32-C5" and that a PSRAM-backed DMA buffer fails
+/// with `DmaBufError::UnsupportedMemoryRegion`. That is FALSE — do not
+/// reintroduce it.** `dma_can_access_psram` **is** set for the C5 under our exact
+/// pin: `esp-metadata-generated 0.4.0` (the version esp-hal 1.1.2 resolves, per
+/// our `Cargo.lock`) emits both `"dma_can_access_psram"` and
+/// `"cargo:rustc-cfg=dma_can_access_psram"` at `src/_build_script_utils.rs:1837`
+/// and `:2085`, inside the `esp32c5` block that spans lines 1696..2298. So
+/// `dma/buffers.rs` takes the *enabled* arm and a PSRAM buffer validates fine.
+///
+/// The retracted claim came from confusing two similarly-named flags: the C5
+/// genuinely lacks `ext_mem_configurable_block_size` — which only gates *tuning*
+/// the external block size at runtime — and that was read as the C5 lacking
+/// PSRAM-DMA capability altogether. Different questions, adjacent names.
+///
+/// And TX is the forgiving direction: `ExternalBurstConfig::min_psram_alignment`
+/// (`dma/buffers.rs:174-195`) returns the burst size for `TransferDirection::In`
+/// but **1** for `Out`, quoting the TRM — *"Size, length, and buffer address
+/// pointer in transmit descriptors do not need to be aligned."* Display output is
+/// TX, so **SPI TX straight out of PSRAM is legal and unaligned-safe here.**
+///
+/// So: prefer internal RAM for the `DmaRxBuf`/`DmaTxBuf` — it is faster and has
+/// no cache-coherency surface — but treat that as a **performance choice**. It is
+/// not a correctness constraint, and a PSRAM framebuffer may now be DMA'd from
+/// directly rather than memcpy'd through internal RAM first.
+///
+/// ★ Scope, which is still worth stating because it is easy to get backwards:
+/// whatever memory rules apply, they apply to the `DmaRxBuf`/`DmaTxBuf` the
+/// **caller** builds and hands to `Spi::with_buffers()`
+/// (`esp-hal-1.1.2/src/spi/master/dma.rs:590`) and which `SpiDmaBus` then owns
+/// (`:846`, field at `:852`) — that is the memory the DMA engine reads. They do
+/// **not** apply to [`SharedSpiBus`]'s own `stage` array below. Nothing DMAs out
+/// of `stage`; the CPU copies from it into the `DmaTxBuf`, at `dma.rs:940`:
+///
+/// ```text
+/// self.tx_buf.as_mut_slice()[..chunk.len()].copy_from_slice(chunk);
+/// ```
+///
+/// The engine never sees the caller's slice. The word "staging" fits both
+/// allocations, which is why a rule phrased as "SPI staging buffers must be
+/// internal RAM" points at the one that cannot matter.
+///
+/// If a PSRAM region is ever added: `psram_allocator!` extends the **same global
+/// heap** rather than creating a second allocator, and unqualified allocations
+/// are first-fit in **insertion order** — so `heap_allocator!` must run *before*
+/// `psram_allocator!` if internal RAM should be preferred by default. With the
+/// correction above this is a *performance* ordering, not a correctness one:
+/// getting it backwards makes default allocations land in PSRAM, which is slower
+/// but works. Use `Vec::new_in(esp_alloc::InternalMemory)` where the speed
+/// actually matters rather than relying on declaration order to enforce it.
+pub const STAGE_BYTES: usize = board::LCD_WIDTH as usize * 2 * 2;
+
+/// Which device the SPI `Config` is currently tuned for.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Tuned {
+    /// Nothing applied yet — the first select must configure.
+    None,
+    Display,
+    Touch,
+}
+
+/// ST7789 memory-write opcodes. `RAMWR` restarts the write at the window
+/// origin; `RAMWR_CONT` resumes where the previous write stopped, which is what
+/// makes a chunked pixel push across several transactions land contiguously.
+const CMD_RAMWR: u8 = 0x2C;
+const CMD_RAMWR_CONT: u8 = 0x3C;
+
+pub struct SharedSpiBus<'d> {
+    spi: SpiDmaBus<'d, Blocking>,
+    dc: Output<'d>,
+    lcd_cs: Output<'d>,
+    touch_cs: Option<Output<'d>>,
+    /// Held, never driven low. Its whole job is to keep the SD card off the bus
+    /// — see [`crate::board::PIN_SD_CS`]. Owning it also makes it impossible
+    /// for another part of the firmware to claim GPIO10 by accident.
+    _sd_cs: Option<Output<'d>>,
+    tuned: Tuned,
+    /// RGB565 byteswap staging (see [`STAGE_BYTES`]).
+    stage: [u8; STAGE_BYTES],
+    /// Next memory-write opcode: `RAMWR` immediately after an address-window
+    /// change, `RAMWR_CONT` for every continuation after that.
+    next_ramwr: u8,
+}
+
+impl<'d> SharedSpiBus<'d> {
+    /// Take ownership of the bus and all three chip selects.
+    ///
+    /// `sd_cs` is required rather than optional on purpose: an undeselected SD
+    /// card clocks along with every display transaction and corrupts it, and a
+    /// board with no card fitted still has a floating pin. Pass it even if you
+    /// never intend to use the slot.
+    pub fn new(
+        spi: SpiDmaBus<'d, Blocking>,
+        dc: Output<'d>,
+        lcd_cs: Output<'d>,
+        // Option-alized on main (S3 uses this bus with NOTHING else on it —
+        // touch is I2C, no SD in play). The C5 passes Some for both, exactly
+        // as before. morpheus: at merge, keep THIS signature and wrap your
+        // call site's two pins in Some() — flagged in advance.
+        touch_cs: Option<Output<'d>>,
+        sd_cs: Option<Output<'d>>,
+    ) -> Self {
+        let mut sd_cs = sd_cs;
+        if let Some(cs) = sd_cs.as_mut() {
+            cs.set_high();
+        }
+        Self {
+            spi,
+            dc,
+            lcd_cs,
+            touch_cs,
+            _sd_cs: sd_cs,
+            tuned: Tuned::None,
+            stage: [0u8; STAGE_BYTES],
+            next_ramwr: CMD_RAMWR,
+        }
+    }
+
+    // -- clock-rate arbitration -------------------------------------------
+
+    fn tune(&mut self, want: Tuned, hz: u32) {
+        if self.tuned == want {
+            return;
+        }
+        let cfg = SpiConfig::default()
+            .with_frequency(Rate::from_hz(hz))
+            .with_mode(esp_hal::spi::Mode::_0);
+        // A rate the peripheral cannot synthesise is a programming error, not a
+        // runtime condition — both rates here are fixed constants.
+        self.spi.apply_config(&cfg).expect("SPI apply_config");
+        self.tuned = want;
+    }
+
+    /// Raise every chip select, guaranteeing a clean transaction boundary
+    /// whatever state the previous caller left behind.
+    ///
+    /// ⚠️ This is load-bearing, and the reason is the *contract's* shape rather
+    /// than this driver's: `PanelDriver` (the watch's `drivers/panel.rs`) has
+    /// `begin_pixels` but **no `end_pixels`**. A conforming caller may therefore
+    /// open a pixel stream and simply never close it, leaving LCD CS asserted
+    /// indefinitely. Two things would then go wrong without this:
+    ///
+    ///   * a following command would be clocked into a still-open RAMWR stream
+    ///     and land in GRAM as pixel data;
+    ///   * a following *touch* read would assert TOUCH CS while LCD CS is still
+    ///     low — two devices driving one MISO line, which is a bus contention
+    ///     fault, not merely a wrong answer.
+    ///
+    /// Making every select start from all-deasserted costs two GPIO writes and
+    /// removes both failure modes structurally, so no caller has to remember.
+    fn deselect_all(&mut self) {
+        self.lcd_cs.set_high();
+        if let Some(cs) = self.touch_cs.as_mut() {
+            cs.set_high();
+        }
+    }
+
+    fn select_display(&mut self) {
+        self.deselect_all();
+        self.tune(Tuned::Display, board::SPI_DISPLAY_HZ);
+        self.lcd_cs.set_low();
+    }
+
+    fn select_touch(&mut self) {
+        self.deselect_all();
+        self.tune(Tuned::Touch, board::SPI_TOUCH_HZ);
+        // A board with no SPI touch never calls touch_read (its touch driver
+        // is a different bus entirely); reaching here with None is a wiring
+        // bug, and selecting nothing is the fail-safe.
+        if let Some(cs) = self.touch_cs.as_mut() {
+            cs.set_low();
+        }
+    }
+
+    // -- command / small-data writes (QspiBus parity) ----------------------
+
+    /// One self-contained command transaction: CS low → DC low → opcode →
+    /// (DC high → payload) → CS high.
+    fn cmd_write(&mut self, reg: u8, data: &[u8]) {
+        self.select_display();
+        self.dc.set_low();
+        let _ = self.spi.write(&[reg]);
+        if !data.is_empty() {
+            self.dc.set_high();
+            let _ = self.spi.write(data);
+        }
+        self.lcd_cs.set_high();
+    }
+
+    /// Command with no parameters.
+    pub fn write_command(&mut self, reg: u8) {
+        self.cmd_write(reg, &[]);
+    }
+
+    /// Command with one parameter byte.
+    pub fn write_c8d8(&mut self, reg: u8, data: u8) {
+        self.cmd_write(reg, &[data]);
+    }
+
+    /// Command with two big-endian u16 parameters — the CASET/RASET shape.
+    /// Same name and signature as `QspiBus::write_c8d16d16`.
+    pub fn write_c8d16d16(&mut self, reg: u8, d1: u16, d2: u16) {
+        self.cmd_write(
+            reg,
+            &[(d1 >> 8) as u8, d1 as u8, (d2 >> 8) as u8, d2 as u8],
+        );
+    }
+
+    /// Command with an arbitrary parameter run (init tables: porch control,
+    /// gamma curves, ...). No `QspiBus` equivalent — the CO5300's init table is
+    /// all single-byte parameters, the ST7789's is not.
+    pub fn write_c8dn(&mut self, reg: u8, data: &[u8]) {
+        self.cmd_write(reg, data);
+    }
+
+    /// Called by [`super::st7789::St7789Display::set_addr_window`] once the new
+    /// CASET/RASET have been sent: the next pixel push must restart at the
+    /// window origin with `RAMWR`, not continue the previous run.
+    pub(crate) fn arm_ramwr(&mut self) {
+        self.next_ramwr = CMD_RAMWR;
+    }
+
+    /// Emit the pending memory-write opcode with CS already low and DC set for
+    /// commands, then leave DC high ready for pixel data. Flips the pending
+    /// opcode to `RAMWR_CONT` so any following chunk resumes rather than
+    /// rewinds.
+    fn open_ramwr(&mut self) {
+        self.dc.set_low();
+        let cmd = self.next_ramwr;
+        let _ = self.spi.write(&[cmd]);
+        self.next_ramwr = CMD_RAMWR_CONT;
+        self.dc.set_high();
+    }
+
+    // -- pixel paths (QspiBus parity) --------------------------------------
+
+    /// Open a streamed pixel transaction, leaving CS LOW. Follow with
+    /// [`stream_pixels`](Self::stream_pixels), close with
+    /// [`end_pixels`](Self::end_pixels).
+    pub fn begin_pixels(&mut self) {
+        self.select_display();
+        self.open_ramwr();
+    }
+
+    /// Stream a continuation chunk of an already-open pixel transaction.
+    ///
+    /// RGB565 goes big-endian on the wire, identical to
+    /// `qspi_bus::byteswap_into`.
+    pub fn stream_pixels(&mut self, pixels: &[u16]) {
+        if pixels.is_empty() {
+            return;
+        }
+        let max_px = STAGE_BYTES / 2;
+        let mut remaining = pixels;
+        while !remaining.is_empty() {
+            let n = remaining.len().min(max_px);
+            for (i, &px) in remaining[..n].iter().enumerate() {
+                self.stage[i * 2] = (px >> 8) as u8;
+                self.stage[i * 2 + 1] = px as u8;
+            }
+            let _ = self.spi.write(&self.stage[..n * 2]);
+            remaining = &remaining[n..];
+        }
+    }
+
+    // NOTE: a raw `&[u8]` pass-through used to live here, for the period when
+    // the contract declared `push_pixels(&[u8])`. It was cheaper (no byteswap,
+    // no staging copy) but it is deliberately gone: the contract was resolved
+    // to `&[u16]` on 2026-08-24 precisely so that byte order stays the driver's
+    // secret. Re-adding a public byte path would re-open the leak, because a
+    // caller holding bytes has necessarily already made a byte-order decision
+    // that belongs here. If an internal fast path ever needs one, keep it
+    // private.
+
+    /// Close a streamed pixel transaction: raise CS.
+    ///
+    /// Not part of the `PanelDriver` contract (which has `begin_pixels` and no
+    /// close). Calling it is still correct and slightly tidier; omitting it is
+    /// safe because every subsequent bus operation re-establishes a clean
+    /// transaction boundary — see [`deselect_all`](Self::deselect_all).
+    pub fn end_pixels(&mut self) {
+        self.lcd_cs.set_high();
+    }
+
+    /// Push a run of RGB565 pixels as one complete transaction.
+    ///
+    /// ★ THE HOT PATH. The watch's `TwoLineFlusher::flush_span` calls exactly
+    /// this, once per (row-pair, span), with `w * 2` pixels — 640 px / 1280 B
+    /// for a full-width strip, which fits [`STAGE_BYTES`] in a single staged
+    /// copy and a single DMA.
+    pub fn write_pixels(&mut self, pixels: &[u16]) {
+        if pixels.is_empty() {
+            return;
+        }
+        self.select_display();
+        self.open_ramwr();
+        self.stream_pixels(pixels);
+        self.lcd_cs.set_high();
+    }
+
+    /// Fill `count` pixels with a single colour.
+    pub fn write_repeat(&mut self, color: u16, count: u32) {
+        if count == 0 {
+            return;
+        }
+        self.select_display();
+        self.open_ramwr();
+
+        let hi = (color >> 8) as u8;
+        let lo = color as u8;
+        let max_px = STAGE_BYTES / 2;
+        let n_first = (count as usize).min(max_px);
+        for i in 0..n_first {
+            self.stage[i * 2] = hi;
+            self.stage[i * 2 + 1] = lo;
+        }
+
+        // The staging buffer holds one full chunk of the (constant) colour, so
+        // every subsequent chunk re-sends the same bytes with no restaging.
+        let mut remaining = count;
+        while remaining > 0 {
+            let n = remaining.min(max_px as u32) as usize;
+            let _ = self.spi.write(&self.stage[..n * 2]);
+            remaining -= n as u32;
+        }
+        self.lcd_cs.set_high();
+    }
+
+    // -- touch path ---------------------------------------------------------
+
+    /// Run one XPT2046 conversion: full-duplex `[cmd, 0, 0]` out, three bytes
+    /// in, at the touch clock rate with the touch CS asserted.
+    ///
+    /// Returns the raw 12-bit result. The XPT2046 clocks its answer out one bit
+    /// after the command's last bit, so the 12 significant bits sit in
+    /// `rx[1]:rx[2]` left-aligned — hence the `>> 3`.
+    pub fn touch_read(&mut self, cmd: u8) -> u16 {
+        let mut rx = [0u8; 3];
+        let tx = [cmd, 0x00, 0x00];
+        self.select_touch();
+        let _ = self.spi.transfer(&mut rx, &tx);
+        if let Some(cs) = self.touch_cs.as_mut() {
+            cs.set_high();
+        }
+        (((rx[1] as u16) << 8) | rx[2] as u16) >> 3
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ use crate::apps::snake::SnakeGame;
 use crate::apps::tetris::TetrisGame;
 use crate::apps::world_snake::WorldSnakeApp;
 use crate::apps::{App, AppInput, AppResult, AppState, Sfx};
-use crate::drivers::co5300::Co5300Display;
+use crate::drivers::ActivePanel;
 use crate::net::familiar::FamUi;
 use crate::net::smol_mesh::{MeshEvent, MESH_MAX_ROWS, PeerView, SmolMesh};
 use crate::net::voice_stt;
@@ -1088,17 +1088,58 @@ async fn main(_spawner: Spawner) -> ! {
     // Raw SpiDma (no SpiDmaBus wrapper): QspiBus owns a single TX DmaTxBuf and
     // drives non-blocking DMA flushes itself (see drivers/qspi_bus.rs). No RX
     // buffer is needed — the panel is write-only.
-    let spi = Spi::new(peripherals.SPI2, spi_config)
-        .expect("SPI failed")
-        .with_sck(peripherals.GPIO0)
-        .with_sio0(peripherals.GPIO1)
-        .with_sio1(peripherals.GPIO2)
-        .with_sio2(peripherals.GPIO3)
-        .with_sio3(peripherals.GPIO4)
-        .with_dma(peripherals.DMA_CH0);
-    let cs = Output::new(peripherals.GPIO5, Level::High, OutputConfig::default());
-    let reset = Output::new(peripherals.GPIO11, Level::High, OutputConfig::default());
-    let mut display = Co5300Display::new(QspiBus::new(spi, cs), reset);
+    #[cfg(any(feature = "board-waveshare-c6", feature = "board-cyd-c5"))]
+    let mut display = {
+        use crate::drivers::co5300::Co5300Display;
+        // The C5 arm still constructs the C6's QSPI driver LINK-ONLY (its
+        // glass runs morpheus's st7789 from feat/cyd-c5-gating; the merge
+        // replaces this arm). The pins below are the C6's.
+        let spi = Spi::new(peripherals.SPI2, spi_config)
+            .expect("SPI failed")
+            .with_sck(peripherals.GPIO0)
+            .with_sio0(peripherals.GPIO1)
+            .with_sio1(peripherals.GPIO2)
+            .with_sio2(peripherals.GPIO3)
+            .with_sio3(peripherals.GPIO4)
+            .with_dma(peripherals.DMA_CH0);
+        let cs = Output::new(peripherals.GPIO5, Level::High, OutputConfig::default());
+        let reset = Output::new(peripherals.GPIO11, Level::High, OutputConfig::default());
+        Co5300Display::new(QspiBus::new(spi, cs), reset)
+    };
+    // The S3 CYD: ILI9341V over plain SPI + DC, morpheus's SharedSpiBus
+    // shape (his C5 block is the template — buffers must stay OFF any PSRAM
+    // allocator, DMA cannot reach PSRAM). Pins from board_es3c28p.rs via
+    // src/board/esp32s3_cyd.rs: SCK 12, MOSI 11, MISO 13, CS 10, DC 46,
+    // backlight 45. Touch is I2C on this board, so the bus's touch/sd CS
+    // lanes are None.
+    #[cfg(feature = "board-esp32s3-cyd")]
+    let mut display = {
+        use crate::drivers::ili9341::Ili9341Display;
+        use crate::drivers::spi_bus::{SharedSpiBus, STAGE_BYTES};
+        use esp_hal::dma::{DmaRxBuf, DmaTxBuf};
+
+        let dc = Output::new(peripherals.GPIO46, Level::High, OutputConfig::default());
+        let lcd_cs = Output::new(peripherals.GPIO10, Level::High, OutputConfig::default());
+        let backlight = Output::new(peripherals.GPIO45, Level::High, OutputConfig::default());
+
+        let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
+            esp_hal::dma_buffers!(64, STAGE_BYTES);
+        let dma_rx = DmaRxBuf::new(rx_descriptors, rx_buffer).expect("dma rx");
+        let dma_tx = DmaTxBuf::new(tx_descriptors, tx_buffer).expect("dma tx");
+
+        let s3_spi_config = SpiConfig::default()
+            .with_frequency(Rate::from_hz(board::SPI_DISPLAY_HZ))
+            .with_mode(SpiMode::_0);
+        let spi = Spi::new(peripherals.SPI2, s3_spi_config)
+            .expect("SPI failed")
+            .with_sck(peripherals.GPIO12)
+            .with_mosi(peripherals.GPIO11)
+            .with_miso(peripherals.GPIO13)
+            .with_dma(peripherals.DMA_CH0)
+            .with_buffers(dma_rx, dma_tx);
+
+        Ili9341Display::new(SharedSpiBus::new(spi, dc, lcd_cs, None, None), backlight)
+    };
     display.init();
     println!("[DISPLAY] OK");
 
@@ -6573,7 +6614,7 @@ async fn main(_spawner: Spawner) -> ! {
 #[cfg(feature = "story")]
 struct StoryPlayUi<'a> {
     shell: &'a mut ShellUi,
-    display: &'a mut crate::drivers::co5300::Co5300Display<'static>,
+    display: &'a mut crate::drivers::ActivePanel<'static>,
     /// Finger-down poll. A `dyn` closure rather than the touch driver so this
     /// struct carries no device generics — same reason `voice_tts::speak_text`
     /// takes `&mut dyn FnMut`.
@@ -6674,7 +6715,7 @@ fn run_fb_app(
     app: &mut dyn App,
     input: &AppInput,
     fb: &mut Framebuffer,
-    display: &mut Co5300Display,
+    display: &mut ActivePanel,
     now: Instant,
     next_flush: &mut Instant,
 ) -> (bool, Option<Sfx>) {

--- a/src/ui/slint_platform.rs
+++ b/src/ui/slint_platform.rs
@@ -44,7 +44,7 @@ use slint::platform::software_renderer::{
 use slint::platform::{Platform, WindowAdapter};
 
 use crate::board;
-use crate::drivers::co5300::Co5300Display;
+use crate::drivers::ActivePanel;
 
 pub const WIDTH: usize = board::LCD_WIDTH as usize; // 410
 pub const HEIGHT: usize = board::LCD_HEIGHT as usize; // 502
@@ -92,7 +92,7 @@ pub fn init_platform() -> Rc<MinimalSoftwareWindow> {
 /// both axes by the vendored renderer's region alignment. Spans whose pairing
 /// guarantee does not hold are skipped and counted, never guessed at.
 pub struct TwoLineFlusher<'a, 'd> {
-    display: &'a mut Co5300Display<'d>,
+    display: &'a mut ActivePanel<'d>,
     /// 2 x WIDTH pixels: even line of the current pair in the first half, odd
     /// line in the second. Only rendered span columns are ever flushed.
     buf: &'a mut [Rgb565Pixel],
@@ -113,7 +113,7 @@ pub struct TwoLineFlusher<'a, 'd> {
 
 impl<'a, 'd> TwoLineFlusher<'a, 'd> {
     pub fn new(
-        display: &'a mut Co5300Display<'d>,
+        display: &'a mut ActivePanel<'d>,
         buf: &'a mut [Rgb565Pixel],
         scratch: &'a mut [u16],
     ) -> Self {

--- a/src/ui/slint_shell.rs
+++ b/src/ui/slint_shell.rs
@@ -13,7 +13,7 @@ use slint::platform::{PointerEventButton, WindowAdapter, WindowEvent};
 use slint::{ComponentHandle, ModelRc, SharedString, VecModel};
 
 use crate::apps::AppState;
-use crate::drivers::co5300::Co5300Display;
+use crate::drivers::ActivePanel;
 use crate::net::names;
 // #58 climate: the real `climate-model` crate (oracle-t9 CONFIRMED-CLEAN @5c0d04c;
 // stub swapped out). Provides ClimateState / ClimateEntity / HvacMode.
@@ -2168,7 +2168,7 @@ impl ShellUi {
 
     /// Run timers/animations and repaint if the scene is dirty. No-op while the
     /// scene is suspended (a game owns the panel via the framebuffer).
-    pub fn render(&mut self, display: &mut Co5300Display) {
+    pub fn render(&mut self, display: &mut ActivePanel) {
         // `suspended` = a game owns the panel (#66). Previously this was implied
         // by `ui.is_none()`; the scene now stays alive, so check it explicitly
         // or the shell would repaint over the game's framebuffer.

--- a/tools/provision.py
+++ b/tools/provision.py
@@ -119,6 +119,12 @@ def main() -> None:
     p.add_argument("--speak", default="ondemand", choices=SPEAK_MODES)
     p.add_argument("--chip", default="esp32c6",
                    help="espflash chip arg (esp32c6 | esp32c5 | esp32s3)")
+    p.add_argument("--config-offset", type=lambda s: int(s, 0), default=CONFIG_PART,
+                   help="config partition offset (default 0xc10000, the C6/C5 "
+                        "table; the S3's partitions-ota-s3.csv carves its entry "
+                        "at a different address — pass what ITS table declares). "
+                        "The firmware self-locates by data/spiffs subtype; this "
+                        "flag only aims the WRITE.")
     p.add_argument("--write", action="store_true",
                    help="actually flash both config slots (default: dry-run print)")
     a = p.parse_args()
@@ -145,7 +151,7 @@ def main() -> None:
         f.write(rec)
         tmp = f.name
     try:
-        for off in (CONFIG_PART, CONFIG_PART + BACKUP_SLOT):
+        for off in (a.config_offset, a.config_offset + BACKUP_SLOT):
             cmd = [os.path.expanduser("~/.cargo/bin/espflash"), "write-bin",
                    "--chip", a.chip, "--port", a.port, f"0x{off:x}", tmp]
             print("+", " ".join(cmd))


### PR DESCRIPTION
Follow-up to #417, from watch main @ 2827ce9: the ILI9341V panel driver (morpheus's glass-proven SharedSpiBus lifted with provenance + an init that deliberately omits the ST7789 voltage/gamma block), the `drivers::ActivePanel` per-board alias, per-board display construction, and `provision.py --config-offset` for the S3's own partition table. Building `board-esp32s3-cyd` from this tree now produces an image that RENDERS the full landscape scene — the artifact for eldritch-insignia's first-glass flash. All three arms verified on the standalone (C6 story, C5, S3 — memory-map-checked). Scope note to keep the record straight after #419's review: the C5's own ST7789/XPT2046 drivers remain on the standalone's feat/cyd-c5-gating (morpheus's active lane) and arrive with his merge — the C5 arm in this tree stays link-only by design until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)