### PR TITLE
fix(mesh): #397 STEP B part 1 — bound three of five raw ESP-NOW sends (no gate churn)

### DIFF
--- a/docs/embassy/PHASE3-PLAN.md
+++ b/docs/embassy/PHASE3-PLAN.md
@@ -303,12 +303,72 @@ before issuing. This keeps the egress counters honest and costs a few lines. **A
 considered and rejected for now:** an esp-radio generation counter — correct, but upstream, and it
 blocks a fix that is live on the fleet today.
 
+> **⚠️ AMENDED 2026-08-25 (STEP B part 1). The drain half of that mitigation is MOOT, and the
+> residual risk is narrower than written above.** Re-derived from
+> `esp-radio-0.18.0/src/esp_now/mod.rs`:
+>
+> **esp-radio already performs the drain itself, on every send, on both paths** — sync `send()` at
+> `mod.rs:560` and `SendFuture::poll`'s first poll at `mod.rs:964` each
+> `ESP_NOW_SEND_CB_INVOKED.store(false, Release)` *immediately before* calling `esp_now_send`. A
+> stale callback that lands **before** the next send is issued is therefore already erased, not
+> misread. The spec'd drain is both unnecessary and unwritable (the flag is private — see §3.4's
+> amendment).
+>
+> **The real residual race, stated exactly:** a callback from an abandoned send that lands *after*
+> our clear-and-issue sets the flag, so our send reads the **previous** send's
+> `ESP_NOW_SEND_STATUS` as its own. Not mitigable locally — that needs the generation counter
+> rejected above. It requires a completion arriving later than `TX_WAIT_MS`, which is uncommon in
+> general and is *precisely* the congestion case this whole step targets, so it is not dismissible
+> either. It lands on the two §3.2(ii) evidence sites.
+>
+> **`TX_ABANDONED` survives, repurposed from DRAIN to TAINT** — the same few lines, better spent:
+> set it whenever any site abandons a send; on entry to an evidence site, if it is set, record the
+> outcome as `otam_to` (untrusted) rather than `otam_ok`, and clear it. A late callback then cannot
+> inflate `otam_ok`. This is what actually protects the instrument §3.2(ii) exists to protect, and it
+> keeps the rule that a timeout is *neither a success nor a confirmed failure*.
+>
+> Confirmed as originally written: `SendFuture` has **no `Drop` impl** (only `SendWaiter` and
+> `EspNowRc` do), so dropping it does not spin. The async path genuinely escapes the hang.
+
 ### 3.4 Two forms, because the stack changes underneath it
 
 - **On today's superloop (land now):** `mem::forget` the waiter to skip *both* spins, then poll
   `ESP_NOW_SEND_CB_INVOKED` against a 30 ms deadline. `mem::forget` is not an optimisation here —
   it is the only way out, because `Drop` spins too. Must cover the `5250` discard site.
 - **Under the executor (STEP T/C):** the watch's `select` form, plus §3.3's mitigation.
+
+> **⚠️ AMENDED 2026-08-25 (STEP B part 1). Both bullets above are wrong, in different ways, and the
+> two forms have collapsed into one.** The plan outranks nothing it cannot compile.
+>
+> **Finding 1 — the "land now" form cannot be written.** `ESP_NOW_SEND_CB_INVOKED` is a **private**
+> static (`esp-radio-0.18.0/src/esp_now/mod.rs:55` — no `pub`, no accessor, no getter anywhere in
+> the crate). Nothing outside esp-radio can poll it. There is **no bounded observation of the sync
+> path available at all**: the choice is spin forever, or do not look. The `mem::forget` half is
+> right and is the only way out of the two spins; the 30 ms poll beside it was never implementable.
+>
+> **Finding 2 — #391 made the second bullet the *available* one.** That bullet defers the `select`
+> form to "under the executor". We have been under the executor since #391 landed
+> `#[esp_rtos::main]` and esp-rtos's `embassy` feature; `espnow = ["wifi", …]`, so embassy-time
+> reaches all five sites, and `mode.rs` already drives ~23 controller futures through
+> `embassy_futures::block_on`. So `block_on(select(send_async(..), Timer::after(..)))` works **today**
+> inside the existing synchronous fns, with no signature changes. The form this plan deferred is the
+> only form that can land.
+>
+> **Consequent split, as executed (JP's team-lead ruling: one concern per PR).**
+>
+> | | sites | treatment |
+> |---|---|---|
+> | **B part 1** (this amendment's PR) | `send_arb_raw`, relay pre-announce, `send_to` | `abandon_tx` = `mem::forget`, read nothing. Zero spin, no timer, no `SendFuture`, **no gate churn**. These three already discarded the status, so not looking costs exactly what they were already throwing away. |
+> | **B part 2** | the two `otam_ok` announce sites | `block_on(select(send_async, Timer 30 ms))` → `otam_to` on timeout, plus §3.3's amended `TX_ABANDONED`-as-taint. Carries a deliberate `check_elect_send_path.py` + `RAW-SEND-SITES` update as a **co-headline**, because `send_async(` does not match that checker's `esp_now.send(` pattern and the invariant it guards is a security one. |
+>
+> **A checker defect found by writing this amendment's own code comment, recorded because it will
+> bite again:** `check_elect_send_path.py` counts `esp_now.send(` **without stripping comments**, so
+> prose *describing* a send is counted as a send and attributed to whatever fn precedes it. A doc
+> comment in `abandon_tx` tripped the gate and blamed `now_ms`. Part 1 works around it by describing
+> the call sites in words; **part 2 gives that checker the same comment-stripping pass
+> `check_station_consumers.py` already has** (where the identical bug was found the same day — a
+> checker whose verdict documentation can flip is worse than none, because the same mechanism yields
+> a false GREEN by commenting a real site out).
 
 ---
 

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -2332,6 +2332,59 @@ pub fn now_ms() -> u64 {
     Instant::now().duration_since_epoch().as_millis()
 }
 
+/// #397 / #335 STEP B (part 1 of 2): retire a `SendWaiter` **without** waiting for the TX-done
+/// callback. Three of smol's five raw-send sites call this; the other two need the outcome and are
+/// handled separately (see below).
+///
+/// ── THE HANG THIS REMOVES ─────────────────────────────────────────────────────────────────────
+/// `esp-radio-0.18.0/src/esp_now/mod.rs`:
+///   * `SendWaiter::wait()` (582-598) — `mem::forget(self)` then
+///     `while !ESP_NOW_SEND_CB_INVOKED.load(Acquire) {}`. A bare spin: no timeout, no yield.
+///   * `impl Drop for SendWaiter` (600-606) — **the same bare spin.**
+///
+/// So a lost TX-done completion does not fail, it pins the CPU until the watchdog resets the board.
+/// And because `Drop` spins too, *dropping* the waiter is not an escape — which is why the
+/// pre-announce site, which discarded the returned `Result` outright, was a hang wearing
+/// fire-and-forget's clothes.
+///
+/// ⚠️ Phrasing note, because it cost a gate run: this comment deliberately does NOT spell the raw
+/// send call in `receiver.method(` form. `tools/check_elect_send_path.py` counts that pattern
+/// WITHOUT stripping comments, so prose describing a send is counted as a send and attributed to
+/// whatever fn precedes it (here `now_ms`, which is how this was found). The checker gains a
+/// comment-stripping pass in STEP B part 2, where it is already being edited; until then, describe
+/// these call sites in words rather than in code.
+///
+/// `mem::forget` skips BOTH spins, and it is the only way out from outside the crate. `SendWaiter`
+/// is `PhantomData` — a ZST — so forgetting it leaks nothing; the only thing "leaked" is the
+/// obligation to observe the callback.
+///
+/// ── WHY NOT THE 30 ms POLL THE PLAN ASKED FOR ─────────────────────────────────────────────────
+/// PHASE3-PLAN §3.4 spec'd "`mem::forget` the waiter, then poll `ESP_NOW_SEND_CB_INVOKED` against a
+/// 30 ms deadline". **That cannot be written.** `ESP_NOW_SEND_CB_INVOKED` is a private static
+/// (`mod.rs:55` — no `pub`, no accessor), so nothing outside esp-radio can read it. There is no
+/// bounded *observation* of the sync path available to us at all: it is spin forever, or don't look.
+/// These three sites already threw the status away (`let _ = waiter.wait()`), so not looking costs
+/// exactly the information they were already discarding, and buys the removal of an unbounded spin.
+///
+/// ── WHAT THIS DELIBERATELY GIVES UP, STATED SO IT IS NOT REDISCOVERED ─────────────────────────
+/// `SendWaiter::Drop`'s spin exists to "prevent the lock on `EspNowSender` getting unlocked before a
+/// callback is invoked" — i.e. to stop a second send being issued while one is outstanding. We are
+/// knowingly declining that serialisation. Two things make it acceptable and one bounds the fallout:
+///   1. esp-radio itself clears the completion flag immediately before issuing each send
+///      (`mod.rs:560` sync, `mod.rs:964` async), so a stale callback that lands *before* the next
+///      send is erased rather than misread.
+///   2. These three sites never read a status, so a misattributed completion changes nothing here.
+///   3. It is NOT free for everyone: a late callback can still be misread by the *next* site that
+///      does read one. That is why the two OTA-announce sites (`otam_ok`) are excluded from this
+///      helper and get a bounded `send_async` + a third `otam_to` counter in STEP B part 2 — a
+///      timeout there is neither a success nor a confirmed failure, and collapsing it into either
+///      would corrupt the only evidence smol has that the announce reached the air.
+#[cfg(feature = "espnow")]
+#[inline]
+fn abandon_tx(waiter: esp_radio::esp_now::SendWaiter<'_>) {
+    core::mem::forget(waiter);
+}
+
 impl RadioManager {
     /// Initialise the radio once. Starts in `WifiSta` mode so the caller can do
     /// an NTP burst before switching to ESP-NOW.
@@ -5083,9 +5136,7 @@ impl RadioManager {
     pub fn send_arb_raw(&mut self, dst: [u8; 6], frame: &[u8]) {
         self.ensure_peer(dst, now_ms());
         match self.esp_now.send(&dst, frame) {
-            Ok(waiter) => {
-                let _ = waiter.wait();
-            }
+            Ok(waiter) => abandon_tx(waiter), // #397: see `abandon_tx`
             Err(e) => log::warn!("smol #237: arb-frame raw send failed: {:?}", e),
         }
     }
@@ -5320,7 +5371,14 @@ impl RadioManager {
                     let t = now_ms();
                     if t.saturating_sub(last) >= PREARM_GAP_MS {
                         let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
-                        let _ = self.esp_now.send(&BROADCAST_ADDRESS, &otam_pre[..pre_len]);
+                        // #397: this `let _ =` USED TO BE the worst of the five. Discarding the
+                        // `Result<SendWaiter>` drops the waiter immediately, and `Drop` carries the
+                        // SAME unbounded spin as `wait()` — so the site that reads as
+                        // fire-and-forget was a hang, and no `waiter.wait()` grep would ever find
+                        // it. Now the waiter is named and abandoned explicitly.
+                        if let Ok(waiter) = self.esp_now.send(&BROADCAST_ADDRESS, &otam_pre[..pre_len]) {
+                            abandon_tx(waiter);
+                        }
                         last = t;
                     }
                     if let Some(recv) = self.esp_now.receive() {
@@ -6370,9 +6428,7 @@ impl RadioManager {
             data
         };
         match self.esp_now.send(dst, out) {
-            Ok(waiter) => {
-                let _ = waiter.wait();
-            }
+            Ok(waiter) => abandon_tx(waiter), // #397: see `abandon_tx`
             Err(e) => log::warn!("smol: esp-now send failed: {:?}", e),
         }
     }


### PR DESCRIPTION
STEP B part **1 of 2** (#335 / #397). The three raw-send sites that never read the send status stop being able to hang the CPU. The two that *do* read it (`otam_ok`) are deliberately untouched and land in part 2 together with the checker/roster change they require — per the ruling that **a gate contract change must not ride inside a behaviour change**.

## The hang

`esp-radio-0.18.0/src/esp_now/mod.rs`:

- `SendWaiter::wait()` (582-598) — `mem::forget(self)` then `while !ESP_NOW_SEND_CB_INVOKED.load(Acquire) {}`. A bare spin: no timeout, no yield.
- `impl Drop for SendWaiter` (600-606) — **the same bare spin.**

A lost TX-done completion therefore does not fail. It pins the CPU until the watchdog resets the board.

Because `Drop` spins too, *dropping* the waiter is not an escape — which is why the relay pre-announce site, which discarded the returned `Result` outright, was **a hang wearing fire-and-forget's clothes**, and why no `waiter.wait()` grep would ever have found it. It is now named and abandoned explicitly.

## Converted (line numbers on `4d9aa50` — every number in the plan had drifted)

| site | fn | before | after |
|---|---|---|---|
| 5130 | `send_arb_raw` | `let _ = waiter.wait()` | `abandon_tx(waiter)` |
| 5371 | relay pre-announce | **discarded `Result`** | `abandon_tx(waiter)` |
| 6422 | `send_to` | `let _ = waiter.wait()` | `abandon_tx(waiter)` |

## ⚠️ Two plan defects found — amended in §3.3/§3.4, not worked around silently

**1. §3.4's "land now" form cannot be written.** It prescribes `mem::forget` "then poll `ESP_NOW_SEND_CB_INVOKED` against a 30 ms deadline". That static is **private** (`mod.rs:55` — no `pub`, no accessor anywhere in the crate). There is no bounded *observation* of the sync path available from outside esp-radio at all: spin forever, or don't look. These three sites already discarded the status, so **not looking costs exactly what they were already throwing away** — and buys the removal of an unbounded spin.

**2. §3.3's "bounded-drain" mitigation is moot.** esp-radio already drains, on every send, on both paths — `ESP_NOW_SEND_CB_INVOKED.store(false)` immediately before `esp_now_send` at `mod.rs:560` (sync) and `mod.rs:964` (async). A stale callback landing *before* the next send is already erased. Amended to **`TX_ABANDONED`-as-taint** for part 2, which is what actually protects §3.2(ii)'s instrument: a timeout is recorded as `otam_to`, neither a success nor a confirmed failure, so a late callback cannot inflate `otam_ok`.

Also recorded: **#391 collapsed §3.4's two forms into one.** The executor and embassy-time are live on every radio tier now, so the form the plan *deferred* is the only form that can land. The plan outranks nothing it cannot compile.

## What this deliberately gives up, stated at the call site

`SendWaiter::Drop`'s spin exists to stop a second send being issued while one is outstanding. We knowingly decline that serialisation. Acceptable because esp-radio re-clears the flag before each send, and because these three sites read no status — but **not free for everyone**: a late callback can still be misread by the next site that *does* read one. That is exactly why the two `otam_ok` sites are excluded from this helper and get bounded sends plus the third counter in part 2.

## Measured, not asserted — same tree, same provisioned seeds, true A/B

```
.stack   86,200 B -> 86,200 B    ZERO movement
.text   875,618 B -> 875,540 B   -78 B (the three spin loops, actually gone)
```

The zero `.stack` delta means **no sentinel-paint re-measure is owed here** and the 12 KB margin is untouched. The `-78 B` `.text` delta is the corroboration that the edit is not a no-op.

## Zero gate churn, by construction

The raw `esp_now.send(` call **stays at all five sites** — only the *wait* changes. So `RAW-SEND-SITES` and `check_elect_send_path.py` are untouched and still read `5 raw send sites across 3 declared fns`.

```
gate.sh fw   → GATE GREEN   elect send path: … 5 raw send sites across 3 declared fns
                            station consumers: 2 across 2 declared fns; 0 embassy_net::new
                            stack: 86200 B (floor 74208 B)
gate.sh host → GATE GREEN   test_check_elect_send_path 12/12 · test_check_station_consumers 21/21
```

## A checker defect this commit's own doc comment found

`check_elect_send_path.py` counts `esp_now.send(` **without stripping comments**, so prose *describing* a send is counted as a send and attributed to the preceding fn — mine tripped the gate and accused `now_ms`. This is the **identical bug** found in `check_station_consumers.py` the same day (#416). Part 1 works around it by describing the call sites in words, noted at the site; **part 2 gives that checker the comment-stripping pass its sibling already has** — a checker whose verdict documentation can flip is worse than none, because the same mechanism yields a false *green* by commenting a real site out.

## Part 2 preview (separate PR)

The two `otam_ok` sites → `block_on(select(send_async, Timer::after(30 ms)))` → `otam_to` on timeout, plus `TX_ABANDONED`-as-taint; **co-headlined** with a deliberate `check_elect_send_path.py` + `RAW-SEND-SITES` update (arm 6 learns the `send_async` form, with proof-of-failure arms for an undeclared `send_async` site and a removed guard), and the security reasoning for the ELECT invariant re-derived against the new form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)