### PR TITLE
targets/c6-watch refresh: S3 touch (FT6336U on the shared FocalTech driver)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ board-esp32s3-cyd = [
     "esp-hal/esp32s3", "esp-rtos/esp32s3", "esp-radio/esp32s3",
     "esp-storage/esp32s3", "esp-bootloader-esp-idf/esp32s3",
     "esp-println/esp32s3", "esp-backtrace/esp32s3",
+    # FT6336U: same FocalTech register map + 0x38 address the C6 driver
+    # speaks (board-class-verified); the coordinate transform is board::*.
+    "has-cap-touch",
 ]
 # Hardware capabilities. Empty markers — they exist to be cfg'd on.
 # AXP2101 PMU: battery gauge, power-key latch, power page.

--- a/src/board/cyd_c5.rs
+++ b/src/board/cyd_c5.rs
@@ -111,3 +111,11 @@ pub const HAS_BOOT_KEY: bool = false;
 // 2.5 MHz on the same bus with per-select retuning.
 pub const SPI_DISPLAY_HZ: u32 = 20_000_000;
 pub const SPI_TOUCH_HZ: u32 = 2_500_000;
+
+// Touch coordinate transform (peripherals/touch.rs applies these after the
+// raw FocalTech read; identity on boards whose touch matches the panel).
+/// UNUSED until morpheus's XPT2046 driver merges (NullTouch today); his
+/// driver carries its own measured calibration transform.
+pub const TOUCH_SWAP_XY: bool = false;
+pub const TOUCH_INVERT_X: bool = false;
+pub const TOUCH_INVERT_Y: bool = false;

--- a/src/board/esp32s3_cyd.rs
+++ b/src/board/esp32s3_cyd.rs
@@ -102,3 +102,12 @@ pub const HAS_BOOT_KEY: bool = true;
 // I2C (FT6336U); nothing selects the SPI touch lane and touch_cs is None.
 pub const SPI_DISPLAY_HZ: u32 = 40_000_000;
 pub const SPI_TOUCH_HZ: u32 = 2_500_000;
+
+// Touch coordinate transform (peripherals/touch.rs applies these after the
+// raw FocalTech read; identity on boards whose touch matches the panel).
+/// board_es3c28p.rs TOUCH_SWAP_XY/INVERT_* — tested-beats-derived values
+/// from the board class; the four-corner calibration on THIS unit may
+/// refine them (s3-cyd bench step).
+pub const TOUCH_SWAP_XY: bool = true;
+pub const TOUCH_INVERT_X: bool = false;
+pub const TOUCH_INVERT_Y: bool = true;

--- a/src/board/waveshare_c6.rs
+++ b/src/board/waveshare_c6.rs
@@ -68,3 +68,10 @@ pub const MEM_SUMMARY: &str = "no PSRAM \u{00b7} 16 MB flash";
 pub const BACKLIGHT_DIMMABLE: bool = true;
 /// BOOT is a first-class input (#59 button map).
 pub const HAS_BOOT_KEY: bool = true;
+
+// Touch coordinate transform (peripherals/touch.rs applies these after the
+// raw FocalTech read; identity on boards whose touch matches the panel).
+/// the FT3168 reports panel-native portrait coordinates directly.
+pub const TOUCH_SWAP_XY: bool = false;
+pub const TOUCH_INVERT_X: bool = false;
+pub const TOUCH_INVERT_Y: bool = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1066,7 +1066,12 @@ async fn main(_spawner: Spawner) -> ! {
     // shutdown otherwise — power + pop discipline (#23).
     let mut amp_en = Output::new(peripherals.GPIO6, Level::Low, OutputConfig::default());
 
-    // === I2C bus (AXP2101 + FT3168 + PCF85063 + QMI8658) ===
+    // === I2C bus ===
+    // C6: AXP2101 + FT3168 + PCF85063 + QMI8658 on SDA8/SCL7 at 400 kHz.
+    // S3 CYD: ONLY the FT6336U touch, on SDA16/SCL15 at 100 kHz (the board
+    // facts' ESPHome-proven rate). C5: compiles the C6 pin arm — its I2C
+    // talks to nothing (fake-bus story, morpheus's lane owns the real one).
+    #[cfg(not(feature = "board-esp32s3-cyd"))]
     let i2c = I2c::new(
         peripherals.I2C0,
         I2cConfig::default().with_frequency(Rate::from_khz(board::I2C_FREQ_HZ / 1000)),
@@ -1074,6 +1079,14 @@ async fn main(_spawner: Spawner) -> ! {
     .expect("I2C failed")
     .with_sda(peripherals.GPIO8)
     .with_scl(peripherals.GPIO7);
+    #[cfg(feature = "board-esp32s3-cyd")]
+    let i2c = I2c::new(
+        peripherals.I2C0,
+        I2cConfig::default().with_frequency(Rate::from_khz(board::I2C_FREQ_HZ / 1000)),
+    )
+    .expect("I2C failed")
+    .with_sda(peripherals.GPIO16)
+    .with_scl(peripherals.GPIO15);
     let i2c_ref = RefCell::new(i2c);
 
     // === Power (read-mostly: rails left as the bootloader configured them) ===
@@ -1180,7 +1193,7 @@ async fn main(_spawner: Spawner) -> ! {
     }
 
     // === Touch (FT3168: INT=GPIO15, RST=GPIO10) ===
-    #[cfg(feature = "has-cap-touch")]
+    #[cfg(all(feature = "has-cap-touch", not(feature = "board-esp32s3-cyd")))]
     let (mut touch_int, mut touch) = {
         let mut touch_rst =
             Output::new(peripherals.GPIO10, Level::High, OutputConfig::default());
@@ -1192,6 +1205,18 @@ async fn main(_spawner: Spawner) -> ! {
         delay.delay_millis(10);
         touch_rst.set_high();
         delay.delay_millis(50);
+        (touch_int, Ft3168Touch::new(RefCellDevice::new(&i2c_ref)))
+    };
+    // S3 CYD (FT6336U): INT on GPIO17; the touch RESET line (GPIO18) is
+    // NEVER configured — tested-beats-derived board fact (configuring it
+    // breaks the part; hardware brings it out of reset). Same driver: the
+    // FocalTech register map and 0x38 address are shared with the FT3168.
+    #[cfg(all(feature = "has-cap-touch", feature = "board-esp32s3-cyd"))]
+    let (mut touch_int, mut touch) = {
+        let touch_int = Input::new(
+            peripherals.GPIO17,
+            InputConfig::default().with_pull(Pull::Up),
+        );
         (touch_int, Ft3168Touch::new(RefCellDevice::new(&i2c_ref)))
     };
     // No cap-touch on this board (the CYD's XPT2046 lands with its own driver

--- a/src/peripherals/touch.rs
+++ b/src/peripherals/touch.rs
@@ -1,5 +1,6 @@
-// FT3168 Touch Controller driver
-// Reference: Arduino_FT3x68.h - I2C address 0x38
+// FocalTech capacitive touch driver — FT3168 (C6 watch) and FT6336U (S3 CYD)
+// speak the same register map at the same 0x38 address; the struct keeps its
+// original FT3168 name. Reference: Arduino_FT3x68.h.
 
 use embedded_hal::i2c::I2c;
 
@@ -104,8 +105,23 @@ impl<I: I2c> Ft3168Touch<I> {
         let y_h = self.read_reg(REG_Y1_H)? as u16;
         let y_l = self.read_reg(REG_Y1_L)? as u16;
 
-        let x = ((x_h & 0x0F) << 8) | x_l;
-        let y = ((y_h & 0x0F) << 8) | y_l;
+        let mut x = ((x_h & 0x0F) << 8) | x_l;
+        let mut y = ((y_h & 0x0F) << 8) | y_l;
+
+        // Board transform (identity on the C6): FocalTech parts report in the
+        // PANEL-NATIVE frame, which is not always the frame the scene draws
+        // in — the S3 CYD drives a 240x320-native panel in 320x240 landscape,
+        // so raw axes swap and the (post-swap) vertical inverts. The consts
+        // are board facts (tested-beats-derived; see each board module).
+        if crate::board::TOUCH_SWAP_XY {
+            core::mem::swap(&mut x, &mut y);
+        }
+        if crate::board::TOUCH_INVERT_X {
+            x = (crate::board::LCD_WIDTH - 1).saturating_sub(x);
+        }
+        if crate::board::TOUCH_INVERT_Y {
+            y = (crate::board::LCD_HEIGHT - 1).saturating_sub(y);
+        }
 
         Ok(Some(TouchPoint {
             x,


### PR DESCRIPTION
Small follow-up to #423, from watch main @ e69a8ea: `has-cap-touch` turns on for `board-esp32s3-cyd` — the FT6336U shares the FT3168's register map and address, so the driver is shared and only the coordinate FRAME differs (board transform consts, identity on the C6 so its behavior is bit-unchanged). Per-board bring-up arms: S3 I2C on SDA16/SCL15 @100kHz, INT GPIO17, and the touch RESET line deliberately never configured (tested-beats-derived board fact). All three arms build on the standalone. With this, eldritch-insignia's first flash gets a scene AND a working finger — the four-corner calibration on the real glass may refine the transform afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)