### PR TITLE
feat(tools): marker guard — refuse to build a chip whose .cargo/config.toml is stale (#280)

### DIFF
--- a/tools/assert_cargo_config.sh
+++ b/tools/assert_cargo_config.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# assert_cargo_config.sh — refuse to build a chip whose `.cargo/config.toml` is STALE. (#280)
+#
+# SOURCE IT for the function, or run it directly for one chip:
+#
+#   . tools/assert_cargo_config.sh && assert_cargo_config esp32s3     # in a script
+#   tools/assert_cargo_config.sh esp32s3                              # by hand
+#
+# ── WHY ───────────────────────────────────────────────────────────────────────────────────────
+# `rust/clock/.cargo/config.toml` is git-TRACKED, and `~/Projects/.stignore` ignores `.cargo`. So
+# on a remote builder the file arrives OUT OF BAND — this repo's own instructions tell agents to
+# "copy .cargo/config.toml if missing". That workaround keeps working just well enough to hide
+# that nothing keeps it CURRENT: a manual copy satisfies "present" and never satisfies "correct".
+#
+# On 2026-08-25 familiar's copy was byte-current except for one hunk — the S3 arm's
+# `-C link-arg=-Tlinkall.x`, added that morning by #398. The C3 `[build] target` was intact, so
+# every C3 build was green and nothing suggested a problem. An S3 build there would have passed
+# `cargo check` (check never links) and then failed the LINK with 129 undefined references —
+# `_bss_start`, `__exception`, the whole vector table — which reads as a broken toolchain, not as
+# a stale file. This turns that into one line, before the build.
+#
+# ── WHY MARKERS AND NOT A CHECKSUM ────────────────────────────────────────────────────────────
+# A checksum needs ground truth from another host, and there is no authority to fetch it from on
+# a builder that is deliberately offline-capable. The markers need only what the repo already
+# declares: `tools/build-matrix.toml` states each chip's `target` and its `config_markers`, so
+# the manifest that knows a chip exists is also the thing that knows what its build needs.
+#
+# ── WHY THE SECTION SCOPE IS THE WHOLE CHECK ──────────────────────────────────────────────────
+# A whole-file `grep -q -- -Tlinkall.x` PASSES on the exact stale file that motivated this, because
+# the two riscv arms carry the marker and only the xtensa arm was missing it. A file-wide check
+# would have reported green on the file whose staleness costs 129 link errors. So markers are
+# asserted INSIDE `[target.<triple>]`, and the section extractor stops at the next `[` heading.
+#
+# ── WHAT IT DOES NOT DO ───────────────────────────────────────────────────────────────────────
+# It does not prove the file is current — only that it carries the markers this chip needs. A
+# stale-but-marker-complete file still passes, and that is the honest limit: this narrows the
+# window to "edits that add a new load-bearing key", which is the moment to add a marker for it.
+# It is a fence around a known cliff, not a proof of freshness.
+set -uo pipefail
+
+_acc_root() { cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd; }
+
+# assert_cargo_config <chip> [config-path]
+# 0 = markers present · 1 = a marker is MISSING (stale) · 2 = cannot check
+assert_cargo_config() {
+    local chip="${1:-}" cfg="${2:-}" root matrix
+    root="$(_acc_root)"
+    matrix="$root/tools/build_matrix.py"
+    cfg="${cfg:-$root/rust/clock/.cargo/config.toml}"
+
+    [ -n "$chip" ] || { echo "assert_cargo_config: no chip given" >&2; return 2; }
+    [ -x "$matrix" ] || { echo "assert_cargo_config: no $matrix" >&2; return 2; }
+    if [ ! -f "$cfg" ]; then
+        echo "REFUSED: $cfg is MISSING." >&2
+        echo "    It is git-tracked but \`.stignore\` ignores \`.cargo\`, so a synced tree may not" >&2
+        echo "    have it. Re-sync from the canonical tree (#280)." >&2
+        return 1
+    fi
+
+    local markers rc=0
+    markers="$("$matrix" config-markers --chip "$chip" 2>&1)" || {
+        echo "assert_cargo_config: $markers" >&2; return 2; }
+    # A chip with no declared markers is a MANIFEST gap, not a pass. Reporting green here would
+    # make "nobody wrote the markers yet" indistinguishable from "the config is correct" — the
+    # vacuous-pass shape this repo keeps paying for.
+    [ -n "$markers" ] || {
+        echo "assert_cargo_config: [chip.$chip] declares no config_markers in build-matrix.toml" >&2
+        echo "    A chip with nothing to assert cannot be verified; add its markers (#280)." >&2
+        return 2; }
+
+    # `seen_target` is NOT `target`: the herestring below appends a trailing newline, so the final
+    # `read` yields an empty line that `continue` skips — after having already blanked `target`.
+    # The first draft's failure message therefore said "[target.]" with the triple missing, which
+    # is the one piece of information the operator needs. Keep the last NON-EMPTY value.
+    local target marker section seen_target="" missing=()
+    while IFS=$'\t' read -r target marker; do
+        [ -n "$target" ] || continue
+        seen_target="$target"
+        # The chip's own section only — see the header. `[target.X]` up to the next `[` heading.
+        section="$(awk -v want="[target.$target]" '
+            $0 ~ /^\[/ { inside = ($0 == want) ? 1 : 0 }
+            inside { print }
+        ' "$cfg")"
+        if [ -z "$section" ]; then
+            echo "REFUSED: $cfg has no [target.$target] section (chip $chip)." >&2
+            echo "    stale out-of-band copy? re-sync from the canonical tree (#280)." >&2
+            return 1
+        fi
+        # -F: markers are literals, not patterns (`-Tlinkall.x` contains a regex `.`).
+        printf '%s' "$section" | grep -qF -- "$marker" || missing+=("$marker")
+    done <<< "$markers"
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "REFUSED: $cfg lacks ${missing[*]} in [target.$seen_target] (chip $chip) — stale out-of-band copy?" >&2
+        echo "    re-sync from the canonical tree (#280)." >&2
+        echo "    Each missing marker is silent at \`cargo check\` and expensive later:" >&2
+        echo "      -Tlinkall.x         check never links; \`ld\` then emits ~129 undefined refs" >&2
+        echo "      force-frame-pointers  esp-backtrace cannot unwind a panic" >&2
+        echo "      linker-flavor       the target link routes through a non-compiler \`cc\` shim" >&2
+        rc=1
+    fi
+    return $rc
+}
+
+# Direct invocation: `tools/assert_cargo_config.sh <chip> [config]`.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    assert_cargo_config "$@" && echo "ok: .cargo/config.toml carries ${1:-?}'s declared markers"
+fi

--- a/tools/build-matrix.toml
+++ b/tools/build-matrix.toml
@@ -76,8 +76,38 @@ canonical_tier = "fleet"
 # The implication ladder is checked by build_matrix.py: ships => builds => checks. You cannot ship
 # what nothing builds, and you cannot build what does not compile.
 
+# ── `config_markers`: WHAT `.cargo/config.toml` MUST SAY FOR THIS CHIP (#280) ────────────────
+# Literal strings that must appear INSIDE this chip's `[target.<triple>]` section of
+# `rust/clock/.cargo/config.toml`. `tools/assert_cargo_config.sh` asserts them before a build.
+#
+# WHY THIS IS DECLARED DATA AND NOT A CHECKSUM. The file is git-TRACKED, but `~/Projects/.stignore`
+# ignores `.cargo`, so the copy on a remote builder arrives OUT OF BAND — this repo's own build
+# instructions tell agents to "copy .cargo/config.toml if missing". A manual copy satisfies
+# "present" and never satisfies "current". On 2026-08-25 familiar's copy was found byte-current
+# except for the S3 arm's `-Tlinkall.x`, added that morning by #398. A checksum would need ground
+# truth from another host; markers need only what this manifest already knows.
+#
+# WHY THE SECTION SCOPE IS LOAD-BEARING. A whole-file grep for `-Tlinkall.x` PASSES on that exact
+# stale file, because the two riscv arms carry it and only the xtensa arm was missing it. The
+# assertion is therefore per-section, and a marker list that "works" under a file-wide grep is not
+# the same check at all.
+#
+# WHY THESE MARKERS. Each is load-bearing AND silent at `cargo check` time, which is the pairing
+# that makes a stale config expensive:
+#   `-Tlinkall.x`          esp-hal's linker script. `cargo check` never links, so its absence is
+#                          invisible until `ld` emits 129 undefined references (#398 measured
+#                          exactly that on the S3: with the line, 129 -> 0).
+#   force-frame-pointers   esp-backtrace needs them to unwind a panic. Absence costs nothing at
+#                          build time and everything at the moment you need a backtrace.
+#   linker-flavor=ld.lld   riscv ONLY. This machine's `cc` is a non-compiler shim, so the target
+#                          link must not route through it. DELIBERATELY ABSENT from the S3 list:
+#                          the xtensa target has no LLD backend and links through esp GCC, so
+#                          pinning rust-lld there would BREAK it. Same reason, opposite action —
+#                          which is precisely why this is per-chip data rather than one global list.
+
 [chip.esp32c3]
 target = "riscv32imc-unknown-none-elf"
+config_markers = ["-Tlinkall.x", "force-frame-pointers", "linker-flavor=ld.lld"]
 builds = true
 ships  = true
 checks = true
@@ -91,6 +121,7 @@ checks = true
 # reason below was rewritten rather than left standing. A `blocked_on` whose stated cause has been
 # fixed reads as a considered decision and is the most expensive kind of stale comment.
 target     = "xtensa-esp32s3-none-elf"
+config_markers = ["-Tlinkall.x", "force-frame-pointers"]
 builds     = false
 ships      = false
 # CHECKS PASS as of #398's S3 arm. The 6 errors this row used to catalogue fell in two moves:
@@ -132,6 +163,7 @@ blocked_on = "ONLY the CI-runner toolchain remains (espup `esp` channel + export
 # The esp32c6-watch already runs this chip in its own repo (#347 Phase 2's third consumer), and
 # Part 1 landed its MEASURED ChipBudget row — which Part 2's per-feature lookup can now select.
 target     = "riscv32imac-unknown-none-elf"
+config_markers = ["-Tlinkall.x", "force-frame-pointers", "linker-flavor=ld.lld"]
 builds     = false
 ships      = false
 # The manifest pin is gone. What blocks a green CI arm is smol's own code, not the chip plumbing:
@@ -155,6 +187,7 @@ checks     = true
 # `riscv32imac` with the C6 — the triple CANNOT tell them apart, which is #349's whole subject;
 # the chip FEATURE is what discriminates now.
 target     = "riscv32imac-unknown-none-elf"
+config_markers = ["-Tlinkall.x", "force-frame-pointers", "linker-flavor=ld.lld"]
 builds     = false
 ships      = false
 # NO ChipBudget row, deliberately: nobody has measured this silicon, and `budget.rs` hands an

--- a/tools/build_matrix.py
+++ b/tools/build_matrix.py
@@ -275,7 +275,8 @@ def check(doc: dict, repro: Path, budget: Path) -> list[str]:
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("command", choices=("emit", "chips", "chip-checks", "ci-matrix", "check"))
+    ap.add_argument("command",
+                    choices=("emit", "chips", "chip-checks", "config-markers", "ci-matrix", "check"))
     ap.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     ap.add_argument("--repro", type=Path, default=DEFAULT_REPRO)
     ap.add_argument("--budget", type=Path, default=DEFAULT_BUDGET)
@@ -283,6 +284,7 @@ def main() -> int:
     ap.add_argument("--for", dest="phase", choices=("check", "clippy"), default="check",
                     help="emit: which gate phase's tier list to produce")
     ap.add_argument("--builds", action="store_true", help="chips: only buildable ones")
+    ap.add_argument("--chip", default=None, help="config-markers: restrict to one chip")
     args = ap.parse_args()
 
     try:
@@ -304,6 +306,29 @@ def main() -> int:
         for name, spec in doc["chips"].items():
             if not args.builds or spec["builds"]:
                 print(name)
+        return 0
+
+    if args.command == "config-markers":
+        # #280: `<target>\t<marker>` per line, for `tools/assert_cargo_config.sh`.
+        #
+        # A SEPARATE COMMAND rather than two more columns on `chip-checks`, deliberately. The
+        # guard has a second caller that wants nothing else from the row (the publish path, for
+        # #413), and widening a tab-separated contract to serve a consumer that needs one field
+        # is how the sentinel-and-shifting-fields bug in `check_chips.sh` was born.
+        #
+        # Chip filter is positional-free: pass `--chip`, or get every chip. An unknown chip is an
+        # ERROR, not an empty result — a guard handed a typo'd chip name must not report success
+        # by finding nothing to check.
+        chips = doc["chips"]
+        if args.chip:
+            if args.chip not in chips:
+                print(f"config-markers: unknown chip {args.chip!r} — "
+                      f"known: {', '.join(sorted(chips))}", file=sys.stderr)
+                return 2
+            chips = {args.chip: chips[args.chip]}
+        for name, spec in chips.items():
+            for marker in spec.get("config_markers") or []:
+                print(f"{spec['target']}\t{marker}")
         return 0
 
     if args.command == "chip-checks":

--- a/tools/check_chips.sh
+++ b/tools/check_chips.sh
@@ -39,6 +39,9 @@ set -uo pipefail   # NOT -e: a failing `cargo check` is DATA here, not an error 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CRATE="$ROOT/rust/clock"
 MATRIX="$ROOT/tools/build_matrix.py"
+# #280 — the stale-config guard. Sourced, because the publish path needs the same function.
+# shellcheck source=/dev/null
+. "$ROOT/tools/assert_cargo_config.sh"
 
 # Per-chip logs go in the REPO, never /tmp (JP directive 2026-08-25 — katana's /tmp is a 16 GB
 # tmpfs, i.e. RAM). Git-ignored via tmp/.gitignore. Absolute, because this script `cd`s to $CRATE.
@@ -92,6 +95,22 @@ while IFS=$'\t' read -r chip target expect toolchain build_std opt_level feature
     # so the default-features path would be the one never exercised against its explicit form.
     args=(check --no-default-features --features "${chip},${features}" --target "$target")
     [ -n "$toolchain" ] && args=("+${toolchain}" "${args[@]}")
+
+    # #280 — BEFORE the build, not after. This script's own header sends operators to familiar,
+    # and familiar is exactly where `.cargo/config.toml` arrives out of band and goes stale: on
+    # 2026-08-25 its copy was current except for the S3 arm's `-Tlinkall.x`. `cargo check` would
+    # not have noticed (check never links) — it is the LINK that emits 129 undefined references,
+    # long after this harness has reported the chip green.
+    #
+    # Counted as a FAIL, deliberately, not a SKIP. A skip is for "the toolchain is absent", which
+    # is not the chip's fault and not a defect; a stale config IS a defect and the tree is wrong
+    # until it is fixed. Blurring the two would put a real problem in the column this script
+    # already warns reads like a green tick.
+    if ! assert_cargo_config "$chip"; then
+        printf '  \033[31mFAIL\033[0m %-9s %s — .cargo/config.toml is stale for this chip (#280)\n' \
+               "$chip" "$target"
+        fail=$((fail + 1)); continue
+    fi
 
     log="$CHIPS_TMP/check-chips-${chip}.log"
     printf '  .... %-9s %s (expect %s)\033[2K\r' "$chip" "$target" "$expect"


### PR DESCRIPTION
Implements the ruling on #280: a **marker-based** staleness guard, not a checksum.

## What was wrong

`rust/clock/.cargo/config.toml` is git-**tracked**, and `~/Projects/.stignore` ignores `.cargo`. So on a remote builder the file arrives **out of band** — this repo's own instructions tell agents to *"copy `.cargo/config.toml` if missing."* That workaround keeps working just well enough to hide that nothing keeps it **current**: a manual copy satisfies "present" and never satisfies "correct".

On 2026-08-25 familiar's copy was byte-current except for one hunk — the S3 arm's `-C link-arg=-Tlinkall.x`, added that morning by #398. The C3 `[build] target` was intact, so every C3 build was green and nothing suggested a problem. An S3 build there would have passed `cargo check` (check never links) and then failed the **link** with 129 undefined references — presenting as a broken toolchain rather than a stale file. familiar has the xtensa toolchain, so that was live, not hypothetical.

## Markers, not a checksum

A checksum needs ground truth from another host, and there is none on a builder that is deliberately offline-capable. Markers need only what the repo already declares — so `[chip.*]` in `build-matrix.toml` grows `config_markers`, and the manifest that knows a chip exists is also what knows what its build needs.

## The section scope IS the check

This is the part I'd most want reviewed, because the naive version is worse than useless:

```
whole-file grep -qF -- '-Tlinkall.x'  on the real stale file  ->  PASSES
section-scoped guard, chip esp32s3    on the same file        ->  REFUSED
```

A file-wide grep passes because the **two riscv arms carry the marker and only the xtensa arm lacked it**. It would have reported green on precisely the file whose staleness costs 129 link errors. So markers are asserted inside `[target.<triple>]`, and I verified this against a reconstruction of the actual drift rather than an invented one.

Markers are per-chip because the *correct* config genuinely differs per chip, not as generalisation-for-its-own-sake: `linker-flavor=ld.lld` is riscv-only and **deliberately absent** from the S3 list — xtensa has no LLD backend and links through esp GCC, so pinning `rust-lld` there would break it. Same reason, opposite action.

## Three vacuous-pass guards

Each would otherwise let the tool report green while guarding nothing:

- a chip with **no declared markers** is a manifest gap (exit 2), not a pass — "nobody wrote the markers yet" must not look like "the config is correct";
- a **missing `[target.<triple>]` section** refuses rather than finding nothing to check;
- an **unknown chip name** is an error, not an empty result.

## Proven on familiar, both directions

```
stale S3 arm  ->  REFUSED: … lacks -Tlinkall.x in [target.xtensa-esp32s3-none-elf] (chip esp32s3)
                            — stale out-of-band copy? re-sync from the canonical tree (#280)
                  FAIL esp32s3 …
                  chips: 0 as declared · 1 wrong · 0 skipped · 0 ACTUALLY RUN
restored      ->  ok: .cargo/config.toml carries esp32s3's declared markers
healthy path  ->  ok esp32c3 riscv32imc-unknown-none-elf — compiles clean
                  chips: 1 as declared · 0 wrong · 1 actually run
```

`0 actually run` is the line that matters: the guard fires **before** the build, which is the whole point — one line instead of 129 undefined references.

## Placement notes

- **`check_chips.sh`**, whose own header says *"⚠️ RUN IT ON familiar, NOT ON katana"* — the exact place the stale file bites. Counted as **FAIL, not SKIP**: a skip means "toolchain absent", which is nobody's defect and which that script already warns reads like a green tick; a stale config *is* a defect.
- **`config-markers` is a new `build_matrix.py` command**, not two more columns on `chip-checks`. The guard has a second caller (the publish path for #413) that wants nothing else from the row, and widening a tab-separated contract to serve a one-field consumer is how `check_chips.sh`'s sentinel-and-shifting-fields bug started.
- **The second site is deliberately untouched.** morpheus-depin3 is in the `repro_build` path right now; I messaged it directly rather than editing around it, and offered the function either as something it calls or as a call I add after it lands. `assert_cargo_config` is sourceable precisely so that's a one-liner wherever the #413 design settles.

## What it does not do

It does not prove the file is current — only that it carries the markers this chip needs. A stale-but-marker-complete file still passes, and the header says so. It narrows the window to "an edit that adds a new load-bearing key", which is exactly the moment to add a marker for it. A fence around a known cliff, not a freshness proof.

The `.stignore` change stays with JP, per the ruling — cross-project sync config isn't mine to flip in passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
