### PR TITLE
feat(tools): the stack-floor gate learns which chip it is measuring (#413 phase 2A)

### DIFF
--- a/.github/workflows/xtensa-spike.yml
+++ b/.github/workflows/xtensa-spike.yml
@@ -204,11 +204,20 @@ jobs:
           test -f "$elf" || { echo "::error::no ELF at $elf"; exit 1; }
           echo "S3_ELF_BYTES=$(stat -c%s "$elf")" >> "$GITHUB_ENV"
           # ⚠️ INFORMATIONAL ONLY, and knowingly incomplete: this reports .text/.rodata but drops
-          # .data/.bss (a readelf -SW column-position quirk this one-liner does not handle). Left
-          # as-is rather than half-fixed, because the S3 has NO stack-floor gate wired at all —
-          # `repro_stack_floor` greps the C3's constant BY NAME, so a non-C3 image would be measured
-          # against the C3's floor and report green. Both the parser and that false-pass are phase-2
-          # work (#413); fixing the parser here would suggest a gate exists when none does.
+          # .data/.bss (a readelf -SW column-position quirk this one-liner does not handle). Kept
+          # incomplete because this spike BUILDS and does not package, so no floor check runs here
+          # and a complete parser would imply a gate exists where none does. The proper parser is
+          # phase-2B work, together with wiring an S3 floor check into the publish path.
+          #
+          # The earlier note here said a chip-blind `repro_stack_floor` would make a non-C3 image
+          # "report green". THAT HAD THE DIRECTION BACKWARDS, and the correction was lost when #422
+          # squash-merged from a SHA that predated it — restated here so main carries the true
+          # version: the C3's floor (74,208) is the HIGHEST of the three (C6 71,680 · S3 72,004), so
+          # a chip-blind check was STRICTER than a non-C3 chip's own. It could false-REJECT a valid
+          # S3 image in [72,004, 74,208) — a 2,204 B window — and could never false-accept on that
+          # roster; today's S3 image measures 116,940 and clears both, so the verdict was correct by
+          # arithmetic coincidence. #413 phase 2A made the lookup per-chip and gave each floor its
+          # provenance, so this whole paragraph is now history rather than a live caveat.
           echo "--- sections (informational, incomplete — see the note in this step)"
           readelf -SW "$elf" | awk '$2 ~ /^\.(text|rodata|data|bss)$/ {printf "%-10s %10d\n", $2, strtonum("0x" $6)}'
 
@@ -239,7 +248,13 @@ jobs:
             echo "\`build-matrix.toml\`: *a compiler that demonstrably mishandled this code at"
             echo "\`opt=\"s\"\` merely LINKING at opt=2 is escape, not proof of correct codegen.*"
             echo
-            echo "⚠️ No stack-floor check runs here — \`repro_stack_floor\` greps the **C3's** constant"
-            echo "by name, so a non-C3 image would be measured against the C3's floor and report"
-            echo "green. That false-pass is phase-2 work (#413)."
+            echo "⚠️ No stack-floor check runs here — this spike builds, it does not package. But the"
+            echo "reason has CHANGED: \`repro_stack_floor\` is now per-chip (#413 phase 2A), so an S3"
+            echo "floor check is possible; wiring one into the publish path is phase 2B."
+            echo
+            echo "The old wording here claimed a chip-blind gate would \"report green\" for a non-C3"
+            echo "image. **That had the direction backwards** — the C3's floor (74,208) is the HIGHEST"
+            echo "of the three (C6 71,680 · S3 72,004), so a chip-blind check was STRICTER: it could"
+            echo "false-REJECT a valid S3 image in [72,004, 74,208), never false-accept, and today's"
+            echo "S3 image (116,940) cleared both floors — correct by arithmetic coincidence."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/rust/clock/src/budget.rs
+++ b/rust/clock/src/budget.rs
@@ -153,6 +153,55 @@ impl ChipBudget {
 // trusting the comment; a number copied forward untested is how the stack floor once ended
 // up at 12,288 B.
 
+/// **How a chip's declared stack floor was arrived at — the number's epistemic status, as DATA.**
+///
+/// #413 phase 2. The three floors on this fleet are three different KINDS of number, and until
+/// this enum existed that difference lived only in prose:
+///
+/// | chip | floor | how |
+/// |---|---|---|
+/// | C3 | 74,208 | [`Derived`](Self::Derived) — measured high-water × 4/3, compile-asserted |
+/// | C6 | 71,680 | [`BootAssert`](Self::BootAssert) — a firmware contract, sitting BELOW the empirical line |
+/// | S3 | 72,004 | [`ObservedSufficient`](Self::ObservedSufficient) — the smallest region proven clean, because the high-water instrument does not work on that chip |
+///
+/// ## Why this is an enum and not a doc comment
+///
+/// `tools/repro_build.sh` prints the provenance beside its verdict, so an operator reading
+/// `stack: 116940 B (floor 72004 B, observed-sufficient)` learns what the gate did and did not
+/// prove. A doc comment cannot reach the shell; a free-text string would rot back into prose. And
+/// an enum makes a fourth kind a **deliberate act in two places**: adding a variant here does not
+/// teach the shell, whose mapping is explicit and FAILS CLOSED on an unknown one. That is the
+/// intended friction — a new epistemic status should not be able to arrive by accident.
+///
+/// ## ⚠️ THE HARDENING RATCHET — the condition attached to this whole design
+///
+/// > when a chip gains a working high-water instrument, this gate HARDENS for that chip —
+/// > derived floors become REQUIRED and observed-sufficient/boot-assert refuse; permissive only
+/// > while measurement is impossible AND documented at the instrument (#398 follow-up for xtensa).
+///
+/// Today the packaging gate accepts every variant and merely reports it (#413 ruling). That
+/// permissiveness is **not a policy** — it is a consequence of `stack-paint` being invalid on
+/// xtensa, and it expires when that is fixed. What the gate protects against is silent `.stack`
+/// collapse from `.bss` growth, and an [`ObservedSufficient`](Self::ObservedSufficient) floor
+/// catches that perfectly well (the S3 sits at 116,940 against 72,004, so a ~40 KB regression
+/// trips it). What it does NOT do is certify an absolute safety margin — hence the ratchet.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FloorProvenance {
+    /// Derived from the highest stack high-water ever MEASURED on hardware for this chip, with a
+    /// safety multiplier, and coupled to that measurement by a compile-time assertion. The strong
+    /// form: the floor cannot drift from its own derivation without the build failing.
+    Derived,
+    /// The smallest `.stack` region PROVEN sufficient by observation — a tier that ran clean — with
+    /// **no high-water number available**, because the measuring instrument does not work on this
+    /// chip. Weaker than [`Derived`](Self::Derived) in a specific way: it says "this much was
+    /// enough for what we ran", not "this much is enough".
+    ObservedSufficient,
+    /// A floor the FIRMWARE asserts at boot — a contract rather than a measurement. Note this one
+    /// can sit BELOW the empirically-established line (the C6 does, by ~1,320 B, and `budget.rs`
+    /// asserts that inversion as a fact to preserve), so it is permissive in a KNOWN direction.
+    BootAssert,
+}
+
 /// **The C3 stack floor — ONE definition, two languages.**
 ///
 /// The minimum linked `.stack` region an image may ship with. Both consumers read *this*:
@@ -195,6 +244,18 @@ impl ChipBudget {
 /// at 12,288 B. And note every peak on record was measured **with the Bard narrating**, so for
 /// a Bard-free image this floor is an upper bound on what is required, not a target.
 pub const ESP32C3_STACK_FLOOR_BYTES: u32 = 74_208;
+
+/// The C3's floor is [`FloorProvenance::Derived`] — the strong form, and the only one on the fleet.
+///
+/// It is `ESP32C3_MEASURED_PEAK_BYTES * 4 / 3` with the assertion below enforcing the coupling, so
+/// the number cannot drift from the measurement it came from without the build failing. **This is
+/// the shape the other two chips are missing**, and #413 phase 2 makes that absence visible rather
+/// than leaving it in prose: grep for `_MEASURED_PEAK_BYTES` and there is exactly one.
+///
+/// ⚠️ Same one-line shell-parser contract as the floor above — `tools/repro_build.sh` matches
+/// `pub const ESP32C3_STACK_FLOOR_PROVENANCE: FloorProvenance = FloorProvenance::` and reads the
+/// variant up to the `;`. Keep it on ONE line.
+pub const ESP32C3_STACK_FLOOR_PROVENANCE: FloorProvenance = FloorProvenance::Derived;
 
 /// The input to that derivation: the highest stack high-water ever **measured on hardware** for
 /// this chip — #335, 2026-08-01, id5 under crown duty, 10/10 byte-identical reports, both
@@ -362,10 +423,27 @@ const _: () = assert!(
 /// Flash headroom after `widen_rom_region` is 1,622,672 B. The C6 is the mirror image of the
 /// Bard's problem on the C3 (flash-comfortable, DRAM-tight) — which is why the two axes are
 /// separate fields and why a verdict that could not name the axis would be useless here.
+/// The C6's floor, promoted from an inline literal to a named const (#413 phase 2) so the shell
+/// gate can read it the same way it reads the C3's, and so the provenance below has somewhere to
+/// live that is not a paragraph.
+///
+/// 71,680 B is the watch firmware's **boot assert** — see `ESP32C6_WATCH_EMPIRICAL_BOOT_LINE_BYTES`
+/// and the assertion that pins the inversion: the declared floor sits ~1,320 B BELOW the line the
+/// hardware bracket actually established. Permissive in a known, signed direction.
+///
+/// ⚠️ One-line shell-parser contract, as the C3's.
+pub const ESP32C6_STACK_FLOOR_BYTES: u32 = 71_680;
+
+/// [`FloorProvenance::BootAssert`] — a contract the firmware enforces, not a measurement.
+///
+/// ⚠️ There is deliberately **no** `ESP32C6_MEASURED_PEAK_BYTES` and therefore no `4/3` assertion:
+/// the C6's number did not come from a high-water run. The missing assert is the point.
+pub const ESP32C6_STACK_FLOOR_PROVENANCE: FloorProvenance = FloorProvenance::BootAssert;
+
 pub const ESP32C6_WATCH: ChipBudget = ChipBudget {
     chip: "esp32c6",
     free_dram_bytes: 80_272,
-    stack_floor_bytes: 71_680,
+    stack_floor_bytes: ESP32C6_STACK_FLOOR_BYTES,
     // partitions.csv (the watch's, NOT smol's partitions-ota.csv): ota_0/ota_1 = 0x600000.
     // Requires the `widen_rom_region` build.rs hook — see the doc note above.
     app_slot_bytes: 0x0060_0000,
@@ -446,10 +524,35 @@ pub const CHIP: ChipBudget = ESP32C6_WATCH;
 /// opt-level moves sections, so the profile is part of this row's provenance).
 /// `app_slot_bytes`/`baseline_image_bytes`: `targets/s3-cyd/partitions-ota-s3.csv`,
 /// espflash save-image against that CSV = 1,028,656 B (16.35% of the slot).
+/// The S3's floor, promoted from an inline literal to a named const (#413 phase 2).
+///
+/// 72,004 B is the `.stack` region of the heaviest-stack tier ever run on this unit
+/// (`stack-paint` = bard + canonical: narration + mesh relay + MQTT + the 4× display), which ran
+/// clean — **the smallest region PROVEN sufficient, not the smallest that works.**
+///
+/// ⚠️ One-line shell-parser contract, as the C3's.
+pub const ESP32S3_STACK_FLOOR_BYTES: u32 = 72_004;
+
+/// [`FloorProvenance::ObservedSufficient`] — and this is the chip the whole enum exists for.
+///
+/// **There is no measured high-water for the S3, because `stack-paint` is INVALID on this chip as
+/// written**: its sentinel is trampled by boot-era machinery sharing the `.stack` region (59,504 B
+/// read "used" one statement after painting, at boot, before anything deep ran), and re-painting
+/// after init crashed the box into a 99-boot exception loop. The `_stack_*_cpu0` symbols alias the
+/// whole-region ones (readelf-verified), so a CPU-slice port is NOT the fix.
+///
+/// ⚠️ **THIS CONST IS THE RATCHET'S TRIGGER.** When the xtensa high-water instrument is fixed
+/// (#398 follow-up), the correct change is: measure the peak, add `ESP32S3_MEASURED_PEAK_BYTES`
+/// with the `4/3` assertion the C3 has, and flip this to [`FloorProvenance::Derived`] — at which
+/// point the packaging gate stops merely reporting the status and starts requiring it. Do NOT flip
+/// this constant to `Derived` on the strength of a clean run; `ObservedSufficient` already means
+/// "it ran clean". `Derived` means the instrument measured how close it came.
+pub const ESP32S3_STACK_FLOOR_PROVENANCE: FloorProvenance = FloorProvenance::ObservedSufficient;
+
 pub const ESP32S3_CYD: ChipBudget = ChipBudget {
     chip: "esp32s3",
     free_dram_bytes: 116_940,
-    stack_floor_bytes: 72_004,
+    stack_floor_bytes: ESP32S3_STACK_FLOOR_BYTES,
     app_slot_bytes: 0x0060_0000,
     baseline_image_bytes: 1_028_656,
 };

--- a/tools/build_matrix.py
+++ b/tools/build_matrix.py
@@ -276,7 +276,8 @@ def check(doc: dict, repro: Path, budget: Path) -> list[str]:
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("command",
-                    choices=("emit", "chips", "chip-checks", "config-markers", "ci-matrix", "check"))
+                    choices=("emit", "chips", "chip-checks", "canonical-chip", "config-markers",
+                             "ci-matrix", "check"))
     ap.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     ap.add_argument("--repro", type=Path, default=DEFAULT_REPRO)
     ap.add_argument("--budget", type=Path, default=DEFAULT_BUDGET)
@@ -370,6 +371,14 @@ def main() -> int:
                              opt(spec.get("build_std")),
                              opt(spec.get("opt_level")),
                              canon_features)))
+        return 0
+
+    if args.command == "canonical-chip":
+        # #413: `tools/gate.sh` needs the chip whose floor its stack arm measures against, and
+        # since that arm builds the CANONICAL tier the answer is `meta.canonical_chip`. Emitted
+        # here rather than hardcoded there, for the same reason every other roster fact is: a
+        # second copy of "the canonical chip is esp32c3" would be free to drift from this one.
+        print(doc["canonical_chip"])
         return 0
 
     if args.command == "ci-matrix":

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -22,7 +22,9 @@
 #      is deliberately NOT repeated in this file, in build-matrix.toml, or anywhere else.
 #   5. the crate's own tests/*.rs suites via cargo test (#350) — bard / budget / input. Nothing
 #      ran these before: 57 tests, including the Bard's bit-for-bit golden, that no gate executed
-#   6. tools/test_build_matrix.sh — proof that (0)'s arms can actually fail
+#   6. tools/test_build_matrix.sh — proof that (0)'s arms can actually fail, and
+#      tools/test_stack_floor.sh — proof the #413 per-chip floor lookup can fail (it replaced a
+#      gate that was green while chip-blind)
 #   7. #351 the BYTE-FREE tier claims, in two DELIBERATELY ASYMMETRIC arms. Read the asymmetry
 #      before deleting either as a duplicate of the other:
 #      (a) THE PROOF. build-matrix.toml's [tier_exclusive] must still agree with the
@@ -128,6 +130,12 @@ esac
 
 # shellcheck source=/dev/null
 . "$ROOT/tools/repro_build.sh"   # REPRO_TARGET, REPRO_FLEET_FEATURES, repro_cargo_args, repro_stack_check
+
+# #413: the stack arm measures the CANONICAL tier, so it must measure against the CANONICAL CHIP's
+# floor — `repro_stack_check` no longer defaults to the C3, deliberately. Read from the manifest
+# rather than written here, so there is no second copy of "the canonical chip is esp32c3".
+CANON_CHIP="$("$ROOT/tools/build_matrix.py" canonical-chip 2>/dev/null || true)"
+[ -n "$CANON_CHIP" ] || { echo "gate: could not resolve meta.canonical_chip from tools/build-matrix.toml" >&2; exit 2; }
 
 JOBS=()
 [ -n "${SMOL_GATE_JOBS:-}" ] && JOBS=(-j "$SMOL_GATE_JOBS")
@@ -474,7 +482,7 @@ if [ "$run_fw" = 1 ]; then
   # it was a third hardcoded copy of 73728, which would have gone on announcing the old number
   # while the gate enforced a new one. "unreadable" here is not a failure; repro_stack_check
   # fails closed on it a few lines down, with the diagnostic.
-  step "stack floor — canonical ELF vs ${REPRO_STACK_FLOOR:-$(repro_stack_floor || echo unreadable)} B"
+  step "stack floor — canonical ELF vs ${REPRO_STACK_FLOOR:-$(repro_stack_floor "$CANON_CHIP" || echo unreadable)} B"
   if repro_cargo_args "$BUILD_ROOT/$CLOCK" 2>/dev/null && \
      (cd "$BUILD_ROOT/$CLOCK" && cargo build --release "${JOBS[@]}" --features "$REPRO_FLEET_FEATURES" "${REPRO_CARGO_ARGS[@]}") \
        >"$GATE_TMP/gate-stack.log" 2>&1; then
@@ -483,7 +491,7 @@ if [ "$run_fw" = 1 ]; then
     # number is visible without opening logs. Written on FAILURE too — "the stack broke the floor"
     # is the case a reader most needs surfaced, and a report that only exists when green would hide
     # exactly that.
-    if out=$(repro_stack_check "$ELF" 2>&1); then
+    if out=$(repro_stack_check "$ELF" "$CANON_CHIP" 2>&1); then
       printf '%s\n' "$out"; printf '%s\n' "$out" > "$STACK_REPORT"; ok "stack floor"
     else
       printf '%s\n' "$out"; printf '%s\n' "$out" > "$STACK_REPORT"; bad "stack floor"
@@ -565,6 +573,19 @@ if [ "$run_host" = 1 ]; then
     printf '%s\n' "$out" | tail -2; ok "test_byte_free"
   else
     printf '%s\n' "$out" | sed 's/^/        /'; bad "test_byte_free"
+  fi
+
+  # #413: the per-chip stack-floor lookup, and the same "prove it can fail" discipline. This one
+  # earns it especially: the OLD chip-blind gate was GREEN throughout and its verdict happened to
+  # be right, because the C3's floor is the highest of the three so a chip-blind check was stricter
+  # than a non-C3 chip's own. Nothing in a passing run could have revealed that. The suite uses a
+  # `readelf` stub, so it can put a .stack inside the 2,204 B false-REJECT window no real image
+  # occupies. Pure text, no cargo, no ELF.
+  step "per-chip stack-floor regression suite (#413)"
+  if out=$("$ROOT/tools/test_stack_floor.sh" 2>&1); then
+    printf '%s\n' "$out" | tail -2; ok "test_stack_floor"
+  else
+    printf '%s\n' "$out" | sed 's/^/        /'; bad "test_stack_floor"
   fi
 
   step "build-matrix checker regression suite (#350)"

--- a/tools/repro_build.sh
+++ b/tools/repro_build.sh
@@ -122,25 +122,105 @@ REPRO_ROOT="${REPRO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null &
 # documented on ESP32C3_STACK_FLOOR_BYTES (one line, plain decimal, comments on their own line).
 # The awk takes everything between `=` and `;` and strips spaces/underscores, so a trailing
 # comment on the line cannot be swallowed into the number; the digits-only test is the backstop.
+# repro_stack_floor <chip>  →  prints "<bytes> <provenance-token>"
+#
+# ── #413 PHASE 2: THIS USED TO BE CHIP-BLIND, AND ITS CORRECTNESS WAS COINCIDENTAL ────────────
+# It read `ESP32C3_STACK_FLOOR_BYTES` by name and `repro_stack_check` applied that number to
+# whatever ELF it was handed. The direction of the resulting error is worth stating exactly,
+# because the obvious guess is wrong: the C3's floor (74,208) is the HIGHEST of the three declared
+# floors (C6 71,680 · S3 72,004), so a chip-blind check was STRICTER than a non-C3 chip's own
+# floor. It could not false-ACCEPT; it could false-REJECT a valid S3 image whose `.stack` landed in
+# [72,004, 74,208) — a 2,204 B window — and it would only false-accept once some chip's legitimate
+# floor exceeded the C3's. It happened to give the right answer for the S3 fleet image because that
+# image measures 116,940 and clears both numbers. Right answer, unrelated reason.
+#
+# ── AND THE PART THAT MADE THE FIX MORE THAN A PARAMETER ──────────────────────────────────────
+# The three floors are three different KINDS of number, so returning "whichever number the row
+# holds" would produce a gate that LOOKS uniform and MEANS three different things:
+#
+#   derived              C3 — measured high-water × 4/3, compile-asserted. The strong form.
+#   boot-assert          C6 — a firmware contract, sitting ~1,320 B BELOW the empirical line.
+#   observed-sufficient  S3 — the smallest region PROVEN clean, because `stack-paint` is INVALID
+#                             on xtensa (sentinel trampled by boot-era machinery; re-painting
+#                             crashed into a 99-boot loop). No high-water exists for that chip.
+#
+# So the provenance travels WITH the number and `repro_stack_check` prints it. An operator reading
+# `stack: 116940 B (floor 72004 B, observed-sufficient)` learns what the gate did and did not prove.
+#
+# ⚠️ THE HARDENING RATCHET (#413 ruling — the condition attached to this decision):
+#
+#     when a chip gains a working high-water instrument, this gate HARDENS for that chip —
+#     derived floors become REQUIRED and observed-sufficient/boot-assert refuse; permissive only
+#     while measurement is impossible AND documented at the instrument (#398 follow-up for xtensa).
+#
+# Today every provenance is accepted and merely reported. That is NOT a policy — it is a
+# consequence of a named instrument defect, and it expires when the defect is fixed. What this gate
+# protects against is silent `.stack` collapse from `.bss` growth, and an observed-sufficient floor
+# catches that perfectly well (the S3 sits 44,936 B above its floor, so a ~40 KB regression trips
+# it). What it does not do is certify an absolute margin.
 repro_stack_floor() {
-  local src="${REPRO_BUDGET_RS:-$REPRO_ROOT/rust/clock/src/budget.rs}" v
+  local chip="${1:-}"
+  case "$chip" in
+    '') echo "repro_stack_floor: a chip is required (esp32c3|esp32c6|esp32s3)" >&2; return 1 ;;
+    *[!a-z0-9]*) echo "repro_stack_floor: implausible chip name '$chip'" >&2; return 1 ;;
+  esac
+  local src="${REPRO_BUDGET_RS:-$REPRO_ROOT/rust/clock/src/budget.rs}" v p tok
   [ -f "$src" ] || return 1
-  v=$(awk '/^pub const ESP32C3_STACK_FLOOR_BYTES: u32 =/ {
+  # Uppercase the chip to get the const prefix. `esp32c3` → `ESP32C3_STACK_FLOOR_BYTES`, which is
+  # why #413 promoted the C6/S3 floors from inline literals to consts NAMED BY CHIP rather than by
+  # board (the rows are ESP32C6_WATCH / ESP32S3_CYD — board names would not map).
+  local pre; pre=$(printf '%s' "$chip" | tr 'a-z' 'A-Z')
+  v=$(awk -v k="^pub const ${pre}_STACK_FLOOR_BYTES: u32 =" '$0 ~ k {
              split($0, a, "="); split(a[2], b, ";"); gsub(/[ _]/, "", b[1]); print b[1]; exit
            }' "$src" 2>/dev/null)
   case "$v" in ''|*[!0-9]*) return 1 ;; esac
-  printf '%s' "$v"
+  # The provenance variant, read from the sibling const.
+  p=$(awk -v k="^pub const ${pre}_STACK_FLOOR_PROVENANCE: FloorProvenance =" '$0 ~ k {
+             n = split($0, a, "::"); split(a[n], b, ";"); gsub(/[ \t]/, "", b[1]); print b[1]; exit
+           }' "$src" 2>/dev/null)
+  # EXPLICIT mapping, FAILING CLOSED on anything unrecognised. This is the deliberate friction the
+  # enum's doc comment describes: adding a `FloorProvenance` variant in Rust does NOT teach this
+  # function, so a new epistemic status cannot arrive by accident — it fails here until someone
+  # decides, in writing, what the gate should do about it.
+  case "$p" in
+    Derived)            tok=derived ;;
+    ObservedSufficient) tok=observed-sufficient ;;
+    BootAssert)         tok=boot-assert ;;
+    '') echo "repro_stack_floor: no ${pre}_STACK_FLOOR_PROVENANCE in $src" >&2; return 1 ;;
+    *)  echo "repro_stack_floor: unknown FloorProvenance::$p — this gate must be taught what it means" >&2; return 1 ;;
+  esac
+  printf '%s %s' "$v" "$tok"
 }
 
 # repro_stack_check <elf>
+# repro_stack_check <elf> <chip>
+#
+# #413: the chip is now REQUIRED and is not defaulted to the C3. A default would restore exactly
+# the chip-blindness this change removes, and it would do so invisibly — the caller that forgot to
+# pass a chip would get a plausible verdict rather than an error.
 repro_stack_check() {
-  local elf="$1" stack_floor="${REPRO_STACK_FLOOR:-$(repro_stack_floor)}"
+  local elf="$1" chip="${2:-}" stack_floor prov
+  case "$chip" in
+    '') echo "FATAL: repro_stack_check needs a chip — refusing to measure an image against an" >&2
+        echo "       unspecified chip's floor. That was the #413 defect: the verdict was correct" >&2
+        echo "       only by arithmetic coincidence because the C3's floor happens to be the" >&2
+        echo "       highest of the three." >&2
+        return 1 ;;
+  esac
+  if [ -n "${REPRO_STACK_FLOOR:-}" ]; then
+    # Documented escape hatch, kept — but it is now LOUD. An operator-supplied number has no
+    # provenance in `budget.rs`, and calling it `derived` would be a lie, so it gets its own token.
+    stack_floor="$REPRO_STACK_FLOOR"; prov="operator-override"
+  else
+    local pair; pair="$(repro_stack_floor "$chip")" || pair=""
+    stack_floor="${pair%% *}"; prov="${pair##* }"
+  fi
   # FAIL CLOSED on an unreadable declaration, for the same reason as the unreadable-ELF branch
   # below: a gate that quietly falls back to a built-in default would measure against a number
   # nobody edited, which is precisely the drift #348 removed. Better to refuse and be fixed.
   case "$stack_floor" in
     ''|*[!0-9]*)
-      echo "FATAL: could not read ESP32C3_STACK_FLOOR_BYTES from ${REPRO_BUDGET_RS:-$REPRO_ROOT/rust/clock/src/budget.rs}" >&2
+      echo "FATAL: could not read the ${chip} stack floor + provenance from ${REPRO_BUDGET_RS:-$REPRO_ROOT/rust/clock/src/budget.rs}" >&2
       echo "       — refusing to measure the stack against a guessed floor. Check that the" >&2
       echo "       declaration is one line of plain decimal (see its doc comment), or set" >&2
       echo "       REPRO_STACK_FLOOR explicitly if you are deliberately overriding it." >&2
@@ -153,12 +233,12 @@ repro_stack_check() {
   if [ -n "$ss" ] && [ -n "$se" ]; then
     local stack_bytes=$(( 0x$ss - 0x$se ))
     if [ "$stack_bytes" -lt "$stack_floor" ]; then
-      echo "FATAL: runtime stack is ${stack_bytes} B, below the ${stack_floor} B floor." >&2
+      echo "FATAL: runtime stack is ${stack_bytes} B, below the ${chip} ${stack_floor} B floor (${prov})." >&2
       echo "       Something grew .bss. Shrink it (nano_llm::SEQ_CAP is the bard's lever) or" >&2
       echo "       reclaim DRAM elsewhere — do NOT ship this image." >&2
       return 1
     fi
-    echo "  stack: ${stack_bytes} B (floor ${stack_floor} B)"
+    echo "  stack: ${stack_bytes} B (floor ${stack_floor} B, ${prov})"
   else
     # FAIL CLOSED. This gate exists precisely because "it links" was not evidence of a runnable
     # image; a gate that waves through an unreadable ELF restores that blind spot exactly, and
@@ -295,7 +375,9 @@ repro_build_bin() {
   # Honor CARGO_TARGET_DIR (verify_image.sh --twice points each build at an isolated dir);
   # default to the in-tree target/ (ota_publish.sh's path) when unset.
   local tdir="${CARGO_TARGET_DIR:-$clock/target}"
-  repro_stack_check "$tdir/${REPRO_TARGET}/release/clock" || return 1
+  # #413: the chip travels with the check. Phase 2A keeps REPRO_CHIP defaulting to esp32c3 —
+  # phase 2B derives it from the manifest alongside REPRO_TARGET, and the two must move together.
+  repro_stack_check "$tdir/${REPRO_TARGET}/release/clock" "${REPRO_CHIP:-esp32c3}" || return 1
   "$espflash" save-image --chip esp32c3 \
     "$tdir/${REPRO_TARGET}/release/clock" "$out" >/dev/null || return 1
 }

--- a/tools/test_stack_floor.sh
+++ b/tools/test_stack_floor.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# test_stack_floor.sh — #413 phase 2. Prove the per-chip stack-floor lookup works AND can FAIL.
+#
+# ── WHY THIS EXISTS, AND WHY A GREEN GATE RUN IS NOT IT ───────────────────────────────────────
+# `repro_stack_floor` used to read the C3's constant by name and `repro_stack_check` applied it to
+# whatever ELF it was handed. That gate was GREEN throughout, and its verdict happened to be right
+# because the C3's floor (74,208) is the HIGHEST of the three declared floors — so a chip-blind
+# check was stricter than a non-C3 chip's own, and the S3's fleet image (116,940) cleared both.
+# Right answer, unrelated reason. Nothing in a passing run could have told anyone.
+#
+# So each case below is a chip/ELF/manifest combination crafted to exercise one arm, and the suite
+# asserts the failures as strictly as the passes — `test_build_matrix.sh`'s discipline, and #350's
+# lesson that a gate demonstrated only in its passing state is not evidence.
+#
+# NO cargo, NO hardware, NO ELF. `repro_stack_check` shells out to `readelf`, so a stub earlier on
+# PATH lets every stack size be chosen exactly. That is what makes the false-REJECT window (a 2,204
+# B band no real image happens to sit in) testable at all.
+#
+# Exit 0 = every case behaved; 1 = otherwise.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+pass=0; fail=0
+ok()   { printf '   \033[32mok\033[0m   %s\n' "$1"; pass=$((pass + 1)); }
+bad()  { printf '   \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail + 1)); }
+
+WORK="$(mktemp -d --tmpdir stack-floor-test-XXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ── the readelf stub ─────────────────────────────────────────────────────────────────────────
+# Emits `-sW` symbol rows in the real column layout (field 2 = Value, field 8 = Name), so the
+# awk in `repro_stack_check` parses it unchanged. STACK_BYTES picks the region size.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/readelf" <<'STUB'
+#!/usr/bin/env bash
+# stub: only the -sW symbol query is used by repro_stack_check
+end=0x40000000
+start=$(printf '0x%x' $(( end + ${STACK_BYTES:-100000} )))
+echo "Symbol table '.symtab' contains 2 entries:"
+echo "   Num:    Value          Size Type    Bind   Vis      Ndx Name"
+echo "     1: ${start#0x}     0 NOTYPE  GLOBAL DEFAULT  ABS _stack_start"
+echo "     2: ${end#0x}     0 NOTYPE  GLOBAL DEFAULT  ABS _stack_end"
+STUB
+chmod +x "$WORK/bin/readelf"
+export PATH="$WORK/bin:$PATH"
+
+# shellcheck source=tools/repro_build.sh
+. "$ROOT/tools/repro_build.sh"
+
+# ── ARM 1: each chip's floor + provenance parses, from the REAL budget.rs ─────────────────────
+echo
+echo "═══ the three floors are three different KINDS of number ═══"
+expect_floor() { # <chip> <bytes> <provenance>
+  local got; got="$(repro_stack_floor "$1" 2>&1)"
+  if [ "$got" = "$2 $3" ]; then ok "$1 → $2 $3"; else bad "$1 → wanted '$2 $3', got '$got'"; fi
+}
+expect_floor esp32c3 74208 derived
+expect_floor esp32c6 71680 boot-assert
+expect_floor esp32s3 72004 observed-sufficient
+
+# ── ARM 2: THE ACCEPTANCE TEST — the false-REJECT window closes ───────────────────────────────
+# A .stack of 73,000 B sits INSIDE [72,004, 74,208): above the S3's floor, below the C3's. Before
+# this change both verdicts came from the C3's number, so the S3 case was a FATAL on a valid image.
+echo
+echo "═══ the 2,204 B false-REJECT window — the defect this change exists to close ═══"
+export STACK_BYTES=73000
+out="$(repro_stack_check /nonexistent-elf esp32s3 2>&1)"; rc=$?
+if [ $rc -eq 0 ]; then ok "S3 image with .stack 73,000 PASSES (its floor is 72,004)"
+else bad "S3 image with .stack 73,000 was REJECTED — the window did not close: $out"; fi
+case "$out" in *observed-sufficient*) ok "and the verdict names the provenance" ;;
+                *) bad "verdict omits the provenance: $out" ;; esac
+
+out="$(repro_stack_check /nonexistent-elf esp32c3 2>&1)"; rc=$?
+if [ $rc -ne 0 ]; then ok "the SAME .stack 73,000 correctly FATALs for the C3 (floor 74,208)"
+else bad "C3 accepted 73,000 B against a 74,208 B floor"; fi
+case "$out" in *esp32c3*74208*) ok "and the FATAL names the chip and its floor" ;;
+                *) bad "FATAL does not name chip+floor: $out" ;; esac
+
+# ── ARM 3: a genuinely thin stack still fails, for every chip ────────────────────────────────
+echo
+echo "═══ the regression it actually guards: .bss growth collapsing .stack ═══"
+export STACK_BYTES=2592   # the #300 bard image's real linked stack
+for c in esp32c3 esp32c6 esp32s3; do
+  out="$(repro_stack_check /nonexistent-elf "$c" 2>&1)"
+  if [ $? -ne 0 ]; then ok "$c refuses a 2,592 B stack (the #300 case)"
+  else bad "$c ACCEPTED a 2,592 B stack"; fi
+done
+unset STACK_BYTES
+
+# ── ARM 4: fail-closed arms ──────────────────────────────────────────────────────────────────
+echo
+echo "═══ fail-closed: every unknown must refuse, never default ═══"
+out="$(repro_stack_check /nonexistent-elf 2>&1)"; [ $? -ne 0 ] \
+  && case "$out" in *"needs a chip"*) ok "no chip → refuses (no silent C3 default)" ;;
+                    *) bad "wrong refusal for a missing chip: $out" ;; esac \
+  || bad "a missing chip was ACCEPTED"
+
+out="$(repro_stack_floor esp32c9 2>&1)"; [ $? -ne 0 ] \
+  && ok "an undeclared chip → refuses" || bad "undeclared chip returned '$out'"
+
+out="$(repro_stack_floor 'esp32c3; rm -rf /' 2>&1)"; [ $? -ne 0 ] \
+  && ok "an implausible chip name → refuses before it reaches awk" \
+  || bad "implausible chip name accepted"
+
+# A budget.rs carrying a FloorProvenance variant the shell has not been taught. This is the
+# deliberate friction: adding a Rust variant must NOT silently acquire a shell meaning.
+sed -e 's/FloorProvenance::Derived;/FloorProvenance::VibesBased;/' \
+    "$ROOT/rust/clock/src/budget.rs" > "$WORK/budget-unknown-prov.rs"
+out="$(REPRO_BUDGET_RS="$WORK/budget-unknown-prov.rs" repro_stack_floor esp32c3 2>&1)"; [ $? -ne 0 ] \
+  && case "$out" in *"must be taught"*) ok "an UNKNOWN FloorProvenance variant → refuses" ;;
+                    *) bad "wrong refusal for an unknown variant: $out" ;; esac \
+  || bad "an unknown FloorProvenance variant was silently accepted as '$out'"
+
+# A budget.rs with the floor const deleted — the #348 drift case.
+grep -v '^pub const ESP32S3_STACK_FLOOR_BYTES' "$ROOT/rust/clock/src/budget.rs" > "$WORK/budget-no-floor.rs"
+out="$(REPRO_BUDGET_RS="$WORK/budget-no-floor.rs" repro_stack_floor esp32s3 2>&1)"; [ $? -ne 0 ] \
+  && ok "a missing floor const → refuses" || bad "missing floor const returned '$out'"
+
+# ── ARM 5: the operator override is honest about having no provenance ────────────────────────
+echo
+echo "═══ the escape hatch does not get to claim a provenance it does not have ═══"
+export STACK_BYTES=100000
+out="$(REPRO_STACK_FLOOR=50000 repro_stack_check /nonexistent-elf esp32s3 2>&1)"
+case "$out" in *operator-override*) ok "REPRO_STACK_FLOOR prints 'operator-override', not 'derived'" ;;
+                *) bad "override did not label itself: $out" ;; esac
+unset STACK_BYTES
+
+echo
+echo "════════════════════════════════════════════"
+printf '  %d passed · %d failed\n' "$pass" "$fail"
+echo "════════════════════════════════════════════"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
`repro_stack_floor` read `ESP32C3_STACK_FLOOR_BYTES` **by name** and `repro_stack_check` applied that number to whatever ELF it was handed. The gate was green throughout and its verdict happened to be right — which is the whole problem.

## The direction, because the obvious guess is wrong

I guessed wrong twice before reading the numbers, so it's stated plainly:

| chip | `stack_floor_bytes` |
|---|---|
| esp32c3 | **74,208** ← the highest |
| esp32c6 | 71,680 |
| esp32s3 | 72,004 |

The C3's floor is the **highest** of the three, so a chip-blind check was **stricter** than a non-C3 chip's own:

- it **could not false-ACCEPT** on today's roster;
- it **could false-REJECT** a valid S3 image whose `.stack` landed in `[72,004, 74,208)` — a **2,204 B** window;
- it would false-accept only once some chip's legitimate floor exceeded the C3's;
- and today it did neither, because the S3 fleet image measures 116,940 and clears both.

So the defect is that the verdict was **correct by arithmetic coincidence** — unrelated to the chip whose image it measured. That is worth fixing on those grounds, not on a false-pass claim that doesn't hold.

## Why this isn't just adding a parameter

**The three floors are three different KINDS of number**, so returning "whichever number the row holds" would give a gate that *looks* uniform and *means* three different things:

| provenance | chip | what it is |
|---|---|---|
| `derived` | C3 | measured high-water × 4/3, **compile-asserted**. The strong form. |
| `boot-assert` | C6 | a firmware contract, sitting ~1,320 B **below** the empirical line |
| `observed-sufficient` | S3 | the smallest region **proven clean** — because `stack-paint` is **invalid on xtensa** (sentinel trampled by boot-era machinery; re-painting crashed into a 99-boot loop). **No high-water exists for that chip at all.** |

For the S3, the naive fix would compare against a number whose own documentation says the measuring instrument doesn't work there. So the provenance travels **with** the value and the gate prints it:

```
stack: 116940 B (floor 72004 B, observed-sufficient)
```

An **enum** rather than a string, because it makes a fourth kind a **deliberate act in two places**: adding a Rust variant does not teach the shell, whose mapping is explicit and **fails closed** on an unknown one. A new epistemic status shouldn't be able to arrive by accident.

## The ratchet (#413 ruling), verbatim in the code

The ruling was **no refusal — publish with provenance stamped.** I had recommended refusing to package a weak-provenance chip and was overruled with a better argument, which is recorded at the code: what this gate protects against is **silent `.stack` collapse from `.bss` growth**, and an observed-sufficient floor catches that perfectly well (the S3 sits 44,936 B above its floor). It does not certify an absolute margin — hence:

> when a chip gains a working high-water instrument, this gate HARDENS for that chip — derived floors become REQUIRED and observed-sufficient/boot-assert refuse; permissive only while measurement is impossible AND documented at the instrument (#398 follow-up for xtensa).

The permissiveness is **not a policy**; it's a consequence of a named instrument defect, and it expires when the defect is fixed. My own note is at the code too: I'd been protecting a property the gate never provided.

## What else changed, and why each

- **`budget.rs`**: the C6/S3 floors were **inline literals**; they're now consts named **by chip** (not by board — the rows are `ESP32C6_WATCH`/`ESP32S3_CYD`, and board names wouldn't map from a chip string). Keeps the one-line shell-parser contract the C3 const already documents, gives each floor a home for its provenance, and makes one asymmetry **visible in code rather than prose**: the C3 has `assert!(floor >= peak * 4/3)` and the S3 *cannot*, because it has no measured peak. **`grep _MEASURED_PEAK_BYTES` now returns exactly one hit** — the missing assert is an absence you can find.
- **`repro_stack_check` requires the chip.** No default: a default would restore chip-blindness *invisibly*, handing a forgetful caller a plausible verdict instead of an error.
- **`REPRO_STACK_FLOOR`** survives as the documented escape hatch but reports `operator-override` — an operator-supplied number has no provenance in `budget.rs`, and calling it `derived` would be a lie.
- **`build_matrix.py canonical-chip`**: gate.sh's stack arm measures the canonical tier, so it needs the canonical chip. Read from the manifest rather than written into gate.sh, so there's no second copy of "the canonical chip is esp32c3".
- **`tools/test_stack_floor.sh`** — 16 cases, wired into gate.sh. It uses a **`readelf` stub**, which is what makes the acceptance test expressible at all: no real image sits in that 2,204 B band, so proving `.stack` 73,000 **passes for the S3 and FATALs for the C3** needs a controllable stack size. Pure text — no cargo, no ELF, no hardware. Every fail-closed arm is asserted too, including an unknown `FloorProvenance` variant and a deleted floor const.

## A lost correction, restored

#422 squash-merged from `6bb171d`, which **predated** my direction fix (`9cf1cc6`) — so main landed the cache drop, the 524 MB cache-cost correction and the cron, but **not** the correction, and has been carrying the backwards "report green" claim in two places since. Both are rewritten here.

Lesson worth recording: **patching a PR body is not patching the merged file**, and a merge armed on a specific SHA silently drops anything pushed after it. Verified with `git merge-base --is-ancestor` rather than assumed.

## Evidence

Builds on familiar, working set under `/var/tmp/ftarget/413p2` per the disk directive.

**Default C3 tier BYTE-IDENTICAL** — same directory, same target dir, only `budget.rs` differing:

```
.text 67,750 · .rodata 19,396 · .data 1,904 · .bss 468 · .stack 315,388
ELF 310,196 B · 5,998 symbols
raw nm md5 bf1948ea967084aa7579b3b40f415920  ← identical, not merely equal after normalising
```

The enum and four consts emit nothing. Also verified the `.cargo/config.toml` in the build tree was byte-identical to canonical (`d7ea95c2…`) — relevant because #280 found a *stale* copy on that same host, and a stale config would have made these numbers suspect.

Suites: `test_stack_floor` **16/0** (new) · `test_build_matrix` **13/0** · `test_ota_publish_guards` **23/0** · `test_ota_ratchet` **16/0** · budget host tests **16/0** · `build_matrix.py check` clean. `bash -n` clean on all three scripts; the workflow parses as YAML. Every consumer of `repro_build.sh` audited — `verify_image.sh` and `repro_at_canonical.sh` use only `repro_cargo_args`/`repro_build_bin` and are unaffected.

## Not here — phase 2B

`REPRO_TARGET` is still a scalar with 6 consumers, and `repro_build_bin` still builds with plain `cargo build` (a non-C3 image also needs `+esp`, build-std and the opt-2 override, all per-invocation). **`REPRO_CHIP` defaults to `esp32c3` precisely so this commit changes no fleet behaviour**; 2B derives it from the manifest alongside the target, and the two must move together. 2B also carries the (chip, profile) sha-lineage note, #280's marker-guard call site, the `readelf` parser rewrite, and provenance onto the artifact metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
