### PR TITLE
fix(mesh): #397 STEP B part 2 — bound the two evidence sends; the ELECT roster learns send_async

### DIFF
--- a/ha/packages/smol_mesh.yaml
+++ b/ha/packages/smol_mesh.yaml
@@ -478,7 +478,12 @@ mqtt:
       icon: "mdi:link-variant"
     # --- #40 leaf-mesh-OTA RELAY PROGRESS (Luna · JP ask 2026-07-11) — the gateway publishes
     # smol/<id>/ota/relaydiag on each burst while relaying the image to this leaf:
-    #   "rx=N otan=M last_wb=W/T otam_tx=A/B settle=S leaf=HxVyNzch<c>"
+    #   "rx=N otan=M last_wb=W/T otam_tx=A/B otam_to=U settle=S leaf=HxVyNzch<c>"
+    # otam_to (#397 STEP B2) = announces whose outcome is NOT evidence either way (the bounded
+    # send outlived 30 ms, or its success may have been an abandoned send's completion). Read it
+    # WITH otam_tx=A/B: A = B + otam_to + confirmed-failures, so "B=0, otam_to=A" (sends never
+    # complete in time) is a DIFFERENT story from "B=0, otam_to=0" (sends confirmed-fail), and
+    # those two were indistinguishable before the counter existed.
     # last_wb=W/T is the LITERAL image-transfer progress (e.g. 4288/4343 = 98.7%). STATE = that
     # percentage (numeric %, drives the dashboard progress bar); the raw fields ride as attributes
     # so a stalling/tailing relay is diagnosable HEADLESS (the mesh-only leaf has no serial).
@@ -502,12 +507,13 @@ mqtt:
         {% if ns.ok and ns.t > 0 %}{{ (100.0 * ns.w / ns.t) | round(1) }}{% else %}unknown{% endif %}
       json_attributes_topic: "smol/8/ota/relaydiag"
       json_attributes_template: >-
-        {% set ns = namespace(rx='', otan='', wb='', otam='', settle='', leaf='') %}
+        {% set ns = namespace(rx='', otan='', wb='', otam='', otam_to='', settle='', leaf='') %}
         {% for t in value.split() %}
           {% if t.startswith('rx=') %}{% set ns.rx = t[3:] %}
           {% elif t.startswith('otan=') %}{% set ns.otan = t[5:] %}
           {% elif t.startswith('last_wb=') %}{% set ns.wb = t[8:] %}
           {% elif t.startswith('otam_tx=') %}{% set ns.otam = t[8:] %}
+          {% elif t.startswith('otam_to=') %}{% set ns.otam_to = t[8:] %}
           {% elif t.startswith('settle=') %}{% set ns.settle = t[7:] %}
           {% elif t.startswith('leaf=') %}{% set ns.leaf = t[5:] %}
           {% endif %}
@@ -516,7 +522,8 @@ mqtt:
         {{ {'rx': ns.rx, 'otan': ns.otan, 'last_wb': ns.wb,
             'wb_done': (wp[0] | int(0)) if wp | length == 2 else 0,
             'wb_total': (wp[1] | int(0)) if wp | length == 2 else 0,
-            'otam_tx': ns.otam, 'settle': ns.settle, 'leaf': ns.leaf, 'raw': value} | tojson }}
+            'otam_tx': ns.otam, 'otam_to': ns.otam_to,
+            'settle': ns.settle, 'leaf': ns.leaf, 'raw': value} | tojson }}
     # --- #48 LED mode — mirror of the retained smol/<id>/config/led (commanded value) ---
     - name: "smol 8 LED"
       unique_id: smol_8_led_mirror

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -49,6 +49,11 @@ use esp_hal::{
     time::Instant,
 };
 use embassy_futures::block_on;
+// #397 STEP B2: the bounded announce send. `select` races the send future against a deadline;
+// `Timer` is the deadline. Both are available on every radio tier because #391 turned on
+// esp-rtos's `embassy` feature (which supplies embassy-time's driver) and `espnow` implies `wifi`.
+use embassy_futures::select::{select, Either};
+use embassy_time::{Duration as EmbassyDuration, Timer};
 use esp_radio::{
     esp_now::{EspNow, EspNowWifiInterface, PeerInfo, BROADCAST_ADDRESS},
     wifi::{scan::ScanConfig, sta::StationConfig, Config, WifiController},
@@ -2383,6 +2388,119 @@ pub fn now_ms() -> u64 {
 #[inline]
 fn abandon_tx(waiter: esp_radio::esp_now::SendWaiter<'_>) {
     core::mem::forget(waiter);
+}
+
+/// #397 / #335 STEP B (part 2 of 2): how long an OTA-announce send may take before we stop
+/// believing its completion. The watch's proven value (`smol_mesh.rs:182`, `TX_WAIT_MS = 30`),
+/// which fixed real UI deaf-windows on hardware.
+///
+/// Not tunable per site on purpose: the two announce sites are the same send of the same frame
+/// under the same radio conditions, and two deadlines would be two behaviours to reason about.
+#[cfg(feature = "espnow")]
+const TX_WAIT: EmbassyDuration = EmbassyDuration::from_millis(30);
+
+/// #397 STEP B2: set when a send's completion was still outstanding at `TX_WAIT`, i.e. we walked
+/// away from a callback that may still land.
+///
+/// ── WHY A FLAG AND NOT A DRAIN (PHASE3-PLAN §3.3 amended) ─────────────────────────────────────
+/// §3.3 spec'd this flag as a trigger to "bounded-drain `ESP_NOW_SEND_CB_INVOKED` before issuing".
+/// That is both impossible (the flag is private to esp-radio) and unnecessary: esp-radio already
+/// clears it immediately before every send, on both paths — `mod.rs:560` (sync) and `mod.rs:964`
+/// (`SendFuture::poll`'s first poll). A stale completion landing *before* the next send is already
+/// erased.
+///
+/// What is left is the case no drain could fix: a completion landing *after* the next send has
+/// cleared the flag and issued, so that send reads the PREVIOUS send's `ESP_NOW_SEND_STATUS` as its
+/// own. Fixing that needs a generation counter inside esp-radio (§3.3 considered and rejected it as
+/// upstream). So instead of pretending to prevent it, this flag makes it VISIBLE: the next
+/// evidence-bearing send records its result as untrusted rather than as proof of egress.
+///
+/// ── WHY IT IS SET ONLY ON TIMEOUT, WHICH IS A SENSITIVITY DECISION ────────────────────────────
+/// `abandon_tx`'s three sites also walk away from completions, and in principle one of those could
+/// land late too. They deliberately do NOT set this flag. Setting it there would mean the
+/// pre-announce site — which fires every 120 ms during the same relay — tainted essentially every
+/// announce, and a taint that is always on carries no information: the instrument would report
+/// "untrusted" forever and §3.2(ii)'s evidence would be lost to the mitigation rather than to the
+/// bug. A timeout is the case we can actually DETECT (a completion provably later than `TX_WAIT`),
+/// and it is the case §3.3 names. The `abandon_tx` residual stays what B1 recorded it as: real,
+/// un-observable from here, and bounded by esp-radio's clear-before-send.
+/// ── WHY `portable_atomic` AND NOT `core::sync::atomic` ────────────────────────────────────────
+/// `riscv32imc` has **no atomic read-modify-write instructions** (no `A` extension), so core's
+/// `AtomicBool` on this target offers only `load`/`store` — `swap` does not exist and the build
+/// fails with "no method named `swap` found for struct `Atomic<T>`". A take-and-clear needs RMW.
+/// `portable-atomic` polyfills it (a critical section under `unsafe-assume-single-core`, which
+/// esp-sync/esp-radio-rtos-driver already enable in this graph), and #391 added the explicit
+/// `portable-atomic` dep line for exactly this: "so the code Phase 1 writes can name the crate".
+/// Load-then-store would also work here — only the superloop task touches this flag, the ESP-NOW
+/// callback touches esp-radio's own globals — but a non-atomic take-and-clear is a trap for the next
+/// reader once P1.4/P1.5 spawn tasks, and the polyfill costs nothing this graph is not already paying.
+#[cfg(feature = "espnow")]
+static TX_ABANDONED: portable_atomic::AtomicBool = portable_atomic::AtomicBool::new(false);
+
+/// #397 STEP B2: the outcome of a bounded announce send. Three states, not two, because
+/// PHASE3-PLAN §3.2(ii) is explicit that under a bounded scheme **a timeout is neither a success
+/// nor a confirmed failure**, and collapsing it into either corrupts the only evidence smol has
+/// that the OTA announce reached the air (`[[suspect-the-instrument-first]]`).
+#[cfg(feature = "espnow")]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum TxOutcome {
+    /// The callback landed inside `TX_WAIT` and reported success, with no outstanding completion
+    /// that could have been misattributed. The only outcome that counts as proof of egress.
+    Confirmed,
+    /// The callback reported failure inside the deadline. A confirmed NON-egress: honest evidence,
+    /// just negative — so it inflates neither counter.
+    Failed,
+    /// Either the deadline passed with no callback, or a callback arrived while a previous send's
+    /// completion was still outstanding (so it may have been that one's). Not egress evidence
+    /// either way.
+    Unproven,
+}
+
+impl RadioManager {
+    /// #397 STEP B2: broadcast one OTA announce, bounded at [`TX_WAIT`].
+    ///
+    /// Replaces `esp_now.send(..)` + `waiter.wait()` at the two sites whose result feeds `otam_ok`.
+    /// The sync waiter cannot be bounded from outside esp-radio at all — both `wait()` and `Drop`
+    /// spin on a private static (see `abandon_tx`) — so the outcome is obtained the only way that
+    /// admits a deadline: race the async send against a timer.
+    ///
+    /// Dropping the loser is safe here, and that is a load-bearing detail rather than an
+    /// assumption: `SendFuture` has **no `Drop` impl** in esp-radio 0.18 (only `SendWaiter` and
+    /// `EspNowRc` do), so the abandoned future does not spin the way an abandoned waiter would.
+    /// What it *does* violate is `send_async`'s doc contract ("the returned future must not be
+    /// dropped before it's ready to avoid getting wrong status for sendings") — which is exactly
+    /// what [`TX_ABANDONED`] exists to surface rather than hide.
+    #[cfg(feature = "espnow")]
+    fn tx_announce_bounded(&mut self, frame: &[u8]) -> TxOutcome {
+        use portable_atomic::Ordering;
+        // Take-and-clear: a taint describes the NEXT reading, once.
+        let tainted = TX_ABANDONED.swap(false, Ordering::AcqRel);
+        // Bind the address first — `&BROADCAST_ADDRESS` inside the future-building expression
+        // would be a temporary whose lifetime ends before `block_on` consumes the future.
+        let dst = BROADCAST_ADDRESS;
+        let outcome = {
+            let fut = self.esp_now.send_async(&dst, frame);
+            block_on(select(fut, Timer::after(TX_WAIT)))
+        };
+        match outcome {
+            Either::First(Ok(())) => {
+                if tainted {
+                    // The completion we just read may belong to the send we abandoned earlier:
+                    // esp-radio's globals carry no generation, so the two are indistinguishable.
+                    TxOutcome::Unproven
+                } else {
+                    TxOutcome::Confirmed
+                }
+            }
+            Either::First(Err(_)) => TxOutcome::Failed,
+            Either::Second(()) => {
+                // We are walking away from an in-flight completion. Say so, so the NEXT reading
+                // knows not to trust itself.
+                TX_ABANDONED.store(true, Ordering::Release);
+                TxOutcome::Unproven
+            }
+        }
+    }
 }
 
 impl RadioManager {
@@ -5506,6 +5624,12 @@ impl RadioManager {
         // #3b OTAM TX-diag: broadcast sends attempted vs returned-Ok (queued + TX-callback ok).
         let mut otam_tx: u16 = 0;
         let mut otam_ok: u16 = 0;
+        // #397 STEP B2 / §3.2(ii): the THIRD counter. `otam_tx` counts attempts and `otam_ok`
+        // counts PROVEN egress; this counts attempts whose outcome is not evidence either way —
+        // a send that outlived TX_WAIT, or one whose success may have been a previous send's
+        // completion (see TX_ABANDONED). Without it a timeout would have to be miscounted as a
+        // failure, and `otam_ok=0 while otam_tx>0` would stop meaning what its doc comment says.
+        let mut otam_to: u16 = 0;
 
         // #3b WAKE-BURST: the leaf lost the gateway during the off-ch6 fetch and is now hopping
         // [1,6,11] (on ch6 only ~⅓ of the time) and/or re-electing over WiFi — so a single OTAM
@@ -5533,10 +5657,13 @@ impl RadioManager {
             if t.saturating_sub(last_wake_ms) >= WAKE_GAP_MS {
                 let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
                 otam_tx = otam_tx.saturating_add(1);
-                if let Ok(waiter) = self.esp_now.send(&BROADCAST_ADDRESS, &otam[..otam_len]) {
-                    if waiter.wait().is_ok() {
-                        otam_ok = otam_ok.saturating_add(1);
-                    }
+                // #397 STEP B2: bounded. `waiter.wait()` here was an unbounded spin on a
+                // completion that may never come; a timeout is now counted as `otam_to` rather
+                // than silently folded into "not ok" (§3.2(ii)).
+                match self.tx_announce_bounded(&otam[..otam_len]) {
+                    TxOutcome::Confirmed => otam_ok = otam_ok.saturating_add(1),
+                    TxOutcome::Unproven => otam_to = otam_to.saturating_add(1),
+                    TxOutcome::Failed => {}
                 }
                 last_wake_ms = t;
             }
@@ -5581,7 +5708,7 @@ impl RadioManager {
                 self.leaf_relay_rx = Some(crate::net::wifi::RelayDiag {
                     leaf_id, rx_any, otan_valid, last_wb: wb as u16, total: total as u16,
                     leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
-                    otam_tx, otam_ok,
+                    otam_tx, otam_ok, otam_to,
                     settle,
                     leaf_ch: ldbg_ch,
                 });
@@ -5613,10 +5740,11 @@ impl RadioManager {
                     // (send_to swallows it) to prove egress.
                     let _ = self.esp_now.set_channel(ESP_NOW_FIXED_CHANNEL);
                     otam_tx = otam_tx.saturating_add(1);
-                    if let Ok(waiter) = self.esp_now.send(&BROADCAST_ADDRESS, &otam[..otam_len]) {
-                        if waiter.wait().is_ok() {
-                            otam_ok = otam_ok.saturating_add(1);
-                        }
+                    // #397 STEP B2: bounded — see the wake-phase twin above.
+                    match self.tx_announce_bounded(&otam[..otam_len]) {
+                        TxOutcome::Confirmed => otam_ok = otam_ok.saturating_add(1),
+                        TxOutcome::Unproven => otam_to = otam_to.saturating_add(1),
+                        TxOutcome::Failed => {}
                     }
                 }
                 for i in 0..wlen_chunks as usize {
@@ -5702,7 +5830,7 @@ impl RadioManager {
                     self.leaf_relay_rx = Some(crate::net::wifi::RelayDiag {
                         leaf_id, rx_any, otan_valid, last_wb: wb as u16, total: total as u16,
                         leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
-                        otam_tx, otam_ok, settle, leaf_ch: ldbg_ch,
+                        otam_tx, otam_ok, otam_to, settle, leaf_ch: ldbg_ch,
                     });
                     return LeafOtaOutcome::RelayFailed;
                 }
@@ -5714,7 +5842,7 @@ impl RadioManager {
         self.leaf_relay_rx = Some(crate::net::wifi::RelayDiag {
             leaf_id, rx_any, otan_valid, last_wb: total as u16, total: total as u16,
             leaf_heard: ldbg_heard, leaf_verdict: ldbg_verdict, leaf_sent: ldbg_sent,
-            otam_tx, otam_ok, settle,
+            otam_tx, otam_ok, otam_to, settle,
             leaf_ch: ldbg_ch,
         });
 
@@ -6383,12 +6511,37 @@ impl RadioManager {
     /// Low-level send helper: fire one frame and wait for the TX callback so we
     /// don't overrun the single in-flight ESP-NOW send slot.
     ///
-    /// RAW-SEND-SITES: send_to:1, send_arb_raw:1, run_leaf_ota_relay:3
+    /// RAW-SEND-SITES: send_to:1, send_arb_raw:1, run_leaf_ota_relay:1, tx_announce_bounded:1
     ///
-    /// Every function permitted to call `esp_now.send` directly, with its call COUNT, checked in
-    /// both directions by `tools/check_elect_send_path.py`. Counts and not just names, because
-    /// adding a fourth send inside `run_leaf_ota_relay` would otherwise slip through a name-only
-    /// allowlist — and an already-listed function is exactly where a new send is easiest to add.
+    /// Every function permitted to reach the ESP-NOW driver directly, with its call COUNT, checked
+    /// in both directions by `tools/check_elect_send_path.py`. Counts and not just names, because
+    /// adding another send inside an already-listed function is exactly where a new send is easiest
+    /// to add and a name-only allowlist would not notice.
+    ///
+    /// ── RESHAPED BY #397 STEP B2, AND THE INVARIANT RE-DERIVED ────────────────────────────────
+    /// Was `run_leaf_ota_relay:3` (5 sites / 3 fns); now `run_leaf_ota_relay:1` +
+    /// `tx_announce_bounded:1` (4 sites / 4 fns). Two things changed and BOTH are roster-visible:
+    /// the two OTA-announce sends moved into one shared helper, and that helper reaches the driver
+    /// via `send_async` — a form the old checker pattern (`send\s*\(`) did not match at all. Left
+    /// alone, bounding those sends would have moved them out of this checker's sight while leaving
+    /// them on the air; the count fell 5 -> 3 and the fail-closed arm fired instead, which is the
+    /// gate working. The checker now counts `send` and `send_async` alike.
+    ///
+    /// **Does the new site widen ELECT's egress surface? No — enumerated, not asserted:**
+    ///   1. `tx_announce_bounded` is PRIVATE (`fn`, not `pub fn`) and has exactly two callers, both
+    ///      in `run_leaf_ota_relay`, both passing `&otam[..otam_len]` — an OTAM announce frame.
+    ///   2. For an ELECT frame to reach it, something would have to obtain `SealedElect`'s bytes.
+    ///      It has no byte accessor and no `pub` field (arm 3 asserts exactly that), so the only
+    ///      way out of a seal is to hand it to a `GroupMacSink`.
+    ///   3. There is one `GroupMacSink` impl and its body routes to `send_to` (arms 1 and 2). So
+    ///      sealed ELECT bytes reach `send_to` or they reach nothing.
+    ///   4. `wire::encode` has one call site, inside `SealedElect::seal` (arm 4), and the frame
+    ///      prefix is written once (arm 5) — so a frame cannot be hand-built to skirt 2-3 either.
+    ///
+    /// The new site is therefore reachable only by OTAM, and it is declared, so a future caller
+    /// changes the roster rather than slipping past it. What this roster does NOT do — for the new
+    /// site or for the pre-existing `send_arb_raw` — is bound what a CALLER may pass; that is what
+    /// arms 1-5 are for, and it is why they are five arms and not a comment.
     ///
     /// Why the list is short and must stay short: this method is the choke that appends #190's
     /// group-MAC trailer, so every entry here is, by construction, a way for a frame to reach the

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -2154,6 +2154,18 @@ pub struct RelayDiag {
     /// `otam_ok>0` while leaf stays H0 ⇒ frame egresses but the leaf's RX drops it (deeper).
     pub otam_tx: u16,
     pub otam_ok: u16,
+    /// #397 STEP B2: announces whose outcome is NOT evidence either way — the send outlived the
+    /// 30 ms bound, or its success may have been a previously-abandoned send's completion (esp-radio
+    /// carries no generation on its status globals). Added because bounding the send introduced a
+    /// third possible outcome, and PHASE3-PLAN §3.2(ii) is explicit that folding a timeout into
+    /// either `otam_ok` or "not ok" corrupts the only evidence smol has that the announce egressed.
+    ///
+    /// READ IT WITH THE OTHER TWO: `otam_tx = otam_ok + otam_to + (confirmed failures)`. So
+    /// `otam_ok=0, otam_to=0, otam_tx>0` still means "every send confirmed-failed" (the original
+    /// peer-table/TX-state diagnosis), whereas `otam_ok=0, otam_to=otam_tx` is the NEW reading:
+    /// the sends are not completing inside the bound at all, which is a radio/timing story rather
+    /// than a send-path one. Those two used to be indistinguishable.
+    pub otam_to: u16,
     /// #3b CHANNEL-diag: iterations spent waiting for the WiFi STA to release the PHY after the
     /// fetch, before pinning ch6. `settle>0` ⇒ the STA WAS still holding the AP channel post-fetch
     /// (confirms the OTAM was egressing off-channel → the leaf H0 cause); `settle=0` ⇒ STA already
@@ -4210,8 +4222,13 @@ fn mqtt_session(
         let mut rval = MqttScratch::new();
         // Gateway RX evidence + the leaf's own LDBG self-report. `leaf=none` ⇒ no LDBG captured
         // (old leaf fw / leaf off-air during the relay); else `H<heard>V<verdict>N<sent>`.
-        let _ = write!(rval, "rx={} otan={} last_wb={}/{} otam_tx={}/{} settle={} leaf=",
-            d.rx_any, d.otan_valid, d.last_wb, d.total, d.otam_tx, d.otam_ok, d.settle);
+        // #397 STEP B2: `otam_to` is appended as its OWN key rather than widening `otam_tx=N/M`
+        // into `N/M/T`. Additive keeps every existing consumer working — the HA control-room card
+        // reads this topic, docs/protocol.md documents the format, and live-vs-repo drift is a
+        // standing problem here, so a format CHANGE would need all three to move together for no
+        // gain. The packet has room: this record is ~60 B against the ~490 B publish cap.
+        let _ = write!(rval, "rx={} otan={} last_wb={}/{} otam_tx={}/{} otam_to={} settle={} leaf=",
+            d.rx_any, d.otan_valid, d.last_wb, d.total, d.otam_tx, d.otam_ok, d.otam_to, d.settle);
         if d.leaf_verdict == 255 {
             let _ = write!(rval, "none");
         } else {

--- a/tools/check_elect_send_path.py
+++ b/tools/check_elect_send_path.py
@@ -51,6 +51,13 @@ SINK_TRAIT = "GroupMacSink"
 # separately — this is the deny-list of everything that skips the trailer.
 FORBIDDEN_SENDERS = ("send_arb_raw", "esp_now.send", "esp_now .send")
 DECL = re.compile(r"RAW-SEND-SITES:\s*([A-Za-z0-9_:,\s]+?)\s*(?:\*/|\n|$)")
+# #397 STEP B2: the roster must count BOTH send forms. `send_async` is a raw egress path exactly as
+# much as `send` is — it reaches `esp_now_send` through `SendFuture::poll` — and the old pattern
+# (`send\s*\(`) does not match `send_async(` at all. So bounding the two OTA-announce sites moved
+# them OUT of this checker's sight while leaving them on the air: the count fell 5 -> 3 and the
+# fail-closed arm fired, which is the gate doing its job and is why this pattern is widened in the
+# same commit as the behaviour change rather than after it.
+RAW_SEND_RE = re.compile(r"esp_now\s*\.\s*send(?:_async)?\s*\(")
 
 
 def fail(msg, *extra):
@@ -62,6 +69,84 @@ def fail(msg, *extra):
 def rust_sources(src: Path):
     return sorted(p for p in src.rglob("*.rs") if p.is_file())
 
+
+def strip_comments(text: str) -> str:
+    """Blank every comment, PRESERVING length and newlines so offsets and line numbers still map.
+
+    Not a nicety — it is load-bearing, and this checker was blind to it until #397 STEP B. A doc
+    comment written to EXPLAIN a raw send spelled it in `receiver.method(` form; arm 6 counted the
+    prose as a real call site and attributed it to whatever fn preceded the comment. A checker whose
+    verdict can be flipped by documentation about the thing it checks is worse than no checker,
+    because the same blindness runs the other way: comment out a real send and the count is still
+    satisfied — a false GREEN on an ABSENCE check, which is the one direction that matters here.
+
+    Shared implementation with `check_station_consumers.py`, where the identical defect was found
+    the same day (2026-08-25) by the same route — writing prose about the invariant. Two independent
+    instances in one day is a property of the template, not an accident; the sweep across the other
+    checkers built to this shape is tracked as #426.
+
+    Handles `//`, `/* */` (nested, as Rust allows), ordinary strings, char literals and raw strings
+    (`r"..."`, `r#"..."#`), because a `//` inside a string literal is not a comment and blanking it
+    would corrupt the code view.
+    """
+    out = list(text)
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        # raw string: r"..." / r#"..."# / r##"..."##
+        if c == "r" and i + 1 < n and text[i + 1] in '"#':
+            j = i + 1
+            hashes = 0
+            while j < n and text[j] == "#":
+                hashes += 1
+                j += 1
+            if j < n and text[j] == '"':
+                close = '"' + "#" * hashes
+                end = text.find(close, j + 1)
+                i = n if end < 0 else end + len(close)
+                continue
+        if c == '"' or c == "'":
+            quote = c
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text[j] == quote:
+                    j += 1
+                    break
+                if text[j] == "\n" and quote == "'":
+                    break  # not a char literal after all (e.g. a lifetime)
+                j += 1
+            i = j
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+            for k in range(i, j):
+                out[k] = " "
+            i = j
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            depth, j = 0, i
+            while j < n:
+                if text.startswith("/*", j):
+                    depth += 1
+                    j += 2
+                elif text.startswith("*/", j):
+                    depth -= 1
+                    j += 2
+                    if depth == 0:
+                        break
+                else:
+                    j += 1
+            for k in range(i, min(j, n)):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = j
+            continue
+        i += 1
+    return "".join(out)
 
 def enclosing_fn(text: str, idx: int):
     """Name of the nearest `fn` declared at or above `idx`. None if there isn't one."""
@@ -94,6 +179,17 @@ def main() -> int:
         fail(f"no firmware source tree at {src}")
         return 2
     files = {p: p.read_text(encoding="utf-8") for p in rust_sources(src)}
+    # #397 STEP B2: two views. `files` is RAW and only the DECL regex reads it, because the
+    # RAW-SEND-SITES roster deliberately lives in a doc comment. Every structural scan below reads
+    # `code`, which has comments blanked with offsets preserved.
+    #
+    # This was not a hypothetical: writing a doc comment that spelled a raw send in
+    # `receiver.method(` form tripped arm 6 and attributed the send to whatever fn preceded the
+    # comment. The false RED is the mild half — the same blindness yields a false GREEN, because a
+    # real send can be commented out and the count still satisfied. An absence check that
+    # documentation can move is not a check. (Identical defect found the same day in
+    # check_station_consumers.py, whose implementation this is; tracked repo-wide as #426.)
+    code = {q: strip_comments(t) for q, t in files.items()}
     if not files:
         fail(f"parsed ZERO rust sources under {src}")
         return 2
@@ -103,7 +199,7 @@ def main() -> int:
 
     # ── arms 1 + 2: the sink impl(s) ──────────────────────────────────────────────────────────
     impls = []
-    for path, text in files.items():
+    for path, text in code.items():
         for m in re.finditer(rf"impl\s+(?:[\w:]+::)?{SINK_TRAIT}\s+for\s+(\w+)", text):
             body = block_after(text, m.end())
             if body is None:
@@ -145,7 +241,7 @@ def main() -> int:
 
     # ── arm 3: SealedElect exposes no way to get at the bytes ─────────────────────────────────
     sealed_impls = 0
-    for path, text in files.items():
+    for path, text in code.items():
         for m in re.finditer(r"impl\s+SealedElect\s*\{", text):
             sealed_impls += 1
             body = block_after(text, m.end() - 1)
@@ -173,7 +269,7 @@ def main() -> int:
 
     # ── arm 4: exactly one firmware call site of the encoder, and it is the seal ───────────────
     encode_sites = []
-    for path, text in files.items():
+    for path, text in code.items():
         for m in re.finditer(r"\bwire::encode\s*\(|(?<![\w:])encode\s*\(\s*f\s*,", text):
             fn = enclosing_fn(text, m.start())
             encode_sites.append((path.relative_to(root), fn))
@@ -197,7 +293,7 @@ def main() -> int:
 
     # ── arm 5: the frame prefix is written exactly once ───────────────────────────────────────
     literal_sites = []
-    for path, text in files.items():
+    for path, text in code.items():
         for m in re.finditer(re.escape(ELECT_LITERAL), text):
             literal_sites.append((path.relative_to(root), text.count("\n", 0, m.start()) + 1))
     if not literal_sites:
@@ -240,8 +336,8 @@ def main() -> int:
         declared[name] = int(count)
 
     actual = {}
-    for path, text in files.items():
-        for m in re.finditer(r"esp_now\s*\.\s*send\s*\(", text):
+    for path, text in code.items():
+        for m in re.finditer(RAW_SEND_RE, text):
             fn = enclosing_fn(text, m.start())
             if fn is None:
                 fail(f"an `esp_now.send` in {path.relative_to(root)} is not inside any fn")
@@ -249,7 +345,7 @@ def main() -> int:
             actual[fn] = actual.get(fn, 0) + 1
     if not actual:
         fail(
-            "found ZERO raw `esp_now.send` call sites — including the `send_to` choke itself.",
+            "found ZERO raw `esp_now.send`/`send_async` call sites — including the `send_to` choke itself.",
             "That cannot be right; the pattern must have changed, so this arm is blind.",
         )
         return 2

--- a/tools/test_check_elect_send_path.sh
+++ b/tools/test_check_elect_send_path.sh
@@ -32,6 +32,21 @@ seed() {
   cp -r "$ROOT/rust/clock/src" "$work/tree/rust/clock/src"
 }
 
+# patch1 <abs-file> <old>TAB<new> — for arms that assert rc=0 and so cannot use `arm`.
+# Deliberately NOT a refactor of `arm` below: `arm` drives the twelve pre-existing arms of a
+# SECURITY gate, and this addition has no business changing how those are executed.
+patch1() {
+  python3 - "$1" "$2" <<'PYEOF'
+import sys
+path, spec = sys.argv[1], sys.argv[2]
+old, new = spec.split("\t")
+s = open(path).read()
+if old not in s:
+    sys.exit(f"fixture setup failed: {old!r} not found — this test needs updating")
+open(path, "w").write(s.replace(old, new, 1))
+PYEOF
+}
+
 # arm <name> <want-rc> <want-substring> <file-rel-to-src> <old>TAB<new>
 arm() {
   local name="$1" want_rc="$2" want="$3" file="$4" spec="$5"
@@ -95,6 +110,30 @@ arm "prefix literal renamed away" 2 "appears NOWHERE" net/mesh_elect.rs \
   "$(printf 'b"SMOLv1 ELECT "\tb"SMOLv1 ELECTX"')"
 arm "declaration deleted" 2 "no \`RAW-SEND-SITES:\` declaration" net/mode.rs \
   "$(printf 'RAW-SEND-SITES:\tRAW-SEND-SITES-WAS-HERE:')"
+
+# ── #397 STEP B2: the `send_async` form, and comment-blindness ────────────────────────────────
+# Arm 6 was widened to count `send_async` because bounding the two OTA-announce sends moved them to
+# that form. A widened pattern is worth exactly as much as its proof of failure: if `send_async` is
+# counted only in the passing direction, the widening is a claim rather than a check.
+echo "== arm 6c: the send_async form is counted too (#397 STEP B2) =="
+arm "undeclared send_async site" 1 "arm 6 (raw-sends)" net/mode.rs \
+  "$(printf 'pub fn crown_term(&self) -> u16 {\tpub fn leak_async(&mut self) {\n        let _ = self.esp_now.send_async(&BROADCAST_ADDRESS, b"x");\n    }\n\n    pub fn crown_term(&self) -> u16 {')"
+arm "extra send_async in a declared fn" 1 "arm 6 (raw-sends)" net/mode.rs \
+  "$(printf 'let fut = self.esp_now.send_async(&dst, frame);\tlet _ = self.esp_now.send_async(&dst, frame);\n            let fut = self.esp_now.send_async(&dst, frame);')"
+
+# Both directions of the comment-stripping fix, because a checker that documentation can move is
+# worse than none — and the FALSE-GREEN direction is the one that matters on an absence check.
+echo "== regression: comments must not move the verdict, either way (#426) =="
+seed
+if patch1 "$work/tree/rust/clock/src/net/mode.rs" \
+  "$(printf 'pub fn crown_term(&self) -> u16 {\t// prose: self.esp_now.send(&x, y) and self.esp_now.send_async(&x, y)\n    /* and a block comment: esp_now.send(a, b); */\n    pub fn crown_term(&self) -> u16 {')"; then
+  out="$("$CHK" "$work/tree" 2>&1)"; rc=$?
+  if [ "$rc" = 0 ]; then ok "prose naming both send forms stays green (rc=0)"
+  else no "PROSE FLIPPED THE VERDICT: rc $rc — $out"; fi
+else no "prose regression (fixture setup)"; fi
+# The false-GREEN direction: commenting a real send out must not satisfy the roster.
+arm "commenting out a real send is caught" 1 "arm 6 (raw-sends)" net/mode.rs \
+  "$(printf 'match self.esp_now.send(dst, out) {\tmatch NOTHING { // self.esp_now.send(dst, out) {')"
 
 echo
 echo "$pass passed, $fail failed"


### PR DESCRIPTION
STEP B part **2 of 2** (#335 / #397). The two raw sends whose result *is* the egress evidence (`otam_ok`) stop spinning on a completion that may never come — and because bounding them changes the **shape of the send path**, the security roster governing that path changes with them, deliberately, here.

**The gate-contract change is the co-headline, not a footnote.** Read that section first.

---

## 1. The behaviour

Both announce sites were `esp_now.send(..)` + `waiter.wait()` — an unbounded spin on a private static. The sync waiter **cannot** be bounded from outside esp-radio (both `wait()` and `Drop` spin; see B1's `abandon_tx`), so the outcome is now obtained the only way that admits a deadline: race the async send against a 30 ms timer with `block_on(select(..))`. Possible today only because #391 turned on esp-rtos's `embassy` feature, and `espnow` implies `wifi`.

Dropping the losing future is safe — **verified, not assumed**: `SendFuture` has no `Drop` impl in esp-radio 0.18 (only `SendWaiter` and `EspNowRc` do). What it *does* violate is `send_async`'s doc contract, "the returned future must not be dropped before it's ready" — which is exactly what `TX_ABANDONED` exists to surface rather than hide.

## 2. The third counter, which is the point

§3.2(ii) is explicit: under a bounded scheme a timeout is **neither a success nor a confirmed failure**, and collapsing it into either corrupts the only evidence smol has that the announce reached the air. So `TxOutcome` has three states and `otam_to` counts the unproven ones.

`otam_tx = otam_ok + otam_to + confirmed-failures`, which makes two readings distinguishable that previously were not:

| reading | meaning |
|---|---|
| `otam_ok=0, otam_to=0` | every send **confirmed-failed** — the original peer-table / TX-state diagnosis |
| `otam_ok=0, otam_to=otam_tx` | sends **never complete inside the bound** — a radio/timing story, not a send-path one |

**`TX_ABANDONED` is §3.3's flag repurposed from *drain* to *taint*.** esp-radio already drains — `store(false)` immediately before every `esp_now_send`, at `mod.rs:560` (sync) and `mod.rs:964` (async) — so the spec'd drain was both unnecessary and unwritable. The case no drain can fix is a completion landing *after* the next send cleared-and-issued, so that send reads the previous one's status as its own. Rather than pretend to prevent it, the flag makes the next reading **declare itself unproven**.

Set on **timeout only** — a sensitivity decision, argued at the static. `abandon_tx`'s sites also walk away from completions, but the pre-announce site fires every 120 ms *in the same relay*, so tainting there would taint essentially every announce, and a taint that is always on carries no information: the instrument would report "untrusted" forever and §3.2(ii)'s evidence would be lost to the mitigation instead of to the bug.

## 3. `riscv32imc` has no atomic RMW

`core::sync::atomic::AtomicBool` on this target offers only load/store — `swap` does not exist, and the build fails with `no method named swap found for struct Atomic<T>`. Uses `portable_atomic::AtomicBool`, which is the explicit dep line **#391 added for exactly this** ("so the code Phase 1 writes can name the crate"). Load-then-store would work today (only the superloop touches the flag) but is a trap once P1.4/P1.5 spawn tasks.

---

## 4. ⚠️ THE CO-HEADLINE — the ELECT roster, reshaped and re-derived

`send_async(` does not match arm 6's `send\s*\(` pattern. So bounding these two sends would have moved them **out of the checker's sight while leaving them on the air**. The count fell 5 → 3 and the fail-closed arm fired — the gate working. Hence, in this commit:

- arm 6 counts `send` **and** `send_async` (`RAW_SEND_RE`);
- `RAW-SEND-SITES: send_to:1, send_arb_raw:1, run_leaf_ota_relay:1, tx_announce_bounded:1` — **4 sites / 4 fns**, was 5 / 3 (the two announce sends funnelled into one shared helper).

**Does the new site widen ELECT's egress surface? No — enumerated, not asserted:**

1. `tx_announce_bounded` is **private** (`fn`, not `pub fn`) with exactly two callers, both in `run_leaf_ota_relay`, both passing `&otam[..otam_len]` — an OTAM announce frame.
2. For an ELECT frame to reach it, something must obtain `SealedElect`'s bytes. It has no byte accessor and no `pub` field — **arm 3 asserts exactly that** — so the only way out of a seal is to hand it to a `GroupMacSink`.
3. There is **one** `GroupMacSink` impl and its body routes to `send_to` (**arms 1-2**). So sealed ELECT bytes reach `send_to` or they reach nothing.
4. `wire::encode` has one call site, inside `SealedElect::seal` (**arm 4**), and the frame prefix is written once (**arm 5**) — so a frame cannot be hand-built to skirt 2-3 either.

The new site is therefore reachable only by OTAM, and it is *declared*, so a future caller reshapes the roster rather than slipping past it. What the roster does **not** do — for this site or the pre-existing `send_arb_raw` — is bound what a *caller* may pass; that is what arms 1-5 are for, and it is why they are five arms and not a comment.

**Also ports `strip_comments` into this checker (#426).** It counted `esp_now.send(` **inside comments**, so B1's doc comment tripped the gate and blamed `now_ms`. The false-RED is the mild half — the same blindness yields a false **GREEN** by commenting a real send out, on an *absence* check.

**Suite: 12 → 16 arms, 0 failed.** New arms: an undeclared `send_async` site trips it · an extra `send_async` in an already-declared fn trips it · prose naming both send forms stays **green** · a commented-out real send is still caught. `patch1` is *added* rather than refactoring `arm`, so the twelve pre-existing security arms execute exactly as before.

## 5. The other half of the instrument

`ha/packages/smol_mesh.yaml` parses this payload **token-wise** — which is why `otam_to=` is appended as its own key instead of widening `otam_tx=A/B` into `A/B/T`: additive keeps every consumer working. Its documented format comment went stale the moment the firmware changed, and the new counter would have surfaced nowhere, so the parser and the named attribute are updated in the same commit. A counter that is published and displayed nowhere is the tree's signature defect shape.

⚠️ **The HA half is repo-only until deployed** — repo and live agree only after that.

## 6. Measured — true A/B, same tree, shared provisioned seeds

```
.stack   86,200 B -> 86,200 B    ZERO movement -> the floor gate is unaffected
.text   875,540 B -> 876,120 B   +580 B (select / Timer / taint / third counter)
gate.sh fw + host: GATE GREEN    4 raw send sites across 4 declared fns
```

### ⚠️ One request, because `.stack` is not the number under pressure

`.stack` is the **available region**, not the **peak**. A `select` frame is transient stack the region size cannot see, and the peak is the figure with only ~1.55× margin (§5.1). So the zero delta above means *the floor gate is safe*, **not** *the peak is unchanged* — and I am not going to let a real measurement carry a claim it does not support.

`probe-rs run` / `espflash monitor` die exit-144 in the agent sandbox, so a sentinel-paint high-water run is a **bench step**. Requesting it rather than claiming it: one `stack-paint` tier run on the P1.3+B2 image would replace the pessimistic-ratio *argument* in §5.1 with a measurement, before STEP T spends any of the 12 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)