### PR TITLE
fix(tools): the comment-blind sweep — probed, not assumed, and one strip_comments (#426)

### DIFF
--- a/tools/check_byte_free.py
+++ b/tools/check_byte_free.py
@@ -61,6 +61,8 @@ import subprocess
 import tomllib
 import sys
 from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from rust_comments import strip_comments  # noqa: E402  (#426)
 
 HERE = Path(__file__).resolve().parent
 DEFAULT_SRC = HERE.parent / "rust" / "clock" / "src"
@@ -138,8 +140,20 @@ def check_source(src: Path) -> list[str]:
     files = rs_files(src)
     gates_by_file = {}
     for p in files:
-        lines = p.read_text(encoding="utf-8").splitlines()
-        gates_by_file[p] = (lines, file_gate(lines), mod_gates(lines))
+        # #426 — TWO VIEWS OF ONE FILE, and the split is the whole fix.
+        #
+        # The GATES are code: `mod_gates` was proved to read a `#[cfg(feature = "bard")] pub mod
+        # mesh_elect;` sitting inside a `/* */` block and record `bard` as that module's gate,
+        # when the real decl five lines away says `espnow`. A checker that mis-attributes a gate
+        # is not merely noisy — every byte-free verdict downstream of it is about the wrong tier.
+        #
+        # The CLAIMS are prose, deliberately: `byte-free` assertions live in comments, and the
+        # proximity rule ("a claim must sit within CLAIM_WINDOW lines of a cfg gate") is checked
+        # against the RAW text. Stripping there would delete the very thing being audited and
+        # leave this checker reporting zero claims, cheerfully, forever.
+        raw = p.read_text(encoding="utf-8").splitlines()
+        code = strip_comments("\n".join(raw)).splitlines()
+        gates_by_file[p] = (raw, file_gate(code), mod_gates(code))
 
     # Every `mod` gate in the crate, by module name — a claim inside `net/cast.rs` is backed
     # by `#[cfg(feature = "cast")] pub mod cast;` in `net.rs`, i.e. by a gate in ANOTHER FILE.

--- a/tools/check_diag_budget.py
+++ b/tools/check_diag_budget.py
@@ -38,6 +38,9 @@ Usage: tools/check_diag_budget.py [path/to/mode.rs]   (exit 0 consistent, 1 drif
 """
 import re
 import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from rust_comments import strip_comments  # noqa: E402  (#426)
 
 FMT = re.compile(r'let mut rec = alloc::format!\(\s*\n\s*"(.*?)",\n', re.S)
 DECL = re.compile(r"DIAG-WIDTHS:\s*(.+)")
@@ -76,7 +79,16 @@ def main() -> int:
         print(f"FATAL: {e}", file=sys.stderr)
         return 2
 
-    mf, mc, mb = FMT.search(src), CORE.search(src), BUDGET.search(src)
+    # #426 — TWO VIEWS. The DECLARATIONS (`DIAG-WIDTHS:` / `DIAG-TAIL:`) live in COMMENTS by
+    # design and are read from `src`; the CODE they are checked against is read from `code`.
+    # Proved necessary: a `/* … rec.push_str("|probe=") … */` written to EXPLAIN the record made
+    # this checker fail with `appended unconditionally but UNDECLARED: probe` — a doc comment
+    # about the invariant breaking the gate that guards it.
+    #
+    # Stripping the WHOLE file would be the opposite mistake: the declarations would vanish and
+    # this checker would have nothing left to check.
+    code = strip_comments(src)
+    mf, mc, mb = FMT.search(code), CORE.search(code), BUDGET.search(code)
     for name, m in (("the DIAG format string", mf), ("DIAG_CORE_MAX", mc), ("DIAG_BUDGET", mb)):
         if not m:
             print(f"FATAL: could not find {name} in {path} — this checker has gone blind, fix it.",
@@ -138,7 +150,12 @@ def main() -> int:
         print(f"FATAL: no DIAG-TAIL: declaration found in {path}.", file=sys.stderr)
         return 2
     try:
-        region = src[src.index(TAIL_START):src.index(TAIL_END, src.index(TAIL_START))]
+        # The markers are found in RAW (`TAIL_START` is itself comment text) and the slice is
+        # taken from CODE. That is exactly why `strip_comments` preserves length and offsets:
+        # an index located in one view is valid in the other, so the two never disagree about
+        # where the protected tail begins.
+        _s = src.index(TAIL_START)
+        region = code[_s:src.index(TAIL_END, _s)]
     except ValueError:
         print(f"FATAL: could not delimit the PROTECTED tail in {path} — this checker has gone "
               "blind, fix it.", file=sys.stderr)

--- a/tools/check_station_consumers.py
+++ b/tools/check_station_consumers.py
@@ -54,6 +54,8 @@ Usage: tools/check_station_consumers.py [repo-root]   (exit 0 ok, 1 violation, 2
 import re
 import sys
 from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from rust_comments import strip_comments  # noqa: E402  (#426 — one implementation, imported)
 
 # The constructor whose call sites ARE the roster.
 DEVICE_CTOR = "SmolWifiDevice::new"
@@ -82,79 +84,9 @@ def rust_sources(src: Path):
     return sorted(p for p in src.rglob("*.rs") if p.is_file())
 
 
-def strip_comments(text: str) -> str:
-    """Blank every comment, PRESERVING length and newlines so offsets and line numbers still map.
-
-    Not a nicety — it is load-bearing, and the first run of this script proved it. The roster's own
-    doc comment explains the hazard using the words `embassy_net::new(interfaces.station, ..)`, and
-    an unstripped scan counted that PROSE as a real call site and failed the gate. A checker whose
-    verdict can be flipped by documentation about the thing it checks is worse than no checker: the
-    same mechanism that produces a false RED here could be used to produce a false GREEN elsewhere
-    (comment out a real site, or bury a roster-shaped string in a comment).
-
-    Handles `//`, `/* */` (nested, as Rust allows), ordinary strings, char literals and raw strings
-    (`r"..."`, `r#"..."#`), because a `//` inside a string literal is not a comment and blanking it
-    would corrupt the code view.
-    """
-    out = list(text)
-    i, n = 0, len(text)
-    while i < n:
-        c = text[i]
-        # raw string: r"..." / r#"..."# / r##"..."##
-        if c == "r" and i + 1 < n and text[i + 1] in '"#':
-            j = i + 1
-            hashes = 0
-            while j < n and text[j] == "#":
-                hashes += 1
-                j += 1
-            if j < n and text[j] == '"':
-                close = '"' + "#" * hashes
-                end = text.find(close, j + 1)
-                i = n if end < 0 else end + len(close)
-                continue
-        if c == '"' or c == "'":
-            quote = c
-            j = i + 1
-            while j < n:
-                if text[j] == "\\":
-                    j += 2
-                    continue
-                if text[j] == quote:
-                    j += 1
-                    break
-                if text[j] == "\n" and quote == "'":
-                    break  # not a char literal after all (e.g. a lifetime)
-                j += 1
-            i = j
-            continue
-        if c == "/" and i + 1 < n and text[i + 1] == "/":
-            j = text.find("\n", i)
-            j = n if j < 0 else j
-            for k in range(i, j):
-                out[k] = " "
-            i = j
-            continue
-        if c == "/" and i + 1 < n and text[i + 1] == "*":
-            depth, j = 0, i
-            while j < n:
-                if text.startswith("/*", j):
-                    depth += 1
-                    j += 2
-                elif text.startswith("*/", j):
-                    depth -= 1
-                    j += 2
-                    if depth == 0:
-                        break
-                else:
-                    j += 1
-            for k in range(i, min(j, n)):
-                if out[k] != "\n":
-                    out[k] = " "
-            i = j
-            continue
-        i += 1
-    return "".join(out)
-
+# strip_comments moved to tools/rust_comments.py (#426). It was duplicated verbatim into
+# check_elect_send_path.py the same day, and the sweep would have made it six copies — so the
+# fix for "a checker counts its own prose" stopped being a thing each checker owns a copy of.
 
 def enclosing_fn(text: str, idx: int):
     """Name of the nearest `fn` declared at or above `idx`. None if there isn't one."""

--- a/tools/check_verifier_wiring.py
+++ b/tools/check_verifier_wiring.py
@@ -58,6 +58,8 @@ Exit:   0 clean (sound / host-only / tracked phantoms) · 1 untracked PHANTOM or
 import re
 import sys
 from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from rust_comments import strip_comments  # noqa: E402  (#426)
 
 # Phantoms that are KNOWN and TRACKED. An entry is a promise that someone owns the decision, so
 # each one must name the issue that owns it — an unexplained entry is just a way to make red go
@@ -104,7 +106,13 @@ def reachable_from(root: Path, crate_src: Path):
             continue
         seen.add(f)
         out.add(f.resolve())
-        lines = f.read_text(encoding="utf-8", errors="replace").splitlines()
+        # #426 — STRIP FIRST. `MOD_DECL` anchors with `^\s*`, so a `//` comment can never match
+        # it; a BLOCK comment puts the decl at line-start and the anchor stops helping. Proved:
+        # `pub mod mesh_elect;` inside `/* */` made this report the verifier SOUND — i.e. that
+        # the firmware compiles a module it does not — which is a false GREEN on an ABSENCE
+        # check, the one direction that matters here.
+        lines = strip_comments(
+            f.read_text(encoding="utf-8", errors="replace")).splitlines()
         for i, line in enumerate(lines):
             m = MOD_DECL.match(line)
             if not m:
@@ -160,7 +168,9 @@ def main() -> int:
 
     rows, phantoms, missing_files = [], [], []
     for main_rs in sorted(experiments.rglob("*.rs")):
-        text = main_rs.read_text(encoding="utf-8", errors="replace")
+        # #426 — same reasoning one level over: a commented-out `#[path = "…"]` must not be
+        # read as a live include, or a verifier gets credited with coverage it does not have.
+        text = strip_comments(main_rs.read_text(encoding="utf-8", errors="replace"))
         verifier = main_rs.relative_to(experiments).parts[0]
         for rel in PATH_ATTR.findall(text):
             target = (main_rs.parent / rel).resolve()

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -604,6 +604,20 @@ if [ "$run_host" = 1 ]; then
     printf '%s\n' "$out" | sed 's/^/        /'; bad "test_config_markers"
   fi
 
+  # #426: prove the comment-blind sweep took, in BOTH directions. Three checkers were counting
+  # matches inside comments; three others read their DECLARATIONS from comments on purpose, so an
+  # over-eager strip would leave those green forever with nothing to check. The "still sees its
+  # declarations" arms sit beside the "no longer sees prose" ones for exactly that reason.
+  #
+  # Every probe uses a BLOCK comment. `//` is safe everywhere — the checkers anchor with `^\s*` —
+  # so a line-comment probe passes against the UNFIXED code too and proves nothing. Pure text.
+  step "comment-blind checker sweep regression suite (#426)"
+  if out=$("$ROOT/tools/test_comment_blind.sh" 2>&1); then
+    printf '%s\n' "$out" | tail -2; ok "test_comment_blind"
+  else
+    printf '%s\n' "$out" | sed 's/^/        /'; bad "test_comment_blind"
+  fi
+
   step "build-matrix checker regression suite (#350)"
   if out=$("$ROOT/tools/test_build_matrix.sh" 2>&1); then
     printf '%s\n' "$out" | tail -2; ok "test_build_matrix"

--- a/tools/rust_comments.py
+++ b/tools/rust_comments.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+r"""One `strip_comments` for every text checker in `tools/`. (#426)
+
+── WHY THIS MODULE EXISTS ────────────────────────────────────────────────────────────────────
+Two checkers were found counting matches inside COMMENTS on the same day (2026-08-25), both by
+the same route — someone wrote a doc comment about the thing being checked and the checker
+counted its own prose. `check_station_consumers.py` (#416) and `check_elect_send_path.py` (#397
+STEP B2) each grew a fix, and the fixes were byte-identical code with different docstrings.
+
+The second one's docstring said "Shared implementation with check_station_consumers.py". It was
+not shared; it was a copy that said it was shared — a correct comment describing a property the
+code did not have, which is the exact defect shape (#371) the checkers exist to catch, appearing
+inside the fix for a different instance of itself.
+
+#426's sweep would have made that six copies. So there is one, here, and the callers import it.
+
+── WHAT A COMMENT-BLIND CHECKER COSTS ────────────────────────────────────────────────────────
+Both directions are real and the cheap-looking one is not the dangerous one:
+
+  false RED    prose about the invariant trips the gate. Annoying, visible, gets worked around
+               by rewording — which leaves the mechanism in place. (#424 did exactly that.)
+  false GREEN  a real site is commented out and the count still passes. Silent, and it is an
+               ABSENCE check's whole job to notice that. `check_verifier_wiring` was proved to
+               report a module SOUND — wired into main.rs — with its `mod` decl inside `/* */`.
+
+── `//` IS SAFE; `/* */` IS THE VECTOR ───────────────────────────────────────────────────────
+Every Rust-side checker anchors its patterns with `^\s*`, so a LINE comment can never match: the
+`//` sits where the anchor demands whitespace. A BLOCK comment puts the construct at line-start
+and the anchor stops helping. This is why the defect survived so long, and why probing with `//`
+— the obvious first attempt — returns a clean bill of health on every one of them.
+
+── SOME CHECKERS READ COMMENTS ON PURPOSE ────────────────────────────────────────────────────
+`check_shed_order` (SHED-ORDER:), `check_diag_budget` (DIAG-WIDTHS:/DIAG-TAIL:) and
+`check_byte_free` (`byte-free` claims) take their DECLARATIONS from comments and compare them
+against code. For those, comments are load-bearing input, not noise: strip the whole file and
+`check_diag_budget` has nothing left to check. Strip for the CODE-side scan only, and pass the
+raw text to the declaration scan. Callers are responsible for that split; this module only
+blanks comments.
+"""
+
+from pathlib import Path
+
+
+def strip_comments(text: str) -> str:
+    """Blank every comment, PRESERVING length and newlines so offsets and line numbers still map.
+
+    Not a nicety — it is load-bearing, and the first run of this script proved it. The roster's own
+    doc comment explains the hazard using the words `embassy_net::new(interfaces.station, ..)`, and
+    an unstripped scan counted that PROSE as a real call site and failed the gate. A checker whose
+    verdict can be flipped by documentation about the thing it checks is worse than no checker: the
+    same mechanism that produces a false RED here could be used to produce a false GREEN elsewhere
+    (comment out a real site, or bury a roster-shaped string in a comment).
+
+    Handles `//`, `/* */` (nested, as Rust allows), ordinary strings, char literals and raw strings
+    (`r"..."`, `r#"..."#`), because a `//` inside a string literal is not a comment and blanking it
+    would corrupt the code view.
+    """
+    out = list(text)
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        # raw string: r"..." / r#"..."# / r##"..."##
+        if c == "r" and i + 1 < n and text[i + 1] in '"#':
+            j = i + 1
+            hashes = 0
+            while j < n and text[j] == "#":
+                hashes += 1
+                j += 1
+            if j < n and text[j] == '"':
+                close = '"' + "#" * hashes
+                end = text.find(close, j + 1)
+                i = n if end < 0 else end + len(close)
+                continue
+        if c == '"' or c == "'":
+            quote = c
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text[j] == quote:
+                    j += 1
+                    break
+                if text[j] == "\n" and quote == "'":
+                    break  # not a char literal after all (e.g. a lifetime)
+                j += 1
+            i = j
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+            for k in range(i, j):
+                out[k] = " "
+            i = j
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            depth, j = 0, i
+            while j < n:
+                if text.startswith("/*", j):
+                    depth += 1
+                    j += 2
+                elif text.startswith("*/", j):
+                    depth -= 1
+                    j += 2
+                    if depth == 0:
+                        break
+                else:
+                    j += 1
+            for k in range(i, min(j, n)):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = j
+            continue
+        i += 1
+    return "".join(out)
+
+
+def _grep_stripped(pattern: str, root: str) -> int:
+    """`rust_comments.py --grep <pattern> <path>` — exit 0 if found in CODE, 1 if not.
+
+    THE SEAM FOR BASH. `tools/status_check.sh` is a shell script and cannot import this module,
+    and its `grep-absent` kind had the same defect from the other end: it greps RAW source, so
+    #148's `grep-absent ELECT_ENFORCE rust/clock/src` failed the doc because the symbol survives
+    as PROSE in `net.rs:121` and `net/election.rs:143` describing the WATCH's flag. The claim was
+    true; the check was reading comments.
+
+    Exposing a CLI rather than letting the shell re-implement stripping is the point: a second
+    implementation in awk would be a second statement of one fact, which is the duplication this
+    module exists to end. One implementation, two callers, one of them over a process boundary.
+    """
+    p = Path(root)
+    # A MISSING PATH IS NOT AN ABSENCE. `rglob` on a nonexistent directory yields nothing and
+    # would return "not found in code" — a vacuous pass, and the same shape `status_check.sh`
+    # already refuses for `grep-absent` against a path that does not exist. Caught by testing
+    # the error case rather than assuming the happy path generalised.
+    if not p.exists():
+        raise FileNotFoundError(f"no such path: {root}")
+    files = [p] if p.is_file() else sorted(p.rglob("*.rs"))
+    if not files:
+        raise FileNotFoundError(f"no .rs files under {root} — refusing to report an absence")
+    for f in files:
+        try:
+            if pattern in strip_comments(f.read_text(encoding="utf-8", errors="replace")):
+                print(f"{f}: found in code")
+                return 0
+        except OSError:
+            continue
+    return 1
+
+
+if __name__ == "__main__":
+    import sys as _sys
+    # EXIT 2 ON ERROR, NEVER 1. `1` means "absent from code" and a caller acts on it; a crash
+    # that also exits 1 is indistinguishable from a real answer. Found the hard way — an
+    # unimported `Path` produced a traceback whose exit code read exactly like the verdict I
+    # was expecting, and briefly looked like a passing test.
+    if len(_sys.argv) == 4 and _sys.argv[1] == "--grep":
+        try:
+            _sys.exit(_grep_stripped(_sys.argv[2], _sys.argv[3]))
+        except Exception as exc:                      # noqa: BLE001 — deliberate: report, do not guess
+            print(f"rust_comments: {exc}", file=_sys.stderr)
+            _sys.exit(2)
+    if len(_sys.argv) == 2:                      # emit the stripped view, for eyeballing
+        print(strip_comments(Path(_sys.argv[1]).read_text(encoding="utf-8", errors="replace")), end="")
+        _sys.exit(0)
+    print("usage: rust_comments.py --grep <pattern> <path> | rust_comments.py <file>", file=_sys.stderr)
+    _sys.exit(2)

--- a/tools/status_check.sh
+++ b/tools/status_check.sh
@@ -142,11 +142,22 @@ while IFS= read -r line; do
       file-exists)
         [ -e "$REPO_ROOT/$a1" ] && ok "$label" || bad "$label  [missing from the tree]" ;;
       grep-absent)
-        if [ ! -d "$REPO_ROOT/$a2" ] && [ ! -f "$REPO_ROOT/$a2" ]; then
-          bad "$label  [search path '$a2' does not exist — a vacuous pass is not a pass]"
-        elif grep -rq -- "$a1" "$REPO_ROOT/$a2" 2>/dev/null; then
-          bad "$label  [still present under $a2]"
-        else ok "$label"; fi ;;
+        # #426 — ASK ABOUT CODE, NOT PROSE. This used to `grep -rq` the raw source, and it cost a
+        # real false RED: `grep-absent ELECT_ENFORCE rust/clock/src` failed #148 because the symbol
+        # survives as PROSE in `net.rs:121` and `net/election.rs:143` describing the WATCH's flag.
+        # The claim was true; the check was reading comments. A grep cannot tell a live symbol from
+        # a sentence about one.
+        #
+        # Delegated to `tools/rust_comments.py --grep` rather than re-implemented in awk here: one
+        # implementation of comment-stripping, two callers, one of them across a process boundary.
+        # A second copy in shell is the duplication that module exists to end.
+        #   rc 0 = present in CODE · 1 = absent from code · 2 = could not check (never "absent")
+        python3 "$REPO_ROOT/tools/rust_comments.py" --grep "$a1" "$REPO_ROOT/$a2" >/dev/null 2>&1
+        case $? in
+          0) bad "$label  [still present in CODE under $a2]" ;;
+          1) ok "$label" ;;
+          *) bad "$label  [could not check '$a2' — a vacuous pass is not a pass]" ;;
+        esac ;;
       *)
         bad "$label  [UNKNOWN check kind '$kind' — a check nobody can evaluate is not a check]" ;;
     esac

--- a/tools/test_comment_blind.sh
+++ b/tools/test_comment_blind.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# test_comment_blind.sh — prove each swept checker ignores comments, in BOTH directions. (#426)
+#
+# ── WHY ───────────────────────────────────────────────────────────────────────────────────────
+# Three checkers were counting matches inside comments. Each is fixed by stripping; this proves
+# the strip took, and — more importantly — that it did NOT strip too much. Three of these
+# checkers read their DECLARATIONS from comments on purpose (`SHED-ORDER:`, `DIAG-WIDTHS:`,
+# `byte-free` claims), so an over-eager strip leaves them with nothing to check and green forever.
+# That failure would look exactly like success, which is why the "still sees its declarations"
+# arms are here beside the "no longer sees prose" ones.
+#
+# BOTH DIRECTIONS, per checker:
+#   false RED    prose about the invariant must not trip the gate
+#   false GREEN  a real site commented out must not still count
+#
+# ── `//` IS SAFE; `/* */` IS THE VECTOR ───────────────────────────────────────────────────────
+# Every Rust-side checker anchors with `^\s*`, so a LINE comment can never match. Probing with
+# `//` returns a clean bill of health on all of them, which is how this survived. Every probe
+# below therefore uses a BLOCK comment; a `//` probe would pass against the unfixed code too and
+# prove nothing.
+#
+# USAGE:  tools/test_comment_blind.sh        # exit 0 = every arm behaved
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$ROOT/tmp/test-comment-blind"
+pass=0; fail=0
+ok()  { printf '   \033[32mok\033[0m   %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '   \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail+1)); }
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+rm -rf "$WORK"; mkdir -p "$WORK"
+
+NET="$ROOT/rust/clock/src/net.rs"
+MODE="$ROOT/rust/clock/src/net/mode.rs"
+cp "$NET" "$WORK/net.orig"; cp "$MODE" "$WORK/mode.orig"
+restore() { cp "$WORK/net.orig" "$NET"; cp "$WORK/mode.orig" "$MODE"; }
+trap 'restore; cleanup' EXIT
+
+echo "── comment-blind sweep (#426)"
+
+# ── 1. the shared helper itself ───────────────────────────────────────────────────────────────
+python3 - <<'PY' && ok "strip_comments: offsets and lines preserved, strings kept" \
+                 || bad "strip_comments: basic properties"
+import sys; sys.path.insert(0, "tools")
+from rust_comments import strip_comments
+src = 'pub mod a;\n/* b\npub mod b;\n*/\n// pub mod c;\nlet s = "/* not a comment */";\n'
+out = strip_comments(src)
+assert len(out) == len(src),                "length not preserved"
+assert out.count("\n") == src.count("\n"),  "newlines not preserved"
+assert "pub mod a;" in out,                 "real decl lost"
+assert "pub mod b;" not in out,             "block comment not blanked"
+assert "/* not a comment */" in out,        "string literal corrupted"
+PY
+
+# ── 2. check_verifier_wiring — the false GREEN ────────────────────────────────────────────────
+# A verifier over a module the firmware does not compile must read PHANTOM. Before the fix a
+# block-commented `pub mod` made it read SOUND: the checker believed the firmware contained code
+# it does not. That is the direction an ABSENCE check exists to catch.
+python3 - "$NET" <<'PY'
+import sys
+p = sys.argv[1]; s = open(p).read()
+open(p, "w").write(s.replace("pub mod mesh_elect;", "/* probe:\npub mod mesh_elect;\n*/", 1))
+PY
+# CAPTURE, THEN MATCH. Under `set -o pipefail` a pipeline takes the FAILING member's status, and
+# this checker exits nonzero precisely when it finds an untracked phantom — so
+# `checker | grep -q PHANTOM` reports failure at the moment it succeeds. Cost one confused debug
+# cycle; same family as the `grep -q`-under-pipefail hazard this repo already has a rule about.
+out="$(python3 "$ROOT/tools/check_verifier_wiring.py" 2>&1 || true)"
+if printf '%s' "$out" | grep -q "mesh_elect_verify.*PHANTOM"; then
+    ok "verifier_wiring: block-commented \`mod\` no longer counts as wired (false GREEN closed)"
+else
+    bad "verifier_wiring: still treats a commented-out mod as wired"
+fi
+restore
+
+# ── 3. check_verifier_wiring — the real decl must still count ─────────────────────────────────
+out="$(python3 "$ROOT/tools/check_verifier_wiring.py" 2>&1 || true)"
+if printf '%s' "$out" | grep -q "mesh_elect_verify.*SOUND"; then
+    ok "verifier_wiring: the REAL decl still counts (not over-stripped)"
+else
+    bad "verifier_wiring: over-stripped — a live module now reads as phantom"
+fi
+
+# ── 4. check_byte_free — prose must not override a real gate ──────────────────────────────────
+python3 - <<'PY' && ok "byte_free: commented cfg no longer overrides the real gate" \
+                 || bad "byte_free: prose still decides a module's gate"
+import importlib.util, sys
+from pathlib import Path
+sys.path.insert(0, "tools")
+from rust_comments import strip_comments
+spec = importlib.util.spec_from_file_location("bf", "tools/check_byte_free.py")
+bf = importlib.util.module_from_spec(spec); a = sys.argv; sys.argv = ["t"]
+spec.loader.exec_module(bf); sys.argv = a
+orig = Path("rust/clock/src/net.rs").read_text()
+doc = orig.replace("pub mod mesh_elect;",
+                   '/* prose:\n#[cfg(feature = "bard")]\npub mod mesh_elect;\n*/\npub mod mesh_elect;', 1)
+got = dict(bf.mod_gates(strip_comments(doc).splitlines())).get("mesh_elect")
+assert got == 'feature = "espnow"', f"gate became {got!r}, expected the real espnow gate"
+PY
+
+# ── 5. check_byte_free — the CLAIMS are prose and must SURVIVE ────────────────────────────────
+# The over-strip direction. `byte-free` assertions live in comments by design; if the strip
+# reached them this reports zero claims and passes forever.
+bf_out="$(python3 "$ROOT/tools/check_byte_free.py" 2>&1 || true)"
+claims=$(printf '%s' "$bf_out" | sed -n 's/.*source: \([0-9][0-9]*\) byte-free claim.*/\1/p')
+if [ "${claims:-0}" -gt 0 ] 2>/dev/null; then
+    ok "byte_free: still reads its $claims prose claims (not over-stripped)"
+else
+    bad "byte_free: reads ZERO claims — the strip reached the declarations"
+fi
+
+# ── 6. check_diag_budget — the false RED ──────────────────────────────────────────────────────
+python3 - "$MODE" <<'PY'
+import sys
+p = sys.argv[1]; s = open(p).read()
+i = s.index("fn diag_record"); j = s.index("room_for", i); k = s.rfind("\n", i, j) + 1
+open(p, "w").write(s[:k] + '        /* probe:\n           if room_for(&mut rec, probe) { rec.push_str("|probe="); }\n        */\n' + s[k:])
+PY
+if python3 "$ROOT/tools/check_diag_budget.py" "$MODE" >/dev/null 2>&1; then
+    ok "diag_budget: prose about the record no longer fails the gate (false RED closed)"
+else
+    bad "diag_budget: a doc comment still breaks the budget check"
+fi
+restore
+
+# ── 7. check_diag_budget — declarations live in comments and must still be read ───────────────
+out="$(python3 "$ROOT/tools/check_diag_budget.py" "$MODE" 2>&1 || true)"
+if printf '%s' "$out" | grep -q "budget="; then
+    ok "diag_budget: still reads DIAG-WIDTHS/DIAG-TAIL from comments (not over-stripped)"
+else
+    bad "diag_budget: lost its declarations — over-stripped"
+fi
+
+# ── 8. status_check's grep-absent — the real ELECT_ENFORCE case ───────────────────────────────
+# The symbol is gone; the STRING survives as prose describing the watch's flag. Asking about
+# code must say absent, and the raw grep must still find the prose — otherwise this arm is
+# testing nothing.
+python3 "$ROOT/tools/rust_comments.py" --grep 'ELECT_ENFORCE' "$ROOT/rust/clock/src" >/dev/null 2>&1
+rc=$?
+if [ $rc -eq 1 ] && grep -rq 'ELECT_ENFORCE' "$ROOT/rust/clock/src" --include='*.rs'; then
+    ok "grep-absent: ELECT_ENFORCE absent from CODE while present as prose (false RED closed)"
+else
+    bad "grep-absent: rc=$rc, or the prose fixture has vanished (arm no longer meaningful)"
+fi
+
+# ── 9. a real symbol must still be FOUND — the over-strip direction ───────────────────────────
+if python3 "$ROOT/tools/rust_comments.py" --grep 'fn diag_record' "$ROOT/rust/clock/src" >/dev/null 2>&1; then
+    ok "grep-absent: a live symbol is still found in code (not over-stripped)"
+else
+    bad "grep-absent: a live symbol reads as absent — over-stripped"
+fi
+
+# ── 10/11. a missing or empty path is NOT an absence ──────────────────────────────────────────
+python3 "$ROOT/tools/rust_comments.py" --grep 'x' /no/such/path >/dev/null 2>&1
+[ $? -eq 2 ] && ok "grep seam: missing path exits 2, never 1 (a crash must not read as absent)" \
+             || bad "grep seam: missing path did not exit 2"
+mkdir -p "$WORK/empty"
+python3 "$ROOT/tools/rust_comments.py" --grep 'x' "$WORK/empty" >/dev/null 2>&1
+[ $? -eq 2 ] && ok "grep seam: a path with no .rs files refuses to report an absence" \
+             || bad "grep seam: empty dir reported an absence"
+
+echo
+echo "   $pass ok, $fail failed"
+[ $fail -eq 0 ] || exit 1

--- a/tools/test_verifier_wiring.sh
+++ b/tools/test_verifier_wiring.sh
@@ -22,6 +22,11 @@ mkcopy() {
   cp -r "$ROOT/rust/clock/src" "$d/rust/clock/src"
   cp -r "$ROOT/experiments/." "$d/experiments/"
   cp "$CHECK" "$d/tools/"
+  # #426 — the checker now imports `tools/rust_comments.py` (one strip_comments, not six copies),
+  # so the FIXTURE TREE has to carry it too. Staging a tool without its dependency made every arm
+  # fail with `ModuleNotFoundError` — a harness that copies a subset of what the real invocation
+  # needs is testing a program that does not exist.
+  cp "$ROOT/tools/rust_comments.py" "$d/tools/"
   printf '%s' "$d"
 }
 


### PR DESCRIPTION
Closes #426.

## Probed, not assumed — and the candidate list is wrong in both directions

Both known instances were found by accident, and neither was predictable from reading the pattern. So every checker in `tools/` was probed by **injection**:

| checker | verdict | evidence |
|---|---|---|
| `check_verifier_wiring.py` | **vulnerable — false GREEN** | `pub mod mesh_elect;` inside `/* */` → reports **SOUND**; it believed the firmware compiles a module it does not |
| `check_byte_free.py` | **vulnerable — wrong attribution** | a block-commented `#[cfg(feature = "bard")]` decl flipped that module's gate from `espnow` to **`bard`** |
| `check_diag_budget.py` | **vulnerable — false RED** | a block-commented `rec.push_str("\|probe=")` → `FATAL … UNDECLARED: probe`, exit 1 |
| `status_check.sh` (`grep-absent`) | **vulnerable — false RED** | already happened: `ELECT_ENFORCE` failed #148 while being genuinely gone as a symbol and present only as prose |
| `check_exclusions.py` | **not vulnerable** | block-commented `mod` correctly excluded (claim files 50 → 49) |
| `check_shed_order.py` | **not vulnerable** | in-block probe left the 11-field order identical |

**`check_exclusions` was named by the issue and is fine; `check_byte_free` and `check_diag_budget` were not named and are both live.** Fixing exactly the three named candidates would have left two instances standing and "fixed" a non-instance — the sweep would itself have been a confident answer about a subset.

## `//` is safe everywhere; `/* */` is the whole vector

Every Rust-side checker anchors with `^\s*`, so a **line** comment can never match — the `//` sits where the anchor demands whitespace. A **block** comment puts the construct at line-start and the anchor stops helping. That's why this survived, and why probing with `//` (the obvious first attempt) returns a clean bill of health on all eight. Every probe in the suite therefore uses a block comment; a `//` probe passes against the *unfixed* code and proves nothing.

## One `strip_comments`, because there were already two

It existed in `check_station_consumers.py` and `check_elect_send_path.py`. I compared them by AST: **the code bodies are identical**, differing only in docstrings. The second one's says:

> *Shared implementation with `check_station_consumers.py` …*

It wasn't shared. It was a copy that said it was shared — the #371 shape appearing inside the fix for a different instance of itself. The sweep would have made it six copies. Now there is one in `tools/rust_comments.py` and the callers import it, which also makes that sentence true.

## Three checkers read comments ON PURPOSE — a blanket strip would break them

`check_shed_order` (`SHED-ORDER:`), `check_diag_budget` (`DIAG-WIDTHS:`/`DIAG-TAIL:`) and `check_byte_free` (`byte-free` claims) take their **declarations** from comments and compare them against code. Strip the whole file and `check_diag_budget` has nothing left to check — a failure that looks exactly like success.

So each fix splits the views:

- **`check_byte_free`** keeps **raw** lines for the claim-proximity rule and passes **stripped** lines to `file_gate`/`mod_gates`.
- **`check_diag_budget`** locates the protected tail's markers in **raw** (`TAIL_START` is itself comment text) and slices **stripped** — which works *only* because the strip preserves length and offsets. That property stops being a nicety here and becomes the mechanism.

## The bash caller got a seam, not a second implementation

`status_check.sh` can't import a Python module, so `rust_comments.py` grew a `--grep` CLI. Writing a second stripper in awk would be the duplication this module exists to end.

Its exit codes matter: `0` = present in code, `1` = absent, `2` = could not check — **never 1 on error**, because a crash exiting 1 is indistinguishable from a real absence. I found that the hard way: an unimported `Path` produced a traceback whose exit code read exactly like the verdict I was expecting and briefly looked like a passing test. A missing path, or a directory with no `.rs` files, exits 2 for the same reason.

**Side effect worth acting on:** with the real fix in, the *original* `grep-absent ELECT_ENFORCE` annotation now passes on its own merits (verified: absent from code, present as prose). @team-lead — the `const.ELECT_ENFORCE` re-anchoring in #148 was the #424-style wording interim, and it can be reverted.

## Regression suite — 11 arms, both directions

```
   ok   strip_comments: offsets and lines preserved, strings kept
   ok   verifier_wiring: block-commented `mod` no longer counts as wired (false GREEN closed)
   ok   verifier_wiring: the REAL decl still counts (not over-stripped)
   ok   byte_free: commented cfg no longer overrides the real gate
   ok   byte_free: still reads its 8 prose claims (not over-stripped)
   ok   diag_budget: prose about the record no longer fails the gate (false RED closed)
   ok   diag_budget: still reads DIAG-WIDTHS/DIAG-TAIL from comments (not over-stripped)
   ok   grep-absent: ELECT_ENFORCE absent from CODE while present as prose (false RED closed)
   ok   grep-absent: a live symbol is still found in code (not over-stripped)
   ok   grep seam: missing path exits 2, never 1 (a crash must not read as absent)
   ok   grep seam: a path with no .rs files refuses to report an absence

   11 ok, 0 failed
```

The "still reads its declarations" arms are as important as the "no longer sees prose" ones — they're the only thing standing between this fix and three checkers that are green forever with nothing to check.

Wired into `gate.sh host` beside its siblings. Pure text, no cargo.

## Coordination

**`check_elect_send_path.py` is deliberately untouched.** It's morpheus-391's, B2 landed hours ago, and I asked whether to convert its copy or leave it. Its duplicate remains pending that answer rather than being an oversight — noted on #426 too. Converting it later is a two-line delete-and-import with no behaviour change.

Rebased onto current main; the `gate.sh` conflict with #432's arm was resolved by keeping **both** (they're siblings, not alternatives). All sibling suites re-run green afterwards: `build_matrix`, `byte_free`, `check_exclusions`, `check_elect_send_path`, `check_station_consumers`, `stack_floor`, `diag_budget`, `config_markers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
