### PR TITLE
feat(tools): the publish path builds and packages any declared chip (#413 phase 2B)

### DIFF
--- a/tools/build_matrix.py
+++ b/tools/build_matrix.py
@@ -29,6 +29,11 @@ DEFAULT_MANIFEST = HERE / "build-matrix.toml"
 DEFAULT_REPRO = HERE / "repro_build.sh"
 DEFAULT_BUDGET = HERE.parent / "rust" / "clock" / "src" / "budget.rs"
 DEFAULT_CARGO = HERE.parent / "rust" / "clock" / "Cargo.toml"
+# #413: the two halves of the chip id<->name map. `net/target.rs` is AUTHORITATIVE — the id is the
+# #349 wire format the device reads out of an image's target descriptor — and `ota_publish.sh`
+# carries a python copy so it can name the chip it is about to stage.
+DEFAULT_TARGET_RS = HERE.parent / "rust" / "clock" / "src" / "net" / "target.rs"
+DEFAULT_OTA_PUBLISH = HERE / "ota_publish.sh"
 
 
 # ── loading ───────────────────────────────────────────────────────────────────
@@ -136,6 +141,44 @@ def repro_fleet_features(path: Path) -> str:
     return m.group(1)
 
 
+def chip_ids_from_firmware(path: Path) -> dict[int, str]:
+    """`CHIP_ESP32C3: u8 = 1;` -> {1: "esp32c3"}. The AUTHORITATIVE map: the id is #349's wire
+    format, so the firmware that stamps it defines it.
+
+    Guarded the way `budget_chips` is: if the count of `CHIP_*` declarations does not match the
+    count of ids parsed, refuse rather than compare a roster we cannot fully read. A regex over
+    Rust is acceptable here (the precedent is `budget_chips`), a SILENT partial parse is not.
+    """
+    text = path.read_text(encoding="utf-8", errors="replace")
+    decls = re.findall(r"^pub const CHIP_(ESP32[A-Z0-9]+): u8 = (\d+);", text, re.M)
+    # `CHIP_UNKNOWN` is deliberately excluded by the pattern: 0 is "no chip", not a chip.
+    literal_count = len(re.findall(r"^pub const CHIP_ESP32[A-Z0-9]+: u8 =", text, re.M))
+    if literal_count != len(decls):
+        raise Bad(f"{path}: found {literal_count} CHIP_ESP32* declarations but parsed "
+                  f"{len(decls)} ids — refusing to compare a roster I cannot fully read")
+    if not decls:
+        raise Bad(f"{path}: no CHIP_ESP32* declarations found — anchor lost, failing closed")
+    return {int(n): name.lower() for name, n in decls}
+
+
+def chip_ids_from_publisher(path: Path) -> dict[int, str]:
+    """The `CHIPS = {1: "esp32c3", ...}` dict inside `ota_publish.sh`'s embedded python.
+
+    Parsed rather than imported because it lives in a heredoc. Same fail-closed guard: the entry
+    count must match, or we are comparing against a partial read.
+    """
+    text = path.read_text(encoding="utf-8", errors="replace")
+    m = re.search(r"^CHIPS = \{(.*?)\}", text, re.M | re.S)
+    if not m:
+        raise Bad(f"{path}: no `CHIPS = {{...}}` map found — anchor lost, failing closed")
+    body = m.group(1)
+    pairs = re.findall(r"(\d+)\s*:\s*\"([a-z0-9]+)\"", body)
+    if len(pairs) != body.count(":"):
+        raise Bad(f"{path}: CHIPS has {body.count(':')} entries but {len(pairs)} parsed — "
+                  f"refusing to compare a map I cannot fully read")
+    return {int(n): name for n, name in pairs}
+
+
 def budget_chips(path: Path) -> set[str]:
     """Chip ids declared as `ChipBudget` consts.
 
@@ -238,6 +281,32 @@ def check(doc: dict, repro: Path, budget: Path) -> list[str]:
         except Bad as exc:
             fails.append(str(exc))
 
+    # 3b. #413: the chip id<->name map agrees between the FIRMWARE (authoritative — the id is
+    #     #349's wire format) and the PUBLISHER's copy. This is the FOURTH copy of the chip roster
+    #     in the tree and the one nothing compared, which is how `ota_publish.sh` came to be
+    #     silently short esp32c5 (id 4). The consequence was not a crash: a valid C5 descriptor
+    #     was reported as ABSENT and the image staged legacy-only, sending anyone debugging it
+    #     into the firmware's descriptor emission. Checked in BOTH directions, so neither side can
+    #     grow or lose a chip alone.
+    try:
+        fw = chip_ids_from_firmware(doc.get("_target_rs") or DEFAULT_TARGET_RS)
+        pub = chip_ids_from_publisher(doc.get("_ota_publish") or DEFAULT_OTA_PUBLISH)
+        for cid, name in sorted(fw.items()):
+            if cid not in pub:
+                fails.append(f"chip id {cid} ({name}) is declared in net/target.rs but MISSING "
+                             f"from ota_publish.sh's CHIPS — a valid {name} image would be "
+                             f"reported as having no target descriptor and staged legacy-only")
+            elif pub[cid] != name:
+                fails.append(f"chip id {cid}: net/target.rs says {name!r}, "
+                             f"ota_publish.sh says {pub[cid]!r}")
+        for cid, name in sorted(pub.items()):
+            if cid not in fw:
+                fails.append(f"chip id {cid} ({name}) is in ota_publish.sh's CHIPS but has no "
+                             f"CHIP_* constant in net/target.rs — the publisher would name a chip "
+                             f"the firmware cannot stamp")
+    except Bad as exc:
+        fails.append(str(exc))
+
     # 4. every cargo feature is covered by a tier, or exempted with a reason.
     #
     # `tools/gate.sh` carried this as an aspiration in a comment — "any feature listed in
@@ -282,6 +351,10 @@ def main() -> int:
     ap.add_argument("--repro", type=Path, default=DEFAULT_REPRO)
     ap.add_argument("--budget", type=Path, default=DEFAULT_BUDGET)
     ap.add_argument("--cargo", type=Path, default=DEFAULT_CARGO)
+    # #413: fixture hooks for the id<->name roster arm, mirroring --budget/--cargo so the
+    # regression suite can craft a SHORT roster instead of sabotaging the real files.
+    ap.add_argument("--target-rs", type=Path, default=DEFAULT_TARGET_RS)
+    ap.add_argument("--ota-publish", type=Path, default=DEFAULT_OTA_PUBLISH)
     ap.add_argument("--for", dest="phase", choices=("check", "clippy"), default="check",
                     help="emit: which gate phase's tier list to produce")
     ap.add_argument("--builds", action="store_true", help="chips: only buildable ones")
@@ -386,6 +459,8 @@ def main() -> int:
         return 0
 
     doc["_cargo_toml"] = args.cargo
+    doc["_target_rs"] = args.target_rs
+    doc["_ota_publish"] = args.ota_publish
     fails = check(doc, args.repro, args.budget)
     jobs = matrix(doc)
     builds = [c for c, s in doc["chips"].items() if s["builds"]]

--- a/tools/ota_publish.sh
+++ b/tools/ota_publish.sh
@@ -343,7 +343,19 @@ SHA="$(sha256sum "$BIN" | cut -d' ' -f1)"
 read_target_desc() { # <bin> → "<hexdesc> <chipname>" on stdout, non-zero if absent/ambiguous
   python3 - "$1" <<'PY'
 import re, sys
-CHIPS = {1: "esp32c3", 2: "esp32c6", 3: "esp32s3"}
+# #413: esp32c5 (id 4) WAS MISSING, and the consequence was not a crash. `CHIPS.get(4)` returned
+# None, this script exited 1, the caller's `if _desc_out=$(read_target_desc ...)` took the
+# pre-#349 branch, and a C5 image with a PERFECTLY VALID descriptor was reported as
+# "no target descriptor in this image" and staged LEGACY-ONLY — invisible to boards routing on
+# smol/ota/staged/<chip>. Fail-closed against publishing a wrong name, but MISATTRIBUTED: it sends
+# whoever debugs it into the firmware's descriptor emission when the bug is this dict.
+#
+# ⚠️ THIS IS THE FOURTH COPY OF THE CHIP ROSTER in the tree (tools/build-matrix.toml,
+# rust/clock/src/budget.rs, rust/clock/src/net/target.rs, here) and it was the one nothing
+# compared. `net/target.rs` is AUTHORITATIVE because the id is the #349 WIRE FORMAT, and
+# `build_matrix.py check` now asserts this map against it in BOTH directions — so this list going
+# short again is a gate failure rather than a mystery at staging time.
+CHIPS = {1: "esp32c3", 2: "esp32c6", 3: "esp32s3", 4: "esp32c5"}
 data = open(sys.argv[1], "rb").read()
 def fnv(b):
     h = 0x811c9dc5

--- a/tools/repro_build.sh
+++ b/tools/repro_build.sh
@@ -33,7 +33,52 @@
 # whatever it was before — the default build is provably untouched (no cfg, no source edit).
 
 # The bare-metal target the fleet builds for (matches .cargo/config.toml `build.target`).
+#
+# ⚠️ #413 PHASE 2B: THIS IS NOW A DEFAULT, NOT A CONSTANT. It is the CANONICAL chip's target, kept
+# as a literal so every existing caller and every recorded C3 measurement is untouched — but it is
+# no longer the only value it can hold. `repro_chip_spec <chip>` re-points it (plus the toolchain,
+# build-std and opt-level that go with that chip) from `tools/build-matrix.toml`, which is the one
+# place the (chip → target, toolchain, build_std, opt_level, features) tuple lives.
+#
+# It stays a scalar-with-a-default rather than becoming a required argument because six consumers
+# read it and a required parameter would make every one of them a caller's problem at once. The
+# per-chip paths call `repro_chip_spec` first; the C3 path does not have to.
 REPRO_TARGET="riscv32imc-unknown-none-elf"
+# The chip that target belongs to. Same reasoning: a default the C3 path never has to think about.
+REPRO_CHIP="${REPRO_CHIP:-esp32c3}"
+# Set by `repro_chip_spec` for non-default chips; empty means "the pinned stable toolchain, no
+# build-std, the profile's own opt-level" — i.e. exactly what the C3 has always used.
+REPRO_TOOLCHAIN="" REPRO_BUILD_STD="" REPRO_OPT_LEVEL=""
+
+# repro_chip_spec <chip> — re-point REPRO_TARGET/CHIP/TOOLCHAIN/BUILD_STD/OPT_LEVEL at one chip.
+#
+# Reads `tools/build_matrix.py chip-checks`, which already emits the whole tuple and is what the
+# xtensa CI spike builds from. Deliberately NOT a second roster here: a publish path that carried
+# its own chip table would be the FIFTH copy of that roster in this repo, and the fourth
+# (`ota_publish.sh`'s id→name dict) was already silently short the C5 when #413 found it.
+#
+# Fields are tab-separated with `-` for empty. A tab is IFS *whitespace*, so bash collapses runs of
+# them and every field after an empty one shifts left — the sentinel is what survives that, and the
+# reason this reads `-` back to empty rather than trusting position alone.
+repro_chip_spec() {
+  local chip="${1:-}" line
+  case "$chip" in
+    '') echo "repro_chip_spec: a chip is required" >&2; return 1 ;;
+    *[!a-z0-9]*) echo "repro_chip_spec: implausible chip name '$chip'" >&2; return 1 ;;
+  esac
+  local matrix="$REPRO_ROOT/tools/build_matrix.py"
+  [ -x "$matrix" ] || { echo "repro_chip_spec: no $matrix" >&2; return 1; }
+  line="$("$matrix" chip-checks 2>/dev/null | awk -F'\t' -v c="$chip" '$1==c')"
+  [ -n "$line" ] || { echo "repro_chip_spec: '$chip' is not a declared chip in build-matrix.toml" >&2; return 1; }
+  local _c _t _e _tc _bs _ol _f
+  IFS=$'\t' read -r _c _t _e _tc _bs _ol _f <<<"$line"
+  [ "$_tc" = "-" ] && _tc=""
+  [ "$_bs" = "-" ] && _bs=""
+  [ "$_ol" = "-" ] && _ol=""
+  [ -n "$_t" ] || { echo "repro_chip_spec: '$chip' declares no target" >&2; return 1; }
+  REPRO_TARGET="$_t"; REPRO_CHIP="$_c"
+  REPRO_TOOLCHAIN="$_tc"; REPRO_BUILD_STD="$_bs"; REPRO_OPT_LEVEL="$_ol"
+}
 
 # #338: the CANONICAL fleet feature set, named once. `repro_build_bin` builds it and `tools/gate.sh`
 # gates it; before this was a variable the list lived only inside the build line below, so CI could
@@ -45,9 +90,19 @@ REPRO_FLEET_FEATURES="${REPRO_FLEET_FEATURES:-espnow,cast,io}"
 # the crate's rust-toolchain.toml, so this MUST be evaluated inside the crate dir (from home it
 # would return `stable`, not the pinned 1.96.1, and the remap prefix would miss the build-std
 # paths). Arg $1 = crate dir (default ".").
+# ⚠️ #413 2B: THE TOOLCHAIN MUST BE THE ONE THAT WILL ACTUALLY BUILD, and for a non-default chip
+# that is NOT what rust-toolchain.toml resolves to. `rustc --print sysroot` in the crate dir picks
+# up `channel = "stable"`; an S3 build runs on espup's `esp` fork, whose sysroot is a DIFFERENT
+# path. Remapping stable's sysroot while build-std compiles `core` out of the esp fork's would
+# leave the fork's absolute paths un-remapped in the image — reproducibility silently broken for
+# the S3 while the C3 stayed perfect, which is the worst shape this file has.
+#
+# So the toolchain travels into the sysroot query. `$REPRO_TOOLCHAIN` is empty for the C3, and
+# `rustc  --print sysroot` with an empty first word is exactly the old command.
 repro_sysroot() {
-  local crate_dir="${1:-.}"
-  ( cd "$crate_dir" 2>/dev/null && "${RUSTC:-rustc}" --print sysroot 2>/dev/null ) || true
+  local crate_dir="${1:-.}" tc="${2:-$REPRO_TOOLCHAIN}" args=()
+  [ -n "$tc" ] && args+=("+$tc")
+  ( cd "$crate_dir" 2>/dev/null && "${RUSTC:-rustc}" "${args[@]}" --print sysroot 2>/dev/null ) || true
 }
 
 # Echo the machine-specific --remap-path-prefix flags (space-separated). Fixed targets
@@ -57,7 +112,7 @@ repro_sysroot() {
 repro_remap_flags() {
   local reg sysroot
   reg="${CARGO_HOME:-$HOME/.cargo}/registry"
-  sysroot="$(repro_sysroot "${1:-.}")"
+  sysroot="$(repro_sysroot "${1:-.}" "${2:-$REPRO_TOOLCHAIN}")"
   [ -n "$sysroot" ] || { echo "repro_build: could not resolve rustc sysroot — cannot remap build-std paths" >&2; return 1; }
   printf -- '--remap-path-prefix=%s=/registry --remap-path-prefix=%s=/rust' "$reg" "$sysroot"
 }
@@ -70,7 +125,7 @@ repro_remap_flags() {
 repro_cargo_args() {
   local reg sysroot
   reg="${CARGO_HOME:-$HOME/.cargo}/registry"
-  sysroot="$(repro_sysroot "${1:-.}")"
+  sysroot="$(repro_sysroot "${1:-.}" "${2:-$REPRO_TOOLCHAIN}")"
   [ -n "$sysroot" ] || { echo "repro_build: could not resolve rustc sysroot — cannot remap build-std paths" >&2; return 1; }
   REPRO_CARGO_ARGS=(
     --config "target.${REPRO_TARGET}.rustflags=[\"--remap-path-prefix=${reg}=/registry\",\"--remap-path-prefix=${sysroot}=/rust\"]"
@@ -273,6 +328,34 @@ repro_build_bin() {
       return 1
       ;;
   esac
+
+  # #280 (lucid): refuse to build a chip whose `.cargo/config.toml` is STALE. The failure this
+  # prevents is specific and was observed on familiar: a config byte-current EXCEPT for the S3
+  # arm's `-C link-arg=-Tlinkall.x`, which `cargo check` cannot notice (check never links) and
+  # which then fails the LINK with 129 undefined references — reading as a broken toolchain
+  # rather than a stale file. The file is git-tracked but `.stignore` ignores `.cargo`, so a
+  # synced tree's copy arrives out of band and nothing keeps it current.
+  #
+  # BOTH non-zero states are fatal HERE, and that is a packaging-boundary judgement rather than
+  # the helper's default: `2` means "could not check" (unknown chip, or no `config_markers`
+  # declared for it), and an image whose build configuration could not be VERIFIED has no
+  # business becoming a published artifact — the same reasoning as the `off-fleet` refusal above.
+  # A chip with no declared markers is a manifest gap to close before publishing that chip, and
+  # failing here is what applies the pressure. Distinct messages so the operator knows which.
+  if [ -r "$REPRO_ROOT/tools/assert_cargo_config.sh" ]; then
+    # shellcheck source=tools/assert_cargo_config.sh
+    . "$REPRO_ROOT/tools/assert_cargo_config.sh"
+    assert_cargo_config "$REPRO_CHIP"
+    case $? in
+      0) : ;;
+      1) echo "FATAL: refusing to package — see the stale-config refusal above (#280)." >&2
+         return 1 ;;
+      *) echo "FATAL: could not VERIFY .cargo/config.toml for '$REPRO_CHIP' (#280). Not a stale" >&2
+         echo "       file — an unverifiable one, which at the packaging boundary is the same" >&2
+         echo "       answer: declare the chip's config_markers in tools/build-matrix.toml." >&2
+         return 1 ;;
+    esac
+  fi
   # #218: no explicit number ⇒ use the COMMITTED ratchet (version.txt), NOT git-count.
   # The caller sets SMOL_RELEASE=1 for a real release (clean `vN Word` stamp); otherwise
   # build.rs marks it dev (`vN+dev.<hash> Word`) so a canary can't masquerade as the release.
@@ -370,14 +453,62 @@ repro_build_bin() {
     # the with-bard lineage by definition. That is the second fork of this lineage (#300 was
     # the first); an image sha only means something relative to the list in force when it was
     # built, so a hash compared across this boundary will disagree and is SUPPOSED to.
-    cargo build --release --features "$REPRO_FLEET_FEATURES" "${REPRO_CARGO_ARGS[@]}"
+    # #413 2B: the chip's toolchain/build-std/opt-level, all PER-INVOCATION and never config keys.
+    #
+    # ⚠️ build-std as a `.cargo/config.toml` key is GLOBAL, and that is the 2026-07-20 regression
+    # that leaked portable-atomic/unsafe-assume-single-core into the HOST build and broke every
+    # cold C3 build. `opt_level` is the same shape for a different reason: the global release
+    # profile is shared with the C3, and every C3 number on record (stack floors, #32 symbol
+    # sizes, byte-reproducibility) was measured against it. Both stay in the environment of this
+    # one command.
+    #
+    # ⚠️ THE OPT-LEVEL IS PART OF THE #44 REPRODUCIBILITY IDENTITY. A per-chip profile override
+    # means the sha lineage is per (chip, PROFILE), not per chip: the S3 builds at opt-level 2 to
+    # dodge an Xtensa LLVM scavenger crash, opt-level moves sections, and two S3 images built at
+    # different opt-levels will differ and are SUPPOSED to. Compare shas only within one
+    # (chip, profile) pair.
+    local _cargo_env=() _toolchain_arg=()
+    [ -n "$REPRO_BUILD_STD" ] && _cargo_env+=("CARGO_UNSTABLE_BUILD_STD=$REPRO_BUILD_STD")
+    [ -n "$REPRO_OPT_LEVEL" ] && _cargo_env+=("CARGO_PROFILE_RELEASE_OPT_LEVEL=$REPRO_OPT_LEVEL")
+    [ -n "$REPRO_TOOLCHAIN" ] && _toolchain_arg=("+$REPRO_TOOLCHAIN")
+    # `env` with an empty array is a no-op prefix, so the C3 path runs the identical command it
+    # always did — which is what makes the byte-identical claim checkable rather than argued.
+    # ── THE FEATURE FORM IS BRANCHED, AND THE BRANCH IS FORCED BY MEASUREMENT ─────────────
+    # The canonical chip keeps its EXACT historical invocation — `--features <tier>` with default
+    # features ON, so `default`'s own chip feature supplies the chip. Non-canonical chips get the
+    # explicit form, because `default` carries the CANONICAL chip and would otherwise hand esp-hal
+    # two chips (or, before that, trip build.rs's #405 feature-vs-triple cross-check, which is
+    # exactly how this was caught: an S3 build died with "chip DISAGREEMENT: feature `esp32c3` but
+    # target triple xtensa-esp32s3-none-elf").
+    #
+    # ⚠️ DO NOT "SIMPLIFY" THIS INTO ONE PATH. The two forms are NOT byte-equivalent, measured:
+    #     --features espnow,cast,io                          -> 072679408c8b4ba1…
+    #     --no-default-features --features esp32c3,espnow,…   -> 2a3365610afea8ed…
+    # Same resolved feature SET, different resolved feature NAME set (`default`/`hw` versus an
+    # explicit `esp32c3`), and feature names feed the crate's `-Cmetadata`. The delta is almost
+    # certainly metadata-only — but the C3 image's byte-identity is a constraint of record, and
+    # "almost certainly" is not the standard. Branching keeps that identity BY CONSTRUCTION
+    # instead of by an equivalence argument that has already failed once.
+    local _canon _feat_args=()
+    _canon="$("$REPRO_ROOT/tools/build_matrix.py" canonical-chip 2>/dev/null || true)"
+    if [ -n "$_canon" ] && [ "$REPRO_CHIP" = "$_canon" ]; then
+      _feat_args=(--features "$REPRO_FLEET_FEATURES")
+    else
+      _feat_args=(--no-default-features --features "$REPRO_CHIP,$REPRO_FLEET_FEATURES")
+    fi
+    env "${_cargo_env[@]}" cargo "${_toolchain_arg[@]}" build --release \
+      --target "$REPRO_TARGET" "${_feat_args[@]}" "${REPRO_CARGO_ARGS[@]}"
   ) || return 1
   # Honor CARGO_TARGET_DIR (verify_image.sh --twice points each build at an isolated dir);
   # default to the in-tree target/ (ota_publish.sh's path) when unset.
   local tdir="${CARGO_TARGET_DIR:-$clock/target}"
-  # #413: the chip travels with the check. Phase 2A keeps REPRO_CHIP defaulting to esp32c3 —
-  # phase 2B derives it from the manifest alongside REPRO_TARGET, and the two must move together.
-  repro_stack_check "$tdir/${REPRO_TARGET}/release/clock" "${REPRO_CHIP:-esp32c3}" || return 1
-  "$espflash" save-image --chip esp32c3 \
+  # #413: the chip travels with the check, and since 2B it is the SAME chip `repro_chip_spec`
+  # resolved the target from — the two cannot disagree because one call sets both.
+  repro_stack_check "$tdir/${REPRO_TARGET}/release/clock" "$REPRO_CHIP" || return 1
+  # #413 2B: `--chip esp32c3` was HARDCODED here. It is the 7th single-chip site in this file and
+  # the only one a `REPRO_TARGET` grep could never find, because it is a different literal in a
+  # different flag — the [[literal-grep-proves-nothing-about-constructed-strings]] case, found by
+  # reading the function rather than searching it.
+  "$espflash" save-image --chip "$REPRO_CHIP" \
     "$tdir/${REPRO_TARGET}/release/clock" "$out" >/dev/null || return 1
 }

--- a/tools/test_build_matrix.sh
+++ b/tools/test_build_matrix.sh
@@ -21,6 +21,8 @@
 #   # EXPECT-JOBS: <n>             the emitted matrix must have exactly n jobs
 #   # BUDGET: <file>               use this budget fixture instead of _budget_ok.rs
 #   # CARGO: <file>                use this Cargo.toml fixture instead of _cargo_empty.toml
+#   # TARGET-RS: <file>            use this net/target.rs fixture (#413 id<->name roster arm)
+#   # OTA-PUBLISH: <file>          use this ota_publish.sh fixture (#413 id<->name roster arm)
 #
 # Exit 0 all cases behaved; 1 otherwise.
 set -uo pipefail
@@ -44,6 +46,10 @@ for case_file in "$CASES"/*.toml; do
   budget="$CASES/$(sed -n 's/^# BUDGET: *//p' "$case_file" | head -1)"
   [ -f "$budget" ] || budget="$CASES/_budget_ok.rs"
   cargo="$CASES/$(sed -n 's/^# CARGO: *//p' "$case_file" | head -1)"
+  targetrs="$CASES/$(sed -n 's/^# TARGET-RS: *//p' "$case_file" | head -1)"
+  [ -f "$targetrs" ] || targetrs="$HERE/../rust/clock/src/net/target.rs"
+  otapub="$CASES/$(sed -n 's/^# OTA-PUBLISH: *//p' "$case_file" | head -1)"
+  [ -f "$otapub" ] || otapub="$HERE/ota_publish.sh"
   [ -f "$cargo" ] || cargo="$CASES/_cargo_empty.toml"
 
   want_fail="$(sed -n 's/^# EXPECT: *//p' "$case_file" | head -1)"
@@ -58,7 +64,8 @@ for case_file in "$CASES"/*.toml; do
     continue
   fi
 
-  out="$("$BM" check --manifest "$case_file" --repro "$REPRO" --budget "$budget" --cargo "$cargo" 2>&1)"
+  out="$("$BM" check --manifest "$case_file" --repro "$REPRO" --budget "$budget" --cargo "$cargo" \
+         --target-rs "$targetrs" --ota-publish "$otapub" 2>&1)"
   rc=$?
 
   if [ -n "$want_bad" ]; then

--- a/tools/test_build_matrix_cases/_ota_publish_conflict.sh
+++ b/tools/test_build_matrix_cases/_ota_publish_conflict.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# #413 fixture: same ids, DIFFERENT name for id 3 — the publisher would announce a chip the
+# firmware never stamps.
+CHIPS = {1: "esp32c3", 2: "esp32c6", 3: "esp32h2", 4: "esp32c5"}

--- a/tools/test_build_matrix_cases/_ota_publish_short.sh
+++ b/tools/test_build_matrix_cases/_ota_publish_short.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# #413 fixture: the REAL defect — the publisher's roster is short esp32c5 (id 4). This is the
+# state ota_publish.sh was actually in, where a valid C5 descriptor read as absent.
+CHIPS = {1: "esp32c3", 2: "esp32c6", 3: "esp32s3"}

--- a/tools/test_build_matrix_cases/_target_rs_ok.rs
+++ b/tools/test_build_matrix_cases/_target_rs_ok.rs
@@ -1,0 +1,6 @@
+// #413 fixture: the AUTHORITATIVE chip id<->name map, as net/target.rs declares it.
+pub const CHIP_UNKNOWN: u8 = 0;
+pub const CHIP_ESP32C3: u8 = 1;
+pub const CHIP_ESP32C6: u8 = 2;
+pub const CHIP_ESP32S3: u8 = 3;
+pub const CHIP_ESP32C5: u8 = 4;

--- a/tools/test_build_matrix_cases/chip_id_roster_conflict.toml
+++ b/tools/test_build_matrix_cases/chip_id_roster_conflict.toml
@@ -1,0 +1,20 @@
+# EXPECT: net/target.rs says
+# TARGET-RS: _target_rs_ok.rs
+# OTA-PUBLISH: _ota_publish_conflict.sh
+# The other direction: same id, different NAME. The publisher would announce a chip the firmware
+# cannot stamp — caught because the arm compares both ways rather than just checking presence.
+[meta]
+canonical_chip = "esp32c3"
+canonical_tier = "fleet"
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+checks = true
+ships = true
+[chip.esp32s3]
+target = "xtensa-esp32s3-none-elf"
+builds = false
+checks = false
+ships = false
+[tier.fleet]
+features = "espnow,cast,io"

--- a/tools/test_build_matrix_cases/chip_id_roster_short.toml
+++ b/tools/test_build_matrix_cases/chip_id_roster_short.toml
@@ -1,0 +1,20 @@
+# EXPECT: MISSING from ota_publish.sh
+# TARGET-RS: _target_rs_ok.rs
+# OTA-PUBLISH: _ota_publish_short.sh
+# The defect #413 found in the wild: the publisher does not know a chip the firmware stamps, so a
+# valid image for it is reported as having NO target descriptor and staged legacy-only.
+[meta]
+canonical_chip = "esp32c3"
+canonical_tier = "fleet"
+[chip.esp32c3]
+target = "riscv32imc-unknown-none-elf"
+builds = true
+checks = true
+ships = true
+[chip.esp32s3]
+target = "xtensa-esp32s3-none-elf"
+builds = false
+checks = false
+ships = false
+[tier.fleet]
+features = "espnow,cast,io"


### PR DESCRIPTION
2A taught the stack gate which chip it was measuring. **2B teaches the publish path the same thing** — `repro_build_bin` can now build, gate and package an image for any chip `tools/build-matrix.toml` declares.

Proven by doing it:

```
S3 via repro_build_bin:  sha256 7b6b1ccbfaccd735…  ·  1,027,184 B
  stack: 96668 B (floor 72004 B, observed-sufficient)
```

That line is 2A's per-chip floor and provenance working on a real non-C3 image, through the real packaging path.

## The C3 is byte-identical, measured on the packaged artifact

`repro_build_bin` before vs after, same directory, same target dir:

```
sha256 483459447458935a7c122982f76447c9dfab7d5a9cfde94f041d540702bc7652 · 1,032,304 B · identical
```

Not sections, not `nm` — **the packaged `.bin`**. Re-verified a second time after the feature-form branch landed.

## Seven single-chip sites, not six

The design counted 6 `REPRO_TARGET` consumers. The 7th was `espflash save-image --chip esp32c3` — a different literal in a different flag, **invisible to the grep that found the other six**. My design's §8 listed exactly this risk as assumed-not-verified (`[[literal-grep-proves-nothing-about-constructed-strings]]`); it was found by *reading* the function rather than searching it.

`repro_chip_spec <chip>` now re-points `REPRO_TARGET/CHIP/TOOLCHAIN/BUILD_STD/OPT_LEVEL` from `build_matrix.py chip-checks` — the one place that tuple lives. Deliberately **not** a second roster: a chip table in the publish path would be the fifth copy in this repo, and the fourth was already broken (below).

## Two bugs caught only by measuring

**1. The sysroot would have been the wrong toolchain's — and this is the nastiest shape available here.** `repro_sysroot` runs `rustc --print sysroot` in the crate dir, which resolves via `rust-toolchain.toml` to **stable**. An S3 build runs on espup's `esp` fork, and the paths are genuinely different (measured: `…/toolchains/stable-x86_64-unknown-linux-gnu` vs `…/toolchains/esp`). Remapping stable's sysroot while `build-std` compiles `core` out of the fork's would leave the fork's absolute paths **un-remapped in the image** — #44 reproducibility silently broken for the S3 **while the C3 stayed perfect**. A defect that only manifests on the new target and is invisible to every existing check. The toolchain now travels into the sysroot query; empty for the C3 means the identical old command.

**2. The feature form is branched, and the branch is forced by measurement.** The first S3 attempt died in `build.rs` — *"chip DISAGREEMENT: feature `esp32c3` but target triple xtensa-esp32s3-none-elf is esp32s3"* — because `--features <tier>` leaves `default` (and its `esp32c3`) on. #405's own feature-vs-triple cross-check catching 2B's incompleteness is the system working.

The obvious fix is one explicit form for everyone. **I tested whether that is byte-equivalent for the C3, and it is not:**

```
--features espnow,cast,io                          -> 072679408c8b4ba1…
--no-default-features --features esp32c3,espnow,…  -> 2a3365610afea8ed…
```

Same resolved feature *set*, different resolved feature *name* set, and names feed the crate's `-Cmetadata`. Almost certainly metadata-only — but the C3's byte-identity is a constraint of record and "almost certainly" is not the standard. So the canonical chip keeps its exact historical invocation and only non-canonical chips get the explicit form: **byte-identity by construction rather than by an equivalence argument that has already failed once.** The measured shas are in the code comment so the simplification cannot be re-attempted blind.

## A latent defect: the publisher did not know the C5

`ota_publish.sh`'s `CHIPS = {1,2,3}` was missing `esp32c5` (id 4), which `net/target.rs` has declared since #349. **The consequence was not a crash**, and that's the instructive part: `CHIPS.get(4)` → `None` → `exit 1` → the caller's `if _desc_out=$(read_target_desc …)` takes the pre-#349 branch → a C5 image with a **perfectly valid** descriptor is reported as *"no target descriptor in this image"* and staged **legacy-only**, invisible to boards routing on `smol/ota/staged/<chip>`. Fail-closed against publishing a wrong name, but **misattributed** — it sends whoever debugs it into the firmware's descriptor emission when the bug is a python dict in the publisher.

That dict was the **fourth copy of the chip roster** (`build-matrix.toml` · `budget.rs` · `net/target.rs` · here) and the one nothing compared — #350's checker only ever compared the first two. So the fix is not `4: "esp32c5"` alone:

- `build_matrix.py check` now asserts the publisher's map against `net/target.rs` **in both directions**. `net/target.rs` is authoritative because the id **is** #349's wire format.
- Two fixture cases prove the arm fails both ways: a short roster, and a same-id/different-name conflict.
- `--target-rs` / `--ota-publish` fixture hooks mirror the existing `--budget` / `--cargo` ones.
- Both parsers carry `budget_chips`-style **count guards** — a partial parse refuses rather than comparing a roster it cannot fully read.

## The (chip, profile) sha lineage

A per-chip profile override makes the #44 identity per **(chip, profile)**, not per chip: the S3 builds at opt-level 2 to dodge an Xtensa LLVM scavenger crash, opt-level moves sections, and two S3 images at different opt-levels differ and are *supposed* to. Recorded at the cargo invocation.

## #280's marker guard, at the packaging boundary

`assert_cargo_config "$REPRO_CHIP"` runs before the build. **Both** non-zero states are fatal here — a packaging-boundary judgement rather than the helper's default. `2` means "could not check" (unknown chip, or no declared markers), and an image whose build configuration could not be *verified* has no business becoming a published artifact — the same reasoning as the existing `off-fleet` refusal. A chip with no markers is a manifest gap to close before publishing it, and failing here applies the pressure.

## Evidence

Builds on familiar, working set under `/var/tmp/ftarget/413p2` per the disk directive.

- **C3 byte-identical through `repro_build_bin`** (above), verified twice
- **S3 packaged**: `7b6b1ccbfaccd735…`, 1,027,184 B, stack 96,668 B against its own 72,004 B floor
- suites: `test_stack_floor` **16/0** · `test_build_matrix` **15/0** (was 13, +2 roster cases) · `test_ota_publish_guards` **23/0** · `test_ota_ratchet` **16/0** · `build_matrix.py check` clean
- `bash -n` clean on `repro_build.sh`, `ota_publish.sh`, `gate.sh`, `test_build_matrix.sh`

## ⚠️ A 20 KB question, stated as hypothesis-with-arithmetic

This S3 fleet-tier build measures `.stack` **96,668 B**, while `ESP32S3_CYD.free_dram_bytes` declares **116,940** ("the fleet image's `.stack` section"). Delta: **20,272 B**.

**Hypothesis (team-lead's, arithmetic verified independently):** `docs/embassy/PHASE3-PLAN.md:494` records the #391 executor's cost as **20,264 B** of DRAM. `20,272 − 20,264 = 8 B`, comfortably inside the documented per-tree provisioning variance. So the row was likely measured on a **pre-#391** image (its provenance sha `5fd23661` dates from #411's development, which based before the executor landed) and this build is post-executor — the executor's `.bss` coming straight out of `.stack`, which is the `[[stack-is-not-headroom]]` mechanism exactly.

**Stated as hypothesis, not conclusion.** It affects no verdict here (both figures clear the 72,004 B floor). If it holds, that row's `free_dram_bytes` needs re-measuring on current main — routed to the s3-cyd lane, whose row it is.

## Not here — phase 3

The `readelf` parser rewrite and the artifact-metadata provenance surface. Both want a per-target **release job** to exist first, which is the natural boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
