### PR TITLE
docs(embassy): the leaf peak (67,400 B) refutes budget.rs's own premise — floor math worked, no constant moved

### DIFF
--- a/docs/embassy/T-SCOPE.md
+++ b/docs/embassy/T-SCOPE.md
@@ -263,11 +263,88 @@ rev-1.
      **byte-identical** to the fleet tier's (86,200 B), so the instrument costs zero DRAM and its
      peak is a peak for the shipped image rather than for a near-miss of it.
 
-   **Still gates T's merge, not T's scoping.** Until a lite run exists, the honest position for the
-   record is unchanged: `.stack` is unmoved by B1/B2 (86,200 B, A/B'd), so the **floor gate** is
-   safe; the **peak** is not measured, and a `select` frame is transient stack the region size
-   cannot see. **Nothing in T should spend the 12 KB until that number exists** — §3.2 confirms
-   12,000 B is all there is, with no reclamation behind it.
+   ### ✅ THE LEAF NUMBER IS IN — and it refutes a premise `budget.rs` states about itself
+
+   **high-water 67,400 B of an 85,096 B region (79% used, 17,696 B free).** 85 samples over ~14 min
+   of real leaf duty (re-election bursts and relay emits visible in the log), stable plateau
+   67,368 → 67,400, **not saturated**.
+
+   **Labels, per §5.1, because they are what make the number usable:** LITE/fleet composition ·
+   **LEAF duty only** (id8 held the crown; the crown leg needs JP's unplug and has not happened) ·
+   real-seeds image, region 85,096 B against the 86,200 B provisioned variant (known seed delta) ·
+   **the #398 boot probe was NOT captured** (attached post-boot). That last one is a real gap in the
+   validity argument, carried by the plateau signature, the instrument's C3 history, and the
+   zero-DRAM A/B — stated, not smoothed.
+
+   **It is a LOWER BOUND.** Crown duty adds pairs 4 and 5 (the OTA fetch, which carries a 4,096 B
+   `OTA_TCP_RX` and the deepest chains in the tree) plus gateway MQTT. The real fleet peak is
+   >= 67,400.
+
+   #### The premise that just expired
+
+   `budget.rs` says, at the floor's own derivation:
+
+   > *"every peak on record was measured **with the Bard narrating**, so for a Bard-free image this
+   > floor is an upper bound on what is required, not a target."*
+
+   **Measurement says the opposite.** The Bard-FREE fleet composition, under mere LEAF duty, peaks
+   **11,744 B ABOVE** the Bard-narrating crown peak (67,400 vs 55,656 — 1.21x). The premise was true
+   when written and expired on 2026-08-25: **all four recorded peaks (T13/#300, #302, #335) predate
+   #391.** The executor put a new floor under every call chain, and it — not Bard narration — is now
+   the dominant term. So 55,656 is not merely *unreproducible* (§the budget.rs note); it is
+   **superseded and low**.
+
+   #### The floor formula, worked through `budget.rs`'s own rules
+
+   The rule is `floor = ceil(peak x 4/3)`, compile-asserted, and the packaging gate is
+   `region >= floor`. Applying it to the new peak:
+
+   | | value |
+   |---|---|
+   | required floor at the new peak | `ceil(67,400 x 4/3)` = **89,867 B** |
+   | actual region (real seeds) | 85,096 B — **short by 4,771 B** |
+   | headroom actually present | 17,696 B = **1.263x** (policy wants 1.333x) |
+
+   The sharper form, which is the one to reason from: **at 4/3, an 85,096 B region can afford a peak
+   of 63,822 B. Leaf duty measures 67,400. The image is 3,578 B past its own policy — at a lower
+   bound.** Robust to the seed delta: the 86,200 B variant affords 64,650 and is still 2,750 B over.
+
+   #### Why the constant is NOT being updated here
+
+   Naively writing `ESP32C3_MEASURED_PEAK_BYTES = 67_400` fails in two places, and the second is the
+   real message:
+
+   1. the const assert `floor >= peak x 4/3` becomes `74,208 >= 89,867` → **the crate stops
+      compiling**;
+   2. raising the floor to 89,867 to satisfy it makes the packaging gate `region >= floor` read
+      `85,096 >= 89,867` → **nothing publishes.**
+
+   Two red gates on firmware that demonstrably runs. And updating a **ship-gating constant from a
+   lower bound** is the wrong direction of error regardless. So: the number is recorded here with
+   its labels, `budget.rs` gets a note that its premise is refuted, and **no constant moves until
+   the crown number exists.**
+
+   #### What the crown number now decides
+
+   It stopped being a nicety. It decides whether the fleet image is inside or outside its own
+   stack policy, and by how much — which is a JP/lead call, not a scoping one. Laying out the
+   options with numbers rather than picking one:
+
+   - **(a) grow the region.** The executor's 20,264 B of DRAM is **96.7% one object**: the embassy
+     task arena, `__embassy_main::POOL` = **19,600 B** (`.bss`, measured). It is sized by the
+     largest task future, and `run()` is the entire superloop as one `async fn`. That is the
+     single biggest lever in the image — and see §6.2, because **T adds `net_task` to that same
+     pool.**
+   - **(b) re-derive the multiplier, with a stated rationale.** 4/3 was calibrated when the
+     measurement was less representative (bench composition, narration workload). A
+     fleet-composition, real-duty peak arguably needs less compensation — but leaf-duty undercuts
+     that argument, so this cannot be settled before the crown leg.
+   - **(c) accept a documented lower ratio.** Legitimate, but it must be written down as a decision
+     with its reason, not arrived at by leaving the constant stale — which is precisely how the
+     previous floor ended up 480 B too low.
+
+   **Nothing in T should spend margin until the crown number exists.** §3.2 confirms 12,000 B (or
+   17,696 B against the real-seeds region) is all there is, with no reclamation behind it.
 2. **`StackResources<N>` sizing — ✅ MEASURED** (order-item 4, done; throwaway const-eval probe on
    the fleet tier, embassy-net 0.9.1 with smol's own feature set `tcp,udp,dhcpv4,medium-ethernet`):
 
@@ -283,9 +360,16 @@ rev-1.
 
    ⚠️ **`StackResources` is NOT T's memory cost, and must not be quoted as if it were.** It is the
    socket *bookkeeping*. The bring-up also needs per-socket rx/tx **buffers** (caller-provided, and
-   in this tree historically 512 B each), the `Stack`/`Runner`, and `net_task`'s own stack — none of
-   which is in the table above. What the table gives is one term, measured, so the others can be
-   added to something real instead of to an estimate.
+   in this tree historically 512 B each), the `Stack`/`Runner`, and `net_task` — none of which is in
+   the table above. What the table gives is one term, measured, so the others can be added to
+   something real instead of to an estimate.
+
+   **And `net_task`'s cost has a known home, which §6.1 found:** a spawned task's future lives in
+   the embassy task arena, `__embassy_main::POOL`, **already 19,600 B** of `.bss` for `run()` alone.
+   T does not merely add a stack — **it enlarges that arena by the size of `net_task`'s future**, in
+   the same `.bss` that shrinks `.stack`. Measure the POOL delta per tier in the same A/B as the
+   `.stack` delta; it is the term most likely to be missed, because nothing in the source names a
+   size.
 
    **The offsetting question T must answer (a question, not a claim):** the smoltcp-era NTP statics
    measured in §3.2 — 3,584 B — belong to `NtpMachine`, which T replaces. Whether T retires them,

--- a/rust/clock/src/budget.rs
+++ b/rust/clock/src/budget.rs
@@ -239,10 +239,30 @@ pub enum FloorProvenance {
 /// passed. It came in **+216 B above #302 and +800 B above T13** — the old floor was derived
 /// from the *lowest* of the four and was knowably 480 B too low.
 ///
-/// **Re-derive this when the peak moves**, with `--features stack-paint` under live radio;
-/// idle numbers are meaningless. A floor copied forward untested is how the last one ended up
-/// at 12,288 B. And note every peak on record was measured **with the Bard narrating**, so for
-/// a Bard-free image this floor is an upper bound on what is required, not a target.
+/// **Re-derive this when the peak moves**, with the paint instrument under live radio; idle numbers
+/// are meaningless. A floor copied forward untested is how the last one ended up at 12,288 B.
+///
+/// ## ⚠️ 2026-08-25 — THE "BARD IS THE DEEPEST PATH" PREMISE IS REFUTED BY MEASUREMENT
+///
+/// This block used to end: *"every peak on record was measured with the Bard narrating, so for a
+/// Bard-free image this floor is an upper bound on what is required, not a target."* That was true
+/// when written and is now **false**, and the sentence is kept above the correction because a
+/// reader who remembers it needs to meet the refutation, not its absence.
+///
+/// A `stack-paint-lite` run on the **Bard-FREE fleet composition**, under mere **LEAF** duty,
+/// measured **67,400 B** — **11,744 B ABOVE** the 55,656 B Bard-narrating crown peak in the table,
+/// and it is a LOWER bound (crown duty adds the OTA-fetch chains). The reason is dating: **all four
+/// peaks in that table predate #391.** The esp-rtos executor put a new floor under every call chain
+/// and is now the dominant term, not Bard narration. So 55,656 is not merely unreproducible — it is
+/// **superseded and low**.
+///
+/// ⚠️ **The constants below are deliberately UNCHANGED, and that is a decision, not an oversight.**
+/// Writing `ESP32C3_MEASURED_PEAK_BYTES = 67_400` would break the assert below (`74,208 >= 89,867`
+/// is false, so the crate stops compiling), and raising the floor to satisfy it would break the
+/// packaging gate (`region 85,096 >= floor 89,867` is false, so nothing publishes) — two red gates
+/// on firmware that runs. Updating a ship-gating constant from a LOWER BOUND is also the wrong
+/// direction of error. The crown-duty leg decides it. Full working, with the options and their
+/// numbers, in `docs/embassy/T-SCOPE.md` §6.1.
 pub const ESP32C3_STACK_FLOOR_BYTES: u32 = 74_208;
 
 /// The C3's floor is [`FloorProvenance::Derived`] — the strong form, and the only one on the fleet.


### PR DESCRIPTION
The `stack-paint-lite` leaf run landed, and it overturns a sentence `budget.rs` states about itself. **No constant is changed** — that is a decision, argued below.

## The number

**high-water 67,400 B of an 85,096 B region (79% used, 17,696 B free).** 85 samples over ~14 min of real leaf duty, plateau 67,368 → 67,400, **not saturated**.

**Labels, per §5.1:** LITE/fleet composition · **LEAF duty only** (crown leg pending JP's unplug) · real-seeds region 85,096 vs 86,200 provisioned · **the #398 boot probe was not captured**. That last is a real gap in the validity argument, carried by the plateau signature, the instrument's C3 history, and the zero-DRAM A/B — stated, not smoothed. **It is a lower bound**: crown duty adds pairs 4/5, the OTA fetch, the deepest chains in the tree.

## The premise that expired

`budget.rs` says, at the floor's derivation:

> *"every peak on record was measured **with the Bard narrating**, so for a Bard-free image this floor is an upper bound on what is required, not a target."*

The Bard-**free** fleet composition, under mere **leaf** duty, peaks **11,744 B above** the Bard-narrating crown peak (67,400 vs 55,656 — 1.21×). The sentence was true when written and expired on 2026-08-25: **all four peaks in that table predate #391.** The executor put a new floor under every call chain and is now the dominant term, not narration. So 55,656 is not merely *unreproducible* — it is **superseded and low**.

## The floor math, through budget.rs's own rule

Rule: `floor = ceil(peak × 4/3)`, compile-asserted; packaging gate `region >= floor`.

| | value |
|---|---|
| required floor at the new peak | `ceil(67,400 × 4/3)` = **89,867 B** |
| actual region (real seeds) | 85,096 B — **short by 4,771 B** |
| headroom present | 17,696 B = **1.263×** (policy wants 1.333×) |

**Sharper, and the form to reason from: at 4/3, an 85,096 B region affords a peak of 63,822 B. Leaf duty measures 67,400. The image is 3,578 B past its own policy — at a lower bound.** Robust to the seed delta: the 86,200 B variant affords 64,650 and is still 2,750 B over.

## Why no constant moves

Writing `ESP32C3_MEASURED_PEAK_BYTES = 67_400` fails twice, and the second is the real message:

1. the const assert becomes `74,208 >= 89,867` → **the crate stops compiling**;
2. raising the floor to satisfy it makes the packaging gate read `85,096 >= 89,867` → **nothing publishes**.

Two red gates on firmware that demonstrably runs — and updating a **ship-gating constant from a lower bound** is the wrong direction of error regardless. The crown leg decides it.

## What the crown number now decides — options with numbers, deliberately not picked

This is a budget-owner call, so it is laid out rather than settled:

- **(a) grow the region.** The executor's 20,264 B of DRAM is **96.7% one object**: the embassy task arena `__embassy_main::POOL` = **19,600 B** (`.bss`, measured), sized by the largest task future — and `run()` is the entire superloop as one `async fn`. The single biggest lever in the image.
- **(b) re-derive the multiplier**, with a stated rationale. 4/3 was calibrated on a less representative measurement; a fleet-composition real-duty peak arguably needs less compensation — but leaf duty undercuts that, so it cannot be settled before the crown leg.
- **(c) accept a documented lower ratio** — legitimate, but written down as a decision with its reason, not reached by leaving a constant stale. That is exactly how the previous floor ended up 480 B too low.

## Folded into §6.2

`net_task`'s future lands in that same 19,600 B POOL. **T does not merely add a stack — it enlarges the arena**, in the `.bss` that shrinks `.stack`. Measure the POOL delta in the same A/B as `.stack`; it is the term most likely to be missed, because nothing in the source names a size.

## Parser contract — verified, including how I got it wrong first

This edit sits directly above the line `repro_stack_floor` parses, and that function fails closed. My first check invoked it **without** the chip argument #413's 2A added; it errored, and a trailing `&&`-chained `echo` printed a success message anyway. The claim was true and the method was not — luck, not verification.

Actually verified: `repro_stack_floor esp32c3` → `74208 derived`, exit 0, **byte-identical** to the same call against the pre-edit `budget.rs` as a control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)