### PR TITLE
fix(tools): finish #426 — the ELECT checker imports the shared strip_comments (it was missed)

### DIFF
--- a/tools/check_elect_send_path.py
+++ b/tools/check_elect_send_path.py
@@ -43,6 +43,8 @@ Usage: tools/check_elect_send_path.py [repo-root]   (exit 0 ok, 1 violation, 2 m
 import re
 import sys
 from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from rust_comments import strip_comments  # noqa: E402  (#426 — one implementation, imported)
 
 # The frame's own prefix, spelled here so a rename of the const cannot silently empty arm 5.
 ELECT_LITERAL = 'b"SMOLv1 ELECT "'
@@ -70,83 +72,10 @@ def rust_sources(src: Path):
     return sorted(p for p in src.rglob("*.rs") if p.is_file())
 
 
-def strip_comments(text: str) -> str:
-    """Blank every comment, PRESERVING length and newlines so offsets and line numbers still map.
-
-    Not a nicety — it is load-bearing, and this checker was blind to it until #397 STEP B. A doc
-    comment written to EXPLAIN a raw send spelled it in `receiver.method(` form; arm 6 counted the
-    prose as a real call site and attributed it to whatever fn preceded the comment. A checker whose
-    verdict can be flipped by documentation about the thing it checks is worse than no checker,
-    because the same blindness runs the other way: comment out a real send and the count is still
-    satisfied — a false GREEN on an ABSENCE check, which is the one direction that matters here.
-
-    Shared implementation with `check_station_consumers.py`, where the identical defect was found
-    the same day (2026-08-25) by the same route — writing prose about the invariant. Two independent
-    instances in one day is a property of the template, not an accident; the sweep across the other
-    checkers built to this shape is tracked as #426.
-
-    Handles `//`, `/* */` (nested, as Rust allows), ordinary strings, char literals and raw strings
-    (`r"..."`, `r#"..."#`), because a `//` inside a string literal is not a comment and blanking it
-    would corrupt the code view.
-    """
-    out = list(text)
-    i, n = 0, len(text)
-    while i < n:
-        c = text[i]
-        # raw string: r"..." / r#"..."# / r##"..."##
-        if c == "r" and i + 1 < n and text[i + 1] in '"#':
-            j = i + 1
-            hashes = 0
-            while j < n and text[j] == "#":
-                hashes += 1
-                j += 1
-            if j < n and text[j] == '"':
-                close = '"' + "#" * hashes
-                end = text.find(close, j + 1)
-                i = n if end < 0 else end + len(close)
-                continue
-        if c == '"' or c == "'":
-            quote = c
-            j = i + 1
-            while j < n:
-                if text[j] == "\\":
-                    j += 2
-                    continue
-                if text[j] == quote:
-                    j += 1
-                    break
-                if text[j] == "\n" and quote == "'":
-                    break  # not a char literal after all (e.g. a lifetime)
-                j += 1
-            i = j
-            continue
-        if c == "/" and i + 1 < n and text[i + 1] == "/":
-            j = text.find("\n", i)
-            j = n if j < 0 else j
-            for k in range(i, j):
-                out[k] = " "
-            i = j
-            continue
-        if c == "/" and i + 1 < n and text[i + 1] == "*":
-            depth, j = 0, i
-            while j < n:
-                if text.startswith("/*", j):
-                    depth += 1
-                    j += 2
-                elif text.startswith("*/", j):
-                    depth -= 1
-                    j += 2
-                    if depth == 0:
-                        break
-                else:
-                    j += 1
-            for k in range(i, min(j, n)):
-                if out[k] != "\n":
-                    out[k] = " "
-            i = j
-            continue
-        i += 1
-    return "".join(out)
+# strip_comments moved to tools/rust_comments.py (#426). This file was where the SECOND copy
+# lived — it was lifted verbatim from check_station_consumers.py the same day, and its
+# docstring claimed to be a "shared implementation" while being a copy. The sweep made the
+# module real; this import is what finally makes that claim true.
 
 def enclosing_fn(text: str, idx: int):
     """Name of the nearest `fn` declared at or above `idx`. None if there isn't one."""


### PR DESCRIPTION
#435 extracted `tools/rust_comments.py` and converted **four** checkers — `check_byte_free`, `check_diag_budget`, `check_station_consumers`, `check_verifier_wiring`. `check_elect_send_path.py` was not among them, so on merged main there are still **two** definitions of `strip_comments`, not one.

**Benign, and that is why it went unnoticed:** the ELECT checker kept its own verbatim copy, so it still stripped correctly and its suite stayed green. The cost is precisely the one #426 exists to remove — a fix to `rust_comments.py` would not reach the checker guarding the ELECT egress invariant.

This is also the copy with the history: it was lifted from `check_station_consumers.py` hours after that file was written, carrying a docstring calling itself a *"shared implementation"* while being a copy. The module made that claim achievable; this import makes it true.

**Verified**

```
def strip_comments in tree      : 1  (tools/rust_comments.py)
check_elect_send_path.py        : 4 raw send sites across 4 declared fns, exit 0
tools/test_check_elect_send_path.sh : 16 passed, 0 failed
```

Both comment-regression arms are in that 16 — prose naming both send forms stays **green**, a commented-out real send is still **caught** — so behaviour is unchanged across the substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)