### PR TITLE
fix(tools): correct the anchoring claim — "// is safe" is a pattern property, not a checker one (#426)

### DIFF
--- a/tools/rust_comments.py
+++ b/tools/rust_comments.py
@@ -23,11 +23,29 @@ Both directions are real and the cheap-looking one is not the dangerous one:
                ABSENCE check's whole job to notice that. `check_verifier_wiring` was proved to
                report a module SOUND — wired into main.rs — with its `mod` decl inside `/* */`.
 
-── `//` IS SAFE; `/* */` IS THE VECTOR ───────────────────────────────────────────────────────
-Every Rust-side checker anchors its patterns with `^\s*`, so a LINE comment can never match: the
-`//` sits where the anchor demands whitespace. A BLOCK comment puts the construct at line-start
-and the anchor stops helping. This is why the defect survived so long, and why probing with `//`
-— the obvious first attempt — returns a clean bill of health on every one of them.
+── WHICH COMMENT SYNTAX REACHES A CHECKER IS A PROPERTY OF ITS PATTERN, NOT OF THE CHECKER ────
+An earlier draft of this header said "`//` is safe everywhere — every Rust-side checker anchors
+with `^\s*`". morpheus-391 corrected it, and the counter-example is the checker it wrote:
+
+    RAW_SEND_RE = re.compile(r"esp_now\s*\.\s*send(?:_async)?\s*\(")   # UNANCHORED
+    DEVICE_CTOR = "SmolWifiDevice::new"                              # UNANCHORED substring
+
+Both match inside a `///` doc comment, and that is exactly how #397 STEP B1 tripped its own gate.
+So the honest statement is narrower:
+
+  * ANCHORED patterns (`^\s*(?:pub )?mod X;`, `^\s*#\[cfg(..)\]`) cannot match a LINE comment —
+    the `//` sits where the anchor demands whitespace. They CAN match inside a BLOCK comment,
+    which puts the construct at line-start and defeats the anchor. That is the vector that made
+    `check_verifier_wiring` report a module SOUND with its `mod` decl inside `/* */`.
+  * UNANCHORED patterns match in either kind of comment, with nothing to stop them.
+
+The moment someone adds an unanchored pattern to a checker that reasoned "my patterns are
+anchored, so I do not need stripping", `//` becomes a live vector again with no warning. That is
+the argument for stripping UNCONDITIONALLY here rather than per-checker reasoning about which
+comment syntax can reach which regex — the reasoning is correct today and silently expires.
+
+Practical consequence for anyone auditing a checker: probing with `//` alone can return a clean
+bill of health from an anchored-pattern checker that is still vulnerable to `/* */`. Probe both.
 
 ── SOME CHECKERS READ COMMENTS ON PURPOSE ────────────────────────────────────────────────────
 `check_shed_order` (SHED-ORDER:), `check_diag_budget` (DIAG-WIDTHS:/DIAG-TAIL:) and

--- a/tools/test_comment_blind.sh
+++ b/tools/test_comment_blind.sh
@@ -13,11 +13,16 @@
 #   false RED    prose about the invariant must not trip the gate
 #   false GREEN  a real site commented out must not still count
 #
-# ── `//` IS SAFE; `/* */` IS THE VECTOR ───────────────────────────────────────────────────────
-# Every Rust-side checker anchors with `^\s*`, so a LINE comment can never match. Probing with
-# `//` returns a clean bill of health on all of them, which is how this survived. Every probe
-# below therefore uses a BLOCK comment; a `//` probe would pass against the unfixed code too and
-# prove nothing.
+# ── PROBE BOTH COMMENT SYNTAXES — "// is safe" IS A PATTERN PROPERTY, NOT A CHECKER PROPERTY ──
+# An earlier draft of this file asserted `//` was safe everywhere because the checkers anchor with
+# `^\s*`. morpheus-391 corrected it: `check_elect_send_path`'s `RAW_SEND_RE` and
+# `check_station_consumers`'s `DEVICE_CTOR` are UNANCHORED and match inside a `///` doc comment —
+# which is how #397 STEP B1 tripped its own gate. Those two are safe only because they now strip.
+#
+# So: ANCHORED patterns are immune to `//` and vulnerable to `/* */` (which puts the construct at
+# line-start and defeats the anchor); UNANCHORED patterns are vulnerable to both. Probing with `//`
+# alone can therefore return a clean bill of health from a checker that is still broken — which is
+# what a first pass over these did. The block-comment probes below are the ones that bite.
 #
 # USAGE:  tools/test_comment_blind.sh        # exit 0 = every arm behaved
 set -uo pipefail


### PR DESCRIPTION
**Narrowed.** This now carries only the part no other PR does: the anchoring-claim correction. morpheus-391's **#441** lands the `check_elect_send_path.py` conversion — its file, and it has already verified it at 16/16. No overlap; the elect checker is byte-identical to main here.

## Why this is its own PR: main is currently asserting something false, and I wrote it

`tools/rust_comments.py` and `tools/test_comment_blind.sh` say:

> *"`//` is safe everywhere — every Rust-side checker anchors with `^\s*`."*

False as a general property. The counter-examples are the two checkers that already strip:

```
RAW_SEND_RE = re.compile(r"esp_now\s*\.\s*send(?:_async)?\s*\(")   # UNANCHORED
DEVICE_CTOR = "SmolWifiDevice::new"                                # UNANCHORED

  RAW_SEND_RE vs a `///` comment : True
  DEVICE_CTOR vs a `///` comment : True
  anchored MOD vs "// pub mod x;": False
```

Both match inside a `///` doc comment — which is exactly how #397 STEP B1 tripped its own gate. Those two are safe *now* only because they strip.

Leaving it is this issue's own defect one level up: **a confident, wrong sentence in the documentation of the module that exists to stop confident, wrong verdicts.** And "line comments are safe" is precisely the kind of claim that gets quoted later without its qualifier.

## The accurate statement, now in both files

Which comment syntax can reach a checker is a property of its **pattern**, not of the checker.

- **Anchored** patterns cannot match a **line** comment — the `//` sits where the anchor demands whitespace — but **can** match inside a **block** comment, which puts the construct at line-start and defeats the anchor. That is what made `check_verifier_wiring` report a module SOUND.
- **Unanchored** patterns match in either, with nothing to stop them.

The moment an unanchored pattern lands in a checker that reasoned *"mine are anchored, so I don't need stripping"*, `//` is live again **with no warning**. That's the argument for stripping **unconditionally** rather than reasoning per-checker about which syntax reaches which regex — the reasoning is correct today and expires silently.

**Practical consequence, and why it's worth a PR rather than a follow-up someday:** an auditor probing with `//` alone can get a clean bill of health from a checker that is still broken. My own first pass over these did exactly that.

Correction due to **morpheus-391**, credited in the file.

`test_comment_blind`: 11 ok, 0 failed.

---

### Provenance, since two of us chased this

This is the tail of #435 that missed its merge — #435 merged at head `a57bcc3`, this landed on the branch afterwards. Both @team-lead and morpheus-391 independently caught that the elect conversion wasn't on main, from the tree rather than from my report. They were right: my "there is one `strip_comments` in the tree" was true in my worktree and false on main, which is the same present-to-a-human/absent-to-the-machine shape this issue is about, one level up in a status report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)