### PR TITLE
feat(coexist): #335 pre-step — CrownApDecision::Deferred, so "I didn't look" stops meaning "there's nothing"

### DIFF
--- a/experiments/ap_select_verify/src/main.rs
+++ b/experiments/ap_select_verify/src/main.rs
@@ -90,6 +90,27 @@ fn main() {
     assert_eq!(crown_next_state(CrownState::Degraded, off, 9, succ), CrownState::Shed, "degraded yields to a cc=1 successor");
     assert_eq!(crown_next_state(CrownState::Degraded, off, 9, no_ctx), CrownState::Degraded, "degraded + no co-channel + no successor → STAY (never crownless)");
 
+    // ---- #335 Deferred: an UNANSWERED question moves NOTHING -------------------------------
+    // The whole point of the variant. `NoAp` and `OffChannelFallback` are findings the ladder is
+    // entitled to act on; a deferral is not a finding, and before #335 it had no way to say so —
+    // both skip-shaped returns in `reassoc_ch6_prefer` spelled themselves `NoAp`, so a mesh-OTA
+    // relay and a failed scan each fed the shed ladder evidence they did not have.
+    //
+    // Neutrality is asserted from EVERY state and under EVERY ctx that would otherwise move it,
+    // because "it happens not to move right now" and "it cannot move" are different claims and
+    // only the second is the invariant.
+    let defer = CrownApDecision::Deferred;
+    assert_eq!(crown_next_state(CrownState::Normal, defer, 0, no_ctx), CrownState::Normal, "deferred: normal stays normal");
+    assert_eq!(crown_next_state(CrownState::Normal, defer, 0, exhausted), CrownState::Normal, "DEFERRED MUST NOT SHED: exhausted+deferred is NOT off-channel evidence");
+    assert_eq!(crown_next_state(CrownState::Shed, defer, SHED_RECLAIM_MAX, no_ctx), CrownState::Shed, "DEFERRED MUST NOT ESCALATE: reclaims>=MAX but nothing was measured");
+    assert_eq!(crown_next_state(CrownState::Shed, defer, 0, no_ctx), CrownState::Shed, "deferred: shed stays shed");
+    assert_eq!(crown_next_state(CrownState::Degraded, defer, 9, succ), CrownState::Degraded, "DEFERRED MUST NOT YIELD: a successor claim is not acted on without a scan");
+    assert_eq!(crown_next_state(CrownState::Degraded, defer, 9, no_ctx), CrownState::Degraded, "deferred: degraded stays degraded");
+    // And it must not RECOVER either — neutral is neutral in both directions. A deferral is not
+    // evidence that a co-channel AP appeared, so it cannot promote a shed crown back to Normal.
+    assert_eq!(crown_next_state(CrownState::Shed, defer, 0, no_ctx), CrownState::Shed, "deferred does not promote: shed !-> normal without a co-channel finding");
+    assert_eq!(crown_next_state(CrownState::Degraded, defer, 0, no_ctx), CrownState::Degraded, "deferred does not promote: degraded !-> normal without a co-channel finding");
+
     // ---- OTA-enable gate ------------------------------------------------------------------
     assert!(ota_enabled(CrownState::Normal), "OTA only when normal");
     assert!(!ota_enabled(CrownState::Degraded), "OTA disabled when degraded");

--- a/rust/clock/src/net/coexist.rs
+++ b/rust/clock/src/net/coexist.rs
@@ -29,7 +29,34 @@ pub enum CrownApDecision {
     /// STRAND signal that feeds the [`crown_next_state`] shed→degraded ladder.
     OffChannelFallback { bssid: [u8; 6], ch: u8 },
     /// No target-SSID AP visible at all.
+    ///
+    /// ⚠️ This is EVIDENCE: "I looked and there was nothing." It feeds the shed ladder. Do not
+    /// reach for it to mean "I did not look" — that is [`Deferred`](Self::Deferred), and the two
+    /// were conflated until #335.
     NoAp,
+    /// **The question was not answered.** No scan happened, or it failed, or the answer did not
+    /// arrive in time — so this carries NO information about the AP situation.
+    ///
+    /// ── WHY A FOURTH VARIANT RATHER THAN REUSING `NoAp` (#335, Addendum A.5) ──────────────────
+    /// `NoAp` and `OffChannelFallback` are both *findings*; the ladder is entitled to act on them
+    /// and does. A failure to look is not a finding, and spending it as one sheds a crown on the
+    /// strength of a scan that never ran. The tree already said so, at
+    /// `mode.rs::reassoc_ch6_prefer`: *"the only 'skip' value available is `NoAp` — which the
+    /// caller cannot distinguish from 'no usable AP exists' and would act on by shedding the
+    /// crown … If this path ever needs guarding, give the decision an explicit `Deferred` variant
+    /// first — do NOT reuse `NoAp`."* This is that variant; that note is now discharged.
+    ///
+    /// The same vocabulary already exists one layer down — `may_scan`'s **"DEFER, NEVER ABANDON"**
+    /// — so this is the decision type catching up with a concept the heap gate already had.
+    ///
+    /// **Contract for producers:** emitting `Deferred` obliges you to leave whatever drives the
+    /// retry untouched, so the question gets asked again on a later tick. A deferred-and-forgotten
+    /// scan is worse than a reboot, because it strands the node while it still looks alive.
+    ///
+    /// **Contract for consumers:** treat it as a NO-OP. [`crown_next_state`] returns the current
+    /// state unchanged for it — not "not co-channel", which is what a `_` arm would have silently
+    /// made it.
+    Deferred,
 }
 
 /// A co-channel AP weaker than this (dBm) is excluded — it can't sustain the ~1 MB pull. Best-RSSI
@@ -108,36 +135,52 @@ pub fn crown_next_state(
     shed_reclaims: u8,
     ctx: CrownCtx,
 ) -> CrownState {
+    // #335: an UNANSWERED question moves nothing, in either direction. Checked first, before any
+    // state arm, because every arm below is written in terms of "co-channel or not" — and a
+    // deferral is neither. This is also why the arms no longer use a `_` wildcard: a wildcard
+    // would have absorbed this variant silently and given it "not co-channel" semantics, which is
+    // precisely the shed-on-a-scan-that-never-ran bug the variant exists to prevent. Adding a
+    // fifth variant must now FAIL TO COMPILE here until someone decides what it means to the
+    // ladder.
+    if matches!(dec, CrownApDecision::Deferred) {
+        return cur;
+    }
     match cur {
         CrownState::Normal => match dec {
             CrownApDecision::CoChannel { .. } => CrownState::Normal,
-            _ => {
+            CrownApDecision::OffChannelFallback { .. } | CrownApDecision::NoAp => {
                 if ctx.reassoc_exhausted {
                     CrownState::Shed
                 } else {
                     CrownState::Normal
                 }
             }
+            // Unreachable — handled above. Spelled out so the match stays exhaustive without a
+            // wildcard, which is the property that makes a future variant a compile error.
+            CrownApDecision::Deferred => cur,
         },
-        CrownState::Shed => {
-            if matches!(dec, CrownApDecision::CoChannel { .. }) {
-                return CrownState::Normal;
+        CrownState::Shed => match dec {
+            CrownApDecision::CoChannel { .. } => CrownState::Normal,
+            CrownApDecision::OffChannelFallback { .. } | CrownApDecision::NoAp => {
+                if shed_reclaims >= SHED_RECLAIM_MAX {
+                    CrownState::Degraded
+                } else {
+                    CrownState::Shed
+                }
             }
-            if shed_reclaims >= SHED_RECLAIM_MAX {
-                CrownState::Degraded
-            } else {
-                CrownState::Shed
+            CrownApDecision::Deferred => cur,
+        },
+        CrownState::Degraded => match dec {
+            CrownApDecision::CoChannel { .. } => CrownState::Normal,
+            CrownApDecision::OffChannelFallback { .. } | CrownApDecision::NoAp => {
+                if ctx.better_successor_cc {
+                    CrownState::Shed
+                } else {
+                    CrownState::Degraded
+                }
             }
-        }
-        CrownState::Degraded => {
-            if matches!(dec, CrownApDecision::CoChannel { .. }) {
-                return CrownState::Normal;
-            }
-            if ctx.better_successor_cc {
-                return CrownState::Shed;
-            }
-            CrownState::Degraded
-        }
+            CrownApDecision::Deferred => cur,
+        },
     }
 }
 

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -3629,16 +3629,28 @@ impl RadioManager {
     /// ⚠️ HW-CANARY-GATED: the scan + reassociate radio path — and whether ESP-NOW coexist follows
     /// the new STA channel — cannot be verified without hardware (same discipline as `run_scan`/OTA).
     /// #367: deliberately NOT heap-gated, unlike `run_scan`. This returns a `CrownApDecision`, and
-    /// the only "skip" value available is `NoAp` — which the caller cannot distinguish from "no
-    /// usable AP exists" and would act on by shedding the crown. Trading a possible allocation
-    /// spike for a spurious crown shed is a bad trade: the shed is certain, the spike is not.
-    /// If this path ever needs guarding, give the decision an explicit `Deferred` variant first —
-    /// do NOT reuse `NoAp`.
+    /// at the time the only "skip" value available was `NoAp` — which the caller cannot distinguish
+    /// from "no usable AP exists" and would act on by shedding the crown. Trading a possible
+    /// allocation spike for a spurious crown shed was a bad trade: the shed is certain, the spike
+    /// is not. That note ended: *"If this path ever needs guarding, give the decision an explicit
+    /// `Deferred` variant first — do NOT reuse `NoAp`."*
+    ///
+    /// ✅ **#335 DISCHARGED IT.** [`CrownApDecision::Deferred`] exists, `crown_next_state` treats it
+    /// as a no-op, and the two skip-shaped returns in this function now use it. So the precondition
+    /// #367 named is satisfied and **heap-gating this path is unblocked** — but deliberately NOT
+    /// done here, because that is a behaviour change with its own risk budget and this commit is a
+    /// vocabulary change. Whoever takes it: the gate is `may_scan`, and its "DEFER, NEVER ABANDON"
+    /// contract is now expressible in the return type.
     fn reassoc_ch6_prefer(&mut self) -> crate::net::coexist::CrownApDecision {
         use crate::net::coexist::{select_crown_ap, ApView, CrownApDecision};
         // COEXIST hard gate: never leave the mesh channel mid mesh-OTA transfer (mirrors run_scan).
+        // #335: `Deferred`, not `NoAp`. This is a DECLINED LOOK — no scan ran — and it returns
+        // EARLY, before the stay-put guard below, so whatever it says reaches `crown_next_state`
+        // unfiltered. As `NoAp` that was the shed ladder being fed "there is no AP" by a gate whose
+        // only claim is "not right now", for the whole duration of every mesh-OTA relay. The retry
+        // is untouched (the caller re-enters on a later tick), which is `Deferred`'s contract.
         if self.ota_leaf.is_active() {
-            return CrownApDecision::NoAp;
+            return CrownApDecision::Deferred;
         }
         let net = &crate::secrets::WIFI_NETWORK;
         // #217 rung-3: incumbent view for the ≥6 dB hysteresis (live rssi via `rssi()` — nebula
@@ -3698,7 +3710,10 @@ impl RadioManager {
                 }
                 select_crown_ap(&views, ESP_NOW_FIXED_CHANNEL, cur)
             }
-            Err(_) => CrownApDecision::NoAp,
+            // #335: a scan that FAILED is not a scan that found nothing. As `NoAp` this spent a
+            // radio error as evidence about the RF environment; `Deferred` says only that the
+            // question went unanswered, and the next tick asks again.
+            Err(_) => CrownApDecision::Deferred,
         };
         // #gateway-election issue 2: a transient scan that MISSED our co-channel incumbent must NOT
         // reassociate us to a WORSE off-channel AP. HW bug: after a fetch-leg-deaf fail, this reassoc
@@ -3722,7 +3737,10 @@ impl RadioManager {
         let (bssid, chan): (Option<[u8; 6]>, Option<u8>) = match decision {
             CrownApDecision::CoChannel { bssid, ch }
             | CrownApDecision::OffChannelFallback { bssid, ch } => (Some(bssid), Some(ch)),
-            CrownApDecision::NoAp => (None, None),
+            // Nothing to pin in either case, for different reasons: `NoAp` looked and found none,
+            // `Deferred` never looked. Named separately rather than merged so the distinction
+            // survives the next edit.
+            CrownApDecision::NoAp | CrownApDecision::Deferred => (None, None),
         };
         // #278/#269 ANNOUNCE BEFORE THE MOVE. This is the last instant the crown is still reachable
         // by the fleet it is about to leave: `disconnect_async` is on the next line. 802.11 solves
@@ -3773,6 +3791,16 @@ impl RadioManager {
         self.my_ap_channel = match decision {
             CrownApDecision::CoChannel { ch, .. } | CrownApDecision::OffChannelFallback { ch, .. } => ch,
             CrownApDecision::NoAp => 0,
+            // #335: KEEP THE PREVIOUS BELIEF. `0` here would mean "we know we are off-channel",
+            // and a deferral knows nothing — writing 0 would erase a still-valid channel on the
+            // strength of a scan that never ran, and `my_ap_channel` gates the stay-put guard
+            // above, so the erasure would disarm the very protection that stops a transient miss
+            // downgrading a healthy co-channel crown.
+            //
+            // This arm was found by the COMPILER, not by review: removing the `_` wildcards in
+            // `crown_next_state` surfaced a third consumer of this enum that a wildcard here had
+            // been quietly absorbing. That is the argument for exhaustive matches, in one commit.
+            CrownApDecision::Deferred => self.my_ap_channel,
         };
         log::warn!(
             "smol #217r3: crown reassoc → co_channel={} ap_ch={} mesh_ch={}",


### PR DESCRIPTION
T pre-step per PHASE3-PLAN **Addendum A.5**, its own commit as that section requires. A **vocabulary** change: no behaviour added, one conflation removed.

## The tree already specified this — and the note is now discharged

`mode.rs::reassoc_ch6_prefer` has said since #367:

> *"the only 'skip' value available is `NoAp` — which the caller cannot distinguish from 'no usable AP exists' and would act on by shedding the crown. … If this path ever needs guarding, give the decision an explicit `Deferred` variant first — do NOT reuse `NoAp`."*

**#367 declined to heap-gate that path for want of this variant, and wrote that down.** The vocabulary already existed one layer lower — `may_scan`'s **"DEFER, NEVER ABANDON"** — so this is the decision type catching up with a concept the heap gate had and couldn't express.

## What was wrong — not only future-proofing

**Two existing returns spelled "couldn't answer" as "looked and found nothing"**, and both fed the shed ladder:

| site | what actually happened | was |
|---|---|---|
| COEXIST hard gate (`ota_leaf.is_active()`) | **no scan runs at all** — and it returns *early*, before the stay-put guard, so its verdict reached `crown_next_state` unfiltered for the whole duration of every mesh-OTA relay | `NoAp` |
| `Err(_)` from the scan | a radio error spent as evidence about the RF environment | `NoAp` |

## The ladder, and the wildcards

`crown_next_state` treats `Deferred` as a **no-op** — returns the current state, checked before any state arm.

**And the `_` wildcards are gone.** A wildcard would have absorbed the new variant silently and handed it *"not co-channel"* semantics — precisely the shed-on-a-scan-that-never-ran bug the variant exists to prevent. A fifth variant must now **fail to compile** until someone decides what it means to the ladder.

**That discipline paid immediately.** Removing the wildcards surfaced a **third consumer review had missed**: `mode.rs:3791`, which sets `my_ap_channel` from the decision. *The compiler found it, not me.* It now keeps the previous belief — writing `0` would assert *"we know we are off-channel"*, and since `my_ap_channel` gates the stay-put guard, erasing it would **disarm the very protection** that stops a transient scan miss downgrading a healthy co-channel crown.

Heap-gating `reassoc_ch6_prefer` is now **unblocked but deliberately not done here** — that's a behaviour change with its own risk budget; this commit is vocabulary. Noted at the site for whoever takes it.

## Host-proven — 8 new cases

Neutrality asserted from **every state, under every ctx that would otherwise move it**, because *"does not move right now"* and *"cannot move"* are different claims and only the second is the invariant:

- must not **shed** — `Normal` + `exhausted` stays `Normal`
- must not **escalate** — `Shed` at `reclaims >= MAX` stays `Shed`
- must not **yield** — `Degraded` with a `cc=1` successor stays `Degraded`
- must not **promote** — a deferral is not evidence a co-channel AP appeared, so it cannot recover `Shed`/`Degraded` → `Normal`

## Measured — true A/B, same tree, shared seeds

```
.stack   86,200 B -> 86,200 B    ZERO movement
.text   876,120 B -> 876,092 B   -28 B

gate.sh fw + host + excl : all three GATE GREEN
ap_select_verify         : ALL CHECKS PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)