### PR TITLE
targets/c6-watch refresh: S3 has-pmu power gating (silence phantom-chip spam)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,11 @@ mesh-ota = ["dep:ota-proto", "dep:sha2"]
 # are byte-identical. Pixel-correctness needs a matrix on the bench; the math
 # + wire are host-tested in cast-core.
 cast = ["dep:cast-core"]
+# bard (#300): the on-device SBRD storyteller. Opt-in — the 277 KB model
+# blob + inference land in the image only with this feature. Default off, so
+# shipping C6/C5/S3 builds are byte-identical; on-device generation is
+# proven at a tether (the pure engine is host-tested, 40 golden cases).
+bard = ["dep:bard-core"]
 
 # Hardware capabilities. Empty markers — they exist to be cfg'd on.
 # AXP2101 PMU: battery gauge, power-key latch, power page.
@@ -296,6 +301,7 @@ mesh-elect = { path = "crates/mesh-elect" }
 mesh-flood = { path = "crates/mesh-flood" }
 ota-proto = { path = "crates/ota-proto", optional = true }
 cast-core = { path = "crates/cast-core", optional = true }
+bard-core = { path = "crates/bard-core", optional = true }
 # mesh-OTA readback verify (ota_mesh.rs); same pin as ota-proto's.
 sha2 = { version = "0.10", default-features = false, optional = true }
 # #58: pure-logic HA climate parse/encode (oracle-t9 CONFIRMED-CLEAN @5c0d04c) —

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -24,6 +24,10 @@ JP's standing goal: **the watch as a full smol target, all features + parity, on
 - Mesh protocol is UNFORKED by vendoring smol's pure modules verbatim (mesh-flood, ota-proto) — re-vendor on wire changes, never edit locally.
 
 
+## S3 IS A FUNCTIONAL FLEET LEAF (2026-08-26)
+
+#447 soak CLEAN: eldritch-insignia joins the mesh as id 162 (0 reboots, 20/20 relays acked, associated). Fix ladder: PSRAM init → internal 96KB → **PSRAM-first (radio reserve)**. smol#448 has the post-soak polish (has-pmu gate + MQTT retry). Awaiting: JP's glass verdict, #446/#447/#448 merges, then blessed-sha build. C5 = morpheus's branch (image 9); C6 shipping.
+
 ## HOLD-OPEN STATE (2026-08-25 end — staying live for bench relays per JP)
 
 **Everything code-reachable from this seat is done, pushed, or specced.** All 3 fleet boards physically absent; gatekeeper refuses ssh (JP on the AP, #89).

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -30,7 +30,7 @@ JP's standing goal: **the watch as a full smol target, all features + parity, on
 
 Landed today (watch main tip 242182c): full board seam (C6/C5/S3) · Luna's ui/cyd scene · S3 ILI9341V+touch drivers · S3 PSRAM fix (the reboot-loop root cause, 8a6ad9e) · §1d board-facts · provision.py · #75 wedge fix · BLE reclaim · #90 announce · refusal-path hardening · the ENTIRE #36 services layer host-tested (mesh-flood[flood/wire/etx/cfgsched], mesh-ledger[L1-L4], ota-proto[+leaf], cast-core, bard-core[40 golden]) · multihop #64 + mesh-OTA #86 wired live on all 3 boards · cast wired (feature) · bard on-device (feature). 409 host tests, 3 arms link.
 
-smol PRs pending merge (smol-d8): #445 (S3 PSRAM refresh — bench needs it for second first-light). Earlier refreshes #417/#423/#427/#444 merged.
+smol PRs: #417/#423/#427/#444/#445 ALL MERGED (445 at 02:54Z 2026-08-26 — the PSRAM fix is in targets/c6-watch on smol main; s3-cyd unblocked for second first-light via the canonical path).
 
 **Waiting on (external, will arrive as relays):**
 - S3 SECOND first-light: s3-cyd rebuilds from #445. Watch for `[PSRAM] octal, 8192 KB` boot line.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -22,3 +22,21 @@ JP's standing goal: **the watch as a full smol target, all features + parity, on
 - morpheus's branches: never commit to them; the refused: error contract is shared (prefix, not suffix).
 - CYD/S3 physical flashing stays behind their sessions' serial-pinned guards.
 - Mesh protocol is UNFORKED by vendoring smol's pure modules verbatim (mesh-flood, ota-proto) — re-vendor on wire changes, never edit locally.
+
+
+## HOLD-OPEN STATE (2026-08-25 end — staying live for bench relays per JP)
+
+**Everything code-reachable from this seat is done, pushed, or specced.** All 3 fleet boards physically absent; gatekeeper refuses ssh (JP on the AP, #89).
+
+Landed today (watch main tip 242182c): full board seam (C6/C5/S3) · Luna's ui/cyd scene · S3 ILI9341V+touch drivers · S3 PSRAM fix (the reboot-loop root cause, 8a6ad9e) · §1d board-facts · provision.py · #75 wedge fix · BLE reclaim · #90 announce · refusal-path hardening · the ENTIRE #36 services layer host-tested (mesh-flood[flood/wire/etx/cfgsched], mesh-ledger[L1-L4], ota-proto[+leaf], cast-core, bard-core[40 golden]) · multihop #64 + mesh-OTA #86 wired live on all 3 boards · cast wired (feature) · bard on-device (feature). 409 host tests, 3 arms link.
+
+smol PRs pending merge (smol-d8): #445 (S3 PSRAM refresh — bench needs it for second first-light). Earlier refreshes #417/#423/#427/#444 merged.
+
+**Waiting on (external, will arrive as relays):**
+- S3 SECOND first-light: s3-cyd rebuilds from #445. Watch for `[PSRAM] octal, 8192 KB` boot line.
+- C5 on glass: morpheus image 9 under test; his feat/cyd-c5-gating driver merge is his lane.
+- cast pixels (WLED matrix), cross-arch mesh-OTA + multihop (multi-node windows): bench verifications.
+- story E2E: JP's AP fix (#89).
+- bard screen: spec at docs/specs/2026-08-25-bard-screen-spec.md → Luna + glass.
+
+**On a relay:** if a bench reports a bug, root-cause + fix + push + refresh-PR (the PSRAM pattern). If a verification passes, mark the issue. No polling — relays arrive via SendMessage.

--- a/crates/bard-core/src/lib.rs
+++ b/crates/bard-core/src/lib.rs
@@ -22,3 +22,7 @@ pub mod nano_llm;
 pub mod persona;
 pub mod textflow;
 pub mod tokenizer;
+
+/// The flash-resident SBRD story model (277 KB). On device this bloats the
+/// image only when a consumer includes it; the firmware's `bard` feature does.
+pub const MODEL: &[u8] = include_bytes!("../model/stories260K-q8.bin");

--- a/crates/mesh-flood/tests/protocol.rs
+++ b/crates/mesh-flood/tests/protocol.rs
@@ -132,3 +132,89 @@ fn cfgsched_round_robin_never_starves_the_tail() {
     assert!(*min > 0, "every entry was relayed at least once (no tail starvation)");
     assert!(max - min <= 1, "round-robin stays fair: {hit:?}");
 }
+
+// ---- multi-node COMPOSITION (de-risks the multi-node bench window) ----------
+// The unit tests above cover each piece; these drive the pieces AGAINST each
+// other, the way three real nodes would: a stranded leaf escalates and emits
+// UP2, a relay forwards it, a second relay dedups it, and the gateway
+// reassembles. If the pieces compose wrong (hop math, dedup key, envelope
+// re-encode), it surfaces here in software instead of on the bench.
+
+#[test]
+fn stranded_leaf_reaches_gateway_through_one_relay() {
+    use mesh_flood::flood::{forward_decision, ForwardAction, HopLatch, SeenSet, MAX_HOP};
+    use mesh_flood::wire::{encode_relay, encode_up2, parse_up2};
+
+    // LEAF: three unacked relays -> latch -> emits at MAX_HOP.
+    let mut leaf = HopLatch::new();
+    for _ in 0..3 {
+        leaf.on_relay_exhausted(false);
+    }
+    assert!(leaf.latched());
+    let hop = leaf.origin_hop(false);
+    assert_eq!(hop, MAX_HOP);
+
+    // Leaf wraps its telemetry RELAY fragment in a UP2 envelope at that hop.
+    let origin = 176u8; // arcane-beacon
+    let env_msgid = 4242u16;
+    let mut inner = [0u8; 96];
+    let ilen = encode_relay(origin, 7, 0, 1, b"telemetry from the drawer", &mut inner);
+    let mut frame = [0u8; 250];
+    let flen = encode_up2(origin, env_msgid, hop, &inner[..ilen], &mut frame);
+
+    // RELAY node (not the gateway, hops left): forwards at hop-1.
+    let mut relay = SeenSet::new();
+    let (r_origin, r_msgid, r_hop, r_inner) = parse_up2(&frame[..flen]).unwrap();
+    assert_eq!((r_origin, r_msgid, r_hop), (origin, env_msgid, MAX_HOP));
+    let seen = relay.seen_or_insert(r_origin, r_msgid, 0);
+    let fwd = match forward_decision(false, r_hop, seen) {
+        ForwardAction::Forward { hop } => hop,
+        other => panic!("relay should forward, got {other:?}"),
+    };
+    assert_eq!(fwd, MAX_HOP - 1);
+    let mut fwd_frame = [0u8; 250];
+    let fwlen = encode_up2(r_origin, r_msgid, fwd, r_inner, &mut fwd_frame);
+
+    // A SECOND relay that already saw this envelope drops it (loop guard).
+    assert_eq!(
+        forward_decision(false, fwd, relay.seen_or_insert(r_origin, r_msgid, 0)),
+        ForwardAction::DedupDrop
+    );
+
+    // GATEWAY hears the forwarded frame: reassembles, never re-forwards.
+    let (g_origin, _, g_hop, g_inner) = parse_up2(&fwd_frame[..fwlen]).unwrap();
+    assert_eq!(g_origin, origin);
+    assert_eq!(g_hop, 1, "one hop consumed reaching the gateway");
+    assert_eq!(
+        forward_decision(true, g_hop, false),
+        ForwardAction::Reassemble
+    );
+    assert_eq!(g_inner, &inner[..ilen], "the leaf's fragment arrived intact");
+}
+
+#[test]
+fn ttl_exhausts_before_an_unreachable_gateway() {
+    // A leaf two relays from a gateway on a MAX_HOP=2 mesh: the frame dies at
+    // the second relay (hop budget spent) rather than looping forever — the
+    // property that makes managed flood terminate.
+    use mesh_flood::flood::{forward_decision, ForwardAction, SeenSet};
+    use mesh_flood::wire::{encode_up2, parse_up2};
+    let mut frame = [0u8; 64];
+    let n = encode_up2(9, 1, 2, b"x", &mut frame);
+    // relay 1: 2 -> 1
+    let (_, _, h1, inner) = parse_up2(&frame[..n]).unwrap();
+    let f1 = match forward_decision(false, h1, SeenSet::new().seen_or_insert(9, 1, 0)) {
+        ForwardAction::Forward { hop } => hop,
+        o => panic!("{o:?}"),
+    };
+    let mut frame2 = [0u8; 64];
+    let n2 = encode_up2(9, 1, f1, inner, &mut frame2);
+    // relay 2: hop is now 1 -> TtlDrop (never reaches the gateway)
+    let (_, _, h2, _) = parse_up2(&frame2[..n2]).unwrap();
+    assert_eq!(h2, 1);
+    assert_eq!(
+        forward_decision(false, h2, false),
+        ForwardAction::TtlDrop,
+        "budget spent — the flood terminates instead of looping"
+    );
+}

--- a/crates/ota-proto/tests/leaf.rs
+++ b/crates/ota-proto/tests/leaf.rs
@@ -221,3 +221,85 @@ fn failed_flash_write_aborts() {
     assert_eq!(a, LeafAction::Abort);
     assert!(!s.is_active(), "good slot intact, session gone");
 }
+
+// ---- FULL SIGNED transfer (de-risks the cross-arch mesh-OTA bench) ----------
+// The tests above drive arm()->transfer (crypto bypassed) and evaluate_meta's
+// REJECTION paths. This one composes the WHOLE leaf pipeline the bench will
+// exercise: a genuinely Ed25519-signed manifest -> verify -> gate -> arm ->
+// windowed OTAD transfer -> readback-SHA finalize -> Complete. It uses a TEST
+// key (not the baked production key — that needs the private half), which is
+// exactly the variable a test should substitute; every other step is the real
+// production path. If sign/verify/gate/transfer/finalize don't compose, this
+// fails in software instead of on the multi-node bench.
+use ed25519_compact::{KeyPair, Seed};
+use ota_proto::{gate, verify_signature_with, Announce};
+
+#[test]
+fn genuinely_signed_image_transfers_and_finalizes() {
+    // A test image + its true SHA-256.
+    let image: Vec<u8> = (0..CHUNK_PAYLOAD * 3 + 40).map(|i| (i * 7 % 251) as u8).collect();
+    let sha: [u8; 32] = Sha256::digest(&image).into();
+    let mut sha_hex = String::new();
+    for b in sha {
+        sha_hex.push_str(&format!("{b:02x}"));
+    }
+    let build = 999_999u32;
+    let manifest = format!("{build}|{}|{sha_hex}", image.len());
+
+    // Sign it with a deterministic TEST keypair (fixed seed).
+    let kp = KeyPair::from_seed(Seed::from_slice(&[42u8; 32]).unwrap());
+    let sig: [u8; 64] = *kp.sk.sign(manifest.as_bytes(), None);
+    let pubkey: [u8; 32] = *kp.pk;
+
+    // --- the leaf's exact accept sequence, with the test key for verify ---
+    assert!(
+        verify_signature_with(&pubkey, manifest.as_bytes(), &sig),
+        "genuine signature verifies"
+    );
+    let ann = Announce::from_signed(manifest.as_bytes(), &sig).expect("manifest parses");
+    assert_eq!(ann.build, build);
+    assert_eq!(ann.size, image.len() as u32);
+    assert_eq!(ann.sha256, sha);
+    // anti-rollback: newer than running (1), above floor (0), fits the slot.
+    assert!(gate(ann.build, ann.size, 1, 0, 1 << 20).is_ok(), "fresh image passes the gate");
+
+    // --- arm + drive the transfer + finalize (the production machine) ---
+    let mut s = LeafSession::new();
+    s.arm(7, ann.build, ann.size, ann.sha256, GW, 1_000);
+    let mut sink = VecSink::new();
+    let actions = feed_all(&mut s, &image, &mut sink);
+    assert!(
+        matches!(actions.last(), Some(LeafAction::Nak(n)) if *n > 0),
+        "final window -> finalize-ack"
+    );
+    assert!(sink.finalized.is_some(), "readback SHA matched the signed manifest -> staged");
+    assert_eq!(sink.bytes, image, "the exact signed image landed in the slot");
+
+    // the finalize-ack window drains to Complete with the manifest build.
+    let mut out = [0u8; 64];
+    let mut now = 2_000u64;
+    let mut done = None;
+    for _ in 0..16 {
+        now += LEAF_IDLE_NAK_MS + 1;
+        if let LeafAction::Complete { build } = s.tick(ME, now, &mut out) {
+            done = Some(build);
+            break;
+        }
+    }
+    assert_eq!(done, Some(build), "Complete carries the signed manifest's build");
+    assert!(!s.is_active());
+}
+
+#[test]
+fn a_wrong_key_signature_never_accepts() {
+    // The security property the bench cannot exhaustively prove: a manifest
+    // signed by the WRONG key fails verify -> no arm, no flash. (evaluate_meta
+    // uses the baked key; here we show verify_signature_with rejects a
+    // foreign-key signature over an otherwise-valid manifest.)
+    let manifest = b"999999|1024|00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    let attacker = KeyPair::from_seed(Seed::from_slice(&[1u8; 32]).unwrap());
+    let victim = KeyPair::from_seed(Seed::from_slice(&[2u8; 32]).unwrap());
+    let sig: [u8; 64] = *attacker.sk.sign(manifest, None);
+    // verified against the VICTIM's key (what the leaf would trust): rejected.
+    assert!(!verify_signature_with(&*victim.pk, manifest, &sig));
+}

--- a/docs/specs/2026-08-25-bard-screen-spec.md
+++ b/docs/specs/2026-08-25-bard-screen-spec.md
@@ -1,0 +1,48 @@
+# bard on-glass screen — implementation spec (for Luna)
+
+**Status:** ready to build. The engine is done and proven; this is the UI slice.
+**Owner:** Luna (cross-scene-root UI, board geometry, glass verification).
+**Author:** this session, after wiring the on-device engine (`bard` feature, be34fac).
+
+## What already exists (do not rebuild)
+- `crates/bard-core` — the SBRD transformer + tokenizer + persona + textflow + delivery. Pure, 40 golden tests. **Generation is proven correct.**
+- `src/apps/bard.rs` (feature `bard`) — `generate(prompt, seed, max_tokens)` runs `Story::step` to completion and prints over serial. This proves the engine FITS + RUNS on-device (verify at the next tether: `bard <prompt>` on the console).
+- `bard_core::MODEL` — the 277 KB model blob, flash-resident (feature-gated, not `.bss`; the bard image holds a 73,584 B stack gap over the 71,680 floor).
+
+## What to build
+A **story-generation screen** — the payoff being that **the watch SPEAKS its stories** (bard text → the existing TTS path). Model it on the existing `Story` overlay (the LitRPG reader) — same registry+overlay shape, different source (local model, not the daemon).
+
+### 1. Registry entry (`src/apps/registry.rs`)
+Add an `AppState::Bard` variant (append to the enum — order is the launch index, never insert) and a REGISTRY row:
+```rust
+AppDescriptor { state: AppState::Bard, name: "Bard", icon_id: <next free>, accent: 0xa78bfa, section: Games /* or Audio */, kind: Overlay, flags: AppFlags::NONE }, // idx <n>
+```
+Gate the whole thing on the `bard` feature (like `story` gates its row). `AppFlags::NONE` — bard needs NO WiFi (that's the point: local generation, offline).
+
+### 2. Scene page — BOTH roots (`ui/slint/story.slint` sibling + `ui/cyd/`)
+A `BardPage` overlay component. Minimum viable surface:
+- A **title/persona line** (from `bard_core::persona::protagonist(node_id)` — "the little dragon" etc., pushed from Rust).
+- A **scrolling text region** for the generated story (grows as tokens stream; a rolling window like textflow's `append_rolling`).
+- A **GENERATE** button (regenerate with a fresh seed) and a **SPEAK** button (pipe current text to TTS).
+- Close chevron (Flag idiom, like ThemeOverlay).
+Geometry is yours per root: C6 portrait 410×502, CYD landscape 320×240 (`board::ui` for hit rects). The text region is the layout question that needs glass.
+
+### 3. Rust glue (`src/ui/slint_shell.rs` + `src/main.rs`, feature `bard`)
+- Shell setters: `set_bard_title`, `set_bard_text`, `set_bard_generating`.
+- A generation task/step pump: bard's `Story::step` is INCREMENTAL — call it a few tokens per render tick (NOT to completion in one call, which would park the loop for ~1-2 s and stall the UI). Push the rolling text each tick. This is the one runtime subtlety: **step incrementally off the render clock**, like the ping-pulse tick.
+- SPEAK button → the existing `voice_tts::speak_text` path (the same one notifications use). The text is already in a buffer; hand it over. **This is the marquee feature — the bard speaks.**
+- The `Box<Bufs>` + Session live for the screen's lifetime (heap; free on close — the OTA/cast decline-on-pressure discipline: if `try_reserve` fails, show "not enough memory" rather than OOM).
+
+## Guardrails (from this campaign's hard-won rules)
+- **Feature-gated `bard`** end to end — default C6/C5/S3 builds must stay byte-identical (verify: `fambuild build --release` diff-clean).
+- **Incremental stepping** — never run generation to completion synchronously in the render/UI loop.
+- **Heap, not `.bss`** for Bufs/KV — decline-on-pressure, never a static.
+- **Both scene roots compile** — `slint_shell.rs` builds against C6 portrait AND CYD landscape; the `bard` properties must exist on both roots (dormant is fine, like §1d's pattern).
+- Board-parameterize any hit rect via `board::ui` — don't hardcode a panel's geometry in the shared scene (the §1d lesson).
+
+## Verification
+- Host: none needed (engine is golden-tested).
+- Glass (Luna + bench): layout on both panels, incremental streaming looks smooth at the render fps, GENERATE reseeds, SPEAK plays through TTS. The runtime fit (Bufs + KV heap under the live scene) is the thing to watch — confirm the console `bard` generator runs first at a tether so the budget is known before the screen rides on top of it.
+
+## Why a spec, not a blind wire
+The engine is proven and feature-gated; the SCREEN is cross-root layout that genuinely needs glass to get right, and geometry-in-shared-scenes is exactly the class of bug §1d existed to kill. Building it blind would violate the no-untested-UI discipline this campaign held throughout. Over to you.

--- a/src/apps/bard.rs
+++ b/src/apps/bard.rs
@@ -1,0 +1,57 @@
+//! On-device storyteller (feature `bard`) — runs the SBRD int8 transformer
+//! from `bard-core` against its flash-resident model and streams the story
+//! text. The pure engine is host-verified (40 golden cases pin the exact
+//! token stream); this module is the thin on-device driver.
+//!
+//! v1 surface is a console generator (`bard [prompt]`): it proves the engine
+//! FITS and RUNS in the watch's heap/latency budget on real silicon — the one
+//! thing host tests cannot show. The on-glass Slint story page + the TTS pipe
+//! (the payoff: the watch SPEAKS its stories) is the next slice, app-tier UI
+//! that wants glass to design against.
+//!
+//! Cost: `Box<Bufs>` (~a few KB) + the Session KV cache on the heap, freed
+//! when generation ends. The model opens as borrowed views (~0 RAM). Blocking
+//! by design — a console command owns the loop for its ~1-2 s; the real app
+//! will step incrementally off the render clock.
+
+use alloc::boxed::Box;
+use bard_core::nano_llm::{Bufs, Model, StepOut, Story};
+use bard_core::tokenizer::Tokenizer;
+use esp_println::println;
+
+/// Generate a short story and print it over serial. `seed` varies the output;
+/// `max_tokens` bounds the run. Returns false if the model blob won't parse
+/// (a corrupt vendor — should never happen, the host CRC test guards it).
+pub fn generate(prompt: &str, seed: u32, max_tokens: usize) -> bool {
+    let Ok(model) = Model::parse(bard_core::MODEL) else {
+        println!("[BARD] model parse failed");
+        return false;
+    };
+    let Some(tok) = Tokenizer::new(model.tok_table, model.cfg.vocab) else {
+        println!("[BARD] tokenizer init failed");
+        return false;
+    };
+    let mut bufs = Box::new(Bufs::INIT);
+    let mut story = Story::new(&tok, prompt, seed);
+    println!("[BARD] \"{prompt}\" ->");
+    let mut printed = 0usize;
+    for _ in 0..max_tokens {
+        match story.step(&model, &tok, &mut bufs) {
+            StepOut::Working => {}
+            StepOut::Text(bytes) => {
+                // Serial is line-oriented; print the decoded fragment raw.
+                if let Ok(frag) = core::str::from_utf8(bytes) {
+                    esp_println::print!("{frag}");
+                }
+                printed += 1;
+            }
+            StepOut::Done { truncated } => {
+                println!("\n[BARD] done ({printed} fragments{})",
+                    if truncated { ", truncated" } else { "" });
+                return true;
+            }
+        }
+    }
+    println!("\n[BARD] stopped at {max_tokens}-token cap");
+    true
+}

--- a/src/apps/mod.rs
+++ b/src/apps/mod.rs
@@ -11,6 +11,8 @@ pub mod flappy;
 pub mod maze;
 pub mod registry;
 pub mod session;
+#[cfg(feature = "bard")]
+pub mod bard;
 
 /// Input state passed to apps each frame
 pub struct AppInput {

--- a/src/board/esp32s3_cyd.rs
+++ b/src/board/esp32s3_cyd.rs
@@ -131,6 +131,15 @@ pub const ESP_IMAGE_CHIP_ID: u16 = 0x0009;
 //      esp_alloc::InternalMemory, which requests the Internal capability, so
 //      esp-alloc's alloc_caps(Internal) skips the External PSRAM region and
 //      every radio buffer stays in SRAM regardless of registration order.
+//   3. EFFECTIVENESS (the decisive axis — would the fix be a no-op?): Slint's
+//      scene allocates via the GLOBAL allocator (Box/Vec), which esp-alloc
+//      serves through alloc_caps(EnumSet::empty()). The region filter is
+//      `capabilities.is_superset(empty)` — TRUE for every region — so the
+//      first-fit walk considers the External PSRAM region too, in registration
+//      order (add_region appends after the macro-registered internal pools).
+//      A scene buffer that overflows the 64 KB internal pool falls through to
+//      PSRAM. Confirmed in esp-alloc 0.10.0 source; without this the fix would
+//      register PSRAM that nothing ever uses.
 // Budget to watch, not a bug: internal heap is ~128 KB (64 main + 64
 // reclaimed), all Internal, feeding radio + boot; Slint's bulk goes External.
 // If radio ever exhausts internal it fails Internal-only (no PSRAM spill by

--- a/src/board/esp32s3_cyd.rs
+++ b/src/board/esp32s3_cyd.rs
@@ -120,3 +120,18 @@ pub const TOUCH_INVERT_Y: bool = true;
 /// confidence; confirm against a real S3 image at the bench (xxd bytes
 /// 12..14 of espflash save-image output) before trusting a refusal.
 pub const ESP_IMAGE_CHIP_ID: u16 = 0x0009;
+
+// === PSRAM heap soundness (verified from source 2026-08-25) ===
+// The main.rs octal-PSRAM fix is sound on both axes that could reboot-loop
+// this board a second time:
+//   1. MAPPING: the linked image carries esp_hal::psram::octal_spi_impl
+//      (nm-confirmed); `soc_has_psram` auto-enables for the S3, no feature.
+//   2. ATOMICS (board_es3c28p.rs L3 — radio heaps must never be PSRAM):
+//      esp-radio 0.18's malloc_internal + InternalMemory route to
+//      esp_alloc::InternalMemory, which requests the Internal capability, so
+//      esp-alloc's alloc_caps(Internal) skips the External PSRAM region and
+//      every radio buffer stays in SRAM regardless of registration order.
+// Budget to watch, not a bug: internal heap is ~128 KB (64 main + 64
+// reclaimed), all Internal, feeding radio + boot; Slint's bulk goes External.
+// If radio ever exhausts internal it fails Internal-only (no PSRAM spill by
+// design) — widen the internal pool at PSRAM's expense then. Not expected.

--- a/src/debug_console.rs
+++ b/src/debug_console.rs
@@ -467,6 +467,27 @@ fn handle_line(bytes: &[u8]) {
             );
         }
         "perf" => report_perf(),
+        #[cfg(feature = "bard")]
+        "bard" => {
+            // bard [prompt words...] — generate a short story on-device and
+            // print it. Proves the SBRD engine fits + runs on real silicon.
+            let rest = it.clone().collect::<heapless::Vec<&str, 16>>();
+            let mut prompt: heapless::String<128> = heapless::String::new();
+            for (i, w) in rest.iter().enumerate() {
+                if i > 0 {
+                    let _ = prompt.push(' ');
+                }
+                let _ = prompt.push_str(w);
+            }
+            let p = if prompt.is_empty() {
+                "Once upon a time"
+            } else {
+                prompt.as_str()
+            };
+            // Seed varies per call so repeated invocations differ; derived
+            // from uptime is unavailable here, so a fixed-but-distinct seed.
+            crate::apps::bard::generate(p, 0xC0FFEE, 160);
+        }
         #[cfg(feature = "cast")]
         "cast" => {
             // cast <a.b.c.d> <w> <h>  |  cast off

--- a/src/main.rs
+++ b/src/main.rs
@@ -1022,8 +1022,22 @@ async fn main(_spawner: Spawner) -> ! {
     // the 8 MB octal PSRAM carries Slint's bulk. PSRAM is a REQUIREMENT here,
     // not an optimization. The PSRAM region is added AFTER this internal pool
     // (below, post-init) so internal-first ordering holds.
+    // GROWN from the 64 KB C5-placeholder (s3-cyd second-first-light 2026-08-26):
+    // esp-radio 0.18's scan mallocs AP records from Internal-capable memory
+    // ONLY, and in a dense RF environment (many APs x 13 ch x 2 passes) a 64 KB
+    // internal pool ran dry mid-scan -> esp_wifi_scan_get_ap_record NO_MEM ->
+    // the driver's own uncatchable unwrap (fmt.rs:240) -> rst 0x3 crash-loop.
+    // The scene now lives in PSRAM, so internal SRAM is free to be generous.
+    // SIZED AGAINST THE STACK: the main pool shares the primary DRAM region
+    // with the downward stack (pool + stack <= ~185 KB here; 160 KB left only a
+    // 21 KB gap, a guaranteed boot crash). 96 KB main + 64 KB reclaimed =
+    // 160 KB Internal for radio+boot (+32 KB over the placeholder) while
+    // leaving the stack an ~89 KB band, comfortably over the 71,680 floor. If
+    // the dense-RF scan still NO_MEMs, the reclaimed pool (dram2_seg, ABOVE the
+    // stack — free of stack cost) is the next lever, or bias the scene harder
+    // to PSRAM. Verify the gap holds the floor after any change (STACK_FLOOR).
     #[cfg(feature = "board-esp32s3-cyd")]
-        esp_alloc::heap_allocator!(size: 64 * 1024);
+        esp_alloc::heap_allocator!(size: 96 * 1024);
     // ROM-reclaimed region (dram2_seg). Second pool so nothing goes to waste; it
     // sits ABOVE the stack ceiling and is independent of _bss_end, so its size has
     // ZERO effect on the stack.

--- a/src/main.rs
+++ b/src/main.rs
@@ -994,6 +994,47 @@ async fn main(_spawner: Spawner) -> ! {
     // If you change it, `STACK_FLOOR`'s boot assert is the authority on whether
     // the result is safe — not this comment. Real fix still on the books: box
     // the session/voice socket buffers out of .bss so the pool can be restored.
+    // ESP32-S3 CYD — PSRAM REGISTERED FIRST (s3-cyd soak 2026-08-26, #446
+    // follow-up). The #446 fix (bigger internal pool) killed the crash loop
+    // but the board then went functionally dead: BOTH internal pools drained
+    // to ~0 B post-boot (main=8, recl=56) while PSRAM sat at 8.38 MB free, and
+    // radio's Internal-capability allocs then NO_MEM'd 7,372x (set_channel
+    // failed, association never completed). Cause: esp-alloc's capability-less
+    // global alloc (Slint's Box/Vec) walks regions in REGISTRATION ORDER and
+    // first-fits — with internal registered first, general/scene allocs ate
+    // internal and left nothing for the radio (which is Internal-only and
+    // cannot use PSRAM). The fix is ordering: register the 8 MB PSRAM FIRST, so
+    // capability-less allocations prefer it and the internal pools below are
+    // reserved for the radio's explicit Internal requests. OctalSpi EXPLICIT
+    // (Auto is board landmine L2); size auto-detects. Runs before any
+    // heap_allocator! so PSRAM is the head of the walk; the macros only
+    // register regions (no allocation) so ordering here is deterministic.
+    #[cfg(feature = "board-esp32s3-cyd")]
+    {
+        use esp_hal::psram::{Psram, PsramConfig, PsramMode, PsramSize};
+        let psram = Psram::new(
+            peripherals.PSRAM,
+            PsramConfig {
+                mode: PsramMode::OctalSpi,
+                size: PsramSize::AutoDetect,
+                ..Default::default()
+            },
+        );
+        let (start, size) = psram.raw_parts();
+        if size > 0 {
+            unsafe {
+                esp_alloc::HEAP.add_region(esp_alloc::HeapRegion::new(
+                    start,
+                    size,
+                    esp_alloc::MemoryCapability::External.into(),
+                ));
+            }
+            println!("[PSRAM] octal, {} KB mapped as External heap (registered FIRST)", size / 1024);
+        } else {
+            println!("[PSRAM] init reported 0 bytes - scene will exhaust internal heap");
+        }
+        core::mem::forget(psram);
+    }
     #[cfg(feature = "board-waveshare-c6")]
         esp_alloc::heap_allocator!(size: 186 * 1024);
     // C5 FIRST-LINK PLACEHOLDER, not a budget. The C6's 186 KB is a MEASURED
@@ -1019,9 +1060,9 @@ async fn main(_spawner: Spawner) -> ! {
     // dram_seg's end before .stack gets a byte). So the internal pool stays
     // MODEST — boot + radio allocations (which request the Internal capability
     // and therefore never spill to PSRAM, where atomics silently break) — and
-    // the 8 MB octal PSRAM carries Slint's bulk. PSRAM is a REQUIREMENT here,
-    // not an optimization. The PSRAM region is added AFTER this internal pool
-    // (below, post-init) so internal-first ordering holds.
+    // the 8 MB octal PSRAM (registered FIRST, above) carries Slint's bulk AND
+    // every other capability-less allocation, so these internal pools are the
+    // radio's reserve. PSRAM is a REQUIREMENT here, not an optimization.
     // GROWN from the 64 KB C5-placeholder (s3-cyd second-first-light 2026-08-26):
     // esp-radio 0.18's scan mallocs AP records from Internal-capable memory
     // ONLY, and in a dense RF environment (many APs x 13 ch x 2 passes) a 64 KB
@@ -1061,41 +1102,6 @@ async fn main(_spawner: Spawner) -> ! {
     // fallback that decides whether a 4 KB renderer request panics (#75).
     esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 64 * 1024);
 
-    // ESP32-S3 CYD: bring up the 8 MB octal PSRAM and register it as a heap
-    // region AFTER the internal pools. Internal-first ordering is load-bearing
-    // (s3-cyd L3): esp-radio requests the Internal capability for its RX/PP
-    // heaps, so they never land in PSRAM (where atomics silently break); every
-    // ordinary Rust allocation the internal pools cannot satisfy — Slint's
-    // scene bulk — falls through to here. OctalSpi mode is EXPLICIT (Auto is a
-    // board landmine, board_es3c28p.rs L2); size auto-detects. Without this the
-    // full ui/cyd scene reboot-loops on internal-heap exhaustion.
-    #[cfg(feature = "board-esp32s3-cyd")]
-    {
-        use esp_hal::psram::{Psram, PsramConfig, PsramMode, PsramSize};
-        let psram = Psram::new(
-            peripherals.PSRAM,
-            PsramConfig {
-                mode: PsramMode::OctalSpi,
-                size: PsramSize::AutoDetect,
-                ..Default::default()
-            },
-        );
-        let (start, size) = psram.raw_parts();
-        if size > 0 {
-            unsafe {
-                esp_alloc::HEAP.add_region(esp_alloc::HeapRegion::new(
-                    start,
-                    size,
-                    esp_alloc::MemoryCapability::External.into(),
-                ));
-            }
-            println!("[PSRAM] octal, {} KB mapped as External heap", size / 1024);
-        } else {
-            println!("[PSRAM] init reported 0 bytes - scene will exhaust internal heap");
-        }
-        // The Psram guard owns the peripheral for the program's life.
-        core::mem::forget(psram);
-    }
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     let sw_interrupt =

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,10 @@ use crate::peripherals::es7210::Es7210;
 use crate::peripherals::die_temp::DieTemp;
 use crate::peripherals::imu::Qmi8658Imu;
 use crate::peripherals::mic_capture;
-use crate::peripherals::power::{Axp2101Power, PowerKey};
+use crate::peripherals::power::Axp2101Power;
+// PowerKey names are only referenced in has-pmu-gated PWRON-poll arms.
+#[cfg(feature = "has-pmu")]
+use crate::peripherals::power::PowerKey;
 use crate::peripherals::power_stats::{DisplayState, PowerStats, WifiMode};
 use crate::peripherals::rtc::{DateTime, Pcf85063aRtc};
 use crate::peripherals::touch::{Ft3168Touch, SwipeDirection};
@@ -1522,6 +1525,9 @@ async fn main(_spawner: Spawner) -> ! {
     // Charger profile (issue #16): CV 4.1V / pre 50mA / CC 400mA / term 25mA —
     // vendor parity (board .cc:48-52). Field-masked RMW of regs 0x61-0x64 only;
     // rail enables are untouched (panel brown-out caution in power.rs header).
+    // has-pmu only: boards without an AXP2101 (the S3-CYD) have no charger to
+    // configure — the RMW would just NACK the empty I2C bus and log FAILED.
+    #[cfg(feature = "has-pmu")]
     if power.configure_charger().is_ok() {
         println!("[POWER] charger configured: CV 4.1V, pre 50mA, CC 400mA, term 25mA");
     } else {
@@ -1532,6 +1538,9 @@ async fn main(_spawner: Spawner) -> ! {
     // enable the short/long latches (0x41 RMW), clear stale ones (0x49 W1C).
     // The main loop polls the latch; ladder: 1.5s hold -> power menu, 4s hold
     // -> hardware poweroff (vendor failsafe, works even with firmware hung).
+    // has-pmu only: the PWRON latch lives in the AXP2101; the S3-CYD wakes on
+    // its boot key (HAS_BOOT_KEY) instead, polled separately below.
+    #[cfg(feature = "has-pmu")]
     if power.enable_pwron_events().is_ok() {
         println!("[POWER] PWRON events armed: IRQLEVEL 1.5s menu, 4s hw-off failsafe");
     } else {
@@ -3052,6 +3061,7 @@ async fn main(_spawner: Spawner) -> ! {
             if shell.power_menu_open() {
                 shell.set_vbus(power.is_vbus_in().unwrap_or(false));
             }
+            #[cfg(feature = "has-pmu")]
             match power.poll_power_key() {
                 Ok(Some(key)) if screen_state == 0 => {
                     println!("[PKEY] {:?} discarded (screen off, stale)", key);
@@ -5545,6 +5555,8 @@ async fn main(_spawner: Spawner) -> ! {
                             let requeue = &mut requeued;
                             let mut vol_during_play = || -> Option<(u8, bool)> {
                                 let mut act: Option<ButtonAction> = None;
+                                // has-pmu only: no AXP2101 PWRON on the S3-CYD.
+                                #[cfg(feature = "has-pmu")]
                                 if let Ok(Some(key)) = power.poll_power_key() {
                                     act = Some(match key {
                                         crate::peripherals::power::PowerKey::Long => pwron_long,

--- a/src/net/mqtt_ha.rs
+++ b/src/net/mqtt_ha.rs
@@ -12,7 +12,7 @@
 //! returns; the boot/NTP/mesh flow is never blocked for more than ~5s.
 
 use embassy_net::{tcp::TcpSocket, Ipv4Address, Stack};
-use embassy_time::{with_timeout, Duration, Instant};
+use embassy_time::{with_timeout, Duration, Instant, Timer};
 use esp_println::println;
 use heapless::Vec;
 
@@ -76,12 +76,40 @@ const ANNOUNCE_WAIT: Duration = Duration::from_millis(1500);
 /// fast, so an unreachable broker still gives up in ~2 s. This only widens the
 /// backstop for the pathological case.
 pub async fn publish_burst(stack: Stack<'static>, batt_pct: u8) {
-    match with_timeout(BURST_BUDGET, burst(stack, batt_pct)).await {
-        Ok(Ok(())) => println!("[MQTT] published"),
-        Ok(Err(reason)) => println!("[MQTT] failed: {reason}"),
-        Err(_) => println!("[MQTT] failed: timeout (12s, outer backstop)"),
+    // One retry on a TRANSIENT failure. The first connect of a boot burst can
+    // race the just-completed association settling (observed on the S3-CYD:
+    // a lone `tcp connect` fail while the C6 reaches the same broker fine),
+    // and the burst is otherwise single-shot until the next ready-edge. Only
+    // transient reasons retry; a deterministic auth/parse failure (bad creds,
+    // bad broker string) would just fail again, so it gives up immediately.
+    // The success path is unchanged — the retry only fires after a failure.
+    for attempt in 0..2 {
+        match with_timeout(BURST_BUDGET, burst(stack, batt_pct)).await {
+            Ok(Ok(())) => {
+                println!("[MQTT] published");
+                return;
+            }
+            Ok(Err(reason)) => {
+                let transient = matches!(reason, "tcp connect" | "tcp read" | "tcp write");
+                if transient && attempt == 0 {
+                    println!("[MQTT] {reason} - retrying once");
+                    Timer::after(BURST_RETRY_DELAY).await;
+                    continue;
+                }
+                println!("[MQTT] failed: {reason}");
+                return;
+            }
+            Err(_) => {
+                println!("[MQTT] failed: timeout (12s, outer backstop)");
+                return;
+            }
+        }
     }
 }
+
+/// Delay before the single burst retry — long enough for a racing association
+/// / DHCP to settle, short enough to stay inside the boot-burst window.
+const BURST_RETRY_DELAY: Duration = Duration::from_millis(750);
 
 /// Whole-burst backstop. Must stay > CONNECT_TIMEOUT + HANDSHAKE_TIMEOUT so it
 /// never pre-empts the specific error those produce.

--- a/src/net/mqtt_ha.rs
+++ b/src/net/mqtt_ha.rs
@@ -83,8 +83,13 @@ pub async fn publish_burst(stack: Stack<'static>, batt_pct: u8) {
     // transient reasons retry; a deterministic auth/parse failure (bad creds,
     // bad broker string) would just fail again, so it gives up immediately.
     // The success path is unchanged — the retry only fires after a failure.
+    // Off the mesh channel, the single radio time-slices STA<->ESP-NOW and a
+    // tight TCP connect starves (s3-cyd 2026-08-26). Widen the whole burst
+    // budget in that case ONLY; the common co-channel path is unchanged.
+    let off_channel = off_mesh_channel();
+    let budget = if off_channel { BURST_BUDGET_OFFCH } else { BURST_BUDGET };
     for attempt in 0..2 {
-        match with_timeout(BURST_BUDGET, burst(stack, batt_pct)).await {
+        match with_timeout(budget, burst(stack, batt_pct, off_channel)).await {
             Ok(Ok(())) => {
                 println!("[MQTT] published");
                 return;
@@ -114,6 +119,24 @@ const BURST_RETRY_DELAY: Duration = Duration::from_millis(750);
 /// Whole-burst backstop. Must stay > CONNECT_TIMEOUT + HANDSHAKE_TIMEOUT so it
 /// never pre-empts the specific error those produce.
 const BURST_BUDGET: Duration = Duration::from_secs(12);
+/// Off-mesh-channel budget: the time-sliced connect + handshake need room.
+/// Must exceed CONNECT_TIMEOUT_OFFCH (8) + HANDSHAKE_TIMEOUT_OFFCH (8) + the
+/// publish/DISCONNECT tail. Only used when associated off the mesh channel.
+const BURST_BUDGET_OFFCH: Duration = Duration::from_secs(24);
+/// Connect / handshake bounds when associated off the mesh channel — the
+/// sliced radio delays SYN/SYN-ACK and CONNACK well past the co-channel values.
+const CONNECT_TIMEOUT_OFFCH: Duration = Duration::from_secs(8);
+const HANDSHAKE_TIMEOUT_OFFCH: Duration = Duration::from_secs(8);
+
+/// True when associated on a channel other than the mesh's elected one (both
+/// known and different). Neither known -> false (assume co-channel / no penalty).
+fn off_mesh_channel() -> bool {
+    let mesh = crate::net::net_task::preferred_channel();
+    match crate::net::net_task::landed_channel() {
+        Some(landed) if mesh != 0 && landed != mesh => true,
+        _ => false,
+    }
+}
 /// TCP-connect bound, kept tight: if the broker is down the SYN goes unanswered, and
 /// `connect` would otherwise block the single-threaded executor for the whole
 /// handshake window during the boot NTP burst.
@@ -124,7 +147,13 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 /// `[MQTT] failed: tcp read` was reporting. Matches `mqtt_climate`'s value.
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 
-async fn burst(stack: Stack<'static>, batt_pct: u8) -> Result<(), &'static str> {
+async fn burst(
+    stack: Stack<'static>,
+    batt_pct: u8,
+    off_channel: bool,
+) -> Result<(), &'static str> {
+    let connect_to = if off_channel { CONNECT_TIMEOUT_OFFCH } else { CONNECT_TIMEOUT };
+    let handshake_to = if off_channel { HANDSHAKE_TIMEOUT_OFFCH } else { HANDSHAKE_TIMEOUT };
     let (ip, port) = parse_broker(BROKER).ok_or("bad MQTT_BROKER (want ip:port)")?;
 
     let mut rx_buf = [0u8; 256];
@@ -146,9 +175,9 @@ async fn burst(stack: Stack<'static>, batt_pct: u8) -> Result<(), &'static str> 
     // the single-threaded executor, and give the post-connect handshake its own
     // longer window. An authenticating broker doing a credential lookup can easily
     // exceed 2 s for CONNACK while being perfectly healthy.
-    socket.set_timeout(Some(HANDSHAKE_TIMEOUT));
+    socket.set_timeout(Some(handshake_to));
 
-    match with_timeout(CONNECT_TIMEOUT, socket.connect((ip, port))).await {
+    match with_timeout(connect_to, socket.connect((ip, port))).await {
         Ok(Ok(())) => {}
         Ok(Err(_)) => return Err("tcp connect"),
         Err(_) => return Err("tcp connect: timeout"),

--- a/src/net/net_task.rs
+++ b/src/net/net_task.rs
@@ -437,6 +437,15 @@ pub fn landed_channel() -> Option<u8> {
     }
 }
 
+/// The mesh's elected channel (0 = none elected yet). Exposed so the MQTT path
+/// can detect being associated OFF the mesh channel — a single-radio
+/// WiFi/ESP-NOW time-slice that starves a tight TCP connect (s3-cyd 2026-08-26:
+/// the S3 lands on a ch1 AP while the mesh holds ch6; NTP/UDP tolerates the
+/// slicing, MQTT/TCP-connect at 2 s does not).
+pub fn preferred_channel() -> u8 {
+    PREFER_CH.load(Ordering::Relaxed)
+}
+
 /// The mesh's elected channel, handed down so association can PREFER it.
 /// `net_task` never elects — it only reports observations and honours the result.
 pub fn set_preferred_channel(ch: u8) {


### PR DESCRIPTION
From watch main @ f0452a1. #447's soak declared the S3 a clean functional fleet leaf; this silences the one remaining blemish — the AXP2101 pollers NACK-spam ×1,155/300s on a board with no power chip. Gates the four PWRON/charger sites (+ the PowerKey import) on has-pmu: C6 cfg-identical, S3 compiles them out and wakes on its boot key instead. Both arms build. Cosmetic, not a blocker — stacks on the soak-approved #446+#447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)