### PR TITLE
targets/c6-watch refresh: S3 ILI9341 arm RAMWR (on-glass GUI fix)

### DIFF
--- a/targets/c6-watch/src/drivers/ili9341.rs
+++ b/targets/c6-watch/src/drivers/ili9341.rs
@@ -108,6 +108,14 @@ impl<'d> Ili9341Display<'d> {
         let y1 = y0 + h - 1;
         self.bus.write_c8d16d16(CMD_CASET, x0, x1);
         self.bus.write_c8d16d16(CMD_RASET, y0, y1);
+        // A new window means the next pixel push must restart at its origin
+        // with RAMWR (0x2C), not resume the prior run with RAMWR_CONT (0x3C).
+        // `SharedSpiBus` latches RAMWR_CONT after the first push, so without
+        // re-arming here every strip after the first lands at the previous
+        // GRAM pointer instead of this window - "chunks displaced/torn", colors
+        // and signal intact (JP on-glass 2026-08-26). The ST7789 sibling's
+        // set_addr_window arms it; the ILI9341 must too.
+        self.bus.arm_ramwr();
     }
 
     pub fn fill_screen(&mut self, color: Rgb565) {


### PR DESCRIPTION
**S3 GUI render fix — JP-verified on glass 2026-08-26.**

## Symptom
S3 (ES3C28P / ILI9341V) GUI rendered garbled: **chunks displaced/torn**, colors and signal intact (not noise, not wrong-color). Masked earlier by the PSRAM/scan crash-loop; surfaced once the board became a stable fleet node.

## Root cause
`SharedSpiBus` emits `RAMWR` (0x2C) for the first pixel push then latches `RAMWR_CONT` (0x3C) for continuations. A new `CASET`/`RASET` window requires the next push to restart at the window origin with `RAMWR` — the bus exposes `arm_ramwr()` for exactly this, and its own doc names `set_addr_window` as the caller. The **ST7789 sibling calls it; the ILI9341 `set_addr_window` omitted it.** So every strip after the first resumed at the previous GRAM pointer instead of its own window → displacement. `emberburrito` (mipidsi, always RAMWR) renders the same panel clean; this DMA path was the only one exercising the continue-opcode with a stale arm.

## Fix
One line: `self.bus.arm_ramwr();` after the `RASET` write in `Ili9341Display::set_addr_window`. `arm_ramwr` is `pub(crate)`, same crate — resolves clean. C6/CO5300 path unaffected.

## Verification
- watch main `928d35d` flashed to S3 (image `62b71f97`) → **JP on glass: "gui looks good"**, no displaced chunks. RAMWR_CONT diagnosis confirmed.
- Orthogonal to #446/#447/#448 (they don't touch `ili9341.rs`) — merges in any order, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)