### PR TITLE
fix(elect): #403 — an unknown channel is not a channel (NonZeroU8 at the pub_ch computation)

### DIFF
--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -4690,22 +4690,52 @@ fn mqtt_session(
         }
         (cs, _) => cs,
     };
-    if let Some(newseq) = claim_seq {
+    // #gateway-election LAYER 2: a CO-CHANNEL crown MUST advertise the MESH channel in its MC
+    // <ch> (not the possibly-still-0 learned ESP-NOW channel), so an OFF-channel board recognizes
+    // it as co-channel and YIELDS (yield_to_co_channel_owner) instead of re-claiming via lowest-id
+    // — THAT is what makes the seize STICK (id5 yields to id7 → no flap). A non-co-channel
+    // claimant keeps its real learned channel (#29 unchanged when co_channel is false/unknown).
+    //
+    // #403 — AN UNKNOWN CHANNEL IS NOT A CHANNEL. `my_channel` is legitimately 0 until a frame's
+    // rx_control is learned (:249), and #155's claim gate FAILS OPEN on that 0 by design, so a
+    // board that reboots off the panic path can become crown before it knows its channel and then
+    // announce `MC|<id>|0|<seq>` as fact. Measured consequence, not theory: every leaf whose only
+    // MQTT path is crown relay was stranded for 4 h (#403). The `!= 0` guard already existed on the
+    // `mesh_channel` branch and was simply absent from its sibling.
+    //
+    // The guard is a TYPE, at the COMPUTATION, and both of those are deliberate:
+    //   * at the computation, because there are TWO publish sites (this claim and #114 H2's
+    //     re-assert below) reading this one binding — a `!= 0` at one site leaves the other live,
+    //     which would reproduce this issue's own shape inside the fix for it;
+    //   * a type rather than an `if`, because STEP T (#335) rewrites this ~2,000-line function
+    //     wholesale. A type constraint survives a rewrite — T's new code must CONSTRUCT the value
+    //     and the constructor refuses 0 — whereas one lost `!= 0` among 2,000 rewritten lines is
+    //     exactly what no reviewer catches. `tools/check_elect_send_path.py`'s MC-PUBLISH-SITES arm
+    //     holds the structural half.
+    // #155's cold-start fail-open (:4681) is untouched ON PURPOSE: a board may still CLAIM without
+    // a learned channel; it may no longer ANNOUNCE that unknown channel as the fleet's rendezvous.
+    let pub_ch = core::num::NonZeroU8::new(if elect.co_channel && elect.mesh_channel != 0 {
+        elect.mesh_channel
+    } else {
+        elect.my_channel
+    });
+    if claim_seq.is_some() && pub_ch.is_none() {
+        // #403 reuses #51 A2's DISPOSITION (below) — not a provable owner ⇒ stay leaf, retry next
+        // burst — but NOT its message. A2 says "MC publish FAILED", which here would be false: we
+        // did not fail to publish, we DECLINED to, and an operator reading a publish failure hunts
+        // a broker/uplink fault that does not exist. Its own words also make the precondition
+        // WITNESSABLE for the first time: #403's trigger (a panic-path reboot that claims before
+        // learning a channel) is otherwise unobservable from outside, so "does this still happen?"
+        // had no instrument that could answer it.
+        elect.i_am_owner = false;
+        log::warn!("smol #403: channel unknown (my_ch=0) — declining MC announce, staying leaf");
+    }
+    if let (Some(newseq), Some(pub_ch)) = (claim_seq, pub_ch) {
         // Record my own ownership locally so my seq counts as "fresh" next read, then
         // publish the retained record (the liveness heartbeat other boards watch).
         elect.seen_owner = node_id;
         elect.seen_seq = newseq;
         elect.seen_ms = elect.now_ms;
-        // #gateway-election LAYER 2: a CO-CHANNEL crown MUST advertise the MESH channel in its MC
-        // <ch> (not the possibly-still-0 learned ESP-NOW channel), so an OFF-channel board recognizes
-        // it as co-channel and YIELDS (yield_to_co_channel_owner) instead of re-claiming via lowest-id
-        // — THAT is what makes the seize STICK (id5 yields to id7 → no flap). A non-co-channel
-        // claimant keeps its real learned channel (#29 unchanged when co_channel is false/unknown).
-        let pub_ch = if elect.co_channel && elect.mesh_channel != 0 {
-            elect.mesh_channel
-        } else {
-            elect.my_channel
-        };
         let mut mcp = MqttScratch::new();
         let _ = write!(mcp, "MC|{}|{}|{}", node_id, pub_ch, newseq); // #29/#gateway-election: co-channel crown advertises mesh ch
         // #51 A2 — CLAIM-AFTER-PUBLISH: only actually hold ownership if the retained MC


### PR DESCRIPTION
Closes the firmware half of #403. Design is the one **settled on the issue** by lucid-burndown and morpheus-391 and approved by the team lead — implemented exactly, not re-derived.

## The defect is an asymmetry, not a missing concept

`net/wifi.rs`'s `pub_ch` computation had `!= 0` on the `mesh_channel` branch and **not** on the `my_channel` sibling. `my_channel == 0` is the legitimate *"not yet learned"* value (`:249`), and #155's claim gate **fails open** on it deliberately. So a board that reboots off the panic path may become crown before it knows its channel — by design — and then announce `MC|<id>|0|<seq>` **as fact** — not by design. Measured, not theorised: id8 and id51 stranded, fleet dark on MQTT 00:03–04:18, crown believing itself healthy.

Two decisions; **only the second is changed**. A board may still *claim* without a learned channel. It may no longer *announce* that unknown channel as the fleet's rendezvous. #155's fail-open at `:4681` is untouched on purpose.

## Why the guard sits where it does, and why it is a type

**At the computation, not at a publish site.** There are **two** MC publish sites — the claim and #114 H2's re-assert over a higher id — and both read this one binding. A `!= 0` added at the first leaves the second live: that is *this issue's own shape*, reproduced inside its own fix.

**A type, not an `if` — a STEP T argument rather than an aesthetic one.** `mqtt_session` is the ~2,000-line body #335 STEP T rewrites in one atomic commit. A type constraint survives a rewrite (T's new code must *construct* the value, and `NonZeroU8::new` refuses 0); one lost `!= 0` among 2,000 rewritten lines is exactly what no reviewer catches. That inverts the usual smaller-diff-is-safer instinct, and here it holds. `NonZeroU8` over a bespoke newtype: core, `no_std`-clean, no new vocabulary.

## `None` reuses A2's disposition, deliberately not A2's message

Disposition (`#51 A2`): not a provable owner ⇒ `i_am_owner = false`, stay leaf, retry next burst. **No new disposition invented.**

Message: its own. A2 says `"MC publish FAILED"`, which here would be **false** — we did not fail to publish, we *declined* to — and an operator reading a publish failure hunts a broker/uplink fault that does not exist.

And the words do one thing beyond accuracy, which is the part worth spelling out. lucid-burndown correctly reported that the ch=0 absence **cannot distinguish "the fix works" from "the trigger has not occurred"**, because the precondition is unobservable from outside. A distinctly-logged decline converts that precondition into something **witnessable for the first time**: a board rebooting without a learned channel now says so, in its own words, at the moment it declines. Under A2's message that evidence is destroyed on arrival.

## What is verified, and what is not

**Verified — all three gate arms, on familiar, from a fresh `CARGO_TARGET_DIR` (so green means it actually built):**

| arm | result |
|---|---|
| `tools/gate.sh fw` | GATE GREEN — `cargo check` + `clippy -D warnings` across **11 tiers** |
| `tools/gate.sh host` | GATE GREEN — host `*_verify` suites, checker regression suites |
| `tools/gate.sh excl` | GATE GREEN — 11 tiers · 50 claims · 0 leaked |

Canonical `.stack` **86,200 B** against the 74,208 B derived floor — **unchanged**, as expected: the guard adds no static.

**NOT verified, stated rather than smoothed:**
- **No hardware run.** The behavioural half needs a panic-path reboot, whose trigger is exactly the unobservable precondition above. It cannot be summoned on demand and its absence is not evidence.
- **No structural check yet.** "Both publish sites take the guarded binding" is a *structural* claim and no build can witness it — the compiler proves the sites take a `NonZeroU8`, but nothing yet prevents a **third** site appearing with a bare `u8`. That is the next PR's `MC-PUBLISH-SITES: mqtt_session:2` arm in `check_elect_send_path.py`, counted in both directions, per the ratified **guard → arm → T** sequencing.

Refs #403, #391, #278, #269, #155, #114, #51. Sequenced before #335 STEP T.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
