### PR TITLE
test(elect): #403 arm 7 — the MC announce roster, counted both ways, and its guarded channel

### DIFF
--- a/docs/embassy/T-SCOPE.md
+++ b/docs/embassy/T-SCOPE.md
@@ -442,8 +442,12 @@ Nothing here needs a decision that has not been taken except `N` in §6.2.
 place): the STEP G roster reaching zero `SmolWifiDevice::new` sites and one `embassy_net::new`
 (§5) · `otam_ok` vs `otam_to` read on the canary before and after, which separates "T broke egress"
 from "T made the path slower" (§5) · a per-tier `.stack` A/B, the only instrument that catches a
-static gated more loosely than its consumer (§3.2) · and a **bench election-canary observation
-post-flash**, because §6.3 changes election timing inside the atomic commit (§6.3).
+static gated more loosely than its consumer (§3.2) · **the MC-publish guard survives the rewrite,
+asserted by the arm and not by reading the diff** (#403 — `check_elect_send_path.py` arm 7: a
+declared `MC-PUBLISH-SITES` roster counted both directions, plus each site's channel argument being
+the `NonZeroU8`-bound `pub_ch`; both announce sites live inside the body T replaces, so a review
+promise was never the right instrument) · and a **bench election-canary observation post-flash**,
+because §6.3 changes election timing inside the atomic commit (§6.3).
 
 *(A "reclaim 3,584 B" step stood at the head of this list until it was measured and refuted — §3.2.
 The margin is 12,000 B and that is the whole budget.)*

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -2632,6 +2632,17 @@ pub(crate) fn ota_fail_is_bulk_deaf(w: u32) -> bool {
 /// `telemetry` empty ⇒ downlink-only (the boot path). Returns whether we CONNECTED
 /// (CONNACK rc=0): that is the "flush delivered" signal for the caller's backoff —
 /// a downlink miss is NOT a failure (the cache simply keeps its prior value).
+///
+/// MC-PUBLISH-SITES: mqtt_session:2
+///
+/// Every function that formats a retained crown announce (`MC|<id>|<ch>|<seq>`), with its call
+/// COUNT, checked in BOTH directions by `tools/check_elect_send_path.py` (arm 7). Counts and not
+/// just names, because #403 *was* a guard present on one branch and absent from its sibling: a
+/// THIRD announce site — inside this function or a new one — is precisely what a name-only
+/// allowlist would wave through. The same arm asserts each site's channel argument is the
+/// `NonZeroU8`-bound value from the single `pub_ch` computation, so "the MC-publish guard survives
+/// STEP T's rewrite" is a red gate rather than a review promise. The two sites today are the #51
+/// claim publish and #114 H2's re-assert over a higher id.
 #[cfg(feature = "wifi")]
 #[allow(clippy::too_many_arguments)]
 fn mqtt_session(

--- a/tools/check_elect_send_path.py
+++ b/tools/check_elect_send_path.py
@@ -30,6 +30,11 @@ because it was ENUMERATED as a way to satisfy the types and still ship the bug:
   6. raw-sends      a new raw `esp_now.send` call site appears. Declared IN THE SOURCE, checked in
                     BOTH directions with counts, so adding a send to an already-listed function
                     fails too.
+  7. mc-publish     #403: an MC crown announce formats a channel that is NOT the `NonZeroU8`-bound
+                    `pub_ch`. Same roster idiom as arm 6 — declared in the source, counted both
+                    ways — because #403's defect WAS a guard present on one branch and absent from
+                    its sibling. See the block above arm 7 for why this one is a type check rather
+                    than a `!= 0` check.
 
 It deliberately does NOT check that `send_to` appends the trailer — that is `should_group_mac`, and
 it is pinned by an ELECT case in `experiments/mac_verify` where the decision is pure and host-tested.
@@ -60,6 +65,19 @@ DECL = re.compile(r"RAW-SEND-SITES:\s*([A-Za-z0-9_:,\s]+?)\s*(?:\*/|\n|$)")
 # fail-closed arm fired, which is the gate doing its job and is why this pattern is widened in the
 # same commit as the behaviour change rather than after it.
 RAW_SEND_RE = re.compile(r"esp_now\s*\.\s*send(?:_async)?\s*\(")
+# ── arm 7 (#403) ──────────────────────────────────────────────────────────────────────────────
+# The crown announce's own format literal, spelled here so a change to the wire shape cannot
+# silently empty this arm (same reasoning as ELECT_LITERAL above).
+MC_FMT_LITERAL = '"MC|{}|{}|{}"'
+MC_DECL = re.compile(r"MC-PUBLISH-SITES:\s*([A-Za-z0-9_:,\s]+?)\s*(?:\*/|\n|$)")
+MC_WRITE_RE = re.compile(r"\bwrite!\s*\(")
+# `let pub_ch = core::num::NonZeroU8::new(…)` — the ONE computation both announce sites read.
+NZ_BIND_RE = re.compile(r"\blet\s+(?:mut\s+)?(\w+)\s*=\s*(?:core::num::)?NonZeroU8::new\s*\(")
+IDENT_RE = re.compile(r"^\w+$")
+# Position of the channel among a site's `write!` arguments: sink, format, node_id, CHANNEL, seq.
+# The wire shape is `MC|<id>|<ch>|<seq>`, so the channel is the second substitution.
+MC_CHANNEL_ARG = 3
+MC_ARG_COUNT = 5
 
 
 def fail(msg, *extra):
@@ -98,6 +116,49 @@ def block_after(text: str, start: int):
             depth -= 1
             if depth == 0:
                 return text[open_at : i + 1]
+    return None
+
+
+def call_args(text: str, macro_end: int):
+    """Top-level, comma-separated arguments of the call whose `(` opens at/after `macro_end`.
+
+    Returns a list of raw argument strings, or None if the parens are unbalanced. Quote-aware so a
+    format literal containing a comma cannot split an argument (none does today; the check should
+    not depend on that staying true).
+    """
+    open_at = text.find("(", macro_end)
+    if open_at < 0:
+        return None
+    depth, in_str, esc, args, cur = 0, False, False, [], []
+    for i in range(open_at, len(text)):
+        c = text[i]
+        if in_str:
+            cur.append(c)
+            if esc:
+                esc = False
+            elif c == "\\":
+                esc = True
+            elif c == '"':
+                in_str = False
+            continue
+        if c == '"':
+            in_str = True
+            cur.append(c)
+            continue
+        if c in "([{":
+            depth += 1
+            if depth == 1:
+                continue
+        elif c in ")]}":
+            depth -= 1
+            if depth == 0:
+                args.append("".join(cur).strip())
+                return args
+        elif c == "," and depth == 1:
+            args.append("".join(cur).strip())
+            cur = []
+            continue
+        cur.append(c)
     return None
 
 
@@ -297,6 +358,122 @@ def main() -> int:
     else:
         total = sum(actual.values())
         notes.append(f"{total} raw send sites across {len(actual)} declared fns")
+
+    # ── arm 7: every MC crown announce formats the GUARDED channel (#403) ─────────────────────
+    # Why this is a TYPE check and not a `!= 0` check, because the difference is the whole point:
+    # `mqtt_session` is the ~2,000-line body STEP T (#335) rewrites in ONE atomic commit. Asserting
+    # that some `!= 0` token exists would pin a token and rot the moment T rewrites the expression
+    # around it — and would pass a rewrite that moved the check to one of the two sites. Asserting
+    # that each site's channel ARGUMENT is a binding produced by `NonZeroU8::new` survives the
+    # rewrite, because T's new code must construct the value through a constructor that refuses 0.
+    #
+    # And the COUNT is what catches the shape #403 actually was: `!= 0` written on one branch and
+    # absent from its sibling. A third announce site is invisible to any check that only inspects
+    # the sites it already knows about.
+    mc_sites = []
+    for path, text in code.items():
+        for m in MC_WRITE_RE.finditer(text):
+            args = call_args(text, m.end() - 1)
+            if args is None or len(args) < 2 or args[1] != MC_FMT_LITERAL:
+                continue
+            fn = enclosing_fn(text, m.start())
+            if fn is None:
+                fail(f"an MC announce in {path.relative_to(root)} is not inside any fn")
+                return 2
+            mc_sites.append((path, fn, args, text.count("\n", 0, m.start()) + 1))
+
+    mc_decl_text = None
+    for text in files.values():
+        m = MC_DECL.search(text)
+        if m:
+            mc_decl_text = m.group(1)
+            break
+    if mc_decl_text is None:
+        fail(
+            "no `MC-PUBLISH-SITES:` declaration found in the firmware source.",
+            "The roster of functions permitted to publish a retained crown announce must live",
+            "where a machine can check it — see arm 7 in this script's docstring.",
+        )
+        return 2
+    mc_declared = {}
+    for tok in re.split(r"[,\s]+", mc_decl_text):
+        if not tok:
+            continue
+        name, _, count = tok.partition(":")
+        if not count.isdigit():
+            fail(f"malformed MC-PUBLISH-SITES entry {tok!r} — expected `fn_name:count`.")
+            return 2
+        mc_declared[name] = int(count)
+
+    if not mc_sites:
+        fail(
+            f"found ZERO MC announce sites — the literal {MC_FMT_LITERAL} appears in no `write!`.",
+            "The announce was reshaped, renamed, or moved to another macro. This arm can no longer",
+            "see the crown's channel, so it refuses to pass: update it deliberately, with the",
+            "roster, in the commit that changes the announce.",
+        )
+        return 2
+
+    mc_actual = {}
+    for _p, fn, _a, _ln in mc_sites:
+        mc_actual[fn] = mc_actual.get(fn, 0) + 1
+    if mc_actual != mc_declared:
+        added = {k: v for k, v in mc_actual.items() if mc_declared.get(k) != v}
+        gone = {k: v for k, v in mc_declared.items() if k not in mc_actual}
+        if added:
+            bad.append(
+                "arm 7 (mc-publish): undeclared or miscounted MC announce sites: "
+                + ", ".join(f"{k}×{v} (declared {mc_declared.get(k, 0)})" for k, v in sorted(added.items()))
+                + ". #403 was a guard present on one publish branch and absent from its sibling; "
+                "an announce site nobody declared is that same shape, and the fleet's rendezvous "
+                "is what it publishes."
+            )
+        if gone:
+            bad.append(
+                "arm 7 (mc-publish): declared but ABSENT: "
+                + ", ".join(f"{k}×{v}" for k, v in sorted(gone.items()))
+                + ". A stale roster entry reads as a considered decision and is worse than none."
+            )
+
+    # The guarded-binding half. Collected per (file, fn) so a `NonZeroU8` bound in some OTHER
+    # function cannot satisfy a site here.
+    nz_binds = set()
+    for path, text in code.items():
+        for m in NZ_BIND_RE.finditer(text):
+            fn = enclosing_fn(text, m.start())
+            if fn is not None:
+                nz_binds.add((path, fn, m.group(1)))
+    for path, fn, args, ln in mc_sites:
+        rel = f"{path.relative_to(root)}:{ln}"
+        if len(args) != MC_ARG_COUNT:
+            fail(
+                f"the MC announce at {rel} has {len(args)} `write!` arguments, expected "
+                f"{MC_ARG_COUNT} (sink, format, id, channel, seq).",
+                "This arm reads the channel positionally, so a reshaped announce makes it blind.",
+                "Update arm 7 in the same commit that reshapes the wire format.",
+            )
+            return 2
+        chan = args[MC_CHANNEL_ARG]
+        if not IDENT_RE.match(chan):
+            bad.append(
+                f"arm 7 (mc-publish): the MC announce at {rel} formats the channel as the "
+                f"expression `{chan}` rather than a guarded binding. #403: a channel computed at "
+                "the publish site is a channel no type refused — `my_channel` is legitimately 0 "
+                "until learned, and announcing that 0 stranded the fleet for 4 h."
+            )
+        elif (path, fn, chan) not in nz_binds:
+            bad.append(
+                f"arm 7 (mc-publish): the MC announce at {rel} formats `{chan}`, which is NOT bound "
+                f"by `NonZeroU8::new` in `{fn}`. The guard is the TYPE, at the one `pub_ch` "
+                "computation both sites read — that is what survives STEP T's rewrite of this "
+                "function, where one lost `!= 0` among 2,000 rewritten lines is what no reviewer "
+                "catches."
+            )
+    if not any(b.startswith("arm 7") for b in bad):
+        notes.append(
+            f"{len(mc_sites)} MC announce site(s) across {len(mc_actual)} declared fn(s), "
+            "channel NonZeroU8-bound"
+        )
 
     if bad:
         print("FATAL: the ELECT send-path invariant is violated.", file=sys.stderr)

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -302,7 +302,12 @@ if [ "$run_fw" = 1 ]; then
   # only on the `send_to` path. Stage 1 wrote that down as prose. This reads source STRUCTURE
   # instead: one sink impl, routed to `send_to`; a sealed frame with no byte accessor; one encoder
   # call site; one spelling of the prefix; and every raw `esp_now.send` declared WITH ITS COUNT.
-  # `tools/test_check_elect_send_path.sh` proves all of those can fail, plus three fail-closed arms.
+  # #403 added arm 7 in the same idiom, one invariant over: every MC crown announce is declared
+  # (`MC-PUBLISH-SITES`, counted both ways) AND formats the `NonZeroU8`-bound channel. An unknown
+  # channel published as the fleet's rendezvous stranded every relay-only leaf for 4 h; both sites
+  # live inside the ~2,000-line body #335 STEP T rewrites atomically, which is why the guard is a
+  # type and this arm counts rather than inspecting the sites it already knows.
+  # `tools/test_check_elect_send_path.sh` proves all of those can fail, plus five fail-closed arms.
   # #335 STEP G. Same idiom, one invariant over: exactly ONE consumer of the STA transport is live
   # per tier. `esp_radio::wifi::Interface` is `Copy`, so `embassy_net::new(station, ..)` does not
   # consume it — a `Stack` can be live beside the `SmolWifiDevice` shim over the same interface, it

--- a/tools/test_check_elect_send_path.sh
+++ b/tools/test_check_elect_send_path.sh
@@ -135,6 +135,65 @@ else no "prose regression (fixture setup)"; fi
 arm "commenting out a real send is caught" 1 "arm 6 (raw-sends)" net/mode.rs \
   "$(printf 'match self.esp_now.send(dst, out) {\tmatch NOTHING { // self.esp_now.send(dst, out) {')"
 
+# ── #403 arm 7: the MC crown announce publishes only a GUARDED channel ───────────────────────
+# The arm exists because the guard lives inside `mqtt_session` — the ~2,000-line body STEP T
+# (#335) rewrites in one atomic commit — and one lost `!= 0` among 2,000 rewritten lines is what
+# no reviewer catches. So every one of these arms is a way T could plausibly ship the regression:
+# a third announce site, an announce in a new function, a channel computed at the publish site,
+# and the binding degraded from a type back to a value. Each must be RED for its own reason.
+echo "== arm 7a: a THIRD announce site inside the declared fn (counts, not just names) =="
+arm "third MC announce site" 1 "arm 7 (mc-publish)" net/wifi.rs \
+  "$(printf 'let mut mcp = MqttScratch::new();\tlet mut mcp = MqttScratch::new();\n        let _ = write!(mcp, "MC|{}|{}|{}", node_id, pub_ch, newseq);')"
+
+echo "== arm 7b: an announce site in a NEW, undeclared fn =="
+arm "undeclared MC announce fn" 1 "arm 7 (mc-publish)" net/wifi.rs \
+  "$(printf 'fn mqtt_session(\tfn leak_mc_announce(elect: \&Elect, node_id: u8, seq: u32) {\n    let mut p = MqttScratch::new();\n    let _ = write!(p, "MC|{}|{}|{}", node_id, elect.my_channel, seq);\n}\n\nfn mqtt_session(')"
+
+echo "== arm 7c: the channel computed AT the publish site, bypassing the binding =="
+arm "channel is an expression" 1 "formats the channel as the expression" net/wifi.rs \
+  "$(printf '"MC|{}|{}|{}", node_id, pub_ch, newseq\t"MC|{}|{}|{}", node_id, elect.my_channel, newseq')"
+
+echo "== arm 7d: THE T regression — the guard degraded from a type back to a value =="
+arm "NonZeroU8 binding removed" 1 "NOT bound by" net/wifi.rs \
+  "$(printf 'let pub_ch = core::num::NonZeroU8::new(if\tlet pub_ch = Some(if')"
+
+echo "== arm 7e: fail-closed — the roster deleted must NOT read as success =="
+arm "MC roster deleted" 2 "no \`MC-PUBLISH-SITES:\` declaration" net/wifi.rs \
+  "$(printf 'MC-PUBLISH-SITES:\tMC-PUBLISH-SITES-WAS-HERE:')"
+
+echo "== arm 7f: fail-closed — the announce reshaped out of this arm's sight =="
+# Needs EVERY site rewritten, so it cannot use `arm` (one replacement). A partial reshape is a
+# different failure (a miscount, arm 7a's shape) and is already covered above.
+seed
+python3 - "$work/tree/rust/clock/src/net/wifi.rs" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+old, new = '"MC|{}|{}|{}"', '"MC/{}/{}/{}"'
+n = s.count(old)
+if n < 2:
+    sys.exit(f"fixture setup failed: expected >=2 {old!r}, found {n} — this test needs updating")
+open(p, "w").write(s.replace(old, new))
+PY
+if [ $? -eq 0 ]; then
+  out="$("$CHK" "$work/tree" 2>&1)"; rc=$?
+  if [ "$rc" != 2 ]; then no "announce reshaped: rc $rc, want 2 — $out"
+  else case "$out" in *"ZERO MC announce sites"*) ok "announce reshaped fails CLOSED (rc=2)" ;;
+       *) no "announce reshaped: rc right, WRONG REASON — $out" ;; esac; fi
+else no "announce reshaped (fixture setup)"; fi
+
+echo "== arm 7g: comments must not move arm 7's verdict, either way (#426) =="
+seed
+if patch1 "$work/tree/rust/clock/src/net/wifi.rs" \
+  "$(printf 'fn mqtt_session(\t// prose: the announce is write!(mcp, "MC|{}|{}|{}", node_id, pub_ch, newseq)\n/* and in a block comment too: write!(p, "MC|{}|{}|{}", a, b, c); */\nfn mqtt_session(')"; then
+  out="$("$CHK" "$work/tree" 2>&1)"; rc=$?
+  if [ "$rc" = 0 ]; then ok "prose naming an MC announce stays green (rc=0)"
+  else no "PROSE FLIPPED THE VERDICT: rc $rc — $out"; fi
+else no "MC prose regression (fixture setup)"; fi
+# And the false-GREEN direction: commenting a real announce out must not satisfy the roster.
+arm "commenting out a real announce is caught" 1 "arm 7 (mc-publish)" net/wifi.rs \
+  "$(printf 'let _ = write!(mcp, "MC|{}|{}|{}", node_id, pub_ch, newseq);\t// let _ = write!(mcp, "MC|{}|{}|{}", node_id, pub_ch, newseq);')"
+
 echo
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
The structural half of #403, written **against the shape that landed** (#450) rather than a predicted one. Stacked on #450 — merge that first; this PR's diff against it is `tools/` + one doc comment + one T-SCOPE line.

## Why a checker at all, when the compiler already refuses a `u8`

`NonZeroU8` proves the two announce sites *we have* take a guarded channel. It cannot prove a **third site does not appear** taking a bare `u8` — and *"there are exactly two announce sites"* is a **structural claim no build and no test can witness**. That gap is precisely the shape #403 already was: `!= 0` written on one branch, absent from its sibling, with nothing counting the siblings.

## Why it is sequenced before STEP T

Both sites live inside `mqtt_session` — the ~2,000-line body #335 STEP T rewrites in **one atomic commit**. This arm is what makes T face a red-if-dropped gate instead of a review promise. Per the team lead's instruction and the repo's idiom, the **declaration and its enforcement land together**: T-SCOPE §7's acceptance list gains *"the MC-publish guard survives the rewrite, asserted by the arm and not by reading the diff"* **in this same commit**.

## Arm 7, in the `RAW-SEND-SITES` idiom

| | |
|---|---|
| **roster** | `MC-PUBLISH-SITES: mqtt_session:2`, declared in the firmware source, checked in **both directions with counts** — a third site inside a declared fn fails exactly as an undeclared fn does |
| **guarded binding** | each site's channel **argument** must be a binding produced by `NonZeroU8::new` in the same fn |
| **fails closed** | no roster, or an announce reshaped out of the arm's sight → exit **2**, never a pass |
| **comment-blind, both ways** | the roster is read from RAW source (it lives in a doc comment); every structural scan reads the comment-**stripped** view (#426) |

**Not "assert a `!= 0` exists".** That pins a token, rots on the first rewrite, and — the part that matters here — would happily pass a rewrite that moved the check to *one* of the two sites, which is #403 again.

## Proof of failure, both directions — 8 new arms, each red for its own reason

```
ok - third MC announce site                        (rc=1)
ok - undeclared MC announce fn                     (rc=1)
ok - channel is an expression                      (rc=1)
ok - NonZeroU8 binding removed                     (rc=1)   <- the regression T could actually ship
ok - MC roster deleted                             (rc=2)
ok - announce reshaped fails CLOSED                (rc=2)
ok - prose naming an MC announce stays green       (rc=0)   <- false-RED direction
ok - commenting out a real announce is caught      (rc=1)   <- false-GREEN direction
```

`test_check_elect_send_path`: **24 passed, 0 failed** (16 before).

## Verified

All three gate arms green on familiar — `fw`, `host`, `excl`.

And the arm was confirmed to actually *run inside the gate*, not merely to exist, because a checker that quietly covers nothing is the failure this file was written about. The `fw` arm now prints:

```
elect send path: 1 `GroupMacSink` impl, routed through send_to; 1 encoder call site(s), all in
SealedElect::seal; 4 raw send sites across 4 declared fns; 2 MC announce site(s) across 1
declared fn(s), channel NonZeroU8-bound
```

A **count**, so "silently did nothing" is distinguishable from "passed". `gate.sh`'s own comment is updated in the same commit (three fail-closed arms → five), because a stale count next to a live check reads as a considered decision.

**Not verified:** nothing here touches hardware or runtime, by construction — arm 7 is a static source check and `pub_ch == 0` is a runtime value. The two halves answer different questions and neither can silence the other; that category boundary is stated in the arm's own comment block.

Refs #403, #278, #269, #426. Sequenced before #335 STEP T.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
