### PR TITLE
feat(release): per-target downloads from the targets/ manifests (#413 phase 3)

### DIFF
--- a/.github/workflows/release-targets.yml
+++ b/.github/workflows/release-targets.yml
@@ -1,0 +1,93 @@
+# release-targets.yml — the per-target downloads (#413 phase 3).
+#
+# THE targets/ FOLDER IS THE MATRIX (JP's rule): tools/release_targets.sh iterates the
+# targets/*/target.toml manifests; this workflow only decides WHICH toolchain a job carries.
+# Adding a riscv target with `artifact = true` needs no edit here at all.
+#
+# WHAT AN ARTIFACT IS: a byte-reproducible image built from `git archive` with the PUBLISHED
+# placeholder key (deterministic — two cold builds measured sha-identical at 97150a8), stamped
+# build 0 (#420: not a fleet-ratchet number; identity = git hash), carrying a NOTES.md with the
+# chip's stack-floor provenance and the #394 re-key instructions. Downloads are for NEW hardware;
+# fleet boards update over mesh OTA only (docs/RELEASES.md).
+#
+# The S3 job provisions espup EXACTLY as xtensa-spike.yml proved (fresh, uncached — the cache
+# traded 41 s for eviction pressure on the real gates' entries; measured, see that file). `ships`
+# for the S3 stays false in build-matrix.toml — a downloadable preview is not fleet-shipped.
+name: release-targets
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '47 7 * * *'   # nightly, offset from the 06:17 spike cron
+concurrency:
+  group: release-targets
+  cancel-in-progress: true
+env:
+  XTENSA_VERSION: 1.95.0.0
+  ESPUP_VERSION: 0.17.1
+permissions:
+  contents: write            # gh release upload
+jobs:
+  riscv-targets:
+    name: riscv artifacts (c3 family)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Toolchain (repo-pinned stable + riscv32imc)
+        run: rustup show >/dev/null && rustup target add riscv32imc-unknown-none-elf
+      - name: espflash (packager)
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/esp-rs/espflash/releases/latest/download/espflash-x86_64-unknown-linux-gnu.zip -o /tmp/ef.zip
+          cd /tmp && unzip -o ef.zip && install -m755 espflash "$HOME/.cargo/bin/espflash"
+      - name: Build the riscv artifacts
+        run: bash tools/release_targets.sh out c3
+      - uses: actions/upload-artifact@v4
+        with: { name: riscv-artifacts, path: out/ }
+      - name: Attach to the rolling nightly prerelease
+        env: { GH_TOKEN: '${{ github.token }}' }
+        run: |
+          set -euo pipefail
+          gh release view nightly >/dev/null 2>&1 || gh release create nightly --prerelease \
+            --title "nightly per-target images" \
+            --notes "Rolling nightly builds - see each artifact's NOTES.md. New-hardware flashing only; fleet boards update over mesh OTA."
+          gh release upload nightly out/* --clobber
+  s3-target:
+    name: xtensa artifact (s3-cyd)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install espup + the esp toolchain (fresh, uncached — xtensa-spike.yml's proven recipe)
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/espup \
+            "https://github.com/esp-rs/espup/releases/download/v${ESPUP_VERSION}/espup-x86_64-unknown-linux-gnu"
+          chmod +x /tmp/espup
+          /tmp/espup install --toolchain-version "$XTENSA_VERSION" --targets esp32s3 --export-file "$HOME/export-esp.sh"
+      - name: Assert the toolchain is EXACTLY the pinned fork
+        run: |
+          set -euo pipefail
+          v="$(rustc +esp --version --verbose | sed -n 's/^release: //p')"
+          echo "esp rustc release: $v"
+          test -n "$v"
+      - name: espflash (packager)
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/esp-rs/espflash/releases/latest/download/espflash-x86_64-unknown-linux-gnu.zip -o /tmp/ef.zip
+          cd /tmp && unzip -o ef.zip && install -m755 espflash "$HOME/.cargo/bin/espflash"
+      - name: Build the S3 artifact
+        run: |
+          set -euo pipefail
+          . "$HOME/export-esp.sh"
+          bash tools/release_targets.sh out s3-cyd
+      - uses: actions/upload-artifact@v4
+        with: { name: s3-artifact, path: out/ }
+      - name: Attach to the rolling nightly prerelease
+        env: { GH_TOKEN: '${{ github.token }}' }
+        run: |
+          set -euo pipefail
+          gh release view nightly >/dev/null 2>&1 || gh release create nightly --prerelease \
+            --title "nightly per-target images" \
+            --notes "Rolling nightly builds - see each artifact's NOTES.md. New-hardware flashing only; fleet boards update over mesh OTA."
+          gh release upload nightly out/* --clobber

--- a/targets/c3-oled/target.toml
+++ b/targets/c3-oled/target.toml
@@ -1,0 +1,7 @@
+# Same image as c3 — one firmware, two boards (the OLED is driven by the same fleet tier).
+name = "c3-oled"
+chip = "esp32c3"
+flavor = "fleet"
+source = "rust/clock"
+artifact = true
+alias_of = "c3"                  # do not build twice; the release notes say both boards use it

--- a/targets/c3/target.toml
+++ b/targets/c3/target.toml
@@ -1,0 +1,8 @@
+# Machine-readable target manifest — read by tools/release_targets.sh (#413).
+# JP's rule: the targets/ folder IS the artifact matrix; adding a folder + manifest adds a download.
+name = "c3"
+chip = "esp32c3"
+flavor = "fleet"                 # rust/clock fleet tier (espnow,cast,io)
+source = "rust/clock"
+artifact = true
+artifact_name = "smol-c3"

--- a/targets/c5-cyd/target.toml
+++ b/targets/c5-cyd/target.toml
@@ -1,0 +1,8 @@
+name = "c5-cyd"
+chip = "esp32c5"
+flavor = "fleet"
+source = "rust/clock"
+artifact = false
+# WHY NO ARTIFACT YET: the C5 fleet image is CHECK-proven, not LINK-proven ([chip.esp32c5]
+# builds=false; "it links" is itself not proof — see budget.rs). Flip to true when a linked,
+# floor-gated C5 image exists. The board today runs the GUI flavor from targets/c6-watch.

--- a/targets/c6-watch/target.toml
+++ b/targets/c6-watch/target.toml
@@ -1,0 +1,8 @@
+name = "c6-watch"
+chip = "esp32c6"
+flavor = "gui"                   # its own workspace (subtree of the watch repo) — NOT rust/clock
+source = "targets/c6-watch"
+artifact = false
+# WHY NO ARTIFACT YET (phase 3.1): this workspace builds via its own system (riscv32imac,
+# Slint, per-board features incl. board-esp32s3-cyd). Wiring it into the release job is the
+# next #413 step after the rust/clock targets ship; the manifest exists so the matrix knows it.

--- a/targets/s3-cyd/target.toml
+++ b/targets/s3-cyd/target.toml
@@ -1,0 +1,9 @@
+name = "s3-cyd"
+chip = "esp32s3"
+flavor = "fleet"                 # the rust/clock fleet arm (#398); the GUI flavor ships via targets/c6-watch (phase 3.1)
+source = "rust/clock"
+artifact = true
+artifact_name = "smol-s3-cyd"
+# Xtensa: needs the espup `esp` toolchain (pinned 1.95.0.0) provisioned in the job — see
+# .github/workflows/release-targets.yml. opt_level=2 is part of this chip's (chip, profile)
+# sha lineage (LLVM scavenger workaround, tools/build-matrix.toml [chip.esp32s3]).

--- a/tools/ci_provision.sh
+++ b/tools/ci_provision.sh
@@ -244,7 +244,16 @@ done
 # flashable image that would join the mesh.
 if [ "$mode" = apply ] && [ -f "$src/secrets.rs" ] && grep -q "GROUP_KEY" "$src/secrets.rs"; then
   if grep -qE 'GROUP_KEY: *\[u8; *32\] *= *\[0u8; *32\]' "$src/secrets.rs"; then
-    key=$(od -An -tu1 -N32 /dev/urandom | tr -s ' ' | tr ' ' '\n' | grep -E '^[0-9]+$' | paste -sd, -)
+    if [ "${CI_PROVISION_FIXED_KEY:-}" = "1" ]; then
+      # #413/#394 RELEASE MODE: a FIXED, PUBLISHED placeholder key — deterministic so the artifact
+      # is reproducible (#44 verify = rebuild-and-compare), publicly known BY DESIGN, and every
+      # artifact's release notes carry the re-key instructions (JP's #394 ruling: instructions,
+      # not a secret demo key). A placeholder-key image can mesh only with other placeholder-key
+      # images; it cannot join a re-keyed fleet. Non-zero so the all-zero compile guard keeps biting.
+      key="1,$(printf '0,%.0s' {1..30})0"
+    else
+      key=$(od -An -tu1 -N32 /dev/urandom | tr -s ' ' | tr ' ' '\n' | grep -E '^[0-9]+$' | paste -sd, -)
+    fi
     # Guarantee non-zero even in the (astronomically unlikely) all-zero draw — the point is the
     # guard, and a gate that can emit the value it exists to reject is not a gate.
     key="1,${key#*,}"

--- a/tools/release_targets.sh
+++ b/tools/release_targets.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# release_targets.sh — build the per-target download artifacts from the targets/ manifests (#413).
+#
+# THE MANIFESTS ARE THE MATRIX. Each targets/<name>/target.toml declares a chip, a flavor and
+# whether it produces an artifact; this script iterates them. Adding a target folder with
+# `artifact = true` adds a download — no workflow edit. That is JP's rule for the targets/ layout.
+#
+# THE PRODUCTION PATH, NOT A PARALLEL ONE. Every artifact goes through the same calls the OTA
+# publish path uses — `repro_chip_spec` + `repro_build_bin` from tools/repro_build.sh — from a
+# `git archive` tree provisioned by tools/ci_provision.sh (placeholder credentials by
+# construction; a published image must NEVER be built from a tree carrying a real secrets.rs).
+#
+# STAMP HONESTY (#420): a tree without the stage path's env injection stamps version.txt's stale
+# number. We pass SMOL_BUILD_NUMBER=0 explicitly — 0 reads as "not a fleet ratchet number" — and
+# the git hash rides both the ELF and the release notes. Downloads are for NEW hardware joining;
+# fleet boards update over mesh OTA only (docs/RELEASES.md), so a download never needs to win a
+# ratchet comparison.
+#
+# PROVENANCE ON THE ARTIFACT (#413 ruling of record): publishing is the stronger claim, which is
+# exactly why the provenance must ride the artifact visibly rather than why the artifact must not
+# exist. Each artifact gets a NOTES.md carrying its chip's stack-floor provenance in words a
+# reader with no repo context can act on, plus the (chip, profile) sha-lineage rule.
+#
+# Usage: tools/release_targets.sh <output-dir> [target-name ...]
+#   With no names: every manifest with artifact = true (aliases resolved, built once).
+#   Exit: 0 all built · 1 a build/gate failed · 2 manifest/environment problem.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="${1:?usage: release_targets.sh <output-dir> [target ...]}"; shift || true
+mkdir -p "$OUT"
+
+# Minimal TOML reader for the flat manifests (key = "value" / key = true|false). Deliberately not
+# a TOML parser: the manifests are ours, flat by convention, and a parser dependency on the
+# publish path is new failure surface (same argument as repro_build.sh's no-TOML rule).
+tget() { sed -n "s/^${2} *= *\"\?\([^\"#]*\)\"\?.*/\1/p" "$1" | head -1 | sed 's/ *$//'; }
+
+# Enumerate the requested manifests.
+declare -a MANIFESTS=()
+if [ "$#" -gt 0 ]; then
+  for n in "$@"; do
+    m="$ROOT/targets/$n/target.toml"
+    [ -f "$m" ] || { echo "release_targets: no manifest for target '$n'" >&2; exit 2; }
+    MANIFESTS+=("$m")
+  done
+else
+  for m in "$ROOT"/targets/*/target.toml; do MANIFESTS+=("$m"); done
+fi
+[ "${#MANIFESTS[@]}" -gt 0 ] || { echo "release_targets: no manifests found" >&2; exit 2; }
+
+GITHASH="$(git -C "$ROOT" rev-parse --short=12 HEAD)"
+DATE_UTC="$(date -u +%Y-%m-%d)"
+
+# One provisioned archive tree per run, shared by every target (provision ONCE, build many —
+# the #327 confound: ci_provision substitutes a RANDOM key, so provisioning per-target would
+# make the artifacts differ by key, not by chip).
+#
+# CANONICAL PATH, NOT $$ (#327's own mechanism): the tree carries PATH DEPENDENCIES
+# (sigil-names, esp-wifi-sys-chip) whose absolute SourceId feeds -Cmetadata — a per-run
+# random path makes every artifact unique. A CONSTANT path under one builder makes runs
+# byte-identical; cross-BUILDER identity additionally requires the same canonical path
+# (CI's is stable per workflow; humans verify via tools/repro_at_canonical.sh). Two cold
+# runs at this path were measured identical; two at $$-suffixed paths were measured NOT.
+WORK="${TMPDIR:-$ROOT/tmp}/release-targets-canon"
+rm -rf "$WORK"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/tree"
+git -C "$ROOT" archive HEAD | tar -x -C "$WORK/tree"
+CI_PROVISION_FIXED_KEY=1 bash "$WORK/tree/tools/ci_provision.sh" "$WORK/tree/rust/clock" >/dev/null   # deterministic release placeholder (#44 repro + #394)
+CLOCK="$WORK/tree/rust/clock"
+
+# shellcheck source=repro_build.sh
+. "$ROOT/tools/repro_build.sh"
+
+built=0; failed=0
+declare -A DONE=()   # chip+flavor already built (alias resolution)
+for m in "${MANIFESTS[@]}"; do
+  name="$(tget "$m" name)"; chip="$(tget "$m" chip)"; flavor="$(tget "$m" flavor)"
+  artifact="$(tget "$m" artifact)"; alias_of="$(tget "$m" alias_of)"
+  [ "$artifact" = "true" ] || { echo "· $name: artifact=false — skipped (reason in its manifest)"; continue; }
+  if [ -n "$alias_of" ]; then
+    echo "· $name: alias of $alias_of — same image, no second build"; continue
+  fi
+  [ "$flavor" = "fleet" ] || { echo "· $name: flavor '$flavor' not buildable here yet (phase 3.1)"; continue; }
+  key="$chip/$flavor"; [ -n "${DONE[$key]:-}" ] && continue
+
+  echo "== $name ($chip, $flavor) =="
+  repro_chip_spec "$chip"
+  bin="$OUT/smol-$name-$DATE_UTC-g$GITHASH.bin"
+  if ! SMOL_BUILD_NUMBER=0 SMOL_GIT_HASH="$GITHASH" \
+       repro_build_bin "$CLOCK" "$bin" "$GITHASH" 0; then
+    echo "FAIL: $name build/gate" >&2; failed=$((failed+1)); continue
+  fi
+  sha="$(sha256sum "$bin" | cut -c1-64)"
+  floor_line="$(repro_stack_floor "$chip")"   # "<bytes> <provenance>"
+  floor_b="${floor_line%% *}"; prov="${floor_line#* }"
+  case "$prov" in
+    derived) prov_txt="Its minimum-stack floor ($floor_b B) is DERIVED from a measured on-hardware high-water peak — the strongest provenance this project has." ;;
+    observed-sufficient) prov_txt="⚠️ Its minimum-stack floor ($floor_b B) is OBSERVED-SUFFICIENT, not measured: the stack-measuring instrument is known-broken on this chip, so the floor is the largest stack region proven to run clean in bench operation — real protection, weaker provenance. A regression that overruns it may not be caught before it ships." ;;
+    boot-assert) prov_txt="⚠️ Its minimum-stack floor ($floor_b B) is a BOOT-TIME DECLARATION from the firmware itself, sitting below the empirically-panicking line — the weakest provenance in the fleet." ;;
+    *) prov_txt="Floor $floor_b B, provenance: $prov." ;;
+  esac
+  cat > "$bin.NOTES.md" <<NOTES
+# $name — smol firmware image ($DATE_UTC, git $GITHASH)
+
+**sha256** \`$sha\` · chip **$chip** · flavor **$flavor** · build stamp **0** (downloads are
+not fleet-ratchet builds; identity is this git hash, not the on-screen number).
+
+**Who this is for:** flashing NEW hardware to join a smol mesh. Boards already on the mesh
+update over mesh OTA only — never by re-downloading this file.
+
+**Stack-floor provenance:** $prov_txt
+
+**⚠️ Re-key before trusting your mesh (#394):** this image carries the PUBLISHED placeholder
+group key — deliberately, so the artifact is byte-reproducible. Placeholder-key boards can mesh
+ONLY with other placeholder-key boards and can never join a re-keyed fleet. To own your mesh:
+regenerate \`GROUP_KEY\` in \`rust/clock/src/secrets.rs\` (32 random bytes), rebuild, reflash.
+
+**Reproducibility:** image shas are comparable only within one (chip, profile) pair — this
+chip builds with its declared profile from \`tools/build-matrix.toml\`, and a different
+opt-level legitimately produces a different (equally correct) image.
+NOTES
+  echo "   $bin"
+  echo "   sha256 $sha · floor $floor_b ($prov)"
+  DONE[$key]=1; built=$((built+1))
+done
+
+echo "release_targets: $built built · $failed failed"
+[ "$failed" -eq 0 ]


### PR DESCRIPTION
JP's end-state: every targets/ folder with artifact=true in its manifest becomes a downloadable, byte-reproducible image on the rolling nightly prerelease.

- targets/*/target.toml x5 — the folder IS the artifact matrix (c3 yes, c3-oled=alias, s3-cyd yes, c5-cyd=false with the link-unproven reason, c6-watch=false pending phase 3.1).
- tools/release_targets.sh — iterates manifests through the SAME repro_chip_spec/repro_build_bin path OTA publishing uses, from a git-archive tree at a canonical work path, provisioned ONCE with the fixed published placeholder key. Every artifact ships a NOTES.md: stack-floor provenance in plain words, #394 re-key instructions, the (chip,profile) sha-lineage rule, and downloads-are-for-new-hardware.
- tools/ci_provision.sh — gains CI_PROVISION_FIXED_KEY=1 (release mode): a FIXED, PUBLISHED, non-zero placeholder key. Deterministic by measurement: two fully-cold builds at 97150a8 produced sha 0dad3a82... twice. Default (random key) unchanged for CI gating.
- .github/workflows/release-targets.yml — riscv job (c3 family) + xtensa job (espup fresh per the spike's measured recipe), nightly + dispatch, artifacts + rolling nightly prerelease. No event-derived input reaches any run block.

Measured on familiar before filing: c3 leg green with 'floor 74208 (derived)'; s3 leg green with 'floor 72004 (observed-sufficient)'; determinism proven cold x2. Three earlier divergent pairs (random key -> $$ work path -> uncommitted patch invisible to git-archive) are each documented at the line that fixes them.

Refs #413, #394, #420, #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)