### PR TITLE
fix(ota): stage must not stamp an identity it cannot honour (#400)

### DIFF
--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -699,6 +699,29 @@ if [ "$run_host" = 1 ]; then
   else
     printf '%s\n' "$out" | sed 's/^/        /'; bad "test_ci_provision"
   fi
+
+  # #400: and the same argument a third time. An audit of `tools/test_*.sh` against this file found
+  # FOUR suites with no gate — so #314's id42-refusal test and the #128 ratchet test have never once
+  # been run by CI, and the safety properties they assert were being maintained on trust. Both of
+  # these guard tools/ota_publish.sh, which is the one script here that can arm the whole fleet.
+  #
+  # Deliberately NOT wired, with reasons, so the remainder is a declared gap and not an oversight:
+  #   • test_ota_verify.sh      — hermetic but slow (>2 min, replays canned MQTT logs). Not wired
+  #     because I did not watch it run to completion, and wiring a suite on the strength of its own
+  #     header comment is the inference this file exists to refuse. Worth a follow-up.
+  #   • test_ha_deploy_guard.sh — MUST NOT be wired. It commits with `git commit -am` by design and
+  #     is built for a scratch clone; running it in a checkout with work in it creates junk commits
+  #     (it has already done so here once). Its refusal to run in a working tree IS the guard.
+  # Both suites below are offline, cargo-free, and leave the working tree byte-unchanged (verified
+  # by running them and checking `git status --porcelain`, not by reading their headers).
+  step "OTA publish guards + ratchet regression suites (#314/#128/#400)"
+  for _t in test_ota_publish_guards test_ota_ratchet; do
+    if out=$("$ROOT/tools/$_t.sh" 2>&1); then
+      printf '%s\n' "$out" | tail -1; ok "$_t"
+    else
+      printf '%s\n' "$out" | sed 's/^/        /'; bad "$_t"
+    fi
+  done
 fi
 
 step "summary"

--- a/tools/ota_publish.sh
+++ b/tools/ota_publish.sh
@@ -14,6 +14,10 @@
 #   ota_publish.sh stage      [<commit>] [--bin <file>] [--build N]  # build+host+publish smol/ota/staged (arms all boards; NO board fetches)
 #   ota_publish.sh install <id>                                      # publish INSTALL → smol/<id>/ota/install (headless per-node canary; the HA Update button is the GUI path). id42 is REFUSED (#314: C6 watch unset-config sentinel, not a node).
 # <commit> defaults to HEAD. --bin <file> skips the cargo build and hosts an existing .bin.
+# IDENTITY (#400): stage BUILDS THE WORKING TREE — it cannot build a commit's source. So a
+#   <commit> that is not HEAD is REFUSED (it would stamp that commit's identity onto these bytes),
+#   and DIRTY tracked build inputs under rust/clock are REFUSED unless you pass --dirty, which
+#   builds a DEV-stamped image (vN+dev.<hash>) since its sha is reproducible from no commit.
 # BUILD number (the staged-line monotonicity value the fw compares): stage RATCHETS it forward —
 #   build = max(`git rev-list --count`, <retained smol/ota/staged build> + 1) — so a prior canary
 #   pin (a --build N left ahead of the count) HEALS the fleet number forward automatically instead
@@ -81,7 +85,10 @@ ADDON="${ADDON:-<addon-slug>}"                  # supervisor addon slug carrying
 SMOL_OTA_SIGNING_KEY_ITEM="${SMOL_OTA_SIGNING_KEY_ITEM:-smol-ota-signing-ed25519}"  # Vaultwarden secureNote holding the ed25519 signing PEM (#32)
 
 die(){ echo "ERROR: $*" >&2; exit 1; }
-usage(){ sed -n '2,23p' "${BASH_SOURCE[0]}"; exit "${1:-1}"; }
+# ⚠️ The line range is a DUPLICATED FACT about the header block's extent — edit the header and it
+# rots silently (help output truncates mid-sentence, and nobody reads help on the happy path).
+# test_ota_publish_guards.sh pins both ends so an edit that forgets this fails instead.
+usage(){ sed -n '2,27p' "${BASH_SOURCE[0]}"; exit "${1:-1}"; }
 
 MODE="${1:-}"; [ -n "$MODE" ] || usage 1
 
@@ -158,6 +165,79 @@ assert_ota_targetable(){ # <id> — returns 0, or prints the refusal and exits 2
       exit 22 ;;
   esac
   return 0
+}
+
+# ---- #400: the stamp must describe the bytes ---------------------------------
+# ROOT CAUSE, stated once: the STAMP is a function of a git ref (HASH/COUNT come from <commit>);
+# the BYTES are a function of the WORKING TREE (repro_build_bin builds $CLOCK). Nothing asserted
+# that those two describe the same source, so the tool whose job is identity could mint a false one.
+#
+# Observed live (the #335 round-trip canary): `stage 1a6349e` published an image stamped
+# `build 919 (1a6349e)` carrying the CURRENT tree's size (byte-identical to the HEAD build staged
+# minutes earlier), the current stack region (106,480 B — that era's code reads ~75K), and a #349
+# target descriptor July-28 code cannot emit. Honest-looking, false provenance.
+#
+# TWO refusals, because the filed instance is only the LOUD half of one defect:
+#   1. a non-HEAD <commit> — the tool cannot build a commit's source, so it must not claim to.
+#   2. DIRTY build inputs — `stage` with no argument, the path every caller in this repo actually
+#      uses, stamped HEAD's hash onto uncommitted bytes AND force-exported SMOL_RELEASE=1, so an
+#      uncommitted canary shipped stamped as a clean release. Fixing only (1) would have left (2)
+#      live on the common path — a guard on one branch and absent on its sibling.
+
+# stage_input_dirt — print the DIRTY TRACKED build inputs (empty output = clean).
+# THE SCOPE IS THE CHECK. Every input whose change alters the image bytes lives under rust/clock:
+# src/, build.rs, Cargo.toml, Cargo.lock, version.txt, rust-toolchain.toml, .cargo/config.toml.
+# A repo-wide check would refuse an unrelated docs or tools edit, and a gate that fires on innocent
+# states is a gate operators learn to route around (#338) — fatal for one guarding a publish.
+# --untracked-files=no is LOAD-BEARING, not tidiness: board.rs and secrets.rs are git-ignored BY
+# DESIGN (.gitignore:27,35) and are therefore permanently untracked, so counting untracked files
+# would make every tree dirty forever and the guard would refuse every stage there is.
+stage_input_dirt(){
+  git -C "${REPO:-.}" status --porcelain --untracked-files=no -- rust/clock
+}
+
+assert_stamp_is_head(){ # <commit> — returns 0, or prints the refusal and exits 22
+  local commit="$1" want have
+  if ! want="$(git -C "${REPO:-.}" rev-parse --verify --quiet "${commit}^{commit}")"; then
+    echo "REFUSED: '$commit' is not a commit in this repository. NOTHING WAS PUBLISHED." >&2
+    exit 22
+  fi
+  have="$(git -C "${REPO:-.}" rev-parse --verify --quiet 'HEAD^{commit}')" || {
+    echo "REFUSED: cannot resolve HEAD. NOTHING WAS PUBLISHED." >&2; exit 22; }
+  [ "$want" = "$have" ] && return 0
+  {
+    echo "REFUSED: stage cannot build '$commit' — it builds the WORKING TREE (#400)."
+    echo "  asked to stamp   $(git -C "${REPO:-.}" rev-parse --short=7 "$want")"
+    echo "  tree is actually $(git -C "${REPO:-.}" rev-parse --short=7 "$have")"
+    echo "  Stamping a commit's identity onto different bytes is what this refusal exists to stop:"
+    echo "  it yields an honest-LOOKING image with a FALSE provenance stamp, and the only reason the"
+    echo "  live instance was caught was an operator cross-checking the numbers by hand."
+    echo "  NOTHING WAS PUBLISHED."
+    echo "  Fix: check the commit out and stage from THERE, so the bytes match the stamp:"
+    echo "    git worktree add ../smol-stage '$commit' && cd ../smol-stage && tools/ota_publish.sh stage"
+    echo "  (a linked worktree has no tools/ota_publish.env of its own; the #128 resolver reads the"
+    echo "  main worktree's copy, so the broker config still resolves.)"
+  } >&2
+  exit 22
+}
+
+assert_stampable_inputs(){ # <allow_dirty:0|1> — returns 0, or prints the refusal and exits 22
+  local allow="$1" dirt
+  dirt="$(stage_input_dirt)"
+  [ -z "$dirt" ] && return 0
+  [ "$allow" = 1 ] && return 0
+  {
+    echo "REFUSED: the tracked build inputs under rust/clock differ from HEAD (#400)."
+    echo "$dirt" | sed 's/^/    /'
+    echo "  An image built now gets HEAD's identity stamped on source that is not HEAD, so the"
+    echo "  announced sha256 is reproducible from no commit and verify_image.sh cannot confirm it."
+    echo "  NOTHING WAS PUBLISHED."
+    echo "  Fix: commit (or stash) the change and re-stage."
+    echo "  Or, to canary uncommitted work on purpose:  --dirty"
+    echo "    That builds a DEV-stamped image (vN+dev.<hash>) rather than a clean release stamp,"
+    echo "    because the bytes answer to no commit — the stamp then says what the image IS."
+  } >&2
+  exit 22
 }
 
 pub_retained(){ # topic, payload  (payload may be empty = retain-delete)
@@ -263,15 +343,28 @@ fi
 
 [ "$MODE" = "stage" ] || usage 1
 shift 1
-COMMIT="HEAD"; BIN=""; BUILD_OVERRIDE=""
+COMMIT="HEAD"; BIN=""; BUILD_OVERRIDE=""; ALLOW_DIRTY=0
 while [ $# -gt 0 ]; do case "$1" in
   --bin) BIN="${2:?}"; shift 2;;
   --build) BUILD_OVERRIDE="${2:?}"; shift 2;;
+  --dirty) ALLOW_DIRTY=1; shift;;
   *) COMMIT="$1"; shift;;
 esac; done
 
 # ---- identity (matches build.rs deploy contract; archive builds have no .git) -
 cd "$REPO"
+# #400: refuse BEFORE the broker read and before the build — a stamp this tool cannot honour must
+# cost nothing to reject. This applies to the --bin path too: the <commit> argument's ONLY effect is
+# provenance, and with a prebuilt image we can verify that claim even less, so `stage <old> --bin
+# <current>` is the same mislabelling by a shorter route.
+assert_stamp_is_head "$COMMIT"
+# The dirty refusal is a claim about BYTES THIS TOOL IS ABOUT TO PRODUCE, so it is conditioned on
+# the build path: on --bin we neither build nor stamp, and refusing an operator's own prebuilt image
+# over the state of a tree it did not come from would be a gate firing on an innocent state.
+# Conditioned HERE rather than called inside the build branch so that BOTH refusals land before the
+# broker read and before any credential is sourced — a stamp this tool cannot honour must cost
+# nothing to reject, which is the same placement property #314's id42 refusal is tested for.
+[ -n "$BIN" ] || assert_stampable_inputs "$ALLOW_DIRTY"
 HASH="$(git rev-parse --short=7 "$COMMIT")"
 COUNT="$(git rev-list --count "$COMMIT")"
 # #128: --build N stays an explicit operator override (canary an UNCOMMITTED image with no
@@ -309,16 +402,33 @@ BUILD="$(choose_build "$COUNT" "$STAGED" "$BUILD_OVERRIDE")"
 # `verify_image.sh <commit>`. No node-id here is consistent with the fleet-shared design
 # above: ONE reproducible image, one sha per commit for the whole fleet.
 if [ -z "$BIN" ]; then
+  # #400: the dirty refusal already fired up at the identity block (before the broker read).
   echo "building reproducible espnow release @ $HASH (build $BUILD) ..."
   BIN="$SMOL_TMP/smol-${BUILD}.bin"
   # #326: staging IS the release act, so stamp it as one HERE rather than hoping the
   # operator remembered `export SMOL_RELEASE=1`. Before this line the release-vs-dev stamp
   # of a STAGED image depended on the operator's shell: repro_build.sh's comment said "the
   # caller sets SMOL_RELEASE=1" and no caller in the repo ever did — 913/915 shipped
-  # release-stamped only because operators exported it by hand. A canary of an uncommitted
-  # image still goes through --bin, which skips this build path entirely, so dev images
-  # cannot masquerade: this export never touches them.
-  SMOL_RELEASE=1 repro_build_bin "$CLOCK" "$BIN" "$HASH" "$BUILD" || die "reproducible build failed"
+  # release-stamped only because operators exported it by hand.
+  #
+  # #400 CORRECTION — this comment used to end: "A canary of an uncommitted image still goes
+  # through --bin, which skips this build path entirely, so dev images cannot masquerade: this
+  # export never touches them." That was FOLKLORE. Nothing routed uncommitted work to --bin, and
+  # nothing checked the tree, so `stage` on a dirty tree reached this line and force-stamped a
+  # CLEAN RELEASE onto uncommitted bytes — the precise masquerade the sentence denied, in the block
+  # whose job is honest release stamping. It is true now because assert_stampable_inputs makes it
+  # true: reaching here means either the inputs match HEAD, or --dirty was named and the stamp
+  # below is deliberately withheld.
+  if [ "$ALLOW_DIRTY" = 1 ] && [ -n "$(stage_input_dirt)" ]; then
+    # NO SMOL_RELEASE: build.rs then stamps `vN+dev.<hash>` (#218's honest-identity path), so the
+    # image reports on-glass and over DIAG that it is not a reproducible release. The stamp is the
+    # only part of this that survives into an incident three weeks from now.
+    echo "⚠️  #400: --dirty — building from UNCOMMITTED inputs; stamping DEV (vN+dev.$HASH), not a release."
+    echo "    The announced sha256 is reproducible from NO commit; verify_image.sh cannot confirm it."
+    repro_build_bin "$CLOCK" "$BIN" "$HASH" "$BUILD" || die "reproducible build failed"
+  else
+    SMOL_RELEASE=1 repro_build_bin "$CLOCK" "$BIN" "$HASH" "$BUILD" || die "reproducible build failed"
+  fi
 fi
 [ -f "$BIN" ] || die "no image at $BIN"
 

--- a/tools/test_ota_publish_guards.sh
+++ b/tools/test_ota_publish_guards.sh
@@ -8,8 +8,22 @@
 #   2. the PLACEMENT — the real script reaches that refusal before it sources a credential or
 #      touches mosquitto. A correct predicate called after the publish would pass level 1.
 #
+# Levels 3-5 add #400: `stage` must not stamp an identity it cannot honour. Same two-level shape,
+# because the same two ways of being wrong apply:
+#   3. the DECISION  — assert_stamp_is_head / assert_stampable_inputs refuse the right states and,
+#      just as importantly, refuse NOTHING else (a guard that refuses every stage is unusable);
+#   4. the PLACEMENT — the real script refuses before credentials, AND on the --dirty path actually
+#      omits SMOL_RELEASE at the repro_build_bin call. That last one is the whole point of the fix
+#      and is invisible to any test that only reads exit codes: the old code force-stamped a clean
+#      release onto uncommitted bytes while a comment three lines up said it could not happen. So
+#      level 4 asserts the ENV AT THE CALL, via a stubbed repro_build.sh, not the printed message.
+#   5. the HELP RANGE — usage() hardcodes `sed -n '2,27p'`, a duplicated fact about how far the
+#      header comment runs. Both ends are pinned so editing the header without it fails here.
+#
 # NO broker, NO vault, NO publish: `bw` and `mosquitto_pub` are PATH-stubbed to touch a marker and
-# fail, so any attempt to use them is both harmless and visible. Runs no git command.
+# fail, so any attempt to use them is both harmless and visible. Levels 1-2 run no git command;
+# levels 3-5 run git against a THROWAWAY fixture repo under /var/tmp — never this checkout, and
+# never /tmp (JP directive: katana's /tmp is a 16 GB tmpfs).
 set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="$HERE/ota_publish.sh"
@@ -67,6 +81,141 @@ out="$(PATH="$stub:$PATH" "$SCRIPT" install 8 2>&1)"; rc=$?
 [ -e "$marks/pub" ] && no "control: id8 published despite a failed credential source" \
                     || ok "control: id8 published nothing (bw stub failed it first)"
 rm -rf "$stub" "$marks"
+
+# ---------------------------------------------------------------------------------------------
+# #400 — the stamp must describe the bytes
+# ---------------------------------------------------------------------------------------------
+TMPROOT="${TMPDIR:-/var/tmp}"; case "$TMPROOT" in /tmp|/tmp/*) TMPROOT=/var/tmp ;; esac
+gitq(){ git -c user.email=t@t -c user.name=t -c commit.gpgsign=false -C "$1" "${@:2}"; }
+
+echo "== 3. the decision: assert_stamp_is_head / assert_stampable_inputs =="
+d3="$(mktemp -d "$TMPROOT/smol400d-XXXXXX")"
+mkdir -p "$d3/rust/clock/src" "$d3/docs"
+echo seed > "$d3/rust/clock/src/lib.rs"; echo doc > "$d3/docs/x.md"
+gitq "$d3" init -q
+gitq "$d3" add rust docs; gitq "$d3" commit -qm one
+echo more >> "$d3/docs/x.md"; gitq "$d3" add docs; gitq "$d3" commit -qm two
+
+# Extract ONLY the functions under test — no side effects, none of the parent's traps.
+eval "$(awk '/^stage_input_dirt\(\)\{/,/^\}/'        "$SCRIPT")"
+eval "$(awk '/^assert_stamp_is_head\(\)\{/,/^\}/'    "$SCRIPT")"
+eval "$(awk '/^assert_stampable_inputs\(\)\{/,/^\}/' "$SCRIPT")"
+for f in stage_input_dirt assert_stamp_is_head assert_stampable_inputs; do
+  type "$f" >/dev/null 2>&1 || { echo "extraction of $f failed" >&2; exit 2; }
+done
+export REPO="$d3"
+
+out="$( (assert_stamp_is_head HEAD) 2>&1 )"; rc=$?
+if [ "$rc" = 0 ] && [ -z "$out" ]; then ok "HEAD accepted, silently"; else no "HEAD refused (rc=$rc) $out"; fi
+out="$( (assert_stamp_is_head "$(gitq "$d3" rev-parse HEAD)") 2>&1 )"; rc=$?
+eq "HEAD by full sha accepted" "0" "$rc"   # the same commit spelled differently is the SAME source
+out="$( (assert_stamp_is_head HEAD~1) 2>&1 )"; rc=$?
+eq "non-HEAD commit exits 22" "22" "$rc"
+case "$out" in *"WORKING TREE"*) ok "refusal names the real cause" ;;    *) no "no cause: $out" ;; esac
+case "$out" in *"NOTHING WAS PUBLISHED"*) ok "refusal states nothing published" ;; *) no "no claim: $out" ;; esac
+case "$out" in *"git worktree add"*) ok "refusal states the fix" ;;      *) no "no fix: $out" ;; esac
+out="$( (assert_stamp_is_head deadbeef99) 2>&1 )"; rc=$?
+eq "unresolvable ref exits 22" "22" "$rc"
+
+# clean tree
+out="$( (assert_stampable_inputs 0) 2>&1 )"; rc=$?
+if [ "$rc" = 0 ] && [ -z "$out" ]; then ok "clean inputs accepted, silently"; else no "clean refused (rc=$rc) $out"; fi
+# THE SCOPE CONTROL, and the arm most worth keeping: dirt OUTSIDE rust/clock must NOT refuse.
+# Without this, "the guard fires" is satisfied by a guard that refuses any dirty repo at all —
+# which would refuse a stage over an unrelated docs edit, and a gate that fires on innocent
+# states is one operators route around (#338). This asserts the scope is load-bearing.
+echo stray >> "$d3/docs/x.md"
+out="$( (assert_stampable_inputs 0) 2>&1 )"; rc=$?
+if [ "$rc" = 0 ] && [ -z "$out" ]; then ok "dirt OUTSIDE rust/clock accepted (scope is real)"; else no "scope too wide: refused an unrelated docs edit (rc=$rc)"; fi
+gitq "$d3" checkout -q -- docs/x.md
+# dirty build input
+echo stray >> "$d3/rust/clock/src/lib.rs"
+out="$( (assert_stampable_inputs 0) 2>&1 )"; rc=$?
+eq "dirty build input exits 22" "22" "$rc"
+case "$out" in *"rust/clock/src/lib.rs"*) ok "refusal NAMES the dirty file" ;; *) no "does not say what is dirty: $out" ;; esac
+case "$out" in *"--dirty"*) ok "refusal offers the named override" ;; *) no "no override offered: $out" ;; esac
+out="$( (assert_stampable_inputs 1) 2>&1 )"; rc=$?
+if [ "$rc" = 0 ] && [ -z "$out" ]; then ok "--dirty accepts the same dirt"; else no "--dirty still refused (rc=$rc) $out"; fi
+# An untracked, git-IGNORED file must not count as dirt: board.rs/secrets.rs are ignored by design
+# and permanently absent from git's index, so counting untracked files would refuse every stage.
+gitq "$d3" checkout -q -- rust/clock/src/lib.rs
+echo 'ignored' > "$d3/rust/clock/src/board.rs"
+printf 'board.rs\n' > "$d3/.gitignore"
+out="$( (assert_stampable_inputs 0) 2>&1 )"; rc=$?
+eq "an ignored untracked build-input file is NOT dirt" "0" "$rc"
+unset REPO
+rm -rf "$d3"
+
+echo "== 4. the placement: refuses before credentials, and omits SMOL_RELEASE on --dirty =="
+# A fixture checkout with a STUBBED repro_build.sh, so the build call is observable without cargo.
+# The stub records the env it was called WITH — the assertion the fix actually needs, and the one
+# the old folklore comment would have passed while being false.
+f4="$(mktemp -d "$TMPROOT/smol400p-XXXXXX")"
+mkdir -p "$f4/tools" "$f4/rust/clock/src/net" "$f4/docs"
+cp "$SCRIPT" "$f4/tools/ota_publish.sh"
+cat > "$f4/tools/repro_build.sh" <<'STUB'
+# test stub: record the release-stamp env AT THE CALL, then fail so nothing is hosted or published.
+repro_build_bin(){ printf '%s' "${SMOL_RELEASE-UNSET}" > "$SMOL400_LOG"; return 1; }
+STUB
+echo '// seed' > "$f4/rust/clock/src/net/etx.rs"; echo doc > "$f4/docs/x.md"
+gitq "$f4" init -q
+gitq "$f4" add tools rust docs; gitq "$f4" commit -qm one
+echo more >> "$f4/docs/x.md"; gitq "$f4" add docs; gitq "$f4" commit -qm two
+
+stub2="$(mktemp -d "$TMPROOT/smol400s-XXXXXX")"; marks2="$(mktemp -d "$TMPROOT/smol400m-XXXXXX")"
+for t in bw mosquitto_pub mosquitto_sub; do
+  printf '#!/usr/bin/env bash\ntouch %s/%s\nexit 1\n' "$marks2" "$t" > "$stub2/$t"; chmod +x "$stub2/$t"
+done
+LOG="$marks2/release"
+run4(){ # [extra stage args...] -> sets R4 (exit code) and OUT4 (output). `stage` is ALREADY supplied,
+        # so `run4` alone is a bare stage; do not pass it again (that becomes the <commit> argument).
+  # Clear EVERY marker, not just the log: these markers are cumulative touch-files, so a previous
+  # run's credential marker would otherwise be read as this run's, and each "refused before
+  # credentials" arm would fail against correct code. (It did, exactly once, while writing this.)
+  rm -f "$LOG" "$marks2/bw" "$marks2/mosquitto_pub" "$marks2/mosquitto_sub"
+  OUT4="$(SMOL400_LOG="$LOG" PATH="$stub2:$PATH" bash "$f4/tools/ota_publish.sh" stage "$@" 2>&1)"; R4=$?
+}
+stamp4(){ [ -f "$LOG" ] && cat "$LOG" || echo "NOT-CALLED"; }
+
+run4;                  eq "clean stage reaches the build"            "1"          "$R4"
+eq  "clean stage stamps a RELEASE (SMOL_RELEASE=1)"                  "1"          "$(stamp4)"
+
+echo '// stray' >> "$f4/rust/clock/src/net/etx.rs"
+run4;                  eq "dirty stage exits 22"                     "22"         "$R4"
+eq  "dirty stage never reached the build"                            "NOT-CALLED" "$(stamp4)"
+[ -e "$marks2/bw" ] && no "dirty stage sourced credentials first" || ok "dirty stage refused before credentials"
+
+run4 --dirty;         eq "--dirty stage reaches the build"          "1"          "$R4"
+# THE KEYSTONE ASSERTION. If this reads "1" the fix is cosmetic: the image would still carry a
+# clean release stamp over uncommitted bytes, which is exactly the masquerade #400 filed.
+eq  "--dirty stage omits SMOL_RELEASE (DEV stamp)"                   "UNSET"      "$(stamp4)"
+case "$OUT4" in *"stamping DEV"*) ok "--dirty says so on stdout" ;; *) no "--dirty is silent about the dev stamp" ;; esac
+gitq "$f4" checkout -q -- rust/clock/src/net/etx.rs
+
+# Scope control at the SCRIPT level, not just the predicate: an unrelated edit must still release.
+echo stray >> "$f4/docs/x.md"
+run4;                  eq "unrelated docs edit does not block a stage" "1"        "$R4"
+eq  "...and still stamps a RELEASE"                                  "1"          "$(stamp4)"
+gitq "$f4" checkout -q -- docs/x.md
+
+run4 HEAD~1;          eq "non-HEAD stage exits 22"                   "22"        "$R4"
+eq  "non-HEAD stage never reached the build"                          "NOT-CALLED" "$(stamp4)"
+[ -e "$marks2/bw" ] && no "non-HEAD stage sourced credentials first" || ok "non-HEAD refused before credentials"
+# Negative control: the credential marker must be ABLE to fire, or the two assertions above prove
+# nothing. A clean stage gets past the guards and hits the broker read on its way to the build.
+run4
+[ -e "$marks2/bw" ] && ok "control: a clean stage DOES reach credentials (markers fire)" \
+                    || no "control: nothing ever reaches credentials — placement arms are vacuous"
+rm -rf "$f4" "$stub2" "$marks2"
+
+echo "== 5. the help range: usage() covers the whole header and no more =="
+help="$(bash "$SCRIPT" 2>&1)"; rc=$?
+eq "no-args prints help and exits 1" "1" "$rc"
+case "$help" in *"--dirty"*)      ok "help documents --dirty" ;;      *) no "help omits --dirty — the sed range is short" ;; esac
+case "$help" in *"IDENTITY (#400)"*) ok "help documents the identity rule" ;; *) no "help omits the #400 rule" ;; esac
+# Both ENDS. Short-range rot truncates the tail; long-range rot spills code into the help text.
+case "$help" in *"choose_build()"*) ok "help reaches the end of the header block" ;; *) no "sed range ends early" ;; esac
+case "$help" in *"set -euo"*|*"die()"*) no "sed range overran into code" ;; *) ok "help stops before the code" ;; esac
 
 echo
 echo "$pass passed, $fail failed"


### PR DESCRIPTION
Closes #400.

## Root cause, stated once

The **stamp** is a function of a git ref (`HASH`/`COUNT` come from `<commit>`, :294-296). The
**bytes** are a function of the **working tree** (`repro_build_bin "$CLOCK"`, :321). Nothing
asserted those two describe the same source — so the one tool in this repo whose job is identity
could mint a false one.

The issue's framing (`stage <commit>` stamps the current tree) is correct but is **the loud half of
one defect**. Fixing only it would have left the quiet half live on the path every caller actually
uses.

| path | before | after |
|---|---|---|
| `stage <non-HEAD>` | stamps that commit's identity on working-tree bytes | **REFUSED (22)** |
| `stage` on a **dirty** tree | stamps HEAD's hash **and force-exports `SMOL_RELEASE=1`** → clean release stamp over uncommitted bytes | **REFUSED (22)** unless `--dirty` |
| `stage --dirty` | n/a | builds **without** `SMOL_RELEASE` → `v<N>+dev.<hash>` (#218) |
| `stage` on a clean tree | release | **unchanged** |

Nothing in this repo passes a `<commit>` to `stage` (checked every caller: `docs/`, `ha/`,
`ONBOARDING.md`, design docs — all use bare `stage` or `--bin`), so refusing it removes no working
capability. Deliberately **not** re-implementing `git archive` staging here: #413's release pipeline
is building exactly that, and a second implementation is the duplication this repo has spent days
removing. Re-enable `stage <commit>` on top of it.

## The folklore I deleted

The build site's comment ended:

> *"A canary of an uncommitted image still goes through `--bin`, which skips this build path
> entirely, so dev images cannot masquerade: this export never touches them."*

Nothing routed uncommitted work to `--bin` and nothing checked the tree. So `stage` on a dirty tree
reached that line and force-stamped a clean release — **the precise masquerade the sentence denied,
inside the block whose job is honest release stamping.** Corrected in place rather than deleted, and
it is true now because `assert_stampable_inputs` makes it true.

## Scope is the check

Build inputs are exactly `rust/clock` (`src`, `build.rs`, `Cargo.toml`, `Cargo.lock`,
`version.txt`, `rust-toolchain.toml`, `.cargo/config.toml` — all of them live there). A repo-wide
dirty check would refuse a stage over an unrelated docs edit, and a gate that fires on innocent
states is one operators route around (#338) — fatal for one guarding a publish. **There is a test
arm asserting dirt *outside* `rust/clock` still releases**, so the scope is load-bearing rather than
incidental.

`--untracked-files=no` is likewise load-bearing, not tidiness: `board.rs`/`secrets.rs` are
git-ignored **by design**, so counting untracked files would refuse every stage there is.

Both refusals land **before the broker read and before any credential is sourced** — the same
placement property #314's id42 refusal is tested for.

## Evidence

**Sabotage-verified** (a suite that stays green against a broken guard is worthless):

| sabotage | result |
|---|---|
| baseline | 56 passed, 0 failed |
| stamp guard neutered | 48 / **8 failed** |
| dirty guard neutered | 50 / **6 failed** |
| re-add `SMOL_RELEASE=1` on the dirty path (the original defect) | 55 / **1 failed** |
| revert the help range to `2,23` | 55 / **1 failed** |

**Level 4 asserts the ENV AT THE CALL**, via a stubbed `repro_build.sh`, because exit codes cannot
see this bug — the old code returned success while stamping a lie. `--dirty` → `UNSET`, clean → `1`.

**End-to-end on real artifacts** (familiar, warm target, same hash/number both arms) — because the
claim my fix rests on is about a stamp, so I measured the stamp rather than inheriting it:

```
SMOL_RELEASE=1  ->  cargo:rustc-env=BUILD_DEV=0    b3267d83...  rel400.bin
(unset)         ->  cargo:rustc-env=BUILD_DEV=1    ee10740b...  dev400.bin
```
Two different images from identical `BUILD_HASH`/`BUILD_NUMBER` — the stamp changes the artifact.
Chain measured, not assumed: guard omits `SMOL_RELEASE` → `BUILD_DEV=1` → `version_is_dev()` →
`v<N>+dev.<hash>`.

Note: grepping the image for `+dev.` would have "confirmed" this and been **meaningless** — that
literal is a runtime format string present in both builds. The discriminator is the emitted
`BUILD_DEV` value.

**All three gate arms GREEN on familiar** (clone of this branch, `ci_provision` generated
board.rs/secrets.rs, per-run sync): `host` rc=0, `fw` rc=0, `excl` rc=0.

## Second finding: four suites had no gate

Auditing `tools/test_*.sh` against `gate.sh` found it runs a **hand-listed** set, and four suites
are absent. Two guard `ota_publish.sh` — the one script that can arm the whole fleet — so **#314's
id42-sentinel refusal and #128's ratchet have never been run by CI.** Their safety properties were
maintained on trust, and my new arms would have been decorative. Both now wired (verified firing:
`OTA publish guards + ratchet regression suites (#314/#128/#400)` → 56/0 and 16/0).

The other two are **declared gaps with reasons at the call site**, not oversights:
- `test_ota_verify.sh` — hermetic but slow (>2 min; I did not watch it finish). Wiring it on the
  strength of its own header comment is the inference gate.sh exists to refuse. Worth a follow-up.
- `test_ha_deploy_guard.sh` — **must never be wired.** It commits with `git commit -am` by design
  and is built for a scratch clone; its refusal to run in a working tree *is* the guard.

## Also: a rot hazard I perturbed, now pinned

`usage()` hardcodes `sed -n '2,27p'` — a duplicated fact about how far the header comment runs. I
had to move it (`23`→`27`), which is the rot happening. Level 5 pins **both ends** (contains
`--dirty`; reaches `choose_build()`; does *not* spill into code), so the next header edit that
forgets fails instead of silently truncating help nobody reads on the happy path.

## Mistakes I made, since they cost real time
1. `run4 stage` → the helper already supplies `stage`, so this ran `stage stage`, `COMMIT="stage"`,
   refused as an unresolvable ref. **My harness was wrong and the code was right** — 8 arms red.
2. Marker touch-files are cumulative; the first clean run's credential marker was read as a later
   run's, failing "refused before credentials" against correct code. Now cleared per run.
3. A fumbled redirect meant `mosquitto_pub` was never stubbed in three hand-probes. The refusals
   preceded the credential seam so the conclusion held, but the *proof* was the marker, not my stub.

Per lane rule (touches `tools/`): **not self-merged**, routed to team-lead.
