### PR TITLE
feat(gate): per-tier writable-static size baseline — a silent resize becomes a diff line (#390)

### DIFF
--- a/tools/check_symbol_sizes.py
+++ b/tools/check_symbol_sizes.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""check_symbol_sizes.py — #390: a per-tier baseline of the big writable statics.
+
+WHAT THIS EXISTS FOR
+--------------------
+#335 P1.1 added six embassy dependency lines and changed NO source. `embassy-net` turned on
+smoltcp's `async` feature; smoltcp is SHARED with the hand-driven gateway (one `v0.13.1` in the
+graph), so `WakerRegistration` per socket grew `net::wifi::NTP_SOCK_STORAGE` from 0x540 to 0x580
+— 64 B of `.data` taken straight out of the `.stack` region, and invisible to:
+
+  * code review        — there was no source diff;
+  * the compiler       — no arity or type change;
+  * `repro_stack_check`— 0.06 % of an aggregate compared against a threshold;
+  * #351's exclusion checker — it asserts PRESENCE/ABSENCE, never size.
+
+It was found by a hand `nm` A/B, which is not a process. This file makes such a resize land as a
+REVIEWED DIFF LINE in `tools/symbol-sizes.<tier>.txt` instead.
+
+It GENERALISES the #300 stack floor rather than duplicating it. The floor watches one derived
+aggregate (`.stack`) against a threshold; this watches the individual statics whose growth is what
+MOVES that aggregate. The floor tells you the roof came down; this tells you which box grew.
+
+WHY KEY ON THE MANGLED NAME, NOT A DEMANGLED ONE
+------------------------------------------------
+#390 proposed keying on "DEMANGLED hash-stripped names". Demangling is the right instinct — the raw
+names carry a crate-metadata hash that churns between builds (`Cs9FWucCYWq3y_`), and it buries the
+signal — but a DEMANGLER IS ITSELF A VERSION-DEPENDENT TRANSFORM. Keying on its output makes this
+baseline depend on which `rustfilt`/`llvm-cxxfilt` happens to be installed, which is the same class
+of churn the baseline exists to eliminate, just relocated into the toolchain. There is also no
+demangler guaranteed present in CI.
+
+So: key on the mangled symbol with the VOLATILE COMPONENTS SUBSTITUTED (not deleted — a placeholder
+keeps the name readable and keeps two distinct symbols distinct). The key then depends only on the
+ELF. Verified on the real canonical ELF: 29 tracked statics, ZERO normalization collisions.
+
+WHAT IS SKIPPED, AND WHY IT IS BROADER THAN THE ISSUE SAID
+----------------------------------------------------------
+#390 named `.L_MergedGlobals*` and `.Lswitch.table.*`. The real ELF also carries
+`.Lanon.<32-hex>.<n>` — CONTENT-ADDRESSED names that move whenever the constant they hold moves.
+Enumerating the three patterns would leave the next one to be discovered the same way. So the rule
+is the general one: `.L` is the assembler's local-label prefix, so ANY `.L*` symbol is
+compiler-generated and not a static anybody declared. 6 of 35 candidates on the canonical ELF.
+
+Usage:
+    check_symbol_sizes.py --tier <name> --elf <path>            # check against the baseline
+    check_symbol_sizes.py --tier <name> --elf <path> --bless    # rewrite the baseline
+    check_symbol_sizes.py --tier <name> --sections F --symbols G # test seam: pre-captured readelf
+
+Exit: 0 = matches baseline · 1 = DRIFT (or a real failure) · 2 = COULD NOT CHECK.
+`2` is distinct on purpose: "the check did not run" must never be reported as "the check passed".
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+# Symbols at or above this many bytes. 256 B is #390's threshold: below it the population is
+# dominated by small per-function statics whose churn would make the baseline unreviewable, which
+# is the failure mode that makes a gate get deleted.
+DEFAULT_THRESHOLD = 256
+
+# A floor on how many statics we expect to find. This is the anti-vacuous-pass guard: if a readelf
+# format change, a section-name change, or a bad filter silently matches nothing, the honest result
+# is a hard failure, NOT "no drift detected". The canonical ELF yields 29; 10 leaves room for tier
+# variation while still catching a filter that has stopped working.
+MIN_SYMBOLS = 10
+
+SECTION_RE = re.compile(r"^\s*\[\s*(\d+)\]\s+(\S+)")
+# The v0 crate disambiguator (`Cs9FWucCYWq3y_`) and the legacy-mangling hash suffix
+# (`17h0123456789abcdefE`). Substituted with a placeholder rather than deleted.
+VOLATILE = [
+    (re.compile(r"Cs[0-9A-Za-z]{8,}_"), "Cs*_"),
+    (re.compile(r"17h[0-9a-f]{16}E"), "17h*E"),
+]
+# Writable static storage. Prefix-matched so `.data.wifi` counts; `.rtc_fast.data` deliberately
+# does NOT (it is a different memory, currently zero-sized, and would need its own budget story).
+TRACKED_SECTION_RE = re.compile(r"^\.(data|bss)\b")
+
+
+def normalize(name):
+    for pat, repl in VOLATILE:
+        name = pat.sub(repl, name)
+    return name
+
+
+def run_readelf(elf, flag):
+    exe = os.environ.get("READELF", "readelf")
+    try:
+        p = subprocess.run([exe, flag, elf], capture_output=True, text=True)
+    except FileNotFoundError:
+        die2("`%s` not found. This check reads the ELF's symbol table; without it the check "
+             "cannot run, which is not the same as passing." % exe)
+    if p.returncode != 0:
+        die2("%s %s %s failed (rc=%d):\n%s" % (exe, flag, elf, p.returncode, p.stderr.strip()))
+    return p.stdout
+
+
+def die2(msg):
+    sys.stderr.write("CANNOT CHECK: %s\n" % msg)
+    sys.exit(2)
+
+
+def parse_sections(text):
+    out = {}
+    for line in text.splitlines():
+        m = SECTION_RE.match(line)
+        if m:
+            out[m.group(1)] = m.group(2)
+    if not out:
+        die2("parsed ZERO sections from `readelf -SW`. The output format is not what this "
+             "checker expects, so every symbol would fall outside .data/.bss and the run would "
+             "vacuously report no drift.")
+    return out
+
+
+def parse_symbols(text, sections, threshold):
+    rows = {}
+    skipped_local = 0
+    saw_object = 0
+    for line in text.splitlines():
+        parts = line.split()
+        # Num: Value Size Type Bind Vis Ndx Name
+        if len(parts) < 8 or parts[3] != "OBJECT":
+            continue
+        saw_object += 1
+        try:
+            size = int(parts[2])
+        except ValueError:
+            continue  # readelf prints hex for huge sizes; none of ours are that large
+        section = sections.get(parts[6])
+        if section is None or not TRACKED_SECTION_RE.match(section):
+            continue
+        if size < threshold:
+            continue
+        name = parts[7]
+        if name.startswith(".L"):
+            skipped_local += 1
+            continue
+        rows[normalize(name)] = (size, section)
+    if saw_object == 0:
+        die2("found ZERO symbols of type OBJECT. Either the ELF is stripped or the symbol-table "
+             "format changed; either way this check did not run.")
+    return rows, skipped_local
+
+
+def load_baseline(path):
+    rows = {}
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("\t")
+            if len(parts) != 3:
+                die2("malformed baseline line in %s: %r (want '<size>\\t<section>\\t<name>')"
+                     % (path, line))
+            rows[parts[2]] = (int(parts[0]), parts[1])
+    return rows
+
+
+def write_baseline(path, tier, rows):
+    total = sum(s for s, _ in rows.values())
+    with open(path, "w") as fh:
+        fh.write("# tools/symbol-sizes.%s.txt — #390 writable-static size baseline.\n" % tier)
+        fh.write("# GENERATED: tools/check_symbol_sizes.py --tier %s --elf <elf> --bless\n" % tier)
+        fh.write("#\n")
+        fh.write("# Every line is a static of >=%d B in .data*/.bss*. A dependency bump that\n"
+                 % DEFAULT_THRESHOLD)
+        fh.write("# resizes one of these shows up HERE as a diff line, which is the whole point:\n")
+        fh.write("# the #390 instance (NTP_SOCK_STORAGE 1344->1408 via a smoltcp feature) had no\n")
+        fh.write("# source diff and no compiler complaint, so review had nothing to look at.\n")
+        fh.write("#\n")
+        fh.write("# Do NOT hand-edit. Re-bless, and explain the delta in the commit message.\n")
+        fh.write("# %d symbols, %d bytes total.\n" % (len(rows), total))
+        fh.write("#\n")
+        fh.write("# size\tsection\tsymbol\n")
+        for name in sorted(rows):
+            size, section = rows[name]
+            fh.write("%d\t%s\t%s\n" % (size, section, name))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tier", required=True)
+    ap.add_argument("--elf")
+    ap.add_argument("--sections", help="pre-captured `readelf -SW` output (test seam)")
+    ap.add_argument("--symbols", help="pre-captured `readelf -sW` output (test seam)")
+    ap.add_argument("--baseline-dir", default=os.path.dirname(os.path.abspath(__file__)))
+    ap.add_argument("--threshold", type=int, default=DEFAULT_THRESHOLD)
+    ap.add_argument("--bless", action="store_true")
+    args = ap.parse_args()
+
+    if args.sections and args.symbols:
+        sec_text = open(args.sections).read()
+        sym_text = open(args.symbols).read()
+    elif args.elf:
+        if not os.path.exists(args.elf):
+            die2("no ELF at %s" % args.elf)
+        sec_text = run_readelf(args.elf, "-SW")
+        sym_text = run_readelf(args.elf, "-sW")
+    else:
+        die2("need --elf, or both --sections and --symbols")
+
+    sections = parse_sections(sec_text)
+    current, skipped = parse_symbols(sym_text, sections, args.threshold)
+
+    if len(current) < MIN_SYMBOLS:
+        die2("only %d tracked statics found (floor is %d). A working filter on this firmware "
+             "finds ~29. Refusing to compare — or to bless — a set this small, because an empty "
+             "or near-empty set makes every future run pass while guarding nothing."
+             % (len(current), MIN_SYMBOLS))
+
+    path = os.path.join(args.baseline_dir, "symbol-sizes.%s.txt" % args.tier)
+
+    if args.bless:
+        write_baseline(path, args.tier, current)
+        print("blessed %s: %d symbols, %d bytes (skipped %d .L* compiler-generated)"
+              % (os.path.basename(path), len(current),
+                 sum(s for s, _ in current.values()), skipped))
+        return 0
+
+    if not os.path.exists(path):
+        die2("no baseline at %s. Create it with --bless and COMMIT it; a missing baseline is a "
+             "gap to close, not a pass." % path)
+
+    base = load_baseline(path)
+    grew, shrank, new, gone = [], [], [], []
+    for name, (size, section) in sorted(current.items()):
+        if name not in base:
+            new.append((name, size, section))
+        elif base[name][0] != size:
+            (grew if size > base[name][0] else shrank).append((name, base[name][0], size))
+    for name, (size, section) in sorted(base.items()):
+        if name not in current:
+            gone.append((name, size, section))
+
+    if not (grew or shrank or new or gone):
+        print("symbol sizes: %d statics, %d bytes — matches %s"
+              % (len(current), sum(s for s, _ in current.values()), os.path.basename(path)))
+        return 0
+
+    delta = sum(s for s, _ in current.values()) - sum(s for s, _ in base.values())
+    sys.stderr.write("SYMBOL SIZE DRIFT (#390) vs %s — net %+d B\n" % (os.path.basename(path), delta))
+    for name, was, now in grew:
+        sys.stderr.write("  GREW   %+7d B  %-8d -> %-8d  %s\n" % (now - was, was, now, name))
+    for name, was, now in shrank:
+        sys.stderr.write("  SHRANK %+7d B  %-8d -> %-8d  %s\n" % (now - was, was, now, name))
+    for name, size, section in new:
+        sys.stderr.write("  NEW    %+7d B  %-19s %s (%s)\n" % (size, "", name, section))
+    for name, size, section in gone:
+        sys.stderr.write("  GONE   %+7d B  %-19s %s (%s)\n" % (-size, "", name, section))
+    sys.stderr.write(
+        "\nThis is not automatically a problem — it is a change that was previously invisible.\n"
+        "If it is intended, re-bless and say WHY in the commit message:\n"
+        "  tools/check_symbol_sizes.py --tier %s --elf <elf> --bless\n"
+        "Watch the .stack region: .data/.bss growth is taken out of it (#300 floor).\n" % args.tier)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -524,6 +524,40 @@ if [ "$run_fw" = 1 ]; then
   else
     printf '   \033[33mSKIP\033[0m byte-free (symbols) — no ELF from the canonical build\n'
   fi
+
+  # #390: the writable-static size baseline, on the SAME ELF the two arms above just used — no
+  # extra build. This generalises the #300 stack floor rather than duplicating it: the floor
+  # watches one derived aggregate (.stack) against a threshold, this watches the individual
+  # statics whose growth is what MOVES that aggregate. The floor says the roof came down; this
+  # says which box grew.
+  #
+  # It exists because #335 P1.1 added six dependency lines and changed no source, and smoltcp's
+  # `async` feature (unified in from embassy-net) grew net::wifi::NTP_SOCK_STORAGE by 64 B of
+  # .data taken out of the .stack region — invisible to code review (no source diff), to the
+  # compiler (no arity change), to repro_stack_check (0.06% of an aggregate), and to #351's
+  # checker (presence, not size). It was found by a hand `nm` A/B, which is not a process.
+  #
+  # The TIER NAME IS DERIVED from the feature set rather than written twice. That is deliberate
+  # beyond tidiness: change REPRO_FLEET_FEATURES and the baseline filename changes with it, so
+  # the checker reports "no baseline — a gap to close, not a pass" instead of silently comparing
+  # the new tier against the old tier's numbers.
+  step "writable-static sizes — canonical ELF vs the #390 baseline"
+  if [ -f "$ELF" ]; then
+    if out=$("$ROOT/tools/check_symbol_sizes.py" --tier "${REPRO_FLEET_FEATURES//,/-}" \
+               --elf "$ELF" 2>&1); then
+      printf '%s\n' "$out" | tail -1; ok "symbol sizes"
+    else
+      # Both 1 (drift) and 2 (could not check) are failures here, and the message distinguishes
+      # them. A resize is not automatically a bug — but it must not land unreviewed, which is the
+      # entire finding of #390.
+      printf '%s\n' "$out" | sed 's/^/        /'; bad "symbol sizes"
+    fi
+  else
+    # SKIP, not fail: the stack-floor arm above already failed loudly on a build that produced no
+    # ELF, so the gate is red regardless and a second red says nothing new. This is the one shape
+    # of skip that is not a vacuous pass — the condition is already reported by a neighbour.
+    printf '   \033[33mSKIP\033[0m symbol sizes — no ELF from the canonical build\n'
+  fi
 fi
 
 if [ "$run_host" = 1 ]; then
@@ -727,6 +761,20 @@ if [ "$run_host" = 1 ]; then
       printf '%s\n' "$out" | sed 's/^/        /'; bad "$_t"
     fi
   done
+
+  # #390: the offline half of the symbol-size guard. The fw arm runs the checker against a real
+  # ELF; this proves the PARSE/NORMALISE/COMPARE logic can fail, using a committed real slice of
+  # readelf output — no cargo, no ELF, no toolchain.
+  # The split is load-bearing in both directions: a readelf output-format change keeps THIS suite
+  # green and turns the fw arm red (only the fw arm sees real readelf), while a logic regression
+  # turns this suite red even on a machine that cannot build firmware at all. Neither arm alone
+  # covers both, which is why both exist.
+  step "symbol-size checker regression suite (#390)"
+  if out=$("$ROOT/tools/test_symbol_sizes.sh" 2>&1); then
+    printf '%s\n' "$out" | tail -1; ok "test_symbol_sizes"
+  else
+    printf '%s\n' "$out" | sed 's/^/        /'; bad "test_symbol_sizes"
+  fi
 fi
 
 step "summary"

--- a/tools/symbol-sizes.espnow-cast-io.txt
+++ b/tools/symbol-sizes.espnow-cast-io.txt
@@ -1,0 +1,41 @@
+# tools/symbol-sizes.espnow-cast-io.txt — #390 writable-static size baseline.
+# GENERATED: tools/check_symbol_sizes.py --tier espnow-cast-io --elf <elf> --bless
+#
+# Every line is a static of >=256 B in .data*/.bss*. A dependency bump that
+# resizes one of these shows up HERE as a diff line, which is the whole point:
+# the #390 instance (NTP_SOCK_STORAGE 1344->1408 via a smoltcp feature) had no
+# source diff and no compiler complaint, so review had nothing to look at.
+#
+# Do NOT hand-edit. Re-bless, and explain the delta in the commit message.
+# 29 symbols, 182066 bytes total.
+#
+# size	section	symbol
+960	.data	TxRxCxt
+2008	.bss	_RNvCs*_7esp_phy9PHY_STATE
+4096	.bss	_RNvNtCs*_5clock3ota12OTA_READBACK
+4096	.data	_RNvNtCs*_5clock3ota9OTA_STAGE
+14784	.bss	_RNvNtCs*_5clock8ota_mesh14OTA_WINDOW_BUF
+696	.data	_RNvNtCs*_8esp_rtos9scheduler9SCHEDULER
+424	.bss	_RNvNtNtCs*_5clock3net4cast10SCREEN_B64
+318	.bss	_RNvNtNtCs*_5clock3net4cast10SCREEN_BMP
+360	.bss	_RNvNtNtCs*_5clock3net4cast11CAST_MIRROR
+14784	.bss	_RNvNtNtCs*_5clock3net4mode13GW_OTA_WINDOW
+512	.bss	_RNvNtNtCs*_5clock3net4wifi10NTP_TCP_RX
+512	.bss	_RNvNtNtCs*_5clock3net4wifi10NTP_TCP_TX
+512	.bss	_RNvNtNtCs*_5clock3net4wifi15NTP_UDP_RX_DATA
+512	.bss	_RNvNtNtCs*_5clock3net4wifi15NTP_UDP_TX_DATA
+1408	.data	_RNvNtNtCs*_5clock3net4wifi16NTP_SOCK_STORAGE
+512	.bss	_RNvNtNtCs*_5clock3net4wifi8MQTT_ACC
+516	.bss	_RNvNtNtCs*_5clock3net4wifi9MQTT_JSON
+98304	.bss	_RNvNvNtCs*_5clock3net9init_heap4HEAP
+4096	.bss	_RNvNvNtCs*_5clock3ota18verify_active_slot10VERIFY_BUF
+19600	.bss	_RNvNvNtCs*_5clock6___main14___embassy_main4POOL
+4096	.bss	_RNvNvNtNtCs*_5clock3net4wifi13run_ota_fetch10OTA_TCP_RX
+592	.bss	gChmCxt
+284	.bss	gScanStruct
+816	.bss	gWpaSm
+3880	.bss	g_cnxMgr
+688	.bss	g_ic
+544	.bss	g_pm
+848	.data	phy_param
+1308	.bss	s_wifi_nvs

--- a/tools/test_symbol_sizes.sh
+++ b/tools/test_symbol_sizes.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# test_symbol_sizes.sh — #390: prove tools/check_symbol_sizes.py can fail, and that it fails for
+# the right reasons and passes for the right reasons.
+#
+# The fixture is a REAL SLICE of `readelf -SW` / `readelf -sW` output from the canonical C3 ELF
+# (espnow,cast,io), not a hand-invented one. That matters here for the same reason it mattered in
+# test_config_markers.sh: a hand-written stand-in drifts from the thing being guarded, and the
+# thing being guarded is a specific tool's output format. Every symbol row below was copied from a
+# real build — including the awkward ones (`.L_MergedGlobals`, `.Lswitch.table`, `.Lanon`, six
+# different crate disambiguators, and a 2560 B .rodata static that must NOT be tracked).
+#
+# DIVISION OF LABOUR, because neither half is sufficient alone:
+#   * THIS suite proves the PARSE + NORMALISE + COMPARE logic, offline, with no cargo and no ELF.
+#   * The gate.sh fw arm proves the REAL `readelf` invocation still parses what this fixture
+#     claims it parses. A readelf output-format change would keep this suite green and turn that
+#     arm red — which is the correct split, since only one of the two can notice it.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="$HERE/check_symbol_sizes.py"
+[ -f "$CHECK" ] || { echo "missing $CHECK" >&2; exit 2; }
+
+pass=0; fail=0
+ok(){ pass=$((pass+1)); echo "ok   - $1"; }
+no(){ fail=$((fail+1)); echo "FAIL - $1"; }
+eq(){ if [ "$2" = "$3" ]; then ok "$1 ($2)"; else no "$1: want [$2] got [$3]"; fi; }
+
+# Never /tmp (JP directive: katana's /tmp is a 16 GB tmpfs).
+TMPROOT="${TMPDIR:-/var/tmp}"; case "$TMPROOT" in /tmp|/tmp/*) TMPROOT=/var/tmp ;; esac
+W="$(mktemp -d "$TMPROOT/symsize-XXXXXX")"
+trap 'rm -rf "$W"' EXIT INT TERM
+
+# ── fixtures: real readelf output, sliced ──────────────────────────────────────────────────────
+cat > "$W/sections.txt" <<'SEC'
+There are 27 section headers, starting at offset 0x252628:
+
+Section Headers:
+  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
+  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
+  [ 1] .trap             PROGBITS        40380000 001000 000644 00  AX  0   0 256
+  [ 4] .rwdata_dummy     NOBITS          3fc80000 00c000 00a0e8 00   A  0   0  4
+  [ 5] .data             PROGBITS        3fc8a0e8 00c0e8 003af0 00 WAM  0   0  8
+  [ 6] .data.wifi        PROGBITS        3fc8dbd8 00fbd8 0001f0 00  WA  0   0  4
+  [ 7] .bss              NOBITS          3fc8ddc8 00fdc8 02b578 00  WA  0   0  8
+  [11] .rodata           PROGBITS        3c000120 010120 010f9c 00 AMSR  0   0  8
+  [16] .rtc_fast.data    PROGBITS        50000000 0fefaa 000000 00   A  0   0  1
+  [19] .stack            NOBITS          3fcb9340 0ff340 0150c0 00  WA  0   0  4
+SEC
+
+# Written by a helper so the churn-immunity arm can re-emit the SAME symbols under a DIFFERENT
+# set of crate-metadata hashes. If normalisation works, both spellings yield an identical baseline.
+emit_symbols(){ # <clock-disambiguator> <phy-disambiguator> > file
+  local C="$1" P="$2"
+  cat <<SYM
+
+Symbol table '.symtab' contains 51478 entries:
+   Num:    Value  Size Type    Bind   Vis      Ndx Name
+     0: 00000000     0 NOTYPE  LOCAL  DEFAULT  UND
+   700: 3fc9818c 98304 OBJECT  LOCAL  DEFAULT    7 _RNvNvNt${C}_5clock3net9init_heap4HEAP
+   261: 3fcb0190 19600 OBJECT  LOCAL  DEFAULT    7 _RNvNvNt${C}_5clock6___main14___embassy_main4POOL
+  1011: 3fc8edec 14784 OBJECT  LOCAL  DEFAULT    7 _RNvNt${C}_5clock8ota_mesh14OTA_WINDOW_BUF
+  1418: 3fc927ac 14784 OBJECT  LOCAL  DEFAULT    7 _RNvNtNt${C}_5clock3net4mode13GW_OTA_WINDOW
+  1019: 3fc8ddec  4096 OBJECT  LOCAL  DEFAULT    7 _RNvNt${C}_5clock3ota12OTA_READBACK
+  1795: 3fc8b208  4096 OBJECT  LOCAL  DEFAULT    5 _RNvNt${C}_5clock3ota9OTA_STAGE
+ 49742: 3fcb79c0  3880 OBJECT  GLOBAL DEFAULT    7 g_cnxMgr
+  5519: 3fcb4f30  2008 OBJECT  LOCAL  DEFAULT    7 _RNv${P}_7esp_phy9PHY_STATE
+  1315: 3fc8c208  1408 OBJECT  LOCAL  DEFAULT    5 _RNvNtNt${C}_5clock3net4wifi16NTP_SOCK_STORAGE
+ 49643: 3fcb731c  1308 OBJECT  GLOBAL DEFAULT    7 s_wifi_nvs
+ 50493: 3fc8d428   960 OBJECT  GLOBAL DEFAULT    5 TxRxCxt
+ 50010: 3fc8d010   848 OBJECT  GLOBAL DEFAULT    5 phy_param
+ 50804: 3fcb8f18   816 OBJECT  GLOBAL DEFAULT    7 gWpaSm
+  8768: 3fcb68e8   516 OBJECT  LOCAL  DEFAULT    7 _RNvNtNt${C}_5clock3net4wifi9MQTT_JSON
+  9001: 3fc8dc00   400 OBJECT  LOCAL  DEFAULT    6 _RNvNtNt${C}_5clock3net4wifi11WIFI_DATSEG
+  8762: 3fcb5d3e   424 OBJECT  LOCAL  DEFAULT    7 _RNvNtNt${C}_5clock3net4cast10SCREEN_B64
+   181: 3fcb5790  1878 OBJECT  LOCAL  DEFAULT    7 .L_MergedGlobals.1366
+   264: 3fc8c7a8  1208 OBJECT  LOCAL  DEFAULT    5 .L_MergedGlobals.1365
+  5174: 3fc8a514   416 OBJECT  LOCAL  DEFAULT    5 .Lswitch.table._RNvXsx_NtCs4XY58JHhTKR_7esp_hal4gpio11InputSignal3fmt
+  4409: 3c00a1e0  2560 OBJECT  LOCAL  DEFAULT   11 _RNvNtCs2GHBDM79E01_15ed25519_compact12edwards2551912BASEPOINT_PC
+  1697: 3c00766c  1560 OBJECT  LOCAL  DEFAULT   11 .Lanon.fc87f6fca5ad39fda60ed8460297fac2.1275
+ 12345: 3fc8a000    64 OBJECT  LOCAL  DEFAULT    7 _RNvNtNt${C}_5clock3net4wifi9TINY_THING
+ 12346: 42020020  4096 FUNC    LOCAL  DEFAULT   14 _RNvNt${C}_5clock3net4wifi7service
+SYM
+}
+emit_symbols Cs9FWucCYWq3y CsjD18A8u66C5 > "$W/symbols.txt"
+
+run(){ python3 "$CHECK" --tier t --baseline-dir "$W" --sections "$W/sections.txt" --symbols "$W/symbols.txt" "$@" 2>&1; }
+
+echo "== 1. bless, then round-trip =="
+out="$(run --bless)"; rc=$?
+eq "bless exits 0" "0" "$rc"
+case "$out" in *"16 symbols"*) ok "bless found the 16 tracked statics" ;; *) no "wrong count: $out" ;; esac
+case "$out" in *"skipped 3 .L"*) ok "bless reports the 3 skipped .L* symbols" ;; *) no "no skip report: $out" ;; esac
+out="$(run)"; rc=$?
+eq "unchanged input exits 0" "0" "$rc"
+case "$out" in *"matches"*) ok "round-trip says matches" ;; *) no "no match line: $out" ;; esac
+
+B="$W/symbol-sizes.t.txt"
+
+echo "== 2. scoping and filtering — what must NOT be tracked =="
+# THE KEEPER ARM. A 2560 B .rodata static is the single largest OBJECT in the fixture. If the
+# section filter is dropped or widened, it lands in the baseline and .rodata growth starts failing
+# a gate that exists to watch WRITABLE statics (.data/.bss are what come out of the .stack region;
+# .rodata is in flash and costs nothing there). "The filter fires" is satisfied by a filter that
+# tracks everything — this is what distinguishes the two.
+grep -q 'BASEPOINT_PC' "$B" && no "a 2560 B .rodata static was tracked — section scope is not doing anything" \
+                            || ok "large .rodata static NOT tracked (section scope is load-bearing)"
+grep -q '\.L_MergedGlobals' "$B" && no ".L_MergedGlobals tracked (renumbers every build)" \
+                                 || ok ".L_MergedGlobals skipped"
+grep -q '\.Lswitch\.table' "$B" && no ".Lswitch.table tracked (the pattern #390 named)" \
+                                || ok ".Lswitch.table skipped"
+grep -q '\.Lanon' "$B" && no ".Lanon tracked (content-addressed, moves with its constant)" \
+                       || ok ".Lanon skipped"
+grep -q 'TINY_THING' "$B" && no "a 64 B static was tracked (threshold ignored)" \
+                          || ok "below-threshold static excluded"
+grep -q 'wifi7service' "$B" && no "a FUNC symbol was tracked (type filter ignored)" \
+                            || ok "FUNC symbol excluded (only OBJECT)"
+grep -q 'WIFI_DATSEG' "$B" && ok ".data.wifi IS tracked (prefix match, not exact)" \
+                           || no ".data.wifi missed — prefix matching is broken"
+
+echo "== 3. normalisation: immune to crate-hash churn =="
+grep -q 'Cs\*_' "$B" && ok "baseline stores the placeholder" || no "no placeholder in baseline"
+grep -q 'Cs9FWucCYWq3y' "$B" && no "the volatile crate hash is IN the baseline — it will churn" \
+                             || ok "volatile crate hash absent from the baseline"
+# The design constraint from the issue, tested directly: the SAME statics rebuilt under DIFFERENT
+# crate-metadata hashes must compare EQUAL. Without this the baseline is red on every rebuild and
+# gets deleted within a week.
+cp "$B" "$W/first.txt"
+emit_symbols CsZZZZZZZZZZZZ CsQQQQQQQQQQQ > "$W/symbols.txt"
+out="$(run)"; rc=$?
+eq "different crate hashes still compare EQUAL" "0" "$rc"
+run --bless >/dev/null 2>&1
+if diff -q "$W/first.txt" "$B" >/dev/null; then ok "baseline is byte-identical under hash churn"; else
+  no "baseline differs under hash churn: $(diff "$W/first.txt" "$B" | head -3)"; fi
+
+echo "== 4. drift is detected, with the right symbol and the right delta =="
+emit_symbols Cs9FWucCYWq3y CsjD18A8u66C5 > "$W/symbols.txt"
+run --bless >/dev/null 2>&1
+sed -i 's/^  1315: 3fc8c208  1408 /  1315: 3fc8c208  1472 /' "$W/symbols.txt"   # the real #390 shape
+out="$(run)"; rc=$?
+eq "a resized static exits 1" "1" "$rc"
+case "$out" in *"net +64 B"*) ok "reports the net delta (+64 B)" ;; *) no "no net delta: $out" ;; esac
+case "$out" in *"GREW"*"1408"*"1472"*) ok "names the GREW transition 1408 -> 1472" ;; *) no "no transition: $out" ;; esac
+case "$out" in *NTP_SOCK_STORAGE*) ok "names the symbol that changed" ;; *) no "does not name the symbol" ;; esac
+# and the direction must be distinguishable, or "something changed" is all a reviewer ever learns
+sed -i 's/^  1315: 3fc8c208  1472 /  1315: 3fc8c208  1344 /' "$W/symbols.txt"
+out="$(run)"; rc=$?
+case "$out" in *"SHRANK"*) ok "a shrink is reported as SHRANK, not GREW" ;; *) no "shrink misreported: $out" ;; esac
+eq "a shrink also exits 1" "1" "$rc"
+
+echo "== 5. NEW and GONE =="
+emit_symbols Cs9FWucCYWq3y CsjD18A8u66C5 > "$W/symbols.txt"
+run --bless >/dev/null 2>&1
+printf '  99999: 3fcb0000  8192 OBJECT  LOCAL  DEFAULT    7 _RNvNt5clock4newly8ARRIVED\n' >> "$W/symbols.txt"
+out="$(run)"; rc=$?
+eq "a new large static exits 1" "1" "$rc"
+case "$out" in *"NEW"*ARRIVED*) ok "reports NEW with the symbol" ;; *) no "no NEW: $out" ;; esac
+emit_symbols Cs9FWucCYWq3y CsjD18A8u66C5 > "$W/symbols.txt"
+grep -v 'g_cnxMgr' "$W/symbols.txt" > "$W/s2" && mv "$W/s2" "$W/symbols.txt"
+out="$(run)"; rc=$?
+eq "a removed static exits 1" "1" "$rc"
+case "$out" in *"GONE"*g_cnxMgr*) ok "reports GONE with the symbol" ;; *) no "no GONE: $out" ;; esac
+
+echo "== 6. vacuous-pass guards: cannot-check is 2, never 0 =="
+emit_symbols Cs9FWucCYWq3y CsjD18A8u66C5 > "$W/symbols.txt"
+out="$(python3 "$CHECK" --tier nope --baseline-dir "$W" --sections "$W/sections.txt" --symbols "$W/symbols.txt" 2>&1)"; rc=$?
+eq "missing baseline exits 2" "2" "$rc"
+case "$out" in *"not a pass"*) ok "missing baseline says so plainly" ;; *) no "weak message: $out" ;; esac
+out="$(run --threshold 999999)"; rc=$?
+eq "a filter matching nothing exits 2 (not 0)" "2" "$rc"
+case "$out" in *"floor is"*) ok "the floor guard explains itself" ;; *) no "no floor message: $out" ;; esac
+echo "garbage" > "$W/badsec.txt"
+out="$(python3 "$CHECK" --tier t --baseline-dir "$W" --sections "$W/badsec.txt" --symbols "$W/symbols.txt" 2>&1)"; rc=$?
+eq "unparseable sections exits 2" "2" "$rc"
+out="$(python3 "$CHECK" --tier t --baseline-dir "$W" --sections "$W/sections.txt" --symbols "$W/badsec.txt" 2>&1)"; rc=$?
+eq "unparseable symbols exits 2" "2" "$rc"
+out="$(READELF=/nonexistent-readelf python3 "$CHECK" --tier t --baseline-dir "$W" --elf "$W/sections.txt" 2>&1)"; rc=$?
+eq "missing readelf exits 2" "2" "$rc"
+out="$(python3 "$CHECK" --tier t --baseline-dir "$W" --elf "$W/no-such.elf" 2>&1)"; rc=$?
+eq "missing ELF exits 2" "2" "$rc"
+# --bless must refuse a vacuous set too, or the guard is bypassable by the one command that
+# rewrites the thing being guarded.
+out="$(run --bless --threshold 999999)"; rc=$?
+eq "--bless also refuses a vacuous set" "2" "$rc"
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #390.

## What was invisible

#335 P1.1 added six embassy dependency lines and changed **no source**. `embassy-net` turned on
smoltcp's `async` feature; smoltcp is *shared* with the hand-driven gateway (one `v0.13.1` in the
graph), so `WakerRegistration` per socket grew `net::wifi::NTP_SOCK_STORAGE` `0x540 → 0x580` — 64 B
of `.data` taken straight out of the `.stack` region, and invisible to every layer at once:

| layer | why it missed |
|---|---|
| code review | there was no source diff |
| the compiler | no arity or type change |
| `repro_stack_check` | 0.06 % of an aggregate, compared against a threshold |
| #351's exclusion checker | asserts presence/absence, never size |

It was found by a hand `nm` A/B, which is not a process. This makes it a **reviewed diff line**.

It **generalises** the #300 stack floor rather than duplicating it: the floor watches one derived
aggregate against a threshold; this watches the individual statics whose growth is what *moves*
that aggregate. The floor says the roof came down; this says which box grew.

Baseline on the canonical C3 tier: **29 statics, 182,066 B**. It pins the **19,600 B embassy task
arena `POOL`** — the static STEP T is about to resize, which is precisely the case this exists for.

## Two design departures from the issue, both deliberate

**1. Keyed on the mangled name, not a demangled one.** #390 proposed "DEMANGLED hash-stripped
names". The instinct is right — raw names carry a crate-metadata hash that churns
(`Cs9FWucCYWq3y_` → `Csa9xoDfnccUU_`) and buries the signal — but **a demangler is itself a
version-dependent transform**, so keying on its output makes the baseline depend on which
`rustfilt`/`llvm-cxxfilt` is installed. That is the same churn class the baseline exists to
eliminate, merely relocated into the toolchain — and no demangler is guaranteed present in CI.
Instead the volatile components are *substituted* with a placeholder (`Cs*_`), so the key depends
only on the ELF. Measured on the real ELF: **zero normalization collisions**, and a test arm proves
two entirely different disambiguator sets yield a **byte-identical** baseline.

**2. Skips `.L*` generally, not the two patterns named.** The issue named `.L_MergedGlobals*` and
`.Lswitch.table.*`. The real ELF *also* carries `.Lanon.<32hex>.<n>` — content-addressed names that
move whenever the constant they hold moves. Enumerating three patterns leaves the fourth to be
discovered the same way. `.L` is the assembler's local-label prefix, so any `.L*` symbol is
compiler-generated and not a static anyone declared. 6 of 35 candidates on the canonical ELF.

Section scope is `.data*`/`.bss*` by prefix, so `.data.wifi` counts. `.rodata` is **excluded on
purpose**: it lives in flash and does not come out of the `.stack` region. A 2560 B `.rodata` static
is the largest OBJECT in the test fixture *specifically so that widening the scope fails an arm* —
"the filter fires" is otherwise satisfied by a filter that tracks everything.

## Exit codes, and the guards that cannot be bypassed

`0` match · `1` drift · **`2` COULD NOT CHECK** — distinct because "the check did not run" must
never read as "the check passed". Four conditions return 2: missing baseline, unparseable sections,
unparseable symbols, and a `MIN_SYMBOLS` floor. **The floor also refuses `--bless`**, so the one
command that rewrites the guard cannot be used to hollow it out.

## Evidence

**Proven on a real resize, end to end on familiar.** Changed `OTA_READBACK: [u8; 4096]` → `4160` in
real source (+64 B, the same magnitude as the original incident), rebuilt, ran the checker:

```
SYMBOL SIZE DRIFT (#390) vs symbol-sizes.espnow-cast-io.txt — net +64 B
  GREW       +64 B  4096     -> 4160      _RNvNtCs*_5clock3ota12OTA_READBACK
```
exit 1. Restored the source, rebuilt → `29 statics, 182066 bytes — matches`, exit 0. No hysteresis.

**Guards, all four proven live:** missing readelf → 2 · missing baseline → 2 · absurd threshold
(filter matches nothing) → 2 · garbage sections → 2.

**Sabotage of the checker** (35-arm suite, baseline 35/0):

| sabotage | suite result |
|---|---|
| section filter dropped | 32 / **3 failed** |
| `.L*` skip removed | 31 / **4 failed** |
| normalization removed | 31 / **4 failed** |
| `MIN_SYMBOLS` floor → 0 | 32 / **3 failed** |
| drift comparison neutered | 25 / **10 failed** |
| size threshold ignored | 30 / **5 failed** |

**All three gate arms GREEN** on a clone of this branch on familiar, with both new arms firing:
```
host: PASS test_symbol_sizes
fw:   symbol sizes: 29 statics, 182066 bytes — matches symbol-sizes.espnow-cast-io.txt
```
Note the fw arm matched the **committed** baseline from a *fresh clone with its own target dir* —
so the baseline reproduces across builds, not merely on the machine that blessed it.

## Wiring

Both halves, and the split is load-bearing in both directions:
- **fw arm** runs the checker on the ELF the stack-floor step already built — **no extra build**.
- **host arm** runs the 35-arm offline suite (committed real slice of readelf output; no cargo).

A readelf output-format change keeps the host suite green and reddens only the fw arm; a logic
regression reddens the host suite even where firmware cannot be built. Neither arm alone covers both.

The **tier name is derived** from `REPRO_FLEET_FEATURES` rather than written twice: change the
canonical feature set and the baseline filename changes with it, so the checker says "no baseline —
a gap to close, not a pass" instead of silently comparing a new tier to an old tier's numbers.

## Adjacent finding — NOT fixed here, flagged

While building this I found the committed `rust/clock/Cargo.lock` is **stale against `Cargo.toml`**:
`mipidsi` (exact-pinned `=0.10.0`) and `embedded-hal-bus` are in `Cargo.toml` and **absent from the
lock**, so any build silently rewrites it. Nothing in `tools/` or `.github/workflows/` passes
`--locked` or `--offline`.

This bears directly on #390: unpinned resolution is *how* a dependency floats within semver and
silently resizes a static. A size baseline is both more valuable and less flaky when the lock is
authoritative. **Not touching it here** — those deps belong to the active S3/display work and
regenerating a lock is a dependency-wave action, not a side effect of a tooling PR. Worth its own
issue; say the word and I'll file it.

(The stale lock does not affect this baseline: both deps are optional and not enabled by
`espnow,cast,io`, so they never link into the canonical ELF. Verified rather than assumed.)

Per lane rule (touches `tools/`): **not self-merged**, routed to team-lead.
