### PR TITLE
feat(gate): tripwire for board constants that declare a fact nobody reads (#419)

### DIFF
--- a/tools/check_board_consts.py
+++ b/tools/check_board_consts.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""check_board_consts.py — #419: a board constant that declares a fact nobody reads.
+
+THE TRAP THIS ARMS AGAINST
+--------------------------
+`targets/c6-watch/src/board/*.rs` is the board-facts seam: `board/mod.rs` re-exports exactly one
+board's constants so consumers write `board::LCD_WIDTH` and never name a board. A constant declared
+there is a STATEMENT ABOUT THE HARDWARE.
+
+The dangerous shape is a board constant with ZERO readers whose NAME is also declared file-locally
+somewhere else. Then two things are true at once: the board says the value is X, and the code that
+would use it quietly uses its own Y. Nothing fails, nothing warns, and nothing compiles differently
+— a declared constant with zero readers is indistinguishable from a wired one at a glance.
+
+Measured cost of one real instance (in the standalone esp32c6-watch repo, where it is live): a
+gesture at dx=-23 dy=31 classified as `Tap` where the board's declared vertical threshold would have
+made it `Down`.
+
+This is LATENT in smol today, not live. `board/cyd_c5.rs` here is the early 107-line form and
+declares none of the three constants; the colliding declarations live in the standalone repo's
+451-line version. **The arming event is a routine subtree refresh** — which is why a tripwire is the
+right artifact and a fix is not. #419 filed it at the smol tracker owner's request; the derivation
+lives in jphein/esp32c6-watch#91.
+
+WHY NOT THE SHELL ONE-LINER FROM THE ISSUE
+------------------------------------------
+#419 proposed a `grep -oE 'pub const'` loop. Two things make it report the wrong answer here:
+
+  1. IT COUNTS COMMENTS AS READERS. `ui/slint_shell.rs` refers to `HOLD_SLOP_PX` in a doc comment
+     ("drifting past [`HOLD_SLOP_PX`] disarms it") as well as in code. A constant mentioned ONLY in
+     prose would read as wired — precisely inverted, since prose about a constant nobody applies is
+     the very thing being hunted. So references are counted in CODE ONLY, via the shared
+     `tools/rust_comments.py` strip (#426). Not a second stripper: that file exists because this
+     repo already collapsed two copies of it into one.
+
+  2. IT HARDCODES `cyd_c5.rs`. There are four board modules (`cyd_c5`, `esp32s3_cyd`,
+     `waveshare_c6`, `mod`), and the same trap arms identically in any of them. Board modules and
+     targets are GLOB-DISCOVERED, for the reason gate.sh already argues about verifier suites: the
+     last list-shaped check silently stopped covering what was added after it.
+
+WHAT FAILS AND WHAT ONLY REPORTS
+--------------------------------
+  * SHADOWED  — 0 code readers AND the name is declared file-locally elsewhere. This is the
+                contradiction. Exit 1.
+  * UNREAD    — 0 code readers, no competing declaration. REPORTED, never failed: the board may
+                legitimately declare a pin or address whose value is hardcoded at its use site
+                (esp32c6-watch#92 tracks 12 such). Failing on these would make the arm fire on a
+                dozen innocent constants on day one, and a gate that cries wolf is one people route
+                around (#338) — which would take the SHADOWED finding down with it.
+
+Exit: 0 clean · 1 a shadowed board constant · 2 COULD NOT CHECK.
+`2` is distinct because "the scan found nothing to scan" must never read as "nothing is wrong".
+"""
+
+import glob
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+try:
+    from rust_comments import strip_comments
+except ImportError:
+    sys.stderr.write("CANNOT CHECK: tools/rust_comments.py not importable — this checker counts "
+                     "references in CODE ONLY and will not fall back to a comment-blind grep, "
+                     "because that inverts the result it exists to produce.\n")
+    sys.exit(2)
+
+PUB_CONST_RE = re.compile(r"^\s*pub const ([A-Z][A-Z_0-9]*)\s*:", re.M)
+# A file-local declaration of the same name, anywhere outside the board seam. Deliberately matches
+# a non-`pub` const too — a private shadow is the more dangerous one, since nothing outside can even
+# observe that it exists.
+def local_const_re(name):
+    return re.compile(r"^\s*(?:pub\s+)?const %s\s*:" % re.escape(name), re.M)
+
+
+def die2(msg):
+    sys.stderr.write("CANNOT CHECK: %s\n" % msg)
+    sys.exit(2)
+
+
+def main():
+    root = sys.argv[1] if len(sys.argv) > 1 else os.path.join(HERE, "..")
+    root = os.path.abspath(root)
+
+    board_files = sorted(
+        p for p in glob.glob(os.path.join(root, "targets", "*", "src", "board", "*.rs"))
+        if os.path.basename(p) != "mod.rs"
+    )
+    if not board_files:
+        die2("found no targets/*/src/board/*.rs. Either the layout moved or the glob is wrong; "
+             "either way this check did not run and must not report success.")
+
+    findings, unread, wired_count = [], [], 0
+
+    for board_file in board_files:
+        target_root = board_file.split(os.sep + "src" + os.sep)[0]
+        target = os.path.basename(target_root)
+        board_dir = os.path.dirname(board_file)
+
+        consts = PUB_CONST_RE.findall(open(board_file, encoding="utf-8", errors="replace").read())
+        if not consts:
+            # Not fatal on its own — a board module may legitimately be a stub — but say so, since
+            # "no constants" and "no findings" look identical in a summary line.
+            print("  note: %s declares no pub consts" % os.path.relpath(board_file, root))
+            continue
+
+        # Every .rs in this target OUTSIDE the board seam, comments stripped once each.
+        others = {}
+        for path in sorted(glob.glob(os.path.join(target_root, "src", "**", "*.rs"),
+                                     recursive=True)):
+            if os.path.dirname(path) == board_dir:
+                continue
+            try:
+                others[path] = strip_comments(open(path, encoding="utf-8",
+                                                   errors="replace").read())
+            except OSError:
+                continue
+        if not others:
+            die2("target %s has a board module but no other .rs files to search. Every constant "
+                 "would score zero readers and be reported, which is noise, not a finding." % target)
+
+        for name in sorted(set(consts)):
+            word = re.compile(r"\b%s\b" % re.escape(name))
+            qualified = re.compile(r"board\s*::\s*%s\b" % re.escape(name))
+            shadows = [p for p, code in others.items() if local_const_re(name).search(code)]
+
+            # THE WHOLE CHECK IS HERE, and a bare-identifier search gets it BACKWARDS.
+            # `ui/slint_shell.rs` declares its own `const HOLD_SLOP_PX = 24` and uses the bare name
+            # at :657. That reference resolves to the FILE-LOCAL const, not to `board::HOLD_SLOP_PX`
+            # — so counting bare occurrences scores the shadowing file as a READER of the board
+            # constant and reports the trap as wired. Verified against the real armed trap before
+            # this line existed: the checker printed "0 SHADOWED", exit 0, with the collision live.
+            # Same identifier, two bindings; only the qualified path names the board's one.
+            #
+            # So: a file that declares its own `const NAME` cannot be a bare reader of the board's
+            # NAME. It can still be a reader via the explicit `board::NAME` path, which resolves
+            # unambiguously even when a local of the same name exists — so that form always counts.
+            readers = [p for p, code in others.items() if qualified.search(code)]
+            readers += [p for p, code in others.items()
+                        if p not in shadows and p not in readers and word.search(code)]
+
+            if readers:
+                wired_count += 1
+                continue
+            rel_board = os.path.relpath(board_file, root)
+            if shadows:
+                findings.append((target, name, rel_board,
+                                 [os.path.relpath(s, root) for s in shadows]))
+            else:
+                unread.append((target, name, rel_board))
+
+    print("board-fact seam: %d board module(s), %d constants with code readers, "
+          "%d unread, %d SHADOWED" % (len(board_files), wired_count, len(unread), len(findings)))
+
+    if unread:
+        print("\n  UNREAD (reported, not failed — a pin/address may be hardcoded at its use site;"
+              "\n  esp32c6-watch#92 tracks the benign remainder):")
+        for target, name, rel in unread:
+            print("    %-28s %s (%s)" % (name, rel, target))
+
+    if not findings:
+        return 0
+
+    sys.stderr.write(
+        "\nSHADOWED BOARD CONSTANT(S) — a board fact with zero code readers, whose name is\n"
+        "declared file-locally elsewhere. The board says one value; the code uses another, and\n"
+        "nothing fails or compiles differently (#419):\n")
+    for target, name, rel, shadows in findings:
+        sys.stderr.write("  %s\n" % name)
+        sys.stderr.write("    declared (unread): %s\n" % rel)
+        for s in shadows:
+            sys.stderr.write("    shadowed by:       %s\n" % s)
+    sys.stderr.write(
+        "\nFix: wire the consumer to `board::%s`, or delete the board declaration. Do NOT wire a\n"
+        "subset — the per-axis SWIPE_MIN and HOLD_SLOP_PX are one bundle, and wiring SWIPE_MIN_Y\n"
+        "without HOLD_SLOP_PX makes hold-slop EQUAL the vertical swipe minimum, so at dy=24 the\n"
+        "hold stays armed while the gesture also qualifies as a swipe — both true at once, which\n"
+        "is the ambiguity the declared invariant exists to prevent (esp32c6-watch#91).\n"
+        % findings[0][1])
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -775,6 +775,28 @@ if [ "$run_host" = 1 ]; then
   else
     printf '%s\n' "$out" | sed 's/^/        /'; bad "test_symbol_sizes"
   fi
+
+  # #419: the board-fact seam. A constant in targets/*/src/board/*.rs is a STATEMENT ABOUT THE
+  # HARDWARE; one with zero code readers whose name is ALSO declared file-locally elsewhere means
+  # the board says X while the code quietly uses Y, and nothing fails, warns, or compiles
+  # differently. Latent in smol today — the arming event is a routine subtree refresh, which is
+  # exactly why this is a tripwire rather than a fix. This is the FIRST gate arm covering
+  # targets/, and it is text-only (no build, no toolchain), so it belongs in the host arm.
+  #
+  # Runs on the real tree, then its own regression suite. Both, because they fail on different
+  # things: the live run catches an actual refresh that arms the trap, and the suite catches the
+  # checker being weakened so that the live run stops being able to see it.
+  step "board-fact seam — declared constants with no readers (#419)"
+  if out=$("$ROOT/tools/check_board_consts.py" "$ROOT" 2>&1); then
+    printf '%s\n' "$out" | head -1; ok "board consts"
+  else
+    printf '%s\n' "$out" | sed 's/^/        /'; bad "board consts"
+  fi
+  if out=$("$ROOT/tools/test_board_consts.sh" 2>&1); then
+    printf '%s\n' "$out" | tail -1; ok "test_board_consts"
+  else
+    printf '%s\n' "$out" | sed 's/^/        /'; bad "test_board_consts"
+  fi
 fi
 
 step "summary"

--- a/tools/test_board_consts.sh
+++ b/tools/test_board_consts.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# test_board_consts.sh — #419: prove tools/check_board_consts.py catches the trap it exists for,
+# clears the fixed version of it, and does not cry wolf on the benign remainder.
+#
+# THE ARM WORTH READING IS 3. It asserts that a NAIVE BARE-IDENTIFIER GREP PASSES ON THE SAME BYTES
+# that the checker fails. That is not a stylistic preference: the first version of this checker
+# counted bare occurrences, and when it was pointed at the real armed trap it printed "0 SHADOWED"
+# and exit 0 — a clean bill of health on the collision — because `ui/slint_shell.rs` uses the bare
+# name and that reference resolves to its OWN file-local const, not to `board::HOLD_SLOP_PX`. Same
+# identifier, two bindings. Arm 3 is what stops that being "simplified" back in.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="$HERE/check_board_consts.py"
+[ -f "$CHECK" ] || { echo "missing $CHECK" >&2; exit 2; }
+
+pass=0; fail=0
+ok(){ pass=$((pass+1)); echo "ok   - $1"; }
+no(){ fail=$((fail+1)); echo "FAIL - $1"; }
+eq(){ if [ "$2" = "$3" ]; then ok "$1 ($2)"; else no "$1: want [$2] got [$3]"; fi; }
+
+TMPROOT="${TMPDIR:-/var/tmp}"; case "$TMPROOT" in /tmp|/tmp/*) TMPROOT=/var/tmp ;; esac
+W="$(mktemp -d "$TMPROOT/boardconst-XXXXXX")"
+trap 'rm -rf "$W"' EXIT INT TERM
+
+# ── fixture: the minimum tree shaped like targets/<t>/src/{board,ui} ───────────────────────────
+mk(){ # <consumer-body>  — rebuilds the fixture with a given consumer file
+  rm -rf "$W/t"; mkdir -p "$W/t/targets/watch/src/board" "$W/t/targets/watch/src/ui"
+  cat > "$W/t/targets/watch/src/board/mod.rs" <<'EOF'
+#[cfg(feature = "board-a")]
+mod board_a;
+#[cfg(feature = "board-a")]
+pub use board_a::*;
+EOF
+  cat > "$W/t/targets/watch/src/board/board_a.rs" <<'EOF'
+pub const LCD_WIDTH: u16 = 320;
+pub const HOLD_SLOP_PX: u16 = 18;
+pub const WS2812_GPIO: u8 = 4;
+EOF
+  printf '%s\n' "$1" > "$W/t/targets/watch/src/ui/shell.rs"
+}
+run(){ python3 "$CHECK" "$W/t" 2>&1; }
+
+echo "== 1. wired via board:: — clean =="
+mk 'use crate::board;
+const OTHER: u16 = 1;
+fn f() { let _ = board::LCD_WIDTH; let _ = board::HOLD_SLOP_PX; let _ = board::WS2812_GPIO; }'
+out="$(run)"; rc=$?
+eq "all consts read via board:: exits 0" "0" "$rc"
+case "$out" in *"0 SHADOWED"*) ok "reports 0 shadowed" ;; *) no "unexpected: $out" ;; esac
+
+echo "== 2. the armed trap: board declares it, consumer shadows it with a file-local =="
+mk 'use crate::board;
+const HOLD_SLOP_PX: u16 = 24;
+fn f() { let _ = board::LCD_WIDTH; let _ = board::WS2812_GPIO; if 5 > HOLD_SLOP_PX {} }'
+out="$(run)"; rc=$?
+eq "a shadowed board constant exits 1" "1" "$rc"
+case "$out" in *"1 SHADOWED"*)     ok "counts exactly one shadowed constant" ;; *) no "count wrong: $out" ;; esac
+case "$out" in *HOLD_SLOP_PX*)     ok "names the constant" ;;                  *) no "unnamed: $out" ;; esac
+case "$out" in *board_a.rs*)       ok "names where it is declared" ;;          *) no "no declaration site" ;; esac
+case "$out" in *shell.rs*)         ok "names the file that shadows it" ;;      *) no "no shadow site" ;; esac
+case "$out" in *"one bundle"*)     ok "warns against wiring a subset" ;;       *) no "no bundle warning" ;; esac
+
+echo "== 3. THE KEEPER — a naive bare grep PASSES on the same bytes =="
+# If this ever fails, the checker has been reduced to a bare-identifier search and has stopped
+# being able to see the trap at all. Exactly the shape #432 arm 4 pins for the config guard.
+if grep -qE '\bHOLD_SLOP_PX\b' "$W/t/targets/watch/src/ui/shell.rs"; then
+  ok "bare-identifier grep DOES find the name in the shadowing file (so it cannot be the test)"
+else
+  no "fixture no longer reproduces the trap — the shadowing file must reference the bare name"
+fi
+# and the qualified form, which is the only one that proves board:: is read, is absent for it
+if grep -qE 'board::HOLD_SLOP_PX' "$W/t/targets/watch/src/ui/shell.rs"; then
+  no "fixture reads board::HOLD_SLOP_PX — that is the FIXED case, not the trap"
+else
+  ok "no qualified read of the board constant (the distinguishing fact)"
+fi
+
+echo "== 4. qualified read WINS even when a file-local of the same name exists =="
+# A file may legitimately declare its own const AND read the board's. `board::NAME` resolves
+# unambiguously, so it must count as a reader and the constant is wired, not shadowed.
+mk 'use crate::board;
+const HOLD_SLOP_PX: u16 = 24;
+fn f() { let _ = board::LCD_WIDTH; let _ = board::WS2812_GPIO;
+         let _ = board::HOLD_SLOP_PX; if 5 > HOLD_SLOP_PX {} }'
+out="$(run)"; rc=$?
+eq "a qualified read clears the shadow" "0" "$rc"
+case "$out" in *"0 SHADOWED"*) ok "not reported as shadowed" ;; *) no "false positive: $out" ;; esac
+
+echo "== 5. comments are not readers (#426 class) =="
+# A constant mentioned ONLY in prose must not read as wired — prose about a constant nobody
+# applies is precisely what is being hunted, so counting it inverts the result.
+mk 'use crate::board;
+const HOLD_SLOP_PX: u16 = 24;
+/// drifting past [`board::HOLD_SLOP_PX`] disarms it
+// let _ = board::HOLD_SLOP_PX;
+fn f() { let _ = board::LCD_WIDTH; let _ = board::WS2812_GPIO; if 5 > HOLD_SLOP_PX {} }'
+out="$(run)"; rc=$?
+eq "a comment-only board:: mention is NOT a reader" "1" "$rc"
+case "$out" in *HOLD_SLOP_PX*) ok "still reported as shadowed despite the doc mention" ;; *) no "comment counted as a reader: $out" ;; esac
+
+echo "== 6. UNREAD is reported, never failed =="
+# A pin whose value is hardcoded at its use site is not a contradiction — no competing
+# declaration exists. Failing these would fire on a dozen innocent constants on day one and the
+# arm would be routed around (#338), taking the SHADOWED finding with it.
+mk 'use crate::board;
+fn f() { let _ = board::LCD_WIDTH; }'
+out="$(run)"; rc=$?
+eq "unread-but-uncontradicted constants exit 0" "0" "$rc"
+case "$out" in *"UNREAD"*)        ok "unread constants are still REPORTED" ;;  *) no "silent: $out" ;; esac
+case "$out" in *WS2812_GPIO*)     ok "names the unread constant" ;;            *) no "unnamed unread" ;; esac
+case "$out" in *"0 SHADOWED"*)    ok "and not counted as shadowed" ;;          *) no "miscounted: $out" ;; esac
+
+echo "== 7. vacuous-pass guards: cannot-check is 2, never 0 =="
+mkdir -p "$W/empty"
+out="$(python3 "$CHECK" "$W/empty" 2>&1)"; rc=$?
+eq "no board modules at all exits 2" "2" "$rc"
+case "$out" in *"did not run"*) ok "explains that it did not run" ;; *) no "weak message: $out" ;; esac
+# a board module with nothing else to search would score every constant as unread = noise
+rm -rf "$W/t2"; mkdir -p "$W/t2/targets/watch/src/board"
+cp "$W/t/targets/watch/src/board/board_a.rs" "$W/t2/targets/watch/src/board/"
+out="$(python3 "$CHECK" "$W/t2" 2>&1)"; rc=$?
+eq "a board module with no consumers exits 2" "2" "$rc"
+
+echo "== 8. the REAL tree — proves the glob still matches this repo's layout =="
+# The fixture arms prove the LOGIC; this proves the checker still finds the real board seam. A
+# layout move (targets/*/src/board/) would keep every arm above green and only fail here.
+out="$(python3 "$CHECK" "$HERE/.." 2>&1)"; rc=$?
+eq "real repo exits 0 (no live shadowed constant)" "0" "$rc"
+n=$(sed -n 's/.*seam: \([0-9]*\) board module.*/\1/p' <<<"$out")
+if [ "${n:-0}" -ge 2 ]; then ok "found $n real board modules (glob matches the layout)"; else
+  no "found ${n:-0} board modules — the glob has stopped matching targets/*/src/board/*.rs"; fi
+w=$(sed -n 's/.*, \([0-9]*\) constants with code readers.*/\1/p' <<<"$out")
+if [ "${w:-0}" -ge 30 ]; then ok "$w real constants have code readers"; else
+  no "only ${w:-0} constants scored readers — reference counting looks broken on the real tree"; fi
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #419. **Stacked on #459 (#390)** — both add arms to the same `gate.sh` block, so this PR's
base is `feat/390-symbol-sizes`. Merge #459 first and I'll retarget, or retarget it yourself; the
only shared file is `gate.sh` and the two arms are adjacent additions.

## The trap

A constant in `targets/*/src/board/*.rs` is a **statement about the hardware** — `board/mod.rs`
re-exports exactly one board's constants so consumers write `board::LCD_WIDTH` and never name a
board. The dangerous shape is a board constant with **zero code readers whose name is also declared
file-locally somewhere else**: the board says X, the code quietly uses Y, and nothing fails, warns,
or compiles differently. A declared constant with no readers is indistinguishable from a wired one
at a glance.

**Latent here, not live** — `board/cyd_c5.rs` in smol is the early 107-line form and declares none
of the three constants; the colliding declarations live in the standalone repo's 451-line version.
The arming event is a **routine subtree refresh**, which is exactly why #419 asked for a tripwire
rather than a fix. Live tree today: `3 board modules, 76 constants with code readers, 16 unread, 0 SHADOWED`, exit 0.

## A bug of my own, and the fix *is* the check

Recording this because it is the whole reason the checker looks the way it does.

My first version counted **bare identifier occurrences**. Pointed at a reconstruction of the real
armed trap — `board/cyd_c5.rs` declaring `HOLD_SLOP_PX = 18` while `ui/slint_shell.rs` keeps its
local `= 24` — it printed:

```
board-fact seam: 3 board module(s), 77 constants with code readers, 16 unread, 0 SHADOWED
rc=0
```

**A clean bill of health on the live collision, and it counted the trap as wired** (77, up from 76).
Because `slint_shell.rs:657` uses the bare name, and that reference resolves to its **own file-local
const at :89**, not to `board::HOLD_SLOP_PX`. Same identifier, two bindings; a bare-identifier
search cannot tell them apart.

So: a file that declares its own `const NAME` **cannot be a bare reader** of the board's `NAME`. It
can still be a reader via the explicit `board::NAME` path, which resolves unambiguously even when a
local of the same name exists — so that form always counts.

I only found this because I tested against the **real trap** instead of a synthetic
"referenced-nowhere" constant. The synthetic case would have passed and proved nothing.

**Arm 3 of the suite asserts that a naive bare grep PASSES on the same bytes the checker fails** —
the mechanical thing that stops this being "simplified" back in. Same shape as #432's arm 4 for the
config guard.

## Two departures from the issue's proposed one-liner

#419 proposed a `grep -oE 'pub const'` loop. Two things make it report the wrong answer here:

1. **It counts comments as readers.** `ui/slint_shell.rs` refers to `HOLD_SLOP_PX` in a doc comment
   (`drifting past [HOLD_SLOP_PX] disarms it`) as well as in code. A constant mentioned *only* in
   prose would read as wired — inverted, since prose about a constant nobody applies is precisely
   what is being hunted. References are counted in **code only**, via the shared
   `tools/rust_comments.py` strip (#426) — not a second stripper, since that file exists because
   this repo already collapsed two copies of it into one.
2. **It hardcodes `cyd_c5.rs`.** There are three board modules (`cyd_c5`, `esp32s3_cyd`,
   `waveshare_c6`) and the trap arms identically in any of them. Modules and targets are
   **glob-discovered**, for the reason `gate.sh` already argues about verifier suites: the last
   list-shaped check silently stopped covering what was added after it.

## What fails vs what only reports

- **SHADOWED** → exit 1. The contradiction.
- **UNREAD** → reported, never failed. A pin or address may legitimately be hardcoded at its use
  site (esp32c6-watch#92 tracks the benign remainder; I find **16** here). Failing these would fire
  on a dozen innocent constants on day one, and a gate that cries wolf is one people route around
  (#338) — which would take the SHADOWED finding down with it.
- **exit 2** = could not check, distinct so that "found nothing to scan" never reads as "nothing is
  wrong". Two guards: no board modules at all; a board module with no consumer files to search.

## Evidence — both directions, on a reconstruction of the real trap

| condition | result |
|---|---|
| board declares `HOLD_SLOP_PX = 18`, `slint_shell.rs` keeps local `= 24` | **exit 1**, names the constant, its declaration site, and the shadowing file |
| consumer rewired to `crate::board::HOLD_SLOP_PX` | exit 0, 77 wired, 0 shadowed |

**Sabotage of the 24-arm suite** (baseline 24/0):

| sabotage | suite result |
|---|---|
| bare-identifier counting (**my original bug**) | 16 / **8 failed** |
| comment stripping removed | 22 / **2 failed** |
| UNREAD made fatal (cry wolf) | 22 / **2 failed** |
| no-board-modules guard dropped | 22 / **2 failed** |

**All three gate arms GREEN** on a clone of this branch on familiar, both new arms firing:
```
── board-fact seam — declared constants with no readers (#419)
board-fact seam: 3 board module(s), 76 constants with code readers, 16 unread, 0 SHADOWED
   PASS board consts
   PASS test_board_consts
```

## Wiring

**First gate arm to cover `targets/`** — `gate.sh` had no coverage there at all. Text-only (no
build, no toolchain), so it sits in the host arm. Runs the live check *and* its regression suite,
because they fail on different things: the live run catches a refresh that arms the trap; the suite
catches the checker being weakened so the live run stops being able to see it. Arm 8 of the suite
runs against the real tree specifically so a layout move (`targets/*/src/board/`) fails somewhere
instead of quietly matching nothing.

## Not done

The issue also notes #417 **under-delivered relative to its description** (claimed `xpt2046`, which
is not in the merged tree; `cyd_c5.rs` arrived in its 107-line form). That is a process observation
about subtree refreshes, not a code defect, and this arm is the mechanical answer to it — a refresh
assumed complete is a refresh whose gaps become invisible. Nothing to fix in the tree.

Per lane rule (touches `tools/`): **not self-merged**, routed to team-lead.
