### PR TITLE
fix(snk): drop the never-emitted v2 score byte — Option B as ruled (#232)

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1149,14 +1149,30 @@ snake** and broadcasts an **absolute, stateless** head snapshot; peers
 | `head_y` | 1 | u8 | world cell Y (toroidal) |
 | `length` | 1 | u8 | segment count; **body dead-reckoned, not sent** |
 
-**Versioning (`ver`) + forward-compat.** The parser is **length-tolerant**: a frame with the `SNK`
-prefix and **≥ 18 B** decodes the stable 18 B v1 core regardless of any trailing bytes. A **v2 = 19 B**
-frame appends a `score` byte at `[18]` (`SNK_FRAME_LEN_V2`, defined on **both** the C3 fleet and the
-esp32c6-watch); **`ver = 1` implies `score == length`**, so a v1 receiver loses nothing. As of this
-writing **no board emits `ver = 2`** — the v2 slot is *reserved-but-inactive*. Who bumps `ver` to 2
-(and thus what a `score` that diverges from `length` means), or whether to drop the dead definition,
-is the open decision in **#232**. A conformant parser reads `[0..18)` unconditionally and reads
-`[18]` **only** when `ver ≥ 2` **and** the frame is ≥ 19 B.
+**Versioning (`ver`) + forward-compat.** There is exactly **one version on the wire: `ver = 1`, 18 B**,
+and **`score == length`** by definition. The parser is **length-tolerant**: a frame with the `SNK`
+prefix and **≥ 18 B** decodes the stable 18 B core regardless of any trailing bytes, which are
+**ignored, not rejected**.
+
+**#232 (decided): the v2 score byte is DROPPED, not reserved.** A `ver = 2` / 19 B frame appending a
+`score` byte at `[18]` was previously defined here and in both firmwares, and **nothing ever emitted
+it** — the single builder that set `ver = 2` had zero callers. It is now removed from the C3 fleet
+rather than left as a reserved slot, because a reserved-but-unreachable wire field reads as a shipped
+capability to the next implementer (the #371 pattern).
+
+Re-adding a score byte later needs **no flag day**, which is why keeping the reservation bought
+little: a parser built to this spec passes the length check on a 19 B frame, matches the prefix,
+ignores byte `[18]`, and reads `score = length` — correct until score actually diverges from length.
+So the cost of dropping is ~6 lines to re-add plus a mixed window where old boards show
+`score == length`; the cost of keeping was a wire slot nobody could reach.
+
+> **Cross-repo status.** The removal has landed for the **C3 fleet** (`rust/clock`). The
+> **esp32c6-watch** copy (`src/apps/world_snake.rs`) still defines the v2 constants and sizes its TX
+> buffer from the 19 B length; it likewise never emits `ver = 2`. That half belongs to the standalone
+> watch repo and reaches smol through a subtree refresh, so it is tracked there rather than patched
+> in `targets/c6-watch/`. **Interop is unaffected either way** by the tolerance described above.
+
+A conformant implementation writes `[0..18)` and reads `[0..18)`; byte `[18]` carries no meaning.
 
 **World / coords.** `u8` per axis → up to **256×256 toroidal** world (design may
 mask to 128/axis via `x & 0x7F`); world size is a game knob. `MAX_PEERS = 16`.

--- a/rust/clock/src/mesh_snake/snake_core.rs
+++ b/rust/clock/src/mesh_snake/snake_core.rs
@@ -121,14 +121,21 @@ pub const VIEW_ROWS: u16 = SCREEN_H_PX / CELL_PX;
 // --- SMOLv1 SNK wire frame (netcode spec §1) -------------------------------
 /// ASCII, sniffer-greppable frame prefix. Exactly 11 bytes.
 pub const SNK_PREFIX: &[u8; 11] = b"SMOLv1 SNK ";
-/// Version 1 frame: 18 B core, no score byte (leaderboard score == length).
+/// Version 1 frame: 18 B core, no score byte — the leaderboard score IS the length.
+///
+/// #232: there is exactly ONE version on the wire. A `ver = 2` frame carrying an explicit
+/// `score` byte at `[18]` was defined here and never emitted by anything — `with_score`, the
+/// only thing that ever set it, had zero callers in either firmware. Dropped rather than left
+/// as a reserved slot, because a reserved-but-unreachable wire field reads as a shipped
+/// capability to the next person who finds it (#371).
+///
+/// Re-adding it is cheap and needs no flag day: a v1 parser handed a 19 B frame passes the
+/// length check, matches the prefix, ignores byte 18, and reads `score = length` — which is
+/// correct until score actually diverges from length. That graceful degradation is why the
+/// forward-compatibility argument for keeping it was weaker than it looked.
 pub const SNK_VER: u8 = 1;
-/// Version 2 frame: 18 B core + 1 B explicit `score` (leaderboard feature).
-pub const SNK_VER_SCORE: u8 = 2;
-/// Total on-wire length of a v1 frame: 11 B prefix + 7 B binary core.
+/// Total on-wire length of a frame: 11 B prefix + 7 B binary core.
 pub const SNK_FRAME_LEN: usize = 18;
-/// Total on-wire length of a v2 frame: v1 core + 1 B score.
-pub const SNK_FRAME_LEN_V2: usize = 19;
 
 // --- flags byte bit layout (design v2: powers + leaderboard) ---------------
 // Named masks so a re-carve (e.g. design v2 splitting off a respawn bit) is a
@@ -573,20 +580,22 @@ impl Camera {
 //   [15]     head_x u8       world cell X (0..=255)
 //   [16]     head_y u8       world cell Y (0..=255)
 //   [17]     length u8       live segment count (body is dead-reckoned, not sent)
-//   [18]     score  u8       ONLY in ver ≥ 2 (SNK_FRAME_LEN_V2 = 19); v1 implies score == length
+//
+// The frame ends at [17]. #232 dropped a never-emitted `[18] score` byte; score == length.
 //
 // Coordinates are u8 (world ≤256/axis). The core stores cells as u16 for
 // dimension-generality; encode narrows to u8, lossless for any world ≤256.
 //
 // Forward-compat policy: parse DEGRADES, it does not reject on version. Any
 // frame with the SNK prefix and ≥ 18 B decodes its stable 18 B core regardless
-// of `ver`; the `score` byte is read only when ver ≥ 2 and ≥ 19 B are present,
-// else `score = length`. So old firmware keeps understanding newer frames
-// (reads the fields it knows, ignores trailing additions), and an unknown
-// power id decodes as its numeric value rather than erroring.
+// of `ver`, and TRAILING BYTES ARE IGNORED rather than rejected. So old firmware
+// keeps understanding newer frames (reads the fields it knows, ignores trailing
+// additions), and an unknown power id decodes as its numeric value rather than
+// erroring. #232 is what makes this policy load-bearing rather than decorative:
+// dropping the `[18]` byte is safe precisely BECAUSE a longer frame still parses.
 
-/// A decoded SMOLv1 SNK frame. Mirrors the on-wire fields 1:1 (with `score`
-/// synthesized from `length` for v1 frames).
+/// A decoded SMOLv1 SNK frame. Mirrors the on-wire fields 1:1, except `score`,
+/// which is derived — see the field.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct SnkFrame {
     pub ver: u8,
@@ -598,7 +607,9 @@ pub struct SnkFrame {
     pub power: u8,
     pub head: Cell,
     pub length: u8,
-    /// Leaderboard score. v1 wire: implied == `length`. v2 wire: explicit byte.
+    /// Leaderboard score. NOT a wire field — always derived as `== length` (#232 removed the
+    /// never-emitted explicit `[18]` byte). Kept as a field because the leaderboard reads it,
+    /// so a future scoring model that diverges from length has one place to change.
     pub score: u8,
 }
 
@@ -626,14 +637,6 @@ impl SnkFrame {
         self
     }
 
-    /// Promote to a v2 frame carrying an explicit `score`.
-    #[inline]
-    pub fn with_score(mut self, score: u8) -> Self {
-        self.ver = SNK_VER_SCORE;
-        self.score = score;
-        self
-    }
-
     /// The active power id (0 = none). Getter mirroring [`SnkFrame::power`].
     #[inline]
     pub const fn power(&self) -> u8 {
@@ -649,14 +652,14 @@ impl SnkFrame {
             | ((self.power & FLAG_POWER_MASK) << FLAG_POWER_SHIFT)
     }
 
-    /// On-wire length for this frame's version (18 for v1, 19 for v2+).
+    /// On-wire length of this frame: always [`SNK_FRAME_LEN`].
+    ///
+    /// #232: kept as a function rather than inlined at the one call site, because it is the
+    /// single place a future versioned frame would reintroduce a length that varies. It is NOT
+    /// a claim that the length varies today — there is one version on the wire.
     #[inline]
     pub const fn wire_len(&self) -> usize {
-        if self.ver >= SNK_VER_SCORE {
-            SNK_FRAME_LEN_V2
-        } else {
-            SNK_FRAME_LEN
-        }
+        SNK_FRAME_LEN
     }
 }
 
@@ -687,17 +690,17 @@ pub fn encode_snk(f: &SnkFrame, out: &mut [u8]) -> Option<usize> {
     out[15] = (f.head.x & 0xff) as u8;
     out[16] = (f.head.y & 0xff) as u8;
     out[17] = f.length;
-    if n == SNK_FRAME_LEN_V2 {
-        out[18] = f.score;
-    }
     Some(n)
 }
 
 /// Parse a SMOLv1 SNK frame, or `None` only if it is too short (< 18 B) or has
 /// the wrong prefix (every foreign SMOLv1 tag — HELLO/ACK/BEACON/TIME/RELAY —
 /// is rejected here). **Version-degrading, not version-rejecting:** the stable
-/// 18 B core decodes for any `ver ≥ 1`; the `score` byte is read only when
-/// `ver ≥ SNK_VER_SCORE` and ≥ 19 B are present, otherwise `score = length`.
+/// 18 B core decodes for any `ver ≥ 1`, and trailing bytes beyond `[17]` are
+/// IGNORED rather than rejected — so a longer future frame from a newer peer
+/// still parses here, it simply contributes nothing beyond the core. That
+/// tolerance is what makes #232's removal of the `[18] score` byte safe without
+/// a flag day. `score` is always `length`.
 /// Total, rejects garbage, never panics.
 pub fn parse_snk(buf: &[u8]) -> Option<SnkFrame> {
     if buf.len() < SNK_FRAME_LEN {
@@ -712,12 +715,11 @@ pub fn parse_snk(buf: &[u8]) -> Option<SnkFrame> {
     }
     let (alive, heading, power) = unpack_flags(buf[14]);
     let length = buf[17];
-    // score: explicit in v2+ when the byte is present, else implied == length.
-    let score = if ver >= SNK_VER_SCORE && buf.len() >= SNK_FRAME_LEN_V2 {
-        buf[18]
-    } else {
-        length
-    };
+    // #232 (the LIVE half of this removal): this was `if ver >= SNK_VER_SCORE && buf.len() >= 19`
+    // — not dead code but an ALWAYS-FALSE branch on the per-frame hot path, since `parse_snk` is
+    // tried first for every ESP-NOW frame and nothing in either firmware ever emitted ver = 2.
+    // Score is definitionally the live segment count.
+    let score = length;
     Some(SnkFrame {
         ver,
         id: buf[12],


### PR DESCRIPTION
Closes #232. **Option B as ruled** — drop the dead v2 definition.

## Premise, re-verified on `origin/main` before cutting

`with_score()` was the only thing in either firmware that set `ver = SNK_VER_SCORE`, and it had
**zero callers** — not in firmware, not in a test. `MeshSnake::make_frame` chains `.with_power()`
and stops, so `ver` keeps its default. The C3 emits v1, always.

## Two hunks, because the halves were dead in different ways

Per the note on the issue — this should not be reviewed as one deletion.

**1. The encode half — genuinely unreachable code.** `SNK_VER_SCORE`, `SNK_FRAME_LEN_V2`,
`with_score()`, `wire_len()`'s branch, and `out[18] = f.score`. Removing these changes nothing that
ever ran.

**2. The parse half — NOT dead code.** `parse_snk` is tried *first* for every ESP-NOW frame
(`net/mode.rs:7621`), so `if ver >= SNK_VER_SCORE && buf.len() >= 19` was an **always-false
comparison on the per-frame hot path**. It is now `score = length` unconditionally. This hunk
changes what executes, however slightly, which is why it is called out separately.

## No flag day — and this is why keeping the reservation bought little

I asserted this on the issue; here is the proof, from the *complete set* of length checks rather
than from reading one function:

- `parse_frame` dispatches on **prefix only** — `data.starts_with(SNK_PREFIX)` — and delegates all
  length validation to `parse_snk`.
- `parse_snk`'s only length rejection is `buf.len() < SNK_FRAME_LEN` (18).
- `grep -nE 'len\(\) == 18|len\(\) != 18|== SNK_FRAME_LEN|!= SNK_FRAME_LEN'` over `net/mode.rs` and
  `mesh_snake/*.rs` → **no match. There is no exact-length gate anywhere in the SNK path.**

So a 19 B frame from some future peer reaches the parser, passes the check, matches the prefix, and
its byte `[18]` is simply never read → `score = length`, which is correct until score actually
diverges from length. Graceful degradation, no partition. Re-adding costs ~6 lines.

That tolerance is the safety argument for this whole removal, so I made the forward-compat comment
say it explicitly rather than leaving it as a property someone has to rediscover.

## What is KEPT, deliberately

- **`wire_len()`**, now returning `SNK_FRAME_LEN`, rather than inlined at its one call site: it is
  the single place a future versioned frame would reintroduce a varying length. Documented as
  exactly that, and **not** as a claim the length varies today — otherwise it becomes a fresh #371
  specimen inside the fix for one.
  (Its only caller is `encode_snk`. `io_wire_len` in `main.rs` is an unrelated local — I read the
  context rather than counting grep matches.)
- **`SnkFrame::score`** as a derived field: the leaderboard reads it (`mesh_snake/mod.rs:508`), so a
  future scoring model that diverges from length has one place to change.

## The spec moves in the same commit

`docs/protocol.md`'s versioning section **plus four stale in-file doc sites**: the byte-layout table,
the forward-compat policy block, `parse_snk`'s contract, and the `score` field's own doc. Leaving any
of them would recreate this issue from the doc side — a spec that still reserves byte 18 after the
code stops honouring it is the same defect pointed the other way.

## Cross-repo half — NOT done here, and it can't be

`targets/c6-watch/src/apps/world_snake.rs` still defines the v2 constants and **sizes its TX buffer
from them** (`pub const SNK_TX_BUF: usize = SNK_FRAME_LEN_V2;`). It likewise never emits `ver = 2`.

That file's canonical home is the standalone esp32c6-watch repo and it reaches smol through a subtree
refresh, so patching it here would be **overwritten by the next refresh** — and the issue's
"delete on both sides" spans two repos, only one of which is this one. Recorded as a cross-repo
status block in `protocol.md` so it reads as a tracked remainder, not an oversight. **Interop is
unaffected either way** by the tolerance above.

## Verification

**All three gate arms GREEN** on a clone of this branch on familiar (`fw`, `host`, `excl`, rc=0) —
so `clippy -D warnings` is clean, i.e. nothing became a dead field or unused import.

```
stack: 86208 B (floor 74208 B, derived)
symbol sizes: 29 statics, 182066 bytes — matches symbol-sizes.espnow-cast-io.txt
```

That second line is #390 (merged an hour ago) confirming this deletion moved **no writable static** —
expected, since what was removed was code rather than data, but it is now checked rather than assumed.

Per lane rule (`rust/clock`): **not self-merged**, routed to team-lead.
