### PR TITLE
feat(gate): exercise #420's identity guard instead of asserting it

### DIFF
--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -558,6 +558,62 @@ if [ "$run_fw" = 1 ]; then
     # of skip that is not a vacuous pass — the condition is already reported by a neighbour.
     printf '   \033[33mSKIP\033[0m symbol sizes — no ELF from the canonical build\n'
   fi
+
+  # #420: identity honesty, exercised rather than asserted. Two boards reported build 345 while
+  # running current code and ~40 min of incident forensics went into a "345-era crown" theory the
+  # number could never have supported. The fix made the unresolvable-hash case say `nogit` instead
+  # of the constant `dev`, and made a build claiming SMOL_RELEASE=1 with no resolvable commit REFUSE.
+  # Neither behaviour was reachable by any existing arm, so it shipped demonstrated-by-hand — and a
+  # guard whose failing path nobody has watched is a guard nobody has watched fail.
+  #
+  # GIT_DIR=/nonexistent is the whole trick: `git rev-parse` then fails exactly as it does in a
+  # `git archive` export or an rsync mirror with no .git, which is what build.rs's env_or_git sees.
+  # It costs one env var — no tree copy. A copied tree would ALSO defeat the warm target dir,
+  # because cargo's unit hashes include the path (#327), so every dependency would rebuild.
+  #
+  # ⚠️ THIS ARM MUST STAY LAST IN THE fw BLOCK. It re-runs build.rs with a different BUILD_HASH,
+  # which changes the crate's fingerprint — so the canonical ELF the three arms above consume is
+  # stale afterwards. Ordering is load-bearing, not cosmetic.
+  step "identity honesty — an archive-like build says 'nogit', a release without identity REFUSES (#420)"
+  if repro_cargo_args "$BUILD_ROOT/$CLOCK" 2>/dev/null; then
+    _id_ok=1
+    # (a) claiming a RELEASE with no resolvable commit must FAIL, and say why.
+    if out=$( cd "$BUILD_ROOT/$CLOCK" && GIT_DIR=/nonexistent SMOL_RELEASE=1 \
+                cargo check --release "${JOBS[@]}" --features "$REPRO_FLEET_FEATURES" \
+                "${REPRO_CARGO_ARGS[@]}" 2>&1 ); then
+      echo "        a RELEASE build with no resolvable identity SUCCEEDED — the #420 refusal is gone"
+      _id_ok=0
+    else
+      case "$out" in
+        *"#420"*) printf '        refuses a release with no identity\n' ;;
+        *) echo "        build failed, but NOT with the #420 refusal — refusing to read an"
+           echo "        unrelated build error as proof the guard fired:"
+           printf '%s\n' "$out" | tail -5 | sed 's/^/          /'; _id_ok=0 ;;
+      esac
+    fi
+    # (b) the same tree, NOT claiming a release, must build and stamp the absence by name. This is
+    # the direction that matters for forensics: `dev` was identical for every such build ever made.
+    if out=$( cd "$BUILD_ROOT/$CLOCK" && GIT_DIR=/nonexistent \
+                cargo check --release "${JOBS[@]}" --features "$REPRO_FLEET_FEATURES" \
+                "${REPRO_CARGO_ARGS[@]}" 2>&1 ); then
+      _bs="${CARGO_TARGET_DIR:-$BUILD_ROOT/$CLOCK/target}/${REPRO_TARGET}/release/build"
+      if grep -qhs 'BUILD_HASH=nogit' "$_bs"/clock-*/output; then
+        printf '        stamps BUILD_HASH=nogit when the commit is unresolvable\n'
+      else
+        echo "        an unidentifiable build did NOT stamp 'nogit' — the fallback is back to"
+        echo "        something that reads like a value:"
+        grep -hs 'BUILD_HASH=' "$_bs"/clock-*/output | sort -u | sed 's/^/          /'
+        _id_ok=0
+      fi
+    else
+      echo "        a dev build with no resolvable identity failed to compile — 'nogit' is meant"
+      echo "        to be BUILDABLE; only the release claim refuses:"
+      printf '%s\n' "$out" | tail -5 | sed 's/^/          /'; _id_ok=0
+    fi
+    [ "$_id_ok" = 1 ] && ok "identity honesty" || bad "identity honesty"
+  else
+    bad "identity honesty (could not resolve cargo args)"
+  fi
 fi
 
 if [ "$run_host" = 1 ]; then


### PR DESCRIPTION
Follow-up to #420 (merged as `fb661cb`), as approved.

## Why

#420 shipped **demonstrated-by-hand**: the `nogit` fallback and the release-without-identity refusal
were proven on familiar and then had no arm. A guard whose failing path nobody has watched is a guard
nobody has watched fail — the same gap #432 closed for the #280 config guard, and the reason #390's
suite exists.

## Two directions, because each alone passes for the wrong reason

**(a)** `SMOL_RELEASE=1` with no resolvable commit must **FAIL**, *and the output must contain
`#420`*. A build that fails for some unrelated reason is explicitly **not** read as proof the guard
fired — otherwise a broken toolchain would look like a working refusal, which is exactly the
"instrument answers a different question" trap.

**(b)** The same tree *without* `SMOL_RELEASE` must **BUILD** and stamp `BUILD_HASH=nogit`. This is
the direction that matters for forensics: `dev` was identical for every unidentifiable build ever
made, so it discriminated nothing precisely when an operator needed it to. It also pins that `nogit`
stays **buildable** — only the *release claim* refuses.

## The mechanism: one env var, no tree copy

`GIT_DIR=/nonexistent` makes `git rev-parse` fail exactly as it does in a `git archive` export or an
rsync mirror with no `.git` — which is what `build.rs`'s `env_or_git` actually sees.

The obvious alternative, copying the tree to a `.git`-less scratch dir, is worse twice over: it needs
a copy *and* it defeats the warm target dir, because cargo's unit hashes include the path (#327), so
every dependency would rebuild. Two `cargo check`s against the existing target dir cost almost
nothing by comparison.

**Measured:** whole `fw` arm **89 s** on familiar with this arm included.

## Ordering is load-bearing, and documented as such

The arm re-runs `build.rs` with a different `BUILD_HASH`, which changes the crate's fingerprint — so
the canonical ELF consumed by the stack-floor, byte-free and symbol-size arms is stale afterwards.
It is therefore **last in the `fw` block**, with a `⚠️` comment saying why. Moving it earlier would
not fail loudly; it would just make three arms above it measure a stale binary. Worth stating at the
site rather than discovering later.

## Evidence — fires, and proven able to fail

Live on familiar:
```
── identity honesty — an archive-like build says 'nogit', a release without identity REFUSES (#420)
        refuses a release with no identity
        stamps BUILD_HASH=nogit when the commit is unresolvable
   PASS identity honesty
```

**Sabotaging `build.rs` — both halves, both caught:**

| sabotage | result |
|---|---|
| remove the fail-closed refusal | **GATE RED** — "a RELEASE build with no resolvable identity SUCCEEDED — the #420 refusal is gone" |
| revert the fallback `nogit` → `dev` | **GATE RED** — "an unidentifiable build did NOT stamp 'nogit' — the fallback is back to something that reads like a value" |
| restored | GATE GREEN |

Each sabotage produces the diagnostic for *its own* failure rather than a generic red, which is what
makes the arm useful at 3 a.m.

No conflict with #461 (#419) — that adds to the `host` block, this to `fw`.

Per lane rule (touches `tools/`): **not self-merged**, routed to team-lead.
