### PR TITLE
refresh(c6-watch): sync subtree to watch main e3872bb (S3 audio + SNK drop + honesty + tooling)

### DIFF
--- a/targets/c6-watch/Cargo.toml
+++ b/targets/c6-watch/Cargo.toml
@@ -48,7 +48,7 @@ board-waveshare-c6 = [
     "esp-hal/esp32c6", "esp-rtos/esp32c6", "esp-radio/esp32c6",
     "esp-storage/esp32c6", "esp-bootloader-esp-idf/esp32c6",
     "esp-println/esp32c6", "esp-backtrace/esp32c6",
-    "has-pmu", "has-imu", "has-audio", "has-cap-touch",
+    "has-pmu", "has-imu", "has-audio-out", "has-audio-in", "has-cap-touch",
     "has-die-temp", "has-light-sleep", "mesh-ota",
 ]
 board-cyd-c5 = [
@@ -74,6 +74,12 @@ board-esp32s3-cyd = [
     # FT6336U: same FocalTech register map + 0x38 address the C6 driver
     # speaks (board-class-verified); the coordinate transform is board::*.
     "has-cap-touch",
+    # ES8311 playback (option B: MCLK-from-pin @16k on GPIO4, AUDIO_BCLK_DERIVED
+    # flipped false @ a605ac2). SFX/beeps/TTS/story. NOT has-audio-in yet — the
+    # S3's mic is the ES8311's own ASDOUT, a different capture path than the C6's
+    # ES7210 (phase 2). Bench-gated: first-listen must confirm the codec locks to
+    # SoC MCLK on GPIO4; fallback is the 44100 BCLK-derived fork.
+    "has-audio-out",
     # mesh-ota rides ed25519-dalek on xtensa (ota-proto's per-arch dep) —
     # ed25519-compact crashes this backend; see ota-proto/Cargo.toml.
     "mesh-ota",
@@ -100,8 +106,15 @@ bard = ["dep:bard-core"]
 has-pmu = []
 # QMI8658 IMU: pedometer, wrist-raise, tilt games.
 has-imu = []
-# ES8311 codec + ES7210 ADC + amp: all sound out, mic, voice, story AUDIO.
-has-audio = []
+# Audio split into two capabilities because the S3-CYD can PLAY but its mic is
+# a different chip topology than the C6's (ES8311-ASDOUT vs the C6's separate
+# ES7210), so one flag was always two claims:
+#   has-audio-out — ES8311 DAC playback: I2S TX + amp. SFX/beeps/TTS/story.
+#                   C6 + S3. (S3: MCLK-from-pin @16k on GPIO4 — option B.)
+#   has-audio-in  — mic capture: I2S RX. C6 = ES7210; S3 = ES8311-ASDOUT (phase 2).
+#                   C6 only for now; enables Voice/STT + the SoundLevel meter.
+has-audio-out = []
+has-audio-in = []
 # Capacitive touch (FT3168). The CYD's XPT2046 is resistive: same TouchPoint
 # contract, different driver + calibration; nothing gates on this yet but the
 # distinction is real (pressure vs contact, debounce needs).

--- a/targets/c6-watch/src/apps/registry.rs
+++ b/targets/c6-watch/src/apps/registry.rs
@@ -151,7 +151,11 @@ impl AppDescriptor {
     pub fn hardware_present(&self) -> bool {
         match self.state {
             AppState::Maze => cfg!(feature = "has-imu"), // tilt-driven
-            AppState::Voice | AppState::Sound => cfg!(feature = "has-audio"),
+            // Voice needs mic capture (has-audio-in); Sound is playback-only
+            // (has-audio-out). The S3 has out but not in yet, so Sound is present
+            // there and Voice is not — the honest per-capability split.
+            AppState::Voice => cfg!(feature = "has-audio-in"),
+            AppState::Sound => cfg!(feature = "has-audio-out"),
             _ => true,
         }
     }

--- a/targets/c6-watch/src/apps/world_snake.rs
+++ b/targets/c6-watch/src/apps/world_snake.rs
@@ -10,7 +10,8 @@
 //
 // Wire format (BYTE-COMPATIBLE with the C3 fleet, build 36+):
 //   [0..11)  "SMOLv1 SNK "  ASCII prefix
-//   [11]     ver    u8      1 (v2 = 19 B with trailing score byte; parse degrades)
+//   [11]     ver    u8      1 (v2 score-byte dropped fleet-wide — smol #232 /
+//                           9522a89; parse still accepts a stray 19 B frame, ignores it)
 //   [12]     id     u8      sender snake id
 //   [13]     tick   u8      wrapping step counter (ordering + dead-reckon base)
 //   [14]     flags  u8      bit0 alive | bits1-2 heading (0=U 1=R 2=D 3=L)
@@ -87,14 +88,10 @@ const DUR_PHOENIX_S: u32 = 10;
 pub const SNK_PREFIX: &[u8; 11] = b"SMOLv1 SNK ";
 /// Version 1 frame: 18 B, no score byte (score == length).
 const SNK_VER: u8 = 1;
-/// Version 2 frame: 18 B core + 1 B explicit score.
-const SNK_VER_SCORE: u8 = 2;
 /// Total on-wire length of a v1 frame.
 const SNK_FRAME_LEN: usize = 18;
-/// Total on-wire length of a v2 frame.
-const SNK_FRAME_LEN_V2: usize = 19;
 /// TX scratch size the main loop should provide.
-pub const SNK_TX_BUF: usize = SNK_FRAME_LEN_V2;
+pub const SNK_TX_BUF: usize = SNK_FRAME_LEN;
 
 // flags byte bit layout (FINAL, cross-board wire contract):
 const FLAG_ALIVE_MASK: u8 = 0b0000_0001;
@@ -164,9 +161,10 @@ pub fn encode_snk(f: &SnkFrame, out: &mut [u8]) -> Option<usize> {
 }
 
 /// Parse a SMOLv1 SNK frame. Version-degrading, not version-rejecting: the
-/// stable 18 B core decodes for any ver >= 1; the score byte is read only when
-/// ver >= 2 and 19 B are present, otherwise score = length. Total, rejects
-/// garbage, never panics.
+/// stable 18 B core decodes for any ver >= 1. score == length always — the v2
+/// explicit score byte was dropped fleet-wide (smol #232 / 9522a89); a legacy
+/// 19 B frame still decodes (its trailing byte is ignored). Rejects garbage,
+/// never panics.
 pub fn parse_snk(buf: &[u8]) -> Option<SnkFrame> {
     if buf.len() < SNK_FRAME_LEN {
         return None; // truncated
@@ -183,11 +181,7 @@ pub fn parse_snk(buf: &[u8]) -> Option<SnkFrame> {
     let heading = Dir::from_bits((flags >> FLAG_HEADING_SHIFT) & FLAG_HEADING_MASK);
     let power = (flags >> FLAG_POWER_SHIFT) & FLAG_POWER_MASK;
     let length = buf[17];
-    let score = if ver >= SNK_VER_SCORE && buf.len() >= SNK_FRAME_LEN_V2 {
-        buf[18]
-    } else {
-        length
-    };
+    let score = length; // v2 explicit-score byte dropped (smol #232 / 9522a89)
     Some(SnkFrame {
         ver,
         id: buf[12],

--- a/targets/c6-watch/src/board/cyd_c5.rs
+++ b/targets/c6-watch/src/board/cyd_c5.rs
@@ -124,6 +124,23 @@ pub const TOUCH_INVERT_Y: bool = false;
 /// board keeps the original FocalTech Monitor init.
 pub const TOUCH_FT6336_ACTIVE_QUIRK: bool = false;
 
+// --- Battery ADC: none known on the NM-CYD-C5 (USB-powered bench board). ---
+pub const HAS_BATT_ADC: bool = false;
+pub const BATT_ADC_GPIO: u8 = 0; // unused while HAS_BATT_ADC is false
+pub const BATT_ADC_DIVIDER: f32 = 1.0; // unused while HAS_BATT_ADC is false
+
+// --- Audio: none verified on the NM-CYD-C5 (its speaker header is un-scoped;
+// flip HAS_AUDIO with real pins if/when the cyd-c5 lane brings it up). -------
+pub const HAS_AUDIO: bool = false;
+pub const I2S_MCLK_GPIO: u8 = 0;
+pub const I2S_BCK_GPIO: u8 = 0;
+pub const I2S_WS_GPIO: u8 = 0;
+pub const I2S_DOUT_GPIO: u8 = 0;
+pub const I2S_DIN_GPIO: u8 = 0;
+pub const AMP_GPIO: u8 = 0;
+pub const AMP_ACTIVE_LOW: bool = false;
+pub const AUDIO_BCLK_DERIVED: bool = false;
+
 /// `chip_id` in the esp-idf app-image header (LE u16 at bytes 12..14) for
 /// this board's SoC. Both OTA paths (WiFi + mesh) refuse a mismatch BEFORE
 /// the first flash write — the wrong arm's image passes the 0xE9 magic check.

--- a/targets/c6-watch/src/board/esp32s3_cyd.rs
+++ b/targets/c6-watch/src/board/esp32s3_cyd.rs
@@ -121,6 +121,39 @@ pub const TOUCH_INVERT_Y: bool = true;
 /// the INT *level*. The C6's FT3168 keeps its original Monitor init.
 pub const TOUCH_FT6336_ACTIVE_QUIRK: bool = true;
 
+// --- Battery ADC (no PMU on this board — the divider IS the gauge) ---------
+/// BAT_ADC on GPIO9 through a 2:1 divider (BOARD.md pin map). Feeds the same
+/// battery_percent path the AXP2101 feeds on the C6. GPIO9 is a strapping-
+/// adjacent pin on some S3 pinouts; on the ES3C28P it is dedicated BAT_ADC.
+pub const HAS_BATT_ADC: bool = true;
+pub const BATT_ADC_GPIO: u8 = 9;
+pub const BATT_ADC_DIVIDER: f32 = 2.0;
+
+// --- Audio (ES8311 + SC8002B 3 W amp — BOARD.md §Audio + emberburrito) -----
+/// The codec already ACKs init over shared I²C (same chip as the C6). These
+/// pins are the ES3C28P's I²S wiring; the silkscreen names data pins from the
+/// CODEC's side, so DIN below is the MIC path (ES8311 ASDOUT → ESP) and DOUT
+/// is PLAYBACK (ESP → ES8311 DSDIN).
+pub const HAS_AUDIO: bool = true;
+pub const I2S_MCLK_GPIO: u8 = 4; // DRIVEN since the option-B flip — see AUDIO_BCLK_DERIVED
+pub const I2S_BCK_GPIO: u8 = 5;
+pub const I2S_WS_GPIO: u8 = 7;
+pub const I2S_DOUT_GPIO: u8 = 8; // ESP → ES8311 DSDIN (playback)
+pub const I2S_DIN_GPIO: u8 = 6; // ES8311 ASDOUT → ESP (microphone)
+/// SC8002B amp shutdown pin: **ACTIVE LOW — LOW = amp ON** (BOARD.md landmine;
+/// inverted vs the C6's GPIO6). Logical-off must drive HIGH.
+pub const AMP_GPIO: u8 = 1;
+pub const AMP_ACTIVE_LOW: bool = true;
+/// FLIPPED 2026-08-26 (was true): drive MCLK on GPIO4, MCLK-from-pin @16 kHz.
+/// Provenance beats the original const: emberburrito's BCLK-derived choice is
+/// by its own header NOT hardware-verified ("proves the API shapes and nothing
+/// about the sound"), while the C6 runs this SAME ES8311 register sequence
+/// MCLK-from-pin (0x3F) at 16 kHz ON GLASS today — and MCLK is physically
+/// wired here (GPIO4). Preserves the 16 kHz story/STT/SFX pipeline whole.
+/// If the S3's I2S0 MCLK fails to lock the codec on the bench, the fallback
+/// is the BCLK-derived + 44100 + resample fork (bigger, riskier — last resort).
+pub const AUDIO_BCLK_DERIVED: bool = false;
+
 /// `chip_id` in the esp-idf app-image header (LE u16 at bytes 12..14) for
 /// this board's SoC. Both OTA paths (WiFi + mesh) refuse a mismatch BEFORE
 /// the first flash write — the wrong arm's image passes the 0xE9 magic check.

--- a/targets/c6-watch/src/board/waveshare_c6.rs
+++ b/targets/c6-watch/src/board/waveshare_c6.rs
@@ -80,6 +80,25 @@ pub const TOUCH_INVERT_Y: bool = false;
 /// board keeps the original FocalTech Monitor init.
 pub const TOUCH_FT6336_ACTIVE_QUIRK: bool = false;
 
+// --- Battery ADC: N/A — this board's gauge is the AXP2101 PMU (has-pmu). ---
+pub const HAS_BATT_ADC: bool = false;
+pub const BATT_ADC_GPIO: u8 = 0; // unused while HAS_BATT_ADC is false
+pub const BATT_ADC_DIVIDER: f32 = 1.0; // unused while HAS_BATT_ADC is false
+
+// --- Audio: this board's live wiring, lifted verbatim from main.rs ---------
+/// The C6 watch drives the codec MCLK-clocked (with_mclk on the peripheral),
+/// unlike the S3 (BCLK-derived). Amp enable is GPIO6 ACTIVE-HIGH (LOW = off,
+/// the boot-safe level main.rs sets first).
+pub const HAS_AUDIO: bool = true;
+pub const I2S_MCLK_GPIO: u8 = 19;
+pub const I2S_BCK_GPIO: u8 = 20;
+pub const I2S_WS_GPIO: u8 = 22;
+pub const I2S_DOUT_GPIO: u8 = 23; // ESP → ES8311 DSDIN (playback)
+pub const I2S_DIN_GPIO: u8 = 21; // ES8311 ASDOUT → ESP (microphone)
+pub const AMP_GPIO: u8 = 6;
+pub const AMP_ACTIVE_LOW: bool = false;
+pub const AUDIO_BCLK_DERIVED: bool = false;
+
 /// `chip_id` in the esp-idf app-image header (LE u16 at bytes 12..14) for
 /// this board's SoC. Both OTA paths (WiFi + mesh) refuse a mismatch BEFORE
 /// the first flash write — the wrong arm's image passes the 0xE9 magic check.

--- a/targets/c6-watch/src/main.rs
+++ b/targets/c6-watch/src/main.rs
@@ -47,7 +47,7 @@ include!("panic_reboot.rs");
 // Chip-gated esp-hal surfaces (#cyd-c5): the C5's esp-hal 1.1.x has no `i2s`
 // module and no `rtc_cntl::sleep`. Gated by CAPABILITY, not chip, per the board
 // model — the board feature says what the hardware has, code asks the capability.
-#[cfg(feature = "has-audio")]
+#[cfg(feature = "has-audio-out")]
 use esp_hal::i2s::master::{Config as I2sConfig, DataFormat, I2s};
 #[cfg(feature = "has-light-sleep")]
 use esp_hal::rtc_cntl::sleep::{GpioWakeupSource, TimerWakeupSource};
@@ -1185,12 +1185,21 @@ async fn main(_spawner: Spawner) -> ! {
     println!("=== smol watch v2 (C6 AMOLED, Embassy) ===");
     let delay = Delay::new();
 
-    // Speaker amp enable (GPIO6). CRITICAL: keep LOW before the ES8311 is
-    // initialized and muted below — a floating I2S line through an enabled
-    // amp produces loud white noise. From v0.8.5 the pin is driven by
-    // audio_out::service_amp (per main-loop tick + inline after each
-    // play_pcm): HIGH only while a queued SFX clip is in flight, LOW + codec
-    // shutdown otherwise — power + pop discipline (#23).
+    // Speaker amp enable. CRITICAL: keep the amp RELEASED before the ES8311 is
+    // initialized and muted below — a floating I2S line through an enabled amp
+    // produces loud white noise. From v0.8.5 the pin is driven by
+    // audio_out::service_amp (per main-loop tick + inline after each play_pcm):
+    // enabled only while a queued clip is in flight, released + codec shutdown
+    // otherwise — power + pop discipline (#23).
+    //
+    // Polarity is a board fact: the C6 (and the C5 arm) drive an active-HIGH
+    // enable on GPIO6, so the released boot level is Level::Low; the S3-CYD's
+    // SC8002B is active-LOW on GPIO1, so its released boot level is Level::High.
+    // service_amp's `amp_drive` mirrors `board::AMP_ACTIVE_LOW` for both edges.
+    // Gating the pin here also frees GPIO6 on the S3 (it is I2S_DIN there).
+    #[cfg(feature = "board-esp32s3-cyd")]
+    let mut amp_en = Output::new(peripherals.GPIO1, Level::High, OutputConfig::default());
+    #[cfg(not(feature = "board-esp32s3-cyd"))]
     let mut amp_en = Output::new(peripherals.GPIO6, Level::Low, OutputConfig::default());
 
     // === I2C bus ===
@@ -1355,8 +1364,18 @@ async fn main(_spawner: Spawner) -> ! {
         crate::peripherals::touch::NullInput,
         crate::peripherals::touch::NullTouch,
     );
-    let _ = touch.init();
-    println!("[TOUCH] OK");
+    // Report by the init result, not aspiration: touch.init() is an I2C write to
+    // the FocalTech part (FT3168 on the C6, FT6336U on the S3), so a NACK means
+    // the controller is absent or at the wrong address — the exact failure a
+    // bench needs to see, and previously swallowed by `let _ =` + an
+    // unconditional "OK" (same non-discriminating-instrument lie the IMU log had,
+    // fixed in ae80072). NullTouch (no-cap-touch boards, e.g. the C5) returns
+    // Infallible, so its Err arm is dead and it always prints OK — correct: the
+    // stub genuinely cannot fail.
+    match touch.init() {
+        Ok(()) => println!("[TOUCH] OK"),
+        Err(_) => println!("[TOUCH] init FAILED (I2C NACK — controller absent or wrong address?)"),
+    }
 
     // === RTC ===
     let mut rtc = Pcf85063aRtc::new(RefCellDevice::new(&i2c_ref));
@@ -1386,8 +1405,15 @@ async fn main(_spawner: Spawner) -> ! {
 
     // === IMU ===
     let mut imu = Qmi8658Imu::new(RefCellDevice::new(&i2c_ref));
-    let _ = imu.init();
-    println!("[IMU] OK");
+    // Print by init result, not unconditionally: a board with no IMU (the
+    // ES3C28P / S3-CYD has none — BSP_CAPS_IMU=0) NACKs on the I2C probe, and
+    // an unconditional "[IMU] OK" is a vacuous instrument that reads identical
+    // whether the part is there or not. The C6 (QMI8658 present) still logs OK.
+    match imu.init() {
+        Ok(true) => println!("[IMU] OK"),
+        Ok(false) => println!("[IMU] absent (WHO_AM_I mismatch - no/other device)"),
+        Err(_) => println!("[IMU] absent (init NACK - no IMU on this board)"),
+    }
 
     // === Audio (ES8311 codec + I2S) ===
     // CRITICAL ORDER (mirrors the S3 reference):
@@ -1430,37 +1456,61 @@ async fn main(_spawner: Spawner) -> ! {
     // Whole-block gate rather than per-line: everything from the I2S config to
     // the TX clock task exists only where the codec + mics do (has-audio). The
     // C5's esp-hal has no `i2s` module, so none of this can even name its types.
-    #[cfg(feature = "has-audio")]
+    #[cfg(feature = "has-audio-out")]
     {
-        println!("[AUDIO] Init I2S (full-duplex, shared clock)...");
+        println!("[AUDIO] Init I2S (playback master + optional mic RX)...");
+        // signal_loopback is the RX-slaves-to-TX-clock trick — only meaningful
+        // when the mic RX half is also built (full-duplex, has-audio-in). A
+        // playback-only board (S3 phase 1) leaves it off: TX just drives the DAC.
         let i2s_config = I2sConfig::default()
             .with_sample_rate(Rate::from_hz(16000))
             .with_data_format(DataFormat::Data16Channel16)
-            .with_signal_loopback(true);
+            .with_signal_loopback(cfg!(feature = "has-audio-in"));
+
+        // Board-gated I2S pins. Option B (AUDIO_BCLK_DERIVED=false @ a605ac2):
+        // MCLK is DRIVEN on BOTH boards via with_mclk — GPIO19 on the C6, GPIO4
+        // on the S3 — so the ES8311 runs MCLK-from-pin (reg 0x01=0x3F, the
+        // glass-proven C6 path) at 16 kHz on the S3 too, no pipeline fork.
+        #[cfg(not(feature = "board-esp32s3-cyd"))]
+        let (p_mclk, p_bclk, p_ws, p_dout) = (
+            peripherals.GPIO19,
+            peripherals.GPIO20,
+            peripherals.GPIO22,
+            peripherals.GPIO23,
+        );
+        #[cfg(feature = "board-esp32s3-cyd")]
+        let (p_mclk, p_bclk, p_ws, p_dout) = (
+            peripherals.GPIO4, // board::I2S_MCLK_GPIO — driven (option B)
+            peripherals.GPIO5, // board::I2S_BCK_GPIO
+            peripherals.GPIO7, // board::I2S_WS_GPIO
+            peripherals.GPIO8, // board::I2S_DOUT_GPIO → ES8311 DSDIN
+        );
+
         let i2s_periph = I2s::new(peripherals.I2S0, peripherals.DMA_CH1, i2s_config)
             .expect("I2S failed")
-            .with_mclk(peripherals.GPIO19);
-        // TX is the I2S MASTER: it drives the shared BCLK(GPIO20)/WS(GPIO22) + MCLK. A
-        // continuous SILENT circular TX (below) keeps them free-running so the ES8311 ADC
-        // clocks data onto ASDOUT; the RX slaves to this clock via signal_loopback (internal).
-        // A circular TX needs EXACTLY descriptor_count() descriptors for its ring buffer.
+            .with_mclk(p_mclk);
+
+        // TX is the I2S MASTER: it drives the shared BCLK/WS + MCLK. A continuous
+        // SILENT circular TX (below) keeps them free-running — the playback seam
+        // AND, on a full-duplex board, the clock the mic ADC needs to shift data
+        // onto ASDOUT. A circular TX needs EXACTLY descriptor_count() descriptors.
         const TX_RING_LEN: usize = audio_out::TX_RING_LEN; // 3072 bytes → 3 descriptors
         const TX_CIRC_DESCS: usize =
             esp_hal::dma::descriptor_count(TX_RING_LEN, esp_hal::dma::CHUNK_SIZE, true);
         static I2S_TX_DESC: StaticCell<[DmaDescriptor; TX_CIRC_DESCS]> = StaticCell::new();
-        let mut i2s_tx = i2s_periph
+        let i2s_tx = i2s_periph
             .i2s_tx
-            .with_bclk(peripherals.GPIO20) // TX-master BCLK → codec (shared w/ RX via loopback)
-            .with_ws(peripherals.GPIO22)   // TX-master WS/LRCK → codec
-            .with_dout(peripherals.GPIO23) // DAC data → ES8311 DSDIN=GPIO23 (schematic I2S_DSDIN)
+            .with_bclk(p_bclk) // TX-master BCLK → codec
+            .with_ws(p_ws) // TX-master WS/LRCK → codec
+            .with_dout(p_dout) // DAC data → ES8311 DSDIN
             .build(I2S_TX_DESC.init([DmaDescriptor::EMPTY; TX_CIRC_DESCS]));
-        // === I2S RX for mic capture (#42 voice + #28 meter) — SLAVE via signal_loopback ===
-        // `i2s_periph.i2s_rx` is still available (partial move — tx took i2s_tx). With
-        // signal_loopback=true the RX shares the TX-master WS/BCK internally (configure()
-        // sets rx_slave_mod + sig_loopback from the Config flag) and just reads DIN(GPIO21)=
-        // ASDOUT — NO with_bclk/with_ws, NO GPIO-matrix hack. This is the ONLY place
-        // I2S0/DMA_CH1 is claimed; voice PTT + the SoundLevel meter subscribe to MIC_CH.
-        // MCLK (GPIO19) is peripheral-wide (with_mclk on i2s_periph). Stays Blocking:
+
+        // === I2S RX for mic capture (#42 voice + #28 meter) — has-audio-in only ===
+        // C6 only for now: the mic is the SEPARATE ES7210 ADC (SLAVE via
+        // signal_loopback, DIN=GPIO21=ASDOUT). The S3's capture is the ES8311's
+        // own ASDOUT (GPIO6) — a different path, phase 2, so it stays cfg'd out
+        // here. `i2s_periph.i2s_rx` is still available (partial move — tx took
+        // i2s_tx). MCLK is peripheral-wide (with_mclk above). Stays Blocking:
         // mic_capture_task drives it via read_dma_circular + poll.
         //
         // v0.6.0 glass crash (Load fault mtval=0x8 in DmaTransferRxCircular::available):
@@ -1468,49 +1518,50 @@ async fn main(_spawner: Spawner) -> ! {
         // walk from chain.last() expecting last.next → first; a padded array leaves trailing
         // EMPTY descriptors whose next=null, so the first available() poll derefs null.
         // descriptor_count() gives the exact count (3 for the ring @ CHUNK_SIZE=4092).
-        const MIC_RX_DESCS: usize = esp_hal::dma::descriptor_count(
-            mic_capture::MIC_RING_LEN,
-            esp_hal::dma::CHUNK_SIZE,
-            true, // circular
-        );
-        static I2S_RX_DESC: StaticCell<[DmaDescriptor; MIC_RX_DESCS]> = StaticCell::new();
-        let i2s_rx = i2s_periph
-            .i2s_rx
-            .with_din(peripherals.GPIO21) // ADC/mic data ← ES8311 ASDOUT=GPIO21 (schematic I2S_ASDOUT)
-            .build(I2S_RX_DESC.init([DmaDescriptor::EMPTY; MIC_RX_DESCS]));
-        // Mic PCM channel (capture task → consumers) + the DMA capture ring.
-        // Channel::new() is const → a plain static; the ring needs a StaticCell.
-        // MIC_RING_LEN is 3 × STEREO_CHUNK = 3072 B (it was 8 KB until the
-        // three-descriptor rework — see mic_capture.rs for the live value).
-        static MIC_RING: StaticCell<[u8; mic_capture::MIC_RING_LEN]> = StaticCell::new();
-        let mic_ring = MIC_RING.init([0u8; mic_capture::MIC_RING_LEN]);
-        _spawner.spawn(
-            mic_capture::mic_capture_task(i2s_rx, mic_ring, MIC_CH.sender())
-                .expect("mic_capture_task token"),
-        );
-        println!("[AUDIO] I2S RX (mic) ready on GPIO21 (DIN <- ES8311 ASDOUT)");
+        #[cfg(feature = "has-audio-in")]
+        {
+            #[cfg(not(feature = "board-esp32s3-cyd"))]
+            let p_din = peripherals.GPIO21; // ES7210 ASDOUT → ESP DIN
+            #[cfg(feature = "board-esp32s3-cyd")]
+            let p_din = peripherals.GPIO6; // ES8311 ASDOUT → ESP DIN (phase 2)
+            const MIC_RX_DESCS: usize = esp_hal::dma::descriptor_count(
+                mic_capture::MIC_RING_LEN,
+                esp_hal::dma::CHUNK_SIZE,
+                true, // circular
+            );
+            static I2S_RX_DESC: StaticCell<[DmaDescriptor; MIC_RX_DESCS]> = StaticCell::new();
+            let i2s_rx = i2s_periph
+                .i2s_rx
+                .with_din(p_din)
+                .build(I2S_RX_DESC.init([DmaDescriptor::EMPTY; MIC_RX_DESCS]));
+            // Mic PCM channel (capture task → consumers) + the DMA capture ring.
+            // MIC_RING_LEN is 3 × STEREO_CHUNK = 3072 B.
+            static MIC_RING: StaticCell<[u8; mic_capture::MIC_RING_LEN]> = StaticCell::new();
+            let mic_ring = MIC_RING.init([0u8; mic_capture::MIC_RING_LEN]);
+            _spawner.spawn(
+                mic_capture::mic_capture_task(i2s_rx, mic_ring, MIC_CH.sender())
+                    .expect("mic_capture_task token"),
+            );
+            println!("[AUDIO] I2S RX (mic) ready (DIN <- codec ASDOUT)");
+        }
 
-        // === Continuous full-duplex TX — the clock generator + playback ring ===
-        // The mic ADC only shifts data onto ASDOUT while it sees BCLK/WS edges. As the
-        // I2S MASTER, our TX must free-run those shared clocks continuously; RX slaves to
-        // them (signal_loopback). We stream this ring forever: the shared BCLK/WS keep
-        // toggling and the ADC keeps clocking real mic data into the RX DMA. The ring is
-        // ZEROS except while a queued SFX clip plays (#23): the clock task substitutes
-        // clip samples via DmaTransferTxCircular::push, and the feeder's tail scrubs the
-        // ring back to all-silence before the amp drops — idle is exactly the proven
-        // silent-clock behavior (amp GPIO6 LOW, data all-zero; no tone, no blasting).
+        // === Continuous TX — the clock generator + playback ring ===
+        // We stream this ring forever so BCLK/WS keep toggling (playback seam +,
+        // on a full-duplex board, the clock the mic ADC needs). The ring is ZEROS
+        // except while a queued SFX clip plays (#23): the clock task substitutes
+        // clip samples via DmaTransferTxCircular::push, and the feeder's tail
+        // scrubs the ring back to all-silence before the amp drops — idle is the
+        // proven silent-clock behavior (amp released, data all-zero; no blasting).
         static TX_RING: StaticCell<[u8; TX_RING_LEN]> = StaticCell::new();
         let tx_ring: &'static [u8] = TX_RING.init([0u8; TX_RING_LEN]);
-        // Clock + playback task; re-arms on CLOCK_REARM (AOD light sleep clock-gates
-        // I2S; the task restarts the DMA after each wake) and per playback session
-        // (see silent_clock_task docs: esp-hal's circular push-state goes Late after
-        // any idle lap, so each session opens on a fresh transfer). This produces the
-        // shared MCLK/BCLK/WS the ES7210 mic ADC (I2S slave) needs.
+        // Clock + playback task; re-arms on CLOCK_REARM (AOD light sleep
+        // clock-gates I2S) and per playback session (esp-hal's circular push-state
+        // goes Late after any idle lap, so each session opens on a fresh transfer).
         _spawner.spawn(
             mic_capture::silent_clock_task(i2s_tx, tx_ring)
                 .expect("silent_clock_task token"),
         );
-        println!("[AUDIO] I2S TX clock+playback task spawned (full-duplex master, re-arms after sleep)");
+        println!("[AUDIO] I2S TX clock+playback task spawned (re-arms after sleep)");
     }
 
 
@@ -1551,7 +1602,11 @@ async fn main(_spawner: Spawner) -> ! {
     // board with no mic ADC every access is an I2C error the callers already
     // handle. Only the INIT is audio-gated.
     let mut mic_adc = Es7210::new(RefCellDevice::new(&i2c_ref));
-    #[cfg(feature = "has-audio")]
+    // has-audio-in only: the ES7210 is the C6's SEPARATE mic ADC. The S3 has no
+    // ES7210 (its mic is the ES8311's own ASDOUT — phase 2), so compiling this
+    // init on the S3 would only NACK at 0x40 and log FAILED. The instance above
+    // stays constructed (the AOD-wake re-init references it in ungated code).
+    #[cfg(feature = "has-audio-in")]
     {
         Timer::after(Duration::from_millis(150)).await; // let silent_clock_task bring the clock up
         match mic_adc.init() {
@@ -1615,7 +1670,20 @@ async fn main(_spawner: Spawner) -> ! {
     // time under the debug-console build (see audio_out::LONG_CLIP docs).
     audio_out::register_chime(ping_chime_pcm);
 
-    // BOOT button (GPIO9 on the C6, strapping pin with pull-up).
+    // BOOT button. C6/C5: GPIO9 (strapping pin, pull-up). S3-CYD (ES3C28P):
+    // GPIO0 — its physical BOOT key and entire button budget (board::
+    // esp32s3_cyd HAS_BOOT_KEY; BOARD.md). GPIO9 on the S3 is BAT_ADC
+    // (board::BATT_ADC_GPIO=9), so binding the button there sampled the ~2 V
+    // divider node — wrong pin AND noise-prone in the middle of the logic
+    // window. cfg-gating fixes button truth AND frees GPIO9 for the battery
+    // ADC. Input::new needs the concrete pin singleton, so this is cfg-gated
+    // per board rather than driven by a u8 const.
+    #[cfg(feature = "board-esp32s3-cyd")]
+    let mut boot_button = Input::new(
+        peripherals.GPIO0,
+        InputConfig::default().with_pull(Pull::Up),
+    );
+    #[cfg(not(feature = "board-esp32s3-cyd"))]
     let mut boot_button = Input::new(
         peripherals.GPIO9,
         InputConfig::default().with_pull(Pull::Up),

--- a/targets/c6-watch/src/peripherals/audio_out.rs
+++ b/targets/c6-watch/src/peripherals/audio_out.rs
@@ -51,6 +51,7 @@ use embedded_hal::i2c::I2c;
 use esp_hal::gpio::Output;
 use heapless::Vec;
 
+use crate::board;
 use crate::peripherals::audio::Es8311;
 use crate::peripherals::mic_capture::STEREO_CHUNK;
 
@@ -598,13 +599,29 @@ pub fn service_amp<I: I2c>(amp: &mut Output<'static>, codec: &mut Es8311<I>) {
         // persisted master volume (#59) so every clip honors the stored level
         // (and stays silent when muted).
         let _ = codec.set_volume(MASTER_VOL_REG.load(Ordering::Relaxed));
-        amp.set_high();
+        amp_drive(amp, true);
         AMP_READY_MS.store(Instant::now().as_millis() as u32, Ordering::Relaxed);
         AMP_READY.store(true, Ordering::Relaxed);
     } else if !want && have {
-        amp.set_low();
+        amp_drive(amp, false);
         let _ = codec.shutdown();
         AMP_READY.store(false, Ordering::Relaxed);
+    }
+}
+
+/// Drive the speaker-amp enable GPIO respecting the board's polarity.
+///
+/// The C6's SGM's enable is active-HIGH (GPIO6); the S3-CYD's SC8002B is
+/// active-LOW (GPIO1, `board::AMP_ACTIVE_LOW`). `on ^ AMP_ACTIVE_LOW` picks the
+/// level: active-high ON = high, active-low ON = low — and the boot-time
+/// `Output::new` level in main.rs mirrors this so the amp is released before
+/// the codec is muted (white-noise discipline #23).
+#[inline]
+fn amp_drive(amp: &mut Output<'static>, on: bool) {
+    if on ^ board::AMP_ACTIVE_LOW {
+        amp.set_high();
+    } else {
+        amp.set_low();
     }
 }
 

--- a/targets/c6-watch/src/peripherals/mic_capture.rs
+++ b/targets/c6-watch/src/peripherals/mic_capture.rs
@@ -28,8 +28,13 @@ use embassy_time::{Duration, Timer};
 // compile unchanged on every board, and a board without `has-audio` simply
 // never spawns the tasks (the spawn sites live inside main.rs's gated audio
 // bring-up block).
-#[cfg(feature = "has-audio")]
-use esp_hal::i2s::master::{I2sRx, I2sTx};
+// Split by direction: the TX half (silent_clock_task + top_up) is the playback
+// path (has-audio-out, C6 + S3); the RX half (mic_capture_task) is the capture
+// path (has-audio-in, C6 only for now — the S3's ES8311-ASDOUT capture is phase 2).
+#[cfg(feature = "has-audio-out")]
+use esp_hal::i2s::master::I2sTx;
+#[cfg(feature = "has-audio-in")]
+use esp_hal::i2s::master::I2sRx;
 use esp_hal::Blocking;
 use heapless::Vec;
 
@@ -140,7 +145,7 @@ const PUSH_POLL_MS: u64 = 4;
 /// up via [`audio_out::PlaybackFeeder`]: clip samples (mono → stereo) while
 /// staged, silence otherwise. Any `Late`/DMA error mid-session aborts the
 /// clip and re-arms — the mic clock always comes back.
-#[cfg(feature = "has-audio")]
+#[cfg(feature = "has-audio-out")]
 #[embassy_executor::task]
 pub async fn silent_clock_task(mut i2s_tx: I2sTx<'static, Blocking>, ring: &'static [u8]) {
     use crate::peripherals::audio_out::{self, PlaybackFeeder};
@@ -225,7 +230,7 @@ async fn rearm_requested() {
 /// the stage buffer drains it in ≤ one-descriptor slices; `& !3` guards whole
 /// stereo frames. Plain fn (not async) so the 1 KB stage stays off the
 /// statically-allocated task future.
-#[cfg(feature = "has-audio")]
+#[cfg(feature = "has-audio-out")]
 fn top_up(
     xfer: &mut esp_hal::dma::DmaTransferTxCircular<'_, I2sTx<'static, Blocking>>,
     feeder: &mut crate::peripherals::audio_out::PlaybackFeeder,
@@ -290,7 +295,7 @@ async fn recording_cleared() {
 /// [`RECORDING`] it pops stereo frames, extracts mono, and `try_send`s chunks
 /// (dropping on channel-full = shed oldest audio under backpressure); while idle
 /// it drains-and-discards so the circular ring never overflows.
-#[cfg(feature = "has-audio")]
+#[cfg(feature = "has-audio-in")]
 #[embassy_executor::task]
 pub async fn mic_capture_task(
     mut i2s_rx: I2sRx<'static, Blocking>,

--- a/targets/c6-watch/src/ui/slint_shell.rs
+++ b/targets/c6-watch/src/ui/slint_shell.rs
@@ -2635,10 +2635,10 @@ fn build_launcher_pages() -> (Vec<LauncherTile>, Vec<SharedString>) {
     };
     let mut tiles: Vec<LauncherTile> = Vec::new();
     let mut titles: Vec<SharedString> = Vec::new();
-    // Audio leads on boards that can speak. Without has-audio the section
-    // holds at most Story, and a launcher that opens onto a near-empty page
-    // reads as breakage — the six games lead instead.
-    let order = if cfg!(feature = "has-audio") {
+    // Audio leads on boards that can speak (has-audio-out — playback). Without
+    // it the section holds at most Story, and a launcher that opens onto a
+    // near-empty page reads as breakage — the six games lead instead.
+    let order = if cfg!(feature = "has-audio-out") {
         [Section::Audio, Section::Games, Section::System]
     } else {
         [Section::Games, Section::System, Section::Audio]

--- a/targets/c6-watch/tools/build-s3.sh
+++ b/targets/c6-watch/tools/build-s3.sh
@@ -11,28 +11,23 @@
 #   3. fetching the xtensa ELF back (fambuild's fetch is hardcoded to the
 #      riscv triple; see the stale-artifact hazard note in fambuild itself).
 #
-# ⚠️ KNOWN BLOCKER (2026-08-25, espup 1.95.0.0): building with the ui/cyd
-# scene set crashes rustc's Xtensa isel —
+# ✅ RESOLVED (2026-08-26): the full ui/cyd scene builds AND renders on the S3
+# (JP glass-verified "gui looks good"). The LINK-ONLY cropped-C6 fallback this
+# script once carried is RETIRED — the build command below uses the real
+# board-esp32s3-cyd feature, no fallback branch. Do not reintroduce the
+# fallback language; it would be a correct-sounding claim about a dead limit.
+#
+# Historical record, kept because the failure mode is subtle and could recur:
+# the ui/cyd scene once crashed rustc's Xtensa isel —
 #   LLVM ERROR: Cannot select: XtensaISD::PCREL_WRAPPER TargetConstantPool
 #     [2 x float] [1.0, 0.0]   (symbol: InnerCydBacklightToggle...inits0_0)
 # at opt 1/2/3 fat LTO (thin LTO: scavenger crash; lto=off: spill crash).
-# The C6 scene set does NOT trigger it, so this script builds with the
-# LINK-ONLY C6 fallback (renders cropped) until the lane resolves it:
-# BISECTED 2026-08-25 (component-removal granularity — expression rewrites
-# are NOT valid proof, slint can normalize them back):
-#   * Stub ONLY CydBacklightToggle's two instantiations -> the FULL ui/cyd
-#     scene LINKS on the S3.
-#   * Restore the component but hold out its one float-expression binding
-#     (`property <bool> on: root.value > 0.5;`) -> LINKS.
-#   * Int-mediate it (Math.round(value*100) >= 50) -> CRASHES again with a
-#     new [0.0, 1.0] constpool: ANY float arithmetic in this component's
-#     bindings triggers the isel bug; float-free bindings are safe.
-# Fix shape (not yet landed): push the on/off bool FROM RUST alongside
-# set_brightness (root `backlight-on` property, in-property on the
-# component) so the scene carries no float expressions in this component.
-# espup 1.98.0.0 was tested and crashes identically — a toolchain bump is
-# NOT a path; the minimal .slint repro for upstream is (s3-cyd owns the
-# draft doc).
+# BISECTED to CydBacklightToggle's one float-expression binding
+# (`property <bool> on: root.value > 0.5;`): ANY float arithmetic in that
+# component's bindings triggered it; float-free bindings were safe. FIX
+# (landed): the on/off bool is pushed FROM RUST alongside set_brightness so
+# the component carries no float expressions. A toolchain bump was NOT the
+# path — espup 1.95.0.0 and 1.98.0.0 both crashed identically.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 TRIPLE=xtensa-esp32s3-none-elf

--- a/targets/c6-watch/tools/ota_push.sh
+++ b/targets/c6-watch/tools/ota_push.sh
@@ -16,6 +16,19 @@
 #                                      # (OTA_BUILD=0 accepts ANY announce and
 #                                      # zero-touch replaces your build — #55).
 #                                      # (combines with --target)
+#   tools/ota_push.sh --url <url>      # OVERRIDE the announced OTA_URL for this
+#                                      # push. The config's OTA_URL host is a
+#                                      # PER-SEAT reachability bet: the S3-CYD
+#                                      # sits on VLAN8 (iot), from which ubox0's
+#                                      # 10.0.11.11:8000 is FIREWALL-DEAD (the
+#                                      # same per-seat trap as the MQTT broker
+#                                      # leg). Announce a URL reachable from the
+#                                      # TARGET watch's VLAN instead — e.g.
+#                                      # http://disks:8087/ota/... (iot->family
+#                                      # is allowed). --url changes only what the
+#                                      # watch is TOLD to fetch; upload the image
+#                                      # to that host yourself (the default
+#                                      # ubox0 upload path assumes the C6 seat).
 #
 # Flow (see docs/ota-deploy.md "Push OTA"):
 #   1. Stamp OTA_BUILD=<unix-seconds> into .cargo/config.toml [env] (gitignored)
@@ -53,6 +66,7 @@ OTA_DEST="ubox0:/home/jp/watch-ota/watch.bin"
 ANNOUNCE_ONLY=0
 CLEAR=0
 TARGET=""
+OTA_URL_OVERRIDE=""
 while [ $# -gt 0 ]; do
     case "$1" in
         --announce-only) ANNOUNCE_ONLY=1 ;;
@@ -65,10 +79,23 @@ while [ $# -gt 0 ]; do
             TARGET="${2:-}"
             [ -n "$TARGET" ] || { echo "ota_push: --target needs a sigil (e.g. eldritch-lantern)" >&2; exit 2; }
             shift ;;
+        --url)
+            OTA_URL_OVERRIDE="${2:-}"
+            [ -n "$OTA_URL_OVERRIDE" ] || { echo "ota_push: --url needs a URL (e.g. http://disks:8087/ota/watch.bin)" >&2; exit 2; }
+            shift ;;
         *) echo "ota_push: unknown argument: $1" >&2; exit 2 ;;
     esac
     shift
 done
+
+# Per-seat OTA_URL override (#s3-cyd VLAN8 firewall trap): the config's OTA_URL
+# is only reachable from the seat it was written for. Announce a URL the TARGET
+# watch's VLAN can actually reach when they differ. Only the ANNOUNCE changes —
+# the image upload (OTA_DEST) is unchanged, so upload to the override host first.
+if [ -n "$OTA_URL_OVERRIDE" ]; then
+    echo "ota_push: OTA_URL override: $OTA_URL -> $OTA_URL_OVERRIDE (per-seat reachability)"
+    OTA_URL="$OTA_URL_OVERRIDE"
+fi
 
 # Fleet topic by default; per-watch topic (watch/<sigil>/ota, both watches'
 # firmware subscribes its own alongside the fleet topic) when targeted. The


### PR DESCRIPTION
Cumulative refresh of `targets/c6-watch` from the standalone watch repo, span `4922dad..e3872bb` (14 commits). **12 files, each byte-identical to watch `e3872bb`** (cross-checked file-by-file).

## Content checklist (verify-the-content, not the description)
- [x] **S3 audio playback (option B)** — `has-audio` → `has-audio-out`/`has-audio-in` split; I2S block board-gated (C6 19/20/22/23/21, S3 4/5/7/8/6), MCLK-from-pin @16k, `AUDIO_BCLK_DERIVED=false`. Files: Cargo.toml, main.rs, audio_out.rs (amp polarity via `board::AMP_ACTIVE_LOW`), mic_capture.rs (TX→out / RX→in), registry.rs (Voice→in/Sound→out), slint_shell.rs (launcher lead→out). **Boot-verified on S3 glass; acoustic first-listen recorded-pending** (no speaker on the bench connector) — silent ⇒ 44100 fork.
- [x] **SNK v2 score-byte drop** (world_snake.rs) — mirrors #232 / 9522a89; watch was already v1-only on the wire ⇒ zero wire change (buffer 19→18, dead v2 parse branch removed).
- [x] **3-board const contracts** (board/{waveshare_c6,cyd_c5,esp32s3_cyd}.rs) — battery-ADC + audio pins/amp/BCLK-derived.
- [x] **Diagnostic honesty** — `[IMU]` and `[TOUCH]` report by init result (no unconditional OK).
- [x] **S3 boot-pin GPIO0** (main.rs, was sampling the BAT_ADC divider node) + **build-s3.sh** header (isel blocker RESOLVED) + **ota_push.sh `--url`** (per-seat OTA_URL; VLAN8 firewall trap).

## Deliberately NOT included
- **battery-ADC gauge** (feat/s3-batt-adc, probe-v2 `d75f362`) — bench-pending; v1 refuted as a false-present (empty connector read 92%), v2 double-enables RTC RDE + IO_MUX FUN_WPD, awaiting empty→0% + cell→real% on glass. Lands in a follow-up refresh on gauge-green.
- **HANDOFF.md** — watch-repo-internal working state.

## Verification
- C6 arm (riscv, full-duplex) build-clean on familiar twice this cycle (be0c7f9, 072845a).
- S3 arm (xtensa) build-clean (s3-cyd-45 verified ba965df); boot-verified on glass (GUI + touch JP-verified; audio pipeline to last electrical step).

Merges by the subtree convention (merge commit) on green.