### PR TITLE
fix(build): gate the committed Cargo.lock — an exact '=' pin nothing enforced (#460)

### DIFF
--- a/tools/check_lock_fresh.sh
+++ b/tools/check_lock_fresh.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# check_lock_fresh.sh — #460. Is the committed Cargo.lock actually consulted?
+#
+# THE DEFECT THIS EXISTS FOR: `rust/clock/Cargo.toml` pins `mipidsi = "=0.10.0"` — the strictest pin
+# cargo has, placed deliberately because s3_oled's ORIENTATION reasoning is tied to 0.10's MADCTL
+# semantics. On 2026-08-26 the committed lock did not contain `mipidsi` at all, and no build path in
+# the repo passed `--locked`, so every build silently REWROTE the lock and no gate noticed. An exact
+# pin enforced only by whoever last read the comment above it.
+#
+# WHY A GATE ARM RATHER THAN `--locked` ON THE BUILD PATHS (#460's option 2, deliberately): adding
+# `--locked` to `repro_build.sh`/`gate.sh`/`fw-gate.yml` changes how everyone builds and collides
+# with whichever lane holds those files. This arm catches the same staleness without touching a
+# single build invocation. If `--locked` is later adopted on the build paths, this arm becomes
+# redundant and should be deleted rather than kept as a second statement of one fact.
+#
+# ── THE INSTRUMENT, AND WHY IT IS SHAPED LIKE THIS ────────────────────────────────────────────────
+#
+# `cargo metadata --locked` resolves the FULL dependency graph (optional deps included — which is
+# the whole point, since #460's two missing entries were both optional) and refuses to rewrite the
+# lock. Fresh lock ⇒ exit 0. Stale lock ⇒ exit 101.
+#
+# ⚠️ `--offline` is NOT used, and that is measured, not stylistic. All six combinations were run:
+#
+#   lock      registry cache   flags                 rc    verdict
+#   healthy   warm             --locked --offline     0    fresh
+#   STALE     warm             --locked --offline   101    stale
+#   healthy   COLD             --locked --offline   101    *** FALSE STALE ***
+#   healthy   COLD             --locked               0    fresh
+#   STALE     COLD             --locked             101    stale
+#   (cargo absent)                                   127   cannot check
+#
+# A cold registry cache plus `--offline` fails on a PERFECTLY FRESH lock ("no matching package named
+# `ed25519-compact` found … offline mode can sometimes cause surprising resolution failures"). On a
+# fresh CI runner that is the normal state, so an `--offline` arm would have been red for a reason
+# that has nothing to do with the lock — a check that fails for the wrong reason, which is worse
+# than no check because it teaches people to ignore it (#338).
+#
+# ⚠️ Therefore exit 101 ALONE IS NOT THE FINDING. This script requires cargo's own discriminating
+# sentence, `because --locked was passed`, before it will say STALE. That sentence was verified
+# present in BOTH stale cases above (warm and cold cache) and absent in the false-stale case. Same
+# discipline as the #420 gate arm, which refuses to read an unrelated build failure as proof the
+# guard fired.
+#
+# THREE OUTCOMES, not two:
+#   0  the lock is fresh — cargo resolved the graph without needing to change it
+#   1  STALE LOCK — the finding
+#   2  COULD NOT CHECK — cargo absent, network unreachable, cold cache under --offline, bad cwd.
+#      NEVER reported as a pass and never reported as staleness. (#280's manifest-gap precedent.)
+#
+# SCOPE: exit-code-bearing for `rust/clock` only. Every other Cargo.lock in the repo is DISCOVERED
+# (not hardcoded — a hand-kept list is what #328 watched rot) and reported informationally. Reason
+# for the split, so it reads as a decision: `targets/*` are other lanes' actively-moving trees, and
+# nothing in-repo states their locks must be fresh. Failing on them would be inventing another
+# lane's requirements (#338). Reporting them means the limit of this gate is VISIBLE rather than
+# something a reader has to infer from its absence (#430: make the drop visible).
+#
+# Usage:
+#   tools/check_lock_fresh.sh              # check rust/clock (exit 0/1/2) + report other locks
+#   tools/check_lock_fresh.sh --self-test  # prove this checker can fail, and cannot falsely fail
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CANON_REL="rust/clock"
+DISCRIMINATOR="because --locked was passed"
+
+# ── the one measurement ───────────────────────────────────────────────────────────────────────────
+# Echoes a verdict word on stdout and returns 0/1/2. `err` receives cargo's stderr.
+probe_lock() { # <crate-dir>
+  local dir="$1" err rc
+  [ -d "$dir" ]            || { echo "CANNOT-CHECK no such directory: $dir"; return 2; }
+  [ -f "$dir/Cargo.toml" ] || { echo "CANNOT-CHECK no Cargo.toml in $dir"; return 2; }
+  [ -f "$dir/Cargo.lock" ] || { echo "CANNOT-CHECK no Cargo.lock in $dir (nothing to enforce)"; return 2; }
+  command -v cargo >/dev/null 2>&1 || { echo "CANNOT-CHECK cargo is not on PATH"; return 2; }
+
+  err="$(cd "$dir" && cargo metadata --locked --format-version 1 2>&1 >/dev/null)"; rc=$?
+  if [ "$rc" -eq 0 ]; then echo "FRESH"; return 0; fi
+  # Non-zero: only cargo's own sentence licenses the STALE verdict.
+  case "$err" in
+    *"$DISCRIMINATOR"*) echo "STALE"; printf '%s\n' "$err" | sed 's/^/      /' >&2; return 1 ;;
+    *) echo "CANNOT-CHECK cargo metadata failed for an unrelated reason (rc=$rc)"
+       printf '%s\n' "$err" | sed 's/^/      /' >&2; return 2 ;;
+  esac
+}
+
+# ── self-test ─────────────────────────────────────────────────────────────────────────────────────
+# Built from the REAL 2026-08-26 drift (the two optional deps #460 measured absent), reconstructed
+# from a copy of the real lock — not a hand-written miniature, which would drift from the thing being
+# guarded and reproduce this issue's own defect.
+self_test() {
+  local pass=0 fail=0
+  # WORK is deliberately GLOBAL: an EXIT trap fires after this function returns, so a `local` here
+  # gives "work: unbound variable" at cleanup time — a real bug this self-test hit on first run.
+  WORK="$(mktemp -d /var/tmp/lockfresh-selftest.XXXXXX)"   # never /tmp: 16 GB tmpfs on this host
+  trap 'rm -rf "${WORK:-}"' EXIT INT TERM
+  local work="$WORK"
+
+  # ⚠️ Copy the whole `rust/` tree, not just `rust/clock`. `Cargo.toml` carries two PATH deps —
+  # `sigil-names` (:87) and `esp-wifi-sys-chip` (:220) — and a lone clock/ copy makes cargo fail at
+  # manifest load with its own exit 101. First run of this self-test did exactly that, and the probe
+  # correctly answered CANNOT-CHECK rather than STALE: an unrelated 101 must never be read as the
+  # finding. Recorded because that near-miss is the arm's whole justification. (Those same two path
+  # deps are #327's cause, which is why they are worth knowing about here.)
+  # `target/` is excluded DURING the copy, not deleted after. A `cp -r` followed by `rm -rf target`
+  # gives the same end state and copies the build output first: on a fresh worktree rust/ is 4 MB and
+  # nobody notices, but on a warm CI runner or a developer's tree target/ is gigabytes, so the arm
+  # would cost minutes and disk for a 0.1 s measurement. Sequence matters even when the result does
+  # not. (tar rather than rsync: no extra dependency.)
+  mkdir -p "$work/rust"
+  tar -cf - --exclude=target -C "$ROOT/rust" . | tar -xf - -C "$work/rust"
+  local C="$work/rust/clock"
+  cp "$C/Cargo.lock" "$work/lock.healthy"
+
+  t() { # <name> <expected-rc> <actual-rc> <verdict-word>
+    if [ "$2" = "$3" ]; then printf '   PASS %-52s rc=%s %s\n' "$1" "$3" "$4"; pass=$((pass+1))
+    else printf '   FAIL %-52s want rc=%s got rc=%s %s\n' "$1" "$2" "$3" "$4"; fail=$((fail+1)); fi
+  }
+
+  local v rc
+  # 1. HEALTHY must pass. A checker that refuses everything "can fail" and is useless.
+  v="$(probe_lock "$C" 2>/dev/null)"; rc=$?
+  t "healthy lock -> FRESH" 0 "$rc" "$v"
+
+  # 2. THE REAL DRIFT: remove exactly the two entries #460 found absent.
+  python3 - "$C/Cargo.lock" <<'PY'
+import re, sys, pathlib
+p = pathlib.Path(sys.argv[1]); blocks = p.read_text().split('\n[[package]]\n')
+keep = [blocks[0]]
+for b in blocks[1:]:
+    m = re.match(r'name = "([^"]+)"', b)
+    if m and m.group(1) in ('mipidsi', 'embedded-hal-bus'):
+        continue
+    keep.append(b)
+p.write_text('\n[[package]]\n'.join(keep))
+PY
+  v="$(probe_lock "$C" 2>/dev/null)"; rc=$?
+  t "the real #460 drift -> STALE" 1 "$rc" "$v"
+
+  # 3. Restored. Proves arm 2 measured the edit and not a broken rig.
+  cp "$work/lock.healthy" "$C/Cargo.lock"
+  v="$(probe_lock "$C" 2>/dev/null)"; rc=$?
+  t "restored -> FRESH again" 0 "$rc" "$v"
+
+  # 4. THE KEEPER. A healthy lock under --offline with a COLD registry cache exits 101 — the arm
+  #    that would have made this gate permanently red on fresh CI runners had --offline been used.
+  #    Asserted as a property of the FLAGS, so nobody "simplifies" --locked into --locked --offline:
+  #    it would not fail loudly, it would fail on every clean checkout for the wrong reason.
+  local empty="$work/empty-cargo-home"; mkdir -p "$empty"
+  ( cd "$C" && CARGO_HOME="$empty" cargo metadata --locked --offline --format-version 1 ) >/dev/null 2>"$work/offline.err"; rc=$?
+  if [ "$rc" -ne 0 ] && ! grep -qF -- "$DISCRIMINATOR" "$work/offline.err"; then
+    printf '   PASS %-52s rc=%s (no discriminator -> our probe would say CANNOT-CHECK, not STALE)\n' \
+      "--offline + cold cache is a FALSE stale" "$rc"; pass=$((pass+1))
+  elif [ "$rc" -eq 0 ]; then
+    printf '   SKIP %-52s cold-cache arm inconclusive: CARGO_HOME override did not cool the cache\n' \
+      "--offline + cold cache is a FALSE stale"
+  else
+    printf '   FAIL %-52s the discriminator appeared on a HEALTHY lock — it cannot discriminate\n' \
+      "--offline + cold cache is a FALSE stale"; fail=$((fail+1))
+  fi
+
+  # 4b. THE DISCRIMINATOR ITSELF, exercised THROUGH probe_lock. A crate copied WITHOUT its sibling
+  #     path deps makes `cargo metadata` exit 101 with no `--locked` sentence — a healthy lock and an
+  #     unrelated failure. Must be CANNOT-CHECK (2), never STALE (1).
+  #
+  #     This arm exists because sabotaging the `case` to read ANY non-zero as STALE was caught by
+  #     NOTHING ELSE in this suite: arms 1/3 are exit-0 paths and arms 5-8 return before cargo runs,
+  #     so the single most important design decision in this file was untested. The fixture is the
+  #     near-miss from this self-test's own first run, kept rather than discarded.
+  mkdir -p "$work/orphan"
+  cp -r "$C" "$work/orphan/clock"
+  rm -rf "$work/orphan/clock/target"
+  v="$(probe_lock "$work/orphan/clock" 2>/dev/null)"; rc=$?
+  t "unrelated cargo 101 -> CANNOT-CHECK not STALE" 2 "$rc" "$v"
+
+  # 5. cargo absent must be CANNOT-CHECK (2), never a pass and never STALE.
+  v="$(PATH=/nonexistent-dir probe_lock "$C" 2>/dev/null)"; rc=$?
+  t "cargo absent -> CANNOT-CHECK" 2 "$rc" "$v"
+
+  # 6-8. Vacuous-pass guards: each of these would otherwise report green while guarding nothing.
+  v="$(probe_lock "$work/does-not-exist" 2>/dev/null)"; rc=$?
+  t "missing directory -> CANNOT-CHECK" 2 "$rc" "$v"
+  mkdir -p "$work/nolock"; cp "$C/Cargo.toml" "$work/nolock/"
+  v="$(probe_lock "$work/nolock" 2>/dev/null)"; rc=$?
+  t "Cargo.toml but no Cargo.lock -> CANNOT-CHECK" 2 "$rc" "$v"
+  mkdir -p "$work/notacrate"
+  v="$(probe_lock "$work/notacrate" 2>/dev/null)"; rc=$?
+  t "not a crate at all -> CANNOT-CHECK" 2 "$rc" "$v"
+
+  # 9. The discovery must SCAN, not carry a list — a hand-kept list is what rots (#328).
+  local found; found="$(discover_locks | wc -l)"
+  if [ "$found" -ge 2 ]; then
+    printf '   PASS %-52s %s locks discovered, source=%s\n' "lock discovery is a scan, not a list" "$found" "$(lock_source)"; pass=$((pass+1))
+  else
+    printf '   FAIL %-52s found %s (a scan that finds ~nothing passes vacuously)\n' \
+      "lock discovery is a scan, not a list" "$found"; fail=$((fail+1))
+  fi
+
+  # 10. The two discovery paths must be DISTINGUISHED, because they give different answers: a build
+  #     mirror has no .git, the `find` fallback then runs, and it cannot tell a tracked lock from a
+  #     gitignored generated one (`experiments/*/Cargo.lock`). Caught on familiar, where the report
+  #     silently listed three build products as repo locks.
+  #
+  #     ⚠️ Asserted against TWO CONSTRUCTED FIXTURES, not against the ambient tree. The first version
+  #     asserted "this repo reports tracked", which is a fact about the ENVIRONMENT rather than about
+  #     this code — and it duly failed on familiar, where the rsync'd mirror legitimately has no .git.
+  #     That is precisely the failure mode this file's header is about (a check that goes red for a
+  #     reason unrelated to what it measures), committed one level inside the fix for it. The property
+  #     wanted is "git present => tracked, git absent => scan", and fixtures can state that anywhere.
+  local ft="$work/fixture-tracked" fs="$work/fixture-scan" got_t got_s
+  mkdir -p "$ft" "$fs"
+  : > "$ft/Cargo.lock"; : > "$fs/Cargo.lock"
+  ( cd "$ft" && git init -q . && git add Cargo.lock ) >/dev/null 2>&1
+  got_t="$( ROOT="$ft"; lock_source )"
+  got_s="$( ROOT="$fs"; lock_source )"
+  if [ "$got_t" = tracked ] && [ "$got_s" = scan ]; then
+    printf '   PASS %-52s git-present=tracked, git-absent=scan\n' "discovery labels which path it took"; pass=$((pass+1))
+  else
+    printf '   FAIL %-52s git-present=%s git-absent=%s (an unlabelled fallback reports build output as repo locks)\n' \
+      "discovery labels which path it took" "$got_t" "$got_s"; fail=$((fail+1))
+  fi
+
+  printf '\n   %s ok, %s failed\n' "$pass" "$fail"
+  [ "$fail" -eq 0 ]
+}
+
+# Every Cargo.lock the repo TRACKS, discovered rather than listed (a hand-kept list is what #328
+# watched rot). `git ls-files` is the authority; DISCOVER_SOURCE records which path was taken.
+#
+# ⚠️ The two paths give DIFFERENT ANSWERS and the fallback's is not a subset — found the hard way.
+# In a rsync'd build mirror there is no `.git`, so the fallback ran, and it reported three extra
+# entries (`experiments/mac_verify`, `ota_http_verify`, `etx_verify`) that the git path never shows.
+# Those are **gitignored generated artifacts** (`.gitignore:76 experiments/*/Cargo.lock`) written by a
+# previous host-verifier run; they do not exist in a clean checkout at all. A bare `find` cannot tell
+# a tracked lock from a build product, so the fallback's list is labelled rather than presented as
+# equivalent. The gated check itself is a fixed path and is unaffected either way — only this
+# informational list could mislead, and an informational list that quietly counts build output is
+# still the wrong number in front of a reader.
+# ⚠️ The source is reported by its OWN function, not by a variable discover_locks sets. Every caller
+# uses `discover_locks | …` or `$(discover_locks)`, and a pipeline or command substitution runs the
+# function in a SUBSHELL — so an assignment inside it never reaches the caller. The first draft did
+# exactly that: `DISCOVER_SOURCE` was always empty at the call site, so the main path would have
+# printed the "filesystem scan, may include generated locks" warning on EVERY run including in a
+# normal git checkout. Caught because the self-test prints the value. Same family as the
+# pipelines-launder-exit-codes trap: a pipeline launders variable assignments too.
+lock_source() {
+  if ( cd "$ROOT" && git ls-files '*Cargo.lock' 2>/dev/null | grep -q . ); then
+    echo tracked
+  else
+    echo scan
+  fi
+}
+
+discover_locks() {
+  if [ "$(lock_source)" = tracked ]; then
+    ( cd "$ROOT" && git ls-files '*Cargo.lock' | sed 's#/Cargo.lock$##' )
+  else
+    ( cd "$ROOT" && find . -name Cargo.lock -not -path '*/target/*' -printf '%h\n' | sed 's#^\./##' )
+  fi
+}
+
+# ── main ──────────────────────────────────────────────────────────────────────────────────────────
+if [ "${1:-}" = "--self-test" ]; then
+  echo "check_lock_fresh --self-test (proving both directions, and that it cannot falsely fail)"
+  self_test; exit $?
+fi
+
+verdict="$(probe_lock "$ROOT/$CANON_REL")"; rc=$?
+case "$rc" in
+  0) echo "ok  $CANON_REL/Cargo.lock is FRESH — cargo resolved the graph without rewriting it" ;;
+  1) echo "STALE LOCK: $CANON_REL/Cargo.lock does not match Cargo.toml (#460)."
+     echo "  A build would silently rewrite it, so any exact '=' pin in Cargo.toml is unenforced"
+     echo "  and two hosts can resolve different graphs from the same commit (#44/#326)."
+     echo "  Fix: cd $CANON_REL && cargo metadata >/dev/null   # resolve, then COMMIT the lock" ;;
+  2) echo "COULD NOT CHECK: $verdict"
+     echo "  Deliberately not reported as a pass and not as staleness — see this file's header." ;;
+esac
+
+# Informational: the locks this arm does NOT gate, named so the limit is visible.
+others="$(discover_locks | grep -v "^$CANON_REL\$" || true)"
+if [ -n "$others" ]; then
+  case "$(lock_source)" in
+    tracked) echo "  not gated by this arm (other lanes' trees; reported so the scope is visible):" ;;
+    *)       echo "  not gated by this arm — FILESYSTEM SCAN (no .git here, e.g. a build mirror), so"
+             echo "  this list may include gitignored generated locks such as experiments/*:" ;;
+  esac
+  while IFS= read -r d; do [ -n "$d" ] && echo "    $d"; done <<<"$others"
+fi
+exit "$rc"

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -169,6 +169,31 @@ else
   printf '%s\n' "$out" | sed 's/^/        /'; bad "sigil vendor"
 fi
 
+# #460 the committed Cargo.lock is actually consulted. Unconditional and early for the same reason as
+# the arm above: if dependency RESOLUTION drifted, every later measurement — the tier checks, the
+# stack floor, #390's symbol-size baseline — is about a graph nobody recorded.
+#
+# `mipidsi` is pinned `=0.10.0` on purpose (s3_oled's ORIENTATION reasoning is tied to 0.10's MADCTL
+# semantics) and on 2026-08-26 the lock did not contain it at all, because no build path passes
+# `--locked` and so every build silently rewrote the file. The strictest pin cargo offers, enforced by
+# nobody. This is #460's option 2 — a gate arm rather than `--locked` spliced into every build
+# invocation, which would change how everyone builds and collide with whichever lane holds those
+# files. If `--locked` is ever adopted on the build paths, DELETE this arm; two statements of one fact
+# is the thing half this file's history is about.
+#
+# THREE outcomes, not two (see the checker's header for the six measured flag/cache combinations):
+# STALE is a hard FAIL; "could not check" (cargo absent, network unreachable) prints loudly and does
+# NOT fail, because that state is the instrument being unavailable rather than a defect in the tree —
+# and if cargo were genuinely missing, every arm below would fail on its own account.
+step "committed Cargo.lock is consulted (#460)"
+out=$("$ROOT/tools/check_lock_fresh.sh" 2>&1); lock_rc=$?
+case "$lock_rc" in
+  0) printf '%s\n' "$out" | sed 's/^/        /'; ok "lock fresh" ;;
+  1) printf '%s\n' "$out" | sed 's/^/        /'; bad "lock fresh" ;;
+  *) printf '%s\n' "$out" | sed 's/^/        /'
+     printf '   \033[33mnote\033[0m %s\n' "lock freshness could not be measured (not a tree defect)" ;;
+esac
+
 # Both firmware halves need `board.rs`/`secrets.rs`, so this runs for either — `excl` on its
 # own in CI would otherwise fail on the missing files rather than on anything it measures.
 if [ "$run_fw" = 1 ] || [ "$run_excl" = 1 ]; then
@@ -697,6 +722,25 @@ if [ "$run_host" = 1 ]; then
     printf '%s\n' "$out" | tail -2; ok "test_config_markers"
   else
     printf '%s\n' "$out" | sed 's/^/        /'; bad "test_config_markers"
+  fi
+
+  # #460: prove the lock arm can fail, and — the harder half — that it cannot fail FALSELY.
+  #
+  # Its keeper arms are the two negatives. `--offline` makes `cargo metadata --locked` exit 101 on a
+  # perfectly FRESH lock whenever the registry cache is cold, which on a clean CI runner is the
+  # normal state; and a crate copied without its sibling path deps exits 101 for a third unrelated
+  # reason. Both are asserted to read as "could not check", never STALE. Without them the checker's
+  # central decision — that only cargo's own `because --locked was passed` sentence licenses the
+  # finding — was untested, and sabotaging it was caught by nothing else in the suite.
+  #
+  # It resolves real dependency graphs rather than matching text, but a warm `cargo metadata --locked`
+  # is ~0.13 s and the whole suite measured 0.9 s here — so it is NOT the slow arm its position might
+  # suggest. Placed last in the pure-text run only because it is the newest.
+  step "Cargo.lock freshness gate regression suite (#460)"
+  if out=$("$ROOT/tools/test_lock_fresh.sh" 2>&1); then
+    printf '%s\n' "$out" | tail -2; ok "test_lock_fresh"
+  else
+    printf '%s\n' "$out" | sed 's/^/        /'; bad "test_lock_fresh"
   fi
 
   # #426: prove the comment-blind sweep took, in BOTH directions. Three checkers were counting

--- a/tools/test_lock_fresh.sh
+++ b/tools/test_lock_fresh.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# test_lock_fresh.sh — #460. Proof that tools/check_lock_fresh.sh can fail, and cannot FALSELY fail.
+#
+# A thin wrapper, deliberately: the arms live next to the checker they exercise (its `--self-test`),
+# because the fixture is the checker's own real drift and splitting them would give two files that
+# have to be kept in step. This file exists so the suite is DISCOVERABLE — `tools/gate.sh`'s host
+# block and the `tools/test_*.sh` audit both walk this naming convention, and a `--self-test` flag
+# hidden inside a checker is found by neither. (That audit, documented at gate.sh:823, is what caught
+# four suites nobody ran.)
+#
+# What it proves, in one line each:
+#   * the real 2026-08-26 drift (mipidsi + embedded-hal-bus absent from the lock) -> STALE
+#   * a healthy lock -> FRESH, before and after that edit (so the STALE arm measured the edit)
+#   * an UNRELATED cargo exit 101 -> "could not check", never STALE  <- the discriminator
+#   * `--offline` on a cold registry cache is a FALSE stale, which is why the checker does not use it
+#   * cargo absent / no Cargo.lock / no Cargo.toml / missing dir -> "could not check", never a pass
+#   * lock discovery is a scan, not a hand-kept list
+set -uo pipefail
+exec "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check_lock_fresh.sh" --self-test


### PR DESCRIPTION
Closes the remaining half of #460. The lock itself was synced on main by the display lane; this is
the part that stops it drifting again.

## What it does

`tools/check_lock_fresh.sh` + one unconditional `gate.sh` arm + `tools/test_lock_fresh.sh` (11 arms).
No build invocation is touched.

`mipidsi` is pinned `=0.10.0` deliberately — s3_oled's ORIENTATION reasoning is tied to 0.10's MADCTL
semantics — and on 2026-08-26 the committed lock did not contain it at all, because nothing passes
`--locked` and so every build silently rewrote the file. The strictest pin cargo offers, enforced by
whoever last read the comment above it.

## Why an arm and not `--locked` on the build paths

#460's own option 2. Splicing `--locked` into `repro_build.sh` / `gate.sh` / `fw-gate.yml` changes how
everyone builds and collides with whichever lane holds those files. The checker's header says to
**delete this arm** if `--locked` is ever adopted there, so it cannot quietly become a second
statement of one fact.

## `--offline` is deliberately NOT used, and that is measured

All six lock/cache/flag combinations were run before choosing:

```
lock      registry cache   flags                 rc    verdict
healthy   warm             --locked --offline     0    fresh
STALE     warm             --locked --offline   101    stale
healthy   COLD             --locked --offline   101    *** FALSE STALE ***
healthy   COLD             --locked               0    fresh
STALE     COLD             --locked             101    stale
(cargo absent)                                   127   cannot check
```

A cold registry cache under `--offline` fails on a perfectly fresh lock — which on a clean CI runner
is the normal state. So **exit 101 alone is not the finding**: the checker requires cargo's own
`because --locked was passed` sentence before it will say STALE, the same discipline as the #420 arm's
refusal to read an unrelated build failure as proof the guard fired.

Three outcomes, not two: `0` fresh · `1` STALE (hard FAIL) · `2` could-not-check (printed loudly,
never a pass, never staleness).

## Scope, and why the limit is printed rather than implied

Exit-code-bearing for `rust/clock` only. The other Cargo.lock files are **discovered** (never a
hand-kept list — that is what #328 watched rot) and reported informationally, because nothing in-repo
states that `targets/*` locks must be fresh and failing on other lanes' actively-moving trees would be
inventing their requirements (#338).

## Evidence

`gate host` / `gate fw` / `gate excl` on familiar, all **GATE_RC=0**, with the arms named:

```
##### GATE host #####  GATE_RC=0    PASS lock fresh    PASS test_lock_fresh    GATE GREEN
##### GATE fw   #####  GATE_RC=0    PASS lock fresh                           GATE GREEN
##### GATE excl #####  GATE_RC=0    PASS lock fresh                           GATE GREEN
```

Self-test **11 ok, 0 failed**. Both sabotages fail it:

```
probe always returns FRESH        -> 10 ok, 1 failed
discriminator removed (any 101 = STALE) -> 10 ok, 1 failed
```

That second sabotage was caught by **nothing** until I added arm 4b, so the suite's most important
assertion was missing until I tried to break it.

## Four bugs found by running it, not by reasoning about it

Each is fixed and documented at the site rather than silently corrected:

1. An `EXIT` trap over a `local` work dir → `work: unbound variable` at cleanup.
2. `cp -r` then `rm -rf target` copies the build output first. Same end state, but gigabytes on a warm
   tree for a 0.13 s measurement. `target/` is now excluded *during* the copy.
3. The discovery source was set inside a function every caller pipes — the subshell swallowed it, so
   the "filesystem scan" warning would have printed on **every** run including normal checkouts.
   *A pipeline launders variable assignments the way it launders exit codes.*
4. My first version of the discovery arm asserted "this repo reports tracked" — a fact about the
   **environment**, not about the code — and it duly went red on familiar, whose rsync'd mirror
   legitimately has no `.git`. That is exactly the failure mode this checker's header is about,
   committed one level inside the fix for it. Now asserted against two constructed fixtures, so the
   property holds anywhere.

Bug 3 surfaced a genuine inconsistency worth knowing: in a `.git`-less build mirror the `find`
fallback reported three `experiments/*` locks the tracked path never shows — **gitignored generated
artifacts** (`.gitignore:76`) left by a previous host-verifier run. The two discovery paths are now
labelled rather than presented as equivalent.

## Honest limits

- The arm needs network on a cold registry cache (that is why `--offline` is out). A network outage
  reads as "could not check" — loud, non-failing — not as staleness.
- It does not prove any *build* consulted the lock; it proves the lock still describes the manifest.
  Adopting `--locked` on the build paths is the stronger property and remains unfiled work.

Routed to @team-lead, not self-merged (`tools/` + shared `gate.sh`).
