### PR TITLE
fix(release): combined SHA256SUMS aggregate job (#413)

### DIFF
--- a/.github/workflows/release-targets.yml
+++ b/.github/workflows/release-targets.yml
@@ -132,3 +132,24 @@ jobs:
             --title "nightly per-target images" \
             --notes "Rolling nightly builds - see each artifact's NOTES.md. New-hardware flashing only; fleet boards update over mesh OTA."
           gh release upload nightly out/* --clobber
+  checksums:
+    # The combined SHA256SUMS docs/RELEASES.md promises. It CANNOT be written per-job: three jobs
+    # each `gh release upload --clobber out/*`, so a per-job file would cover only whichever job
+    # uploaded last (#474 found the file missing for exactly this reason). This job runs after all
+    # three and checksums what is actually downloadable — the release's current .bin assets —
+    # so `sha256sum -c SHA256SUMS` works from a download directory regardless of which job built what.
+    name: combined SHA256SUMS
+    needs: [riscv-targets, riscv-gui-targets, s3-target]
+    if: ${{ always() && contains(needs.*.result, 'success') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Regenerate SHA256SUMS over the release's bin assets
+        env: { GH_TOKEN: '${{ github.token }}' }
+        run: |
+          set -euo pipefail
+          mkdir dl && cd dl
+          gh release download nightly --repo "$GITHUB_REPOSITORY" --pattern '*.bin'
+          sha256sum *.bin > SHA256SUMS
+          echo "covering $(wc -l < SHA256SUMS) artifacts"
+          gh release upload nightly SHA256SUMS --clobber --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
Fixes #496.

The #474 matrix audit found \`docs/RELEASES.md\` promising a \`SHA256SUMS\` asset (\`sha256sum -c SHA256SUMS\`) that the nightly never contained. Root cause it could not be a per-job file: \`riscv-targets\` / \`riscv-gui-targets\` / \`s3-target\` each \`gh release upload nightly out/* --clobber\`, so whichever job finished last would overwrite the file with one covering only its own artifacts.

Fix: a fourth \`checksums\` job, \`needs\` all three, \`if: always() && any-success\`, that downloads the release's current \`*.bin\` assets and regenerates \`SHA256SUMS\` over what is actually downloadable. Partial-failure runs stay honest — the file always matches the asset list at generation time.

Reader-facing instructions in README/site were already corrected by #474; this restores the promised asset so both are true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)