### PR TITLE
fix(release): verify-command residuals from the #496 sweep

### DIFF
--- a/.github/workflows/release-targets.yml
+++ b/.github/workflows/release-targets.yml
@@ -137,7 +137,9 @@ jobs:
     # each `gh release upload --clobber out/*`, so a per-job file would cover only whichever job
     # uploaded last (#474 found the file missing for exactly this reason). This job runs after all
     # three and checksums what is actually downloadable — the release's current .bin assets —
-    # so `sha256sum -c SHA256SUMS` works from a download directory regardless of which job built what.
+    # so `sha256sum -c --ignore-missing SHA256SUMS` works from a download directory regardless of
+    # which job built what. (--ignore-missing is part of the documented command, docs/RELEASES.md:
+    # the file covers all ten artifacts and a reader downloads one; bare -c exits 1 on a good file.)
     name: combined SHA256SUMS
     needs: [riscv-targets, riscv-gui-targets, s3-target]
     if: ${{ always() && contains(needs.*.result, 'success') }}

--- a/tools/release_targets.sh
+++ b/tools/release_targets.sh
@@ -105,6 +105,9 @@ for m in "${MANIFESTS[@]}"; do
 **sha256** \`$sha\` · chip **$chip** · flavor **$flavor** · build stamp **0** (downloads are
 not fleet-ratchet builds; identity is this git hash, not the on-screen number).
 
+Verify your download (the release's \`SHA256SUMS\` covers every artifact; you have one):
+\`sha256sum -c --ignore-missing SHA256SUMS\` — or compare against the sha256 above directly.
+
 **Who this is for:** flashing NEW hardware to join a smol mesh. Boards already on the mesh
 update over mesh OTA only — never by re-downloading this file.
 
@@ -328,6 +331,9 @@ for m in "${MANIFESTS[@]}"; do
 # $aname — smol GUI firmware image ($DATE_UTC, git $GITHASH)
 
 **sha256** \`$sha\` · chip **$chip** · flavor **gui** · board feature \`$gui_board\`
+
+Verify your download (the release's \`SHA256SUMS\` covers every artifact; you have one):
+\`sha256sum -c --ignore-missing SHA256SUMS\` — or compare against the sha256 above directly.
 
 This is the **rich-GUI** firmware — the touch/Slint watch shell from \`targets/c6-watch\`, not
 the \`rust/clock\` fleet image. Both speak the same SMOLv1 mesh; they are different programs.


### PR DESCRIPTION
Post-#501 sweep (lucid-burndown3) found the old bare `sha256sum -c` form surviving in two places that could regress the fix: the checksums job's own comment (now disagreeing with the docs it implements — a future reconciler had even odds of taking `--ignore-missing` back out) and the per-artifact NOTES.md, which travels with the download but carried no verify command at all. Both aligned with docs/RELEASES.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)