### PR TITLE
docs(ota): record the OTA retreat floor where an operator will look — and correct #401's hash (#401)

### DIFF
--- a/docs/ota.md
+++ b/docs/ota.md
@@ -286,6 +286,52 @@ Three layers, in order of how bad the image is:
    re-enters the bootloader, but the real defense is that **only one board was ever at risk** —
    that's the whole point of canary.
 
+## How far back can an OTA go — the retreat floor (#401)
+
+**An OTA can only reach back to `f80cba9` (2026-08-01).** Anything older is **USB-only**.
+
+The reason is #349 working as designed, not a bug: the finalize-time suitability check refuses an
+image whose written slot carries **no target descriptor** (`TargetReject` absent — *"cannot read → do
+not install"*). Every pre-#349 image is descriptor-less, so it downloads in full and is refused at the
+very last step.
+
+`f80cba9` is the first commit whose `build.rs` emits `SMOL_CHIP_ID`, i.e. the first image that
+describes itself. **Recompute it rather than trusting this line** — that is the point of printing the
+command instead of only the hash:
+
+```bash
+git log --reverse --format='%h %ad %s' --date=short -S SMOL_CHIP_ID -- rust/clock/build.rs | head -1
+# f80cba9 2026-08-01 feat(ota): images self-describe their target and devices refuse unsuitable ones (#349)
+```
+
+### The floor is BELOW the Embassy dep wave, which is better than it sounds
+
+#349 landed at **15:18** and the #233 matched-set (`b2537c4`, esp-hal 1.1 / esp-radio 0.18 /
+esp-rtos 0.3) at **15:43** the same afternoon — **25 minutes later**. So the descriptor floor sits
+*under* the dep wave, and an OTA-retreat past #233 is **not** structurally impossible the way retreat
+past #349 is.
+
+```bash
+git log --oneline f80cba9..b2537c4 | wc -l    # 7 — the last of which IS the #233 landing itself
+```
+
+Whether a tree from that era still *builds* today is a separate question and is **untested** — the
+claim here is only about what the device will accept.
+
+### ⚠️ If you are reading #401, its cited hash is wrong
+
+#401 named `60fc1ed` as the floor and identified it with "the #233 landing". Neither holds:
+`60fc1ed` is a **docs** commit from **2026-07-28**, four days *before* #349, and it emits no
+`SMOL_CHIP_ID` anywhere in `rust/clock/`. An image built there is exactly the case #401 correctly says
+is USB-only — so following that hash produces a full download and a refusal. The #233 landing is
+`b2537c4`. #401's *conclusion* (pre-#349 retreat is USB-only) was right; its coordinates were not.
+
+### If a genuine pre-#349 retreat image is ever needed
+
+Old tree + cherry-picked descriptor emission (`build.rs`'s `SMOL_CHIP_ID` plus the embed), built in a
+**detached worktree** so the old tree is never checked out over a live one. That produces a
+descriptor-bearing image of pre-#349 code, which the finalize check will then accept.
+
 ## If a board bricks — USB recovery
 
 A board that won't come back (case 3 above) is recovered over USB, exactly like a first


### PR DESCRIPTION
Closes #401 — whose deliverable is the **record**, not a code change, and **corrects its central hash.**

## Why this is a docs PR and not a firmware one

#401's title is *"finding:"*, it carries no acceptance list, and its body says *"This is #349 working
as designed, not a bug."* Its stated purpose is *"the pre-#349 gap is recorded here so nobody
discovers it during an incident."*

That purpose was not being served. The fact existed **only in the tracker** — `git grep` across
`docs/`, `rust/clock/src/ota.rs` and `tools/` found nothing — and nobody greps the tracker
mid-incident. They read `docs/ota.md`, the operator guide, which already has *"How recovery works"* and
*"If a board bricks — USB recovery"*. The new section goes between them, because *"how far back can I
go over the air?"* is the question that belongs there.

It also means **#401 was never T-blocked**. The inherited table listed it under `main.rs`/`wifi.rs`/
`budget.rs`; it touches none of them. That reclassification is on #335 with the sequenced post-T list.

## ⚠️ The correction, and it is the reason this PR matters more than a transcription

#401 named **`60fc1ed`** as the retreat floor and identified it with *"the #233 landing"*. Neither holds:

```
60fc1ed  2026-07-28 09:42  docs: the Embassy verdict inverted …        <- a DOCS commit, 4 days
                                                                          BEFORE #349
$ git grep -c SMOL_CHIP_ID 60fc1ed -- rust/clock/
0                                                                      <- emits no descriptor

f80cba9  2026-08-01 15:18  feat(ota): images self-describe their target (#349)   <- the REAL floor
b2537c4  2026-08-01 15:43  feat(deps): #233 matched-set …                        <- the #233 landing
```

An image built at `60fc1ed` is **exactly** the descriptor-less case #401 correctly says is USB-only.
So an operator following that hash during an incident gets a full ~1 MB download and a refusal at
finalize — the worst possible moment to find out. #401's *conclusion* was right; its coordinates were
not.

## And the corrected picture is better than #401 reports

#349 landed at **15:18**, the #233 matched-set at **15:43** — 25 minutes later. So the descriptor floor
sits **below** the Embassy dep wave, and OTA-retreat past #233 is **not** structurally impossible the
way retreat past #349 is. Seven commits sit in that window.

Whether a tree from that era still *builds* today is a separate question and is **untested** — the
section says so explicitly. The claim is only about what the device will accept.

## The section hands off a CHECK, not a STATE

It prints the command that **recomputes** the floor rather than only the hash:

```bash
git log --reverse --format='%h %ad %s' --date=short -S SMOL_CHIP_ID -- rust/clock/build.rs | head -1
# f80cba9 2026-08-01 feat(ota): images self-describe their target and devices refuse unsuitable ones (#349)
```

A reader can falsify it in one line, and it cannot go quietly stale the way the hash in #401 did. Same
for the window size — a printed command with its answer, not prose arithmetic.

## Self-caught while writing it

I first wrote *"Six commits sit in that window"* next to a command that prints **7** (`A..B` includes
`B`). A stated number disagreeing with the command beside it is the exact defect class this lane has
been clearing all shift, so it became a printed command with its output instead.

## Verification

- **Both commands in the section were run verbatim** and reproduce as shown.
- `tools/status_check.sh` → **21/21, rc=0** (I edited a doc, so I re-ran the doc checker).
- Added lines scanned for LAN/secret strings: clean.
- `git merge-tree --write-tree origin/main` → clean.
- Docs-only, single file. No gate arm exercises `docs/ota.md`, so no build evidence applies or is
  claimed.

Routed to @team-lead, not self-merged.
