### PR TITLE
feat(gate): #438 — the paint instrument's warrant, machine-checked, with byte-identity INVERTED

### DIFF
--- a/tools/check_paint_warrant.py
+++ b/tools/check_paint_warrant.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""#438/#335: prove the stack-paint instrument is CONSERVATIVE against the image we ship.
+
+Why this exists, and why #438's prose was not enough.
+
+`stack-paint-lite` (#438) exists because the previous paint composition was a NEAR-MISS of the
+shipped image: it hard-required `bard`, and #434 found that composition could not even boot. #438's
+whole warrant — the sentence that made its measurements trustworthy — was:
+
+    "its `.stack` is byte-identical to the fleet tier's (86,200 B), so the instrument costs zero
+     DRAM and its peak is a peak for the shipped image rather than for a near-miss of it."
+
+**That sentence was PROSE, and on 2026-08-27 it silently stopped being true.** STEP T (#335) grew
+`.bss` on both tiers by different amounts, and the two regions came apart by 1,136 B. Nothing
+announced it, because nothing was checking it. The peak measured on that instrument was about to
+decide a ship gate at a ~1 KB margin.
+
+WHAT REPLACES IT — and the replacement INVERTS the original claim, which is the point.
+
+⚠️ **BYTE-IDENTITY IS NOW A FAILURE, NOT A PASS.** On 2026-08-27 a bench handoff shipped two paint
+images that were byte-identical in region to the fleet tier, passed every other check — md5, region,
+`stack_paint` symbol count, seed verification — and were **MUTE**. `ESP_LOG` is compile-time on this
+tree: without `ESP_LOG=info` the sentinel is compiled IN and its report line is compiled OUT. The
+board runs the instrument and says nothing; the soak returns no number.
+
+So #438's "byte-identical, zero DRAM" warrant was never true of an image that can PERFORM the
+measurement. It described the silent build. The instrument as it must actually be flashed costs
+~1.1 KB of region, and a paint image that costs *nothing* is a paint image that reports nothing.
+
+The three things worth asserting, in order of what they catch:
+
+  1. FITNESS FOR PURPOSE — the paint ELF contains the report line the soak reads. This is the check
+     that would have caught the silent handoff, and no other check on that list could have.
+  2. CONSERVATISM — `paint_region <= fleet_region`
+
+     `_stack_start` is pinned at the top of DRAM, so the boundary that moves is `_stack_end`, rising
+     as `.bss` grows. A paint image with a SMALLER region runs with LESS room than the image we
+     ship, and the instrument only ever ADDS stack use of its own, so `P_paint >=~ P_shipped` — the
+     fail-safe direction. The forbidden direction: if the paint image had MORE room, a peak that
+     fits during the soak could be one the shipped image cannot hold, and the gate would read green
+     off a measurement taken under easier conditions than shipping.
+  3. SANITY BAND — the delta sits inside `[MIN_DELTA, MAX_DELTA]`. The LOWER bound is the inverted
+     claim: a zero delta means the instrument cost nothing, which means it is not really there. The
+     UPPER bound catches a paint tier that has drifted into carrying something else entirely.
+
+Checks 1 and 3's lower bound overlap deliberately — they catch the same defect by different means
+(a missing string vs a missing cost), and after 2026-08-27 that redundancy is bought and paid for.
+
+⚠️ THIS ARM NEEDS SHIPPED-GEOMETRY ELFs. Do NOT feed it the `excl` arm's binaries: those are built
+with `CARGO_PROFILE_RELEASE_DEBUG=line-tables-only`, which gate.sh's own header records as CHANGING
+the image (464,180 of 1,027,816 ALLOC bytes differ; `.text` grew 46 B). A region comparison between
+two debug-geometry binaries answers a different question than the one asked here.
+
+Fails CLOSED: a missing symbol, an unreadable ELF, or a nonsensical region exits 2 rather than
+passing. An instrument-validity check that can quietly cover nothing is the exact defect it exists
+to prevent — see #438 above.
+
+Usage:
+  check_paint_warrant.py --fleet-elf <path> --paint-elf <path>
+  check_paint_warrant.py --fleet-syms <file> --paint-syms <file>   # pre-captured `readelf -sW`
+Exit: 0 ok · 1 warrant violated · 2 malformed/blind
+"""
+import argparse
+import re
+import subprocess
+import sys
+
+# The two symbols the linker script defines around the stack region. Spelled here so a rename
+# cannot silently empty this arm — it will fail closed instead.
+START_SYM = "_stack_start"
+END_SYM = "_stack_end"
+# A region below this is not a plausible C3 stack; treat it as a broken read, not a tiny stack.
+MIN_PLAUSIBLE_REGION = 4096
+# The line the soak actually greps for. If this is absent the board is MUTE and the image is
+# useless no matter how good every other number looks — see the docstring's 2026-08-27 incident.
+REPORT_MARKER = b"#434 paint"
+# Sanity band on `fleet_region - paint_region`. Measured on d2cf3aa: 1,136 B (fleet tier) and
+# 1,088 B (espnow tier) with ESP_LOG=info. The bounds are deliberately loose — this is a band, not
+# a pin, because the exact cost moves with the log level and with the image around it. What it
+# refuses is a delta of ZERO (an instrument that costs nothing is not present) and a delta so large
+# the paint tier must be carrying something other than the instrument.
+MIN_DELTA = 1
+MAX_DELTA = 8192
+
+
+def die(code, msg, *extra):
+    print(f"FATAL: {msg}", file=sys.stderr)
+    for line in extra:
+        print(f"  {line}", file=sys.stderr)
+    return code
+
+
+def read_syms(elf=None, syms_file=None):
+    """Symbol text, or None meaning BLIND (caller must exit 2, never 1).
+
+    ⚠️ An unreadable input must NOT share an exit code with a violated warrant. An earlier draft of
+    this file let `open()` raise, which exited 1 — the same code as "the paint image is roomier than
+    the shipped image". CI reading rc==1 would have reported a real, alarming, and entirely
+    fictional finding whenever a path was wrong. A new way to fail needs its own name.
+    """
+    if syms_file:
+        try:
+            with open(syms_file, encoding="utf-8", errors="replace") as fh:
+                return fh.read()
+        except OSError as e:
+            print(f"FATAL: cannot read {syms_file}: {e}", file=sys.stderr)
+            return None
+    try:
+        r = subprocess.run(["readelf", "-sW", elf], capture_output=True, text=True)
+    except OSError as e:
+        print(f"FATAL: cannot run readelf: {e}", file=sys.stderr)
+        return None
+    if r.returncode != 0:
+        print(f"FATAL: readelf failed on {elf}: {r.stderr.strip()[:200]}", file=sys.stderr)
+        return None
+    return r.stdout
+
+
+def region_of(text, label):
+    """(_stack_start - _stack_end) from `readelf -sW` output, or (None, reason)."""
+    found = {}
+    for line in text.splitlines():
+        f = line.split()
+        # readelf -sW: Num: Value Size Type Bind Vis Ndx Name
+        if len(f) >= 8 and f[7] in (START_SYM, END_SYM):
+            try:
+                found[f[7]] = int(f[1], 16)
+            except ValueError:
+                return None, f"{label}: {f[7]} has an unparseable value {f[1]!r}"
+    for s in (START_SYM, END_SYM):
+        if s not in found:
+            return None, (
+                f"{label}: `{s}` is ABSENT from the symbol table. The linker script renamed it, or "
+                "this is not a linked firmware ELF. This arm cannot compare regions it cannot find."
+            )
+    region = found[START_SYM] - found[END_SYM]
+    if region < MIN_PLAUSIBLE_REGION:
+        return None, (
+            f"{label}: region computes to {region} B, below the {MIN_PLAUSIBLE_REGION} B plausibility "
+            "floor. That is a broken read (symbols swapped, or a stripped/partial ELF), not a small "
+            "stack — refusing to compare."
+        )
+    return region, None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fleet-elf")
+    ap.add_argument("--paint-elf")
+    ap.add_argument("--fleet-syms", help="pre-captured `readelf -sW` output (test seam)")
+    ap.add_argument("--paint-syms", help="pre-captured `readelf -sW` output (test seam)")
+    a = ap.parse_args()
+
+    if not (a.fleet_elf or a.fleet_syms) or not (a.paint_elf or a.paint_syms):
+        return die(2, "both a fleet and a paint input are required (--*-elf or --*-syms).")
+
+    fleet_txt = read_syms(a.fleet_elf, a.fleet_syms)
+    paint_txt = read_syms(a.paint_elf, a.paint_syms)
+    if fleet_txt is None:
+        return die(2, f"could not read symbols from the fleet ELF ({a.fleet_elf}).")
+    if paint_txt is None:
+        return die(2, f"could not read symbols from the paint ELF ({a.paint_elf}).")
+
+    fleet, err = region_of(fleet_txt, "fleet")
+    if err:
+        return die(2, err)
+    paint, err = region_of(paint_txt, "paint")
+    if err:
+        return die(2, err)
+
+    # ── check 1: FITNESS FOR PURPOSE ──────────────────────────────────────────────────────────
+    # Only meaningful against a real ELF; with the --*-syms test seam there is no binary to scan.
+    if a.paint_elf:
+        try:
+            with open(a.paint_elf, "rb") as fh:
+                blob = fh.read()
+        except OSError as e:
+            return die(2, f"cannot read the paint ELF for the report-line check: {e}")
+        if REPORT_MARKER not in blob:
+            print("FATAL: the paint image is MUTE — it cannot produce a measurement.", file=sys.stderr)
+            print(
+                f"  `{REPORT_MARKER.decode()}` is absent from {a.paint_elf}.\n"
+                "  `ESP_LOG` is COMPILE-TIME on this tree: the sentinel is compiled in and its\n"
+                "  report line is compiled out, so the board runs the instrument and says nothing.\n"
+                "  Rebuild with `ESP_LOG=info`. (2026-08-27: two handoff images shipped in exactly\n"
+                "  this state and passed md5, region, symbol-count and seed checks — every number\n"
+                "  looked right and the soak would have returned nothing.)",
+                file=sys.stderr,
+            )
+            return 1
+
+    # ── check 2: CONSERVATISM ─────────────────────────────────────────────────────────────────
+    delta = fleet - paint
+    if delta < 0:
+        print("FATAL: the paint instrument has MORE stack room than the image we ship.", file=sys.stderr)
+        print(
+            f"  fleet region {fleet} B · paint region {paint} B · paint is {-delta} B LARGER.\n"
+            "  A peak measured under easier conditions than shipping cannot bound the shipped\n"
+            "  image: the soak could pass a depth the fleet image has no room for. Do NOT read a\n"
+            "  peak off this pair.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # ── check 3: SANITY BAND ──────────────────────────────────────────────────────────────────
+    if delta < MIN_DELTA:
+        print("FATAL: the paint instrument costs NOTHING, so it is not really there.", file=sys.stderr)
+        print(
+            f"  fleet region {fleet} B · paint region {paint} B · delta {delta} B.\n"
+            "  ⚠️ Byte-identity USED to be #438's warrant. It is now a FAILURE: a paint build that\n"
+            "  costs no region is the signature of a build with the reporting compiled out. The\n"
+            "  instrument as it must actually be flashed costs ~1.1 KB.",
+            file=sys.stderr,
+        )
+        return 1
+    if delta > MAX_DELTA:
+        print("FATAL: the paint tier costs far more region than the instrument explains.", file=sys.stderr)
+        print(
+            f"  fleet region {fleet} B · paint region {paint} B · delta {delta} B "
+            f"(band {MIN_DELTA}..{MAX_DELTA}).\n"
+            "  The paint tier is carrying something beyond the sentinel — check its feature set\n"
+            "  before reading a peak off it; the measurement would describe a different program.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"  paint warrant: fleet {fleet} B · paint {paint} B — paint is {delta} B tighter "
+        f"(conservative, in band), report line present"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -537,6 +537,53 @@ if [ "$run_fw" = 1 ]; then
   # absence — fat LTO can inline a linked module until no symbol survives — so a pass here
   # adds confidence and never stands alone. Skipped, not failed, if the build above did not
   # produce an ELF: a corroboration arm must not invent a verdict.
+  # #438/#335: the stack-paint instrument's own VALIDITY, machine-checked instead of prose.
+  #
+  # #438's warrant was a sentence: "its `.stack` is byte-identical to the fleet tier's (86,200 B),
+  # so the instrument costs zero DRAM and its peak is a peak for the shipped image rather than for
+  # a near-miss of it." On 2026-08-27 that quietly stopped being true — STEP T moved `.bss` by
+  # different amounts on the two tiers and the regions came apart by 1,136 B, with nothing
+  # announcing it because nothing was checking. The peak read off that instrument was about to
+  # decide a ship gate at a ~1 KB margin. #434 is the precedent for what a near-miss instrument
+  # costs; this is the check that would have caught its return.
+  #
+  # Byte-identity is NOT what is asserted — that would be demanding a coincidence back. The
+  # checkable claim is that the measurement errs SAFE: `paint_region <= fleet_region`, so the
+  # instrument always runs with at-most-as-much room as the image we ship.
+  #
+  # ⚠️ Built into its OWN CARGO_TARGET_DIR on purpose. The canonical ELF lives at
+  # `<target>/<triple>/release/clock` and a paint build with the shared target dir would OVERWRITE
+  # it — after which the byte-free arm below would silently measure the paint image instead of the
+  # shipped one. Separate dir, and this step is placed AFTER the stack floor read for the same
+  # reason. (It also cannot reuse the `excl` arm's binaries: those are built with
+  # `line-tables-only` debug, which this file's own header records as CHANGING the image.)
+  step "paint-instrument warrant — paint vs fleet region (#438)"
+  PAINTDIR="${SMOL_GATE_PAINT_DIR:-$GATE_TMP/gate-paint-$(printf %s "$ROOT" | cksum | cut -d' ' -f1)}"
+  FLEET_ELF="${CARGO_TARGET_DIR:-$BUILD_ROOT/$CLOCK/target}/${REPRO_TARGET}/release/clock"
+  if [ ! -f "$FLEET_ELF" ]; then
+    printf '   \033[33mSKIP\033[0m paint warrant — no canonical ELF to compare against\n'
+  # ⚠️ `ESP_LOG=info` is NOT optional and NOT cosmetic. `ESP_LOG` is COMPILE-TIME here: without it
+  # the sentinel is compiled IN and its report line is compiled OUT, so the board runs the
+  # instrument and says nothing. An arm that built the paint tier without it would compare two
+  # images NEITHER of which we flash, see byte-identity, and pass — validating a build nobody
+  # measures with, which is the exact defect class this arm exists to catch. (2026-08-27: two
+  # handoff images shipped in precisely that state and passed md5, region, symbol-count and seed
+  # checks. Every number looked right; the soak would have returned nothing.)
+  elif (cd "$BUILD_ROOT/$CLOCK" && CARGO_TARGET_DIR="$PAINTDIR" ESP_LOG=info \
+          cargo build --release --bin clock "${JOBS[@]}" \
+          --features "stack-paint-lite,$REPRO_FLEET_FEATURES" "${REPRO_CARGO_ARGS[@]}") \
+        >"$GATE_TMP/gate-paint.log" 2>&1; then
+    if out=$("$ROOT/tools/check_paint_warrant.py" --fleet-elf "$FLEET_ELF" \
+               --paint-elf "$PAINTDIR/${REPRO_TARGET}/release/clock" 2>&1); then
+      printf '%s\n' "$out"; ok "paint warrant"
+    else
+      printf '%s\n' "$out"; bad "paint warrant"
+    fi
+  else
+    bad "paint warrant (stack-paint-lite build failed)"
+    tail -15 "$GATE_TMP/gate-paint.log" | sed 's/^/        /'
+  fi
+
   step "byte-free corroboration — symbols in the canonical ELF (#351)"
   ELF="${CARGO_TARGET_DIR:-$BUILD_ROOT/$CLOCK/target}/${REPRO_TARGET}/release/clock"
   if [ -f "$ELF" ]; then
@@ -786,6 +833,20 @@ if [ "$run_host" = 1 ]; then
     printf '%s\n' "$out" | tail -2; ok "test_check_elect_send_path"
   else
     printf '%s\n' "$out" | sed 's/^/        /'; bad "test_check_elect_send_path"
+  fi
+
+  # #438/#335: the paint-warrant arm guards an INSTRUMENT rather than the firmware, which makes its
+  # own falsifiability the whole question — a validity check that cannot fail is indistinguishable
+  # from the prose sentence it replaced, and that sentence is precisely what rotted. Two arms drive
+  # the roomier-paint case (including a ONE-BYTE divergence, because a silent tolerance is how a
+  # warrant erodes), three fail closed on a renamed symbol / a nonsense region / an unreadable
+  # input. That last one is not padding: an unreadable input must exit 2 (BLIND) and never 1
+  # (VIOLATED), or a wrong path gets reported as a real and alarming finding that never happened.
+  step "paint-warrant checker regression suite (#438)"
+  if out=$("$ROOT/tools/test_paint_warrant.sh" 2>&1); then
+    printf '%s\n' "$out" | tail -2; ok "test_paint_warrant"
+  else
+    printf '%s\n' "$out" | sed 's/^/        /'; bad "test_paint_warrant"
   fi
 
   # #335 STEP G, same reasoning one invariant over: every arm of the station-consumer checker is an

--- a/tools/test_paint_warrant.sh
+++ b/tools/test_paint_warrant.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# test_paint_warrant.sh — proves tools/check_paint_warrant.py can FAIL (#438/#335).
+#
+# The arm it tests exists because a PROSE warrant rotted silently: #438 asserted the paint tier's
+# `.stack` was byte-identical to the fleet tier's, that stopped being true under STEP T, and nothing
+# noticed because nothing was checking. A replacement check that only ever passes would be the same
+# failure wearing a green badge — so every arm below drives the checker into a specific wrong state
+# and asserts it goes red FOR THE RIGHT REASON, not merely red.
+#
+# SAFETY: operates only on synthetic `readelf -sW` fixtures under mktemp, via the checker's
+# documented --*-syms test seam. It never reads a real ELF and never writes inside the repo.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHK="$ROOT/tools/check_paint_warrant.py"
+pass=0; fail=0
+ok(){ pass=$((pass+1)); echo "ok   - $1"; }
+no(){ fail=$((fail+1)); echo "FAIL - $1"; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# A minimal `readelf -sW`-shaped fixture. Columns: Num: Value Size Type Bind Vis Ndx Name
+# `_stack_start` and `_stack_end` are what the checker reads; the decoys exist so a sloppy
+# substring match would pick the wrong line and this suite would catch it.
+syms() { # syms <file> <start-hex> <end-hex>
+  cat > "$1" <<EOF
+Symbol table '.symtab' contains 4 entries:
+   Num:    Value  Size Type    Bind   Vis      Ndx Name
+     1: $2     0 NOTYPE  GLOBAL DEFAULT  ABS $START_NAME
+     2: $3     0 NOTYPE  GLOBAL DEFAULT  ABS $END_NAME
+     3: 3fc00000  1024 OBJECT  LOCAL  DEFAULT    7 _stack_start_decoy_object
+     4: 40000c58     0 NOTYPE  GLOBAL DEFAULT  ABS r_co_list_pool_init
+EOF
+}
+START_NAME=_stack_start
+END_NAME=_stack_end
+
+run() { "$CHK" --fleet-syms "$work/fleet.txt" --paint-syms "$work/paint.txt" 2>&1; }
+
+echo "== baseline: the REAL post-T pair must pass (paint tighter = conservative) =="
+# fleet 73,112 = 0x3fcce400-0x3fcbc668 · paint 71,976 = 0x3fcce400-0x3fcbcad8 — measured 2026-08-27
+syms "$work/fleet.txt" 3fcce400 3fcbc668
+syms "$work/paint.txt" 3fcce400 3fcbcad8
+out="$(run)"; rc=$?
+if [ "$rc" = 0 ]; then
+  case "$out" in *"paint is 1136 B tighter"*) ok "post-T pair passes with the right delta" ;;
+    *) no "post-T pair passed but the delta is wrong — $out" ;; esac
+else no "post-T pair FAILED (rc=$rc) — $out"; fi
+
+# ⚠️ THIS ARM IS INVERTED from the original suite, and the inversion is the lesson.
+# Byte-identity was #438's WARRANT and is now a FAILURE: a paint build costing zero region is the
+# signature of one built without ESP_LOG, i.e. with the report line compiled out. On 2026-08-27 two
+# such images shipped to a bench handoff and passed md5, region, symbol-count and seed checks.
+echo "== INVERTED: a byte-identical pair is now RED (an instrument that costs nothing is absent) =="
+syms "$work/fleet.txt" 3fcce400 3fcb9348
+syms "$work/paint.txt" 3fcce400 3fcb9348
+out="$(run)"; rc=$?
+if [ "$rc" != 1 ]; then no "byte-identical: rc $rc, want 1 — $out"
+else case "$out" in *"costs NOTHING"*) ok "byte-identical pair is caught (rc=1)" ;;
+  *) no "byte-identical: rc right, WRONG REASON — $out" ;; esac; fi
+
+echo "== the sanity band's UPPER bound: an implausibly large delta is RED =="
+syms "$work/fleet.txt" 3fcce400 3fcb9348
+syms "$work/paint.txt" 3fcce400 3fcc9348   # region 20,664 = 65,536 B TIGHTER (end RAISED, not lowered)
+out="$(run)"; rc=$?
+if [ "$rc" != 1 ]; then no "huge delta: rc $rc, want 1 — $out"
+else case "$out" in *"far more region than the instrument explains"*) ok "over-band delta is caught (rc=1)" ;;
+  *) no "huge delta: rc right, WRONG REASON — $out" ;; esac; fi
+
+echo "== THE ARM: paint with MORE room than the shipped image must be RED =="
+# This is the whole point. If the instrument is roomier than the fleet image, a soak can pass a
+# depth the shipped image cannot hold — a green read off easier-than-shipping conditions.
+syms "$work/fleet.txt" 3fcce400 3fcbcad8   # fleet 71,976
+syms "$work/paint.txt" 3fcce400 3fcbc668   # paint 73,112  <- roomier
+out="$(run)"; rc=$?
+if [ "$rc" != 1 ]; then no "roomier paint: rc $rc, want 1 — $out"
+else case "$out" in *"MORE stack room"*) ok "roomier paint is caught (rc=1)" ;;
+  *) no "roomier paint: rc right, WRONG REASON — $out" ;; esac; fi
+
+echo "== THE ARM: even ONE byte of extra room is caught (no silent tolerance) =="
+syms "$work/fleet.txt" 3fcce400 3fcbcad8
+syms "$work/paint.txt" 3fcce400 3fcbcad7   # exactly 1 B roomier
+out="$(run)"; rc=$?
+if [ "$rc" = 1 ]; then ok "1 B of extra room is caught (rc=1)"
+else no "1 B roomier: rc $rc, want 1 — a silent tolerance is how the prose warrant rotted"; fi
+
+echo "== fail-closed: a renamed/absent boundary symbol must NOT read as success =="
+syms "$work/fleet.txt" 3fcce400 3fcbc668
+START_NAME=_stack_beginning   # the rename this arm must survive by failing, not by passing
+syms "$work/paint.txt" 3fcce400 3fcbcad8
+START_NAME=_stack_start
+out="$(run)"; rc=$?
+if [ "$rc" != 2 ]; then no "missing symbol: rc $rc, want 2 — $out"
+else case "$out" in *"is ABSENT from the symbol table"*) ok "absent boundary symbol fails CLOSED (rc=2)" ;;
+  *) no "missing symbol: rc right, WRONG REASON — $out" ;; esac; fi
+
+echo "== fail-closed: a nonsense region (symbols swapped) must NOT read as success =="
+syms "$work/fleet.txt" 3fcbc668 3fcce400   # start below end -> negative region
+syms "$work/paint.txt" 3fcce400 3fcbcad8
+out="$(run)"; rc=$?
+if [ "$rc" != 2 ]; then no "swapped symbols: rc $rc, want 2 — $out"
+else case "$out" in *"plausibility floor"*) ok "swapped symbols fail CLOSED (rc=2)" ;;
+  *) no "swapped symbols: rc right, WRONG REASON — $out" ;; esac; fi
+
+# An unreadable input must exit 2 (BLIND), never 1 (VIOLATED). Asserting the exact code, not merely
+# "non-zero": the first draft of the checker let open() raise, which exited 1 — so a wrong path
+# would have been reported by CI as "the paint image is roomier than the shipped image", a real and
+# alarming finding that never happened. Sharing an exit code IS sharing a name.
+echo "== fail-closed: an unreadable input is BLIND (rc=2), not VIOLATED (rc=1) =="
+syms "$work/paint.txt" 3fcce400 3fcbcad8
+out="$("$CHK" --fleet-syms "$work/does-not-exist.txt" --paint-syms "$work/paint.txt" 2>&1)"; rc=$?
+if [ "$rc" != 2 ]; then no "missing file: rc $rc, want 2 (1 would impersonate a violation) — $out"
+else case "$out" in *"cannot read"*) ok "unreadable input fails CLOSED as BLIND (rc=2)" ;;
+  *) no "missing file: rc right, WRONG REASON — $out" ;; esac; fi
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Makes #438's warrant machine-checked instead of prose — and **inverts** it, because the sentence was true of an image that cannot perform the measurement.

## The inversion

#438's warrant was a sentence:

> *"its `.stack` is byte-identical to the fleet tier's (86,200 B), so the instrument costs zero DRAM and its peak is a peak for the shipped image rather than for a near-miss of it."*

**`ESP_LOG` is compile-time on this tree.** Without `ESP_LOG=info` the sentinel is compiled **in** and its report line is compiled **out** — the board runs the instrument and says nothing. So a paint build that costs **zero region is the signature of a mute build**. #438 didn't go stale; it described the silent configuration, which is the one nobody can measure with.

Measured with `ESP_LOG=info` on both trees:

| tree | fleet | paint | delta |
|---|---|---|---|
| `main` @ `94288aa` | 86,216 | 85,088 | **1,128 B tighter** |
| `d2cf3aa` (STEP T) | 73,112 | 71,976 | **1,136 B tighter** |

The instrument *as it must actually be flashed* has always cost ~1.1 KB. **Byte-identity is now a failure.**

## The arm — three checks, ordered by what they catch

1. **Fitness for purpose** — the paint ELF contains the `#434 paint` report line.
   This is the check that would have caught the 2026-08-27 incident, and **no other check could have**: two handoff images shipped **mute** and passed md5, region, `stack_paint` symbol count *and* seed verification. Every number looked right; the soak would have returned nothing.
2. **Conservatism** — `paint_region ≤ fleet_region`. `_stack_start` is pinned at the top of DRAM, so a tighter paint image runs with *less* room than we ship and its high-water is at-least-as-large ⇒ fail-safe. The forbidden direction is a *roomier* instrument: a peak measured under easier conditions than shipping cannot bound the shipped image.
3. **Sanity band** — delta in `[1, 8192]`. The lower bound *is* the inversion; the upper bound catches a paint tier carrying something beyond the sentinel.

Checks 1 and 3's lower bound overlap **deliberately** — the same defect caught by two different means (a missing string, a missing cost). After 2026-08-27 that redundancy is bought and paid for.

## Validated against reality, not only fixtures

```
the real flight image (ESP_LOG=info)  -> rc 0   "1136 B tighter, in band, report line present"
the SILENT image actually shipped     -> rc 1   "the paint image is MUTE"
current main 94288aa                  -> rc 0   1,128 B tighter
```

That middle line is the one that matters: **the arm fails on the exact artifact this PR's author shipped by mistake**, and passes the corrected one.

## Proof of failure — 8 arms, each red for its own reason

```
roomier paint                          (rc 1)
ONE byte roomier — no silent tolerance (rc 1)
byte-identical — THE INVERTED ARM      (rc 1)
over-band delta                        (rc 1)
renamed boundary symbol                (rc 2)
nonsense region (symbols swapped)      (rc 2)
unreadable input — rc 2, NOT rc 1      (rc 2)
```

The last one is not padding. An unreadable path must exit **2 (blind)**, never **1 (violated)**, or a wrong path gets reported by CI as *"the paint instrument is roomier than the shipped image"* — a real and alarming finding that never happened. A new way to fail needs its own name.

**A fixture bug this suite caught in itself:** the over-band arm initially *lowered* `_stack_end`, which *raises* the region — so it tripped the conservatism check instead. It failed as **"rc right, WRONG REASON"** rather than passing silently, because every arm asserts the *reason*, not just the exit code. That is the property that makes a proof-of-failure suite worth having.

## Gate wiring

`gate.sh` builds the paint tier with `ESP_LOG=info` into its **own** `CARGO_TARGET_DIR`. The canonical ELF lives at the shared path and a paint build there would **overwrite** it — after which the byte-free arm would silently measure the paint image instead of the shipped one.

Refs #438, #434, #335.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
