### PR TITLE
fix(mesh): #503 — the bounded announce send polls an embassy Timer under block_on, and panics (#397)

### DIFF
--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -46,14 +46,15 @@ use esp_hal::{
     // #335 P1.2: SoftwareInterruptControl / TimerGroup are gone from this module —
     // `esp_rtos::start` and the peripherals it consumes moved to `main`.
     rng::Rng,
-    time::Instant,
+    time::{Duration, Instant},
 };
 use embassy_futures::block_on;
-// #397 STEP B2: the bounded announce send. `select` races the send future against a deadline;
-// `Timer` is the deadline. Both are available on every radio tier because #391 turned on
-// esp-rtos's `embassy` feature (which supplies embassy-time's driver) and `espnow` implies `wifi`.
+// #397 STEP B2: the bounded announce send. `select` races the send future against a deadline.
+//
+// ⚠️ #503: the deadline is an `esp_hal` INSTANT, deliberately NOT an `embassy_time::Timer`, and
+// this module no longer imports `embassy_time` at all. See `tx_announce_bounded` for the panic
+// that choice avoids — it is not a style preference.
 use embassy_futures::select::{select, Either};
-use embassy_time::{Duration as EmbassyDuration, Timer};
 use esp_radio::{
     esp_now::{EspNow, EspNowWifiInterface, PeerInfo, BROADCAST_ADDRESS},
     wifi::{scan::ScanConfig, sta::StationConfig, Config, WifiController},
@@ -2396,8 +2397,11 @@ fn abandon_tx(waiter: esp_radio::esp_now::SendWaiter<'_>) {
 ///
 /// Not tunable per site on purpose: the two announce sites are the same send of the same frame
 /// under the same radio conditions, and two deadlines would be two behaviours to reason about.
+///
+/// ⚠️ #503: an `esp_hal::time::Duration`, not an `embassy_time::Duration`. The value and meaning
+/// are unchanged; the type is what keeps the deadline off embassy-time's timer queue.
 #[cfg(feature = "espnow")]
-const TX_WAIT: EmbassyDuration = EmbassyDuration::from_millis(30);
+const TX_WAIT: Duration = Duration::from_millis(30);
 
 /// #397 STEP B2: set when a send's completion was still outstanding at `TX_WAIT`, i.e. we walked
 /// away from a callback that may still land.
@@ -2480,7 +2484,38 @@ impl RadioManager {
         let dst = BROADCAST_ADDRESS;
         let outcome = {
             let fut = self.esp_now.send_async(&dst, frame);
-            block_on(select(fut, Timer::after(TX_WAIT)))
+            // 🔴 #503 — WHY THIS IS NOT `Timer::after(TX_WAIT)`, which is what it used to be.
+            //
+            // `block_on` builds its own waker over a null pointer (embassy-futures
+            // `block_on.rs:6`), so the waker it polls with is NOT an Embassy task waker. An
+            // `embassy_time::Timer`, on first poll, hands that waker to embassy-time's timer
+            // queue, which calls `task_from_waker` — and that PANICS on a foreign waker
+            // (embassy-executor `raw/waker.rs:35`), because this tree does not enable
+            // embassy-time's `generic-queue` escape hatch (`Cargo.toml`: features = ["log"]).
+            //
+            // It was LATENT rather than instant death because `select` polls A first and returns
+            // without polling B when A is already `Ready` (embassy-futures `select.rs:64-67`).
+            // A send that completes on its first poll never polls the timer. So the panic fires
+            // only when `send_async` is genuinely PENDING — a contended radio — which is exactly
+            // the post-OTA-relay announce, and exactly where the fleet bench found it: a crown
+            // died at `staged+VERIFIED` + one announce, reproducibly, on both attempts.
+            //
+            // The fix removes the foreign-waker condition instead of tolerating it: a deadline
+            // polled from `esp_hal::time::Instant` needs no waker, no timer queue and no
+            // executor, so there is nothing left to mismatch. `block_on` re-polls unconditionally
+            // (it ignores wakes), so `Pending` here is a bounded spin — which is precisely what
+            // #397 STEP B2 set out to build, and what the pre-#397 unbounded `waiter.wait()` was
+            // not. `TX_WAIT`'s value, the `Unproven`/`Confirmed`/`Failed` arms and the
+            // `TX_ABANDONED` take-and-clear below are all unchanged.
+            let deadline = Instant::now() + TX_WAIT;
+            let expiry = core::future::poll_fn(move |_cx| {
+                if Instant::now() >= deadline {
+                    core::task::Poll::Ready(())
+                } else {
+                    core::task::Poll::Pending
+                }
+            });
+            block_on(select(fut, expiry))
         };
         match outcome {
             Either::First(Ok(())) => {


### PR DESCRIPTION
A crown that completes an OTA relay fetch dies. Reproduced twice on the bench, both times
within a second of `staged+VERIFIED`, both times at:

    panicked at embassy-executor-0.10.0/src/raw/waker.rs:35:5

THE MECHANISM — three facts that only panic in combination:

1. `tx_announce_bounded` raced the send against `Timer::after(TX_WAIT)` inside `block_on`.
2. `embassy_futures::block_on` builds its waker over a null pointer (block_on.rs:6), so it is
   NOT an Embassy task waker. An `embassy_time::Timer`, on first poll, hands that waker to
   embassy-time's timer queue, which calls `task_from_waker` — and that PANICS on a foreign
   waker (embassy-executor raw/waker.rs:35). This tree does not enable embassy-time's
   `generic-queue`, which is the escape hatch the panic message names.
3. `select` polls A first and returns WITHOUT polling B when A is already `Ready`
   (embassy-futures select.rs:64-67).

(3) is why this was latent rather than instant death: a send that completes on its first poll
never polls the timer. The panic fires only when `send_async` is genuinely PENDING — a
contended radio — which is precisely the announce that follows a 1 MB OTA relay fetch. Both
`tx_announce_bounded` call sites are inside `run_leaf_ota_relay`.

THE FIX removes the foreign-waker CONDITION rather than tolerating it. A deadline polled from
`esp_hal::time::Instant` needs no waker, no timer queue and no executor, so there is nothing
left to mismatch. `block_on` re-polls unconditionally (it ignores wakes), so a `Pending`
expiry is a bounded spin — which is exactly what #397 STEP B2 set out to build, and what the
pre-#397 unbounded `waiter.wait()` was not.

Unchanged: `TX_WAIT`'s value (30 ms), the `Confirmed`/`Unproven`/`Failed` arms, the
`TX_ABANDONED` take-and-clear, and the "abandoned future does not spin because `SendFuture`
has no `Drop`" argument — the future is dropped identically on the expiry branch.

Side effect worth having: `net/mode.rs` no longer imports `embassy_time` at all. `Timer` and
`EmbassyDuration` had exactly one use each, both here.

WHY NOT the alternatives:
  - enabling `embassy-time/generic-queue-N` would make a foreign waker WORK rather than making
    it not happen, and changes the timer subsystem fleet-wide for a local defect;
  - making `tx_announce_bounded` async and awaiting the select is the cleaner long-term shape,
    but `run_leaf_ota_relay` is SYNC on main, so it cannot land here without a cascade. #335
    STEP T makes that caller async, so T may convert this site to a native `.await` as
    post-merge cleanup — deliberately not as a rider on a brick-class fix.

EXPOSURE: the live fleet is NOT affected. `3b69ca7` (#397 STEP B2, which introduced the line)
is build 1336; the fleet runs 922 (`efe62c5`, 2026-07-28), and `git merge-base --is-ancestor`
confirms 3b69ca7 is not in it. Main-only, so no fleet roll is needed ahead of this.

CANARY: #335 STEP T's bench cycle doubles as this fix's canary rather than needing its own
flash. It reproduces the exact conditions — a crown completing a relay fetch, then announcing
on a contended radio — which is the only path known to make `send_async` pend. And the fix is
unreachable-by-construction rather than merely untriggered: with no `Timer` there is no timer
queue call and no waker to mismatch. A separate main-only flash would exercise strictly less.

Gates: fw GREEN · host GREEN · excl GREEN.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>