### PR TITLE
docs(release): correct the runbook — the build number is an OUTPUT, not an input (v1446 Molten Gear)

### DIFF
--- a/docs/RELEASE-RUNBOOK-v1446.md
+++ b/docs/RELEASE-RUNBOOK-v1446.md
@@ -1,18 +1,18 @@
-# v346 release runbook — the checklist, not the rationale
+# v1446 release runbook — the checklist, not the rationale
 
 > ## 🟡 PREP ONLY. Nothing in this file fires before JP's go.
 > This exists so that when STEP T merges and the paint bound passes, task #19 **executes from a
 > checklist instead of being reconstructed**. It is written ahead of the event on purpose.
 
-> ### ⏳ DELETE OR SUPERSEDE THIS FILE ONCE v346 IS CUT.
-> Its v346 specifics become history the moment the release exists, and anything in it that turns out
+> ### ⏳ DELETE OR SUPERSEDE THIS FILE ONCE v1446 IS CUT.
+> Its v1446 specifics become history the moment the release exists, and anything in it that turns out
 > to be *generally* true about versioned releases belongs in `docs/RELEASES.md` instead. A
 > version-stamped runbook with no expiry is how a repo accumulates procedures nobody can date — the
 > same reason `xtensa-spike.yml`'s schedule block carries a deletion condition.
 
 ## What this file deliberately does NOT restate
 
-`docs/RELEASES.md` § *"The versioned release ceremony (`v346` will be the first)"* already covers the
+`docs/RELEASES.md` § *"The versioned release ceremony (`v1446 Molten Gear` is the first)"* already covers the
 **why**: the repro-build property (a fixed `(commit, node-id)` builds to the same bytes, so the sha256
 *is* the identity), #44's two causes (rustc's absolute paths, the wall-clock app descriptor), the
 `repro_build.sh`-is-a-sourced-library trap, and sigil names being history that is never re-synced.
@@ -41,26 +41,53 @@ main; **verify the merge product.**
 
 ## 1. The version number and its sigil word
 
+> ### 🔴 CORRECTED 2026-08-28 — the first draft of this step was WRONG, and wrong in the direction
+> that ships a mislabelled release. Read the guard before the commands.
+>
+> **The build number is an OUTPUT of the ratchet, not an input you choose.** `ota_publish.sh stage`
+> computes it as `choose_build(count, staged, override)` = `max(git rev-list --count, retained staged
+> build + 1)`, and passes it as `SMOL_BUILD_NUMBER` (`repro_build.sh:406`). `build.rs:72` reads
+> `env_or_file("SMOL_BUILD_NUMBER", "version.txt")` — **env WINS over the file.** So on the release
+> path `version.txt` is the *fallback for non-stage builds*, **not** the number that ships.
+>
+> The first draft said "bump `version.txt` 345 → 346, and v346 is *Riveted Gear*." Both halves were
+> internally consistent and jointly wrong: the ratchet would have stamped a different number while
+> `RELEASES.md` said v346.
+
+**The order is: learn the number → derive the word → make `version.txt` agree.**
+
 ```bash
-# 1a. bump the released build number
-$EDITOR rust/clock/version.txt     # 345 -> 346
+# 1a. LEARN the number the ratchet will use. Do not choose it.
+git rev-list --count HEAD                     # the honest commit count
+tools/ota_publish.sh legacy-line esp32c3      # (preflight, unrelated — see §2)
+#   the retained staged build is the other input; `stage` prints the chosen BUILD before it publishes.
+
+# 1b. DERIVE the word from THAT number (never from version.txt, never by continuing a pattern).
+# 1c. THEN set version.txt to match, so a non-stage build reports the same lineage.
 ```
 
-**v346 is `Riveted Gear`.** Derived, not chosen — `version_name_for()` in
+**This release is `v1446` — `Molten Gear`.** Derived, not chosen — `version_name_for()` in
 `rust/clock/src/net/names.rs:256`:
 
 ```
 noun = FORGE.nouns[n % 20]          adj = FORGE.adjectives[(n / 20) % 20]
-346 -> nouns[6]="Gear",  adjectives[17]="Riveted"
+1446 -> nouns[6]="Gear",  adjectives[(1446/20)%20 = 12]="Molten"
 ```
 
 Verified against every naming control the docs already carry — `341 → Bellows`, `342 → Crucible`,
-`345 → Riveted Furnace`, `905 → Flux Furnace`. All four reproduce, which is what makes the formula
-reading trustworthy rather than assumed.
+`345 → Riveted Furnace`, `905 → Flux Furnace`. All four reproduce.
 
-⚠️ **Always write the number and the word together** (`v346 Riveted Gear`) — per `DOC-UPKEEP.md`, that
+> ⚠️ **And here is the lesson the first draft paid for, because those four controls did not save it.**
+> They verify the **word against the number**. They say nothing about whether the *number* is right.
+> `DOC-UPKEEP`'s rule — *"name it WITH its sigil word so the pair self-checks"* — catches a
+> mismatched pair; it cannot catch a **correctly-derived word on the wrong number**, which is
+> self-consistent and wrong. **A self-checking pair checks the RELATION, not the INPUTS.**
+> Verify the number against `choose_build`'s output *first*, then derive the word from it.
+
+⚠️ **Always write the number and the word together** (`v1446 Molten Gear`) — per `DOC-UPKEEP.md`, that
 pair self-checks, and it is how "build 905 Riveted Furnace" was caught. Never put a bare live build
-number in prose.
+number in prose. **But see the guard above: the pair self-checking is not the same as the number being
+right.**
 
 ---
 
@@ -111,8 +138,11 @@ release-stamped **only because operators exported it by hand.**
 
 ⚠️ **So the stamp does not mean "this is the versioned release."** It means *"an identity-bearing,
 reproducible build of HEAD with clean inputs"* — which a routine canary stage also is. **The thing
-that makes v346 v346 is the NUMBER in `version.txt`.** Do not read a release stamp on a staged canary
-as a release having happened.
+that makes v1446 v1446 is the NUMBER the ratchet chose** — `choose_build`'s output, carried as
+`SMOL_BUILD_NUMBER`. (⚠️ The first draft of this sentence said "the number in `version.txt`", which is
+the same error §1 corrects: on the release path the env var overrides the file. `version.txt` is what a
+NON-stage build falls back to.) Do not read a release stamp on a staged canary as a release having
+happened.
 
 ---
 
@@ -166,8 +196,8 @@ healthy, then the next. The tooling enforces the shape; the discipline is yours.
 
 - Per-target artifacts ride `tools/release_targets.sh` / the release workflow (#413), which walks the
   `targets/*/target.toml` manifests. The combined `SHA256SUMS` job landed in #499.
-- **`docs/RELEASES.md` header table** currently reads `first one | nightly-2026-08-24 | **v346** — not
-  yet cut`. Flipping that row is part of cutting the release, not a follow-up.
+- **`docs/RELEASES.md` header table** now reads `first one | nightly-2026-08-24 | **v1446 Molten Gear**
+  — in canary`. Flipping it to *cut* is part of cutting the release, not a follow-up.
 - Verify the published assets by **reading the release**, not the workflow's green tick — a green job
   is a claim about a job.
 
@@ -221,3 +251,7 @@ value is entirely in being right:
    The arm exists at `ota_publish.sh:504` and has two test arms. §3 is the corrected version.
 2. The sigil word is **computed**, with four documented controls reproduced, rather than continued from
    the v345 pattern by hand.
+3. **And that was still not enough** (found 2026-08-28, during the canary): the four controls verified
+   the WORD against the NUMBER while the number itself came from `version.txt`, which the release path
+   overrides. Corrected in §1, and the general form is worth more than the fix — *thorough verification
+   of the wrong proposition is the failure mode that survives being careful*.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -11,7 +11,7 @@ this page exists to prevent.
 | byte-reproducible? | **no** | **yes** — that is the point |
 | credentials | **placeholder** (see below) | placeholder |
 | what it is for | USB-flashing a **new or bench** board | the same, plus being the thing OTA serves |
-| first one | `nightly-2026-08-24` | **v346** — not yet cut |
+| first one | `nightly-2026-08-24` | **v1446 `Molten Gear`** — in canary |
 
 > ## The one rule
 >
@@ -77,7 +77,7 @@ was checked there rather than assumed.
 
 ---
 
-## The versioned release ceremony (`v346` will be the first)
+## The versioned release ceremony (`v1446 Molten Gear` is the first)
 
 The thing that makes a versioned release different is **`tools/repro_build`** and the property it
 buys: **a fixed `(commit, node-id)` builds to the same bytes on any machine, so the sha256 IS the
@@ -323,8 +323,8 @@ it. A future release that *has* been flashed should say so, and say on what.
 
 ## See also
 
-- [RELEASE-RUNBOOK-v346.md](RELEASE-RUNBOOK-v346.md) — the **executable checklist** for cutting
-  v346, written ahead of the event so task #19 runs from a list instead of a reconstruction. It
+- [RELEASE-RUNBOOK-v1446.md](RELEASE-RUNBOOK-v1446.md) — the **executable checklist** for cutting
+  v1446, written ahead of the event so task #19 runs from a list instead of a reconstruction. It
   deliberately does not restate the ceremony above, and it carries its own deletion condition.
 - [BUILDING.md](BUILDING.md) — toolchain, `secrets.rs`, flashing, and the gotchas in full.
 - [ota.md](ota.md) — the signed OTA path fleet boards actually use, including leaf mesh-OTA.


### PR DESCRIPTION
**My error, caught by the runbook's own step 1 during the canary — and wrong in the direction that ships
a mislabelled release.** Urgent because task #19 is live.

## What was wrong

The first draft said *"bump `version.txt` 345 → 346, and v346 is `Riveted Gear`."* Both halves were
internally consistent and **jointly wrong**:

```
build.rs:72          env_or_file("SMOL_BUILD_NUMBER", "version.txt")     <- ENV WINS
repro_build.sh:406   export SMOL_BUILD_NUMBER="$number"
ota_publish.sh       BUILD = choose_build(count, staged, override)
                           = max(git rev-list --count, retained staged + 1)
```

On the release path **`version.txt` is the fallback for non-stage builds, not the number that ships.**
The ratchet would have stamped its own number while `RELEASES.md` said v346.

## The step is INVERTED, not patched

**Learn the number from the ratchet → derive the word from *that* number → set `version.txt` to agree.**
The number is an *output*, so it cannot be chosen first. That ordering is now the guard at the top of §1.

**This release is `v1446` — `Molten Gear`.** Computed: `1446 % 20 = 6 → "Gear"`,
`(1446/20) % 20 = 12 → "Molten"`, with all four documented controls reproducing (341 Bellows,
342 Crucible, 345 Riveted Furnace, 905 Flux Furnace).

## ⚠️ The lesson, written into §1, because the controls did NOT save me

Four naming controls verify the **word against the number**. They say nothing about whether the
**number** is right.

`DOC-UPKEEP`'s rule — *"name it WITH its sigil word so the pair self-checks"* — catches a **mismatched
pair**. It cannot catch a **correctly-derived word on the wrong number**, which is self-consistent and
wrong. **A self-checking pair checks the RELATION, not the INPUTS.**

That is the **second time today** the same shape got me: with #237 I checked an issue's neighbours and
dependencies and never checked whether the thing had *shipped*. Both times, thorough verification of the
wrong proposition — which is the failure mode that survives being careful, and is why it is in the
runbook's provenance section rather than only in a commit message.

## Also fixed — all mine, all found by re-sweeping after the first pass

- **The file name.** `RELEASE-RUNBOOK-v346.md` → `-v1446.md`. A v346-named runbook for a v1446 release
  is exactly the mislabelling it exists to prevent. `RELEASES.md`'s See-also pointer follows it.
- **§3 said** *"the thing that makes v346 v346 is the NUMBER in `version.txt`"* — **doubly wrong**: wrong
  number, **and** it repeated the very error §1 now corrects.
- **§6 and the preamble** quoted `RELEASES.md` text that this commit changes.
- `RELEASES.md`: header row and ceremony heading now name **v1446 Molten Gear** (row says *in canary*;
  flipping it to *cut* stays part of cutting the release).

## Deliberately left

Three **dated** references — the peer-sourced design doc's *"v346+ rolls"*, `HANDOFF-2026-07-28`, and
`embassy-ota-verification`'s *"the v346 wave"*. Those are records of their moment, not live operator
instructions; same call the ROADMAP de-rot made about snapshots. Flagging rather than silently editing
another lane's design doc for a shorthand.

## Verification

`tools/status_check.sh` **21/21 rc=0** · re-swept: the only surviving "v346" in the runbook is the two
lines that **record** the first draft's error · `merge-tree` clean · selective staging (the `git add -A`
guard fired on my first attempt and was right to).

Routed to @team-lead — and worth landing ahead of the canary's next step, since the runbook is what
task #19 executes from.
