### PR TITLE
fix(diag): the margin a designer READS is now machine-checked — it advertised 31 B against a real 22

### DIFF
--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -287,13 +287,35 @@ const DIAG_BUDGET: usize = 512 - 4 - "smol/255/diag".len();
 /// a field's TYPE (u8→3, u16→5, u32→10) or the longest member of a fixed string set — so this is a
 /// bound, not an observation, and it cannot be flattered by a board being in a mild state.
 ///
-///   167  format-string literal (keys, `|` separators, `DIAG|` prefix)
-///   228  the 32 positional values at type-max width, after the u32 `up=` narrowing
-///    69  the four PROTECTED appends (`DIAG-TAIL` below) — unconditional, so inside the bound
+/// The three terms of `DIAG_CORE_MAX`, in order:
 ///
-/// **Numbers, re-derived 2026-08-01 (#306/#323).** `DIAG_BUDGET` 495 · core **464** · **margin 31 B**,
-/// and every term is now machine-checked — there is no longer a "proven vs hopeful" split to keep
-/// straight, which was itself a trap worth removing.
+///   `literal`     the format-string literal (keys, `|` separators, `DIAG|` prefix)
+///   `positional`  the positional values at type-max width, after the u32 `up=` narrowing
+///   `tail`        the PROTECTED appends (`DIAG-TAIL` below) — unconditional, so inside the bound
+///
+/// **Every number lives on ONE machine-checked line and nowhere else in this block.** Everything
+/// else here declares an INPUT; this declares the READ-OUT, because the read-out is what drifted.
+/// `check_diag_budget.py` re-derives all six and fails the build on disagreement, printing the
+/// corrected line — so this is a fact a machine keeps true, not a comment somebody remembered:
+///
+/// DIAG-DERIVED: literal=167 positional=237 tail=69 core=473 budget=495 margin=22
+///
+/// ⚠️ **`margin` is the budget for any new field — take it from that line and nowhere else.** For
+/// three weeks this block said **31 B** while the truth was 22, and that gap was not cosmetic: it
+/// was a WRONG AFFORDANCE. #471 needs a 30 B three-way `mac_fail` split. Against 31 it fits with a
+/// byte to spare, passes review *against this very doc block*, and lands the core 8 B past a CLIFF
+/// that publishes NOTHING — a whole fleet of healthy boards going silent, which is the exact
+/// outcome `DIAG_CORE_MAX` exists to make impossible. Against the real 22 it does not fit, and
+/// #471 takes the 15 B two-way split instead. Same feature, opposite design, decided entirely by
+/// which number the designer read.
+///
+/// How it drifted is worth keeping, because it is not carelessness and it will recur wherever a
+/// checker's coverage stops short of what a human reads: `fef377d` (#323) widened `ota=11`→`ota=20`
+/// and the second term 228→237. It updated both **because this checker refused the build until it
+/// did** — and left the prose two lines above alone, because nothing asked. The drift resumed at
+/// precisely the checker's coverage boundary, in the very next commit to touch the constant, one
+/// day after the checker landed to stop exactly this. A number in prose is a copy of mutable state
+/// with no invalidation channel; the repair is not to correct the copy but to give it a channel.
 ///
 /// Two hand-sums were wrong in OPPOSITE directions, which is why nothing had visibly broken:
 ///   * the positional term read **220** against a type-provable **228** — `rst=` counted at

--- a/tools/check_diag_budget.py
+++ b/tools/check_diag_budget.py
@@ -45,6 +45,14 @@ from rust_comments import strip_comments  # noqa: E402  (#426)
 FMT = re.compile(r'let mut rec = alloc::format!\(\s*\n\s*"(.*?)",\n', re.S)
 DECL = re.compile(r"DIAG-WIDTHS:\s*(.+)")
 TAIL_DECL = re.compile(r"DIAG-TAIL:\s*(.+)")
+# #382: the DERIVED numbers a human reads. Everything above is a declaration of an INPUT, which is
+# why the inputs stopped drifting and the read-out did not: `fef377d` (#323) widened `ota=11`->`ota=20`
+# and `228`->`237` because this checker refused the build until it did, and left the prose two lines
+# above at "core 464 - margin 31 B" because nothing asked. The drift resumed at exactly this
+# checker's coverage boundary, in the very next commit to touch the constant. A number in prose is a
+# copy of mutable state with no invalidation channel; the fix is to give it one.
+DERIVED_DECL = re.compile(r"DIAG-DERIVED:\s*(.+)")
+DERIVED_ORDER = ("literal", "positional", "tail", "core", "budget", "margin")
 # The unconditional appends live between the PROTECTED-tail banner and the sheddable block. Only
 # `rec.push_str` counts: the #181 ledger strings are BUILT in that region but appended via
 # `room_for`, so they shed and are correctly outside the bound.
@@ -194,6 +202,57 @@ def main() -> int:
     margin = budget - core
     if margin < 0:
         fail.append(f"the core does NOT fit: {core} > budget {budget}")
+
+    # 5. #382: the DERIVED read-out must match what was just derived.
+    #
+    # Checks 1-4 all prove a declared INPUT against the source. None of them looks at the numbers a
+    # reader is actually shown, so those went stale the first time an input legitimately moved — and
+    # a stale margin is not a cosmetic defect here, it is a WRONG AFFORDANCE. The prose advertised
+    # 31 B against a real 22 B, which is enough room to design a 30 B field, pass review against the
+    # doc block, and put the core 8 B past a CLIFF that publishes nothing at all.
+    #
+    # So the read-out is a declaration too, and this proves it. On mismatch we print the corrected
+    # line verbatim: a checker that says "wrong" and makes you re-derive by hand is a checker people
+    # route around, and the whole failure being fixed here is what happens when a human is the only
+    # thing keeping two numbers equal.
+    truth = {
+        "literal": terms[0],
+        "positional": terms[1],
+        "tail": sum(terms[2:]),
+        "core": core,
+        "budget": budget,
+        "margin": margin,
+    }
+    md = DERIVED_DECL.search(src)
+    if not md:
+        print(f"FATAL: no DIAG-DERIVED: declaration found in {path}. Add this line to the "
+              f"DIAG_CORE_MAX doc block:\n    /// DIAG-DERIVED: "
+              + " ".join(f"{k}={truth[k]}" for k in DERIVED_ORDER), file=sys.stderr)
+        return 2
+    got = {}
+    for tok in md.group(1).split():
+        k, _, v = tok.partition("=")
+        if not v.lstrip("-").isdigit() or k not in truth:
+            print(f"FATAL: DIAG-DERIVED: has a malformed or unknown term {tok!r}; expected "
+                  f"{' '.join(DERIVED_ORDER)}.", file=sys.stderr)
+            return 2
+        got[k] = int(v)
+    missing = [k for k in DERIVED_ORDER if k not in got]
+    if missing:
+        print(f"FATAL: DIAG-DERIVED: is missing {', '.join(missing)} — a PARTIAL read-out is how "
+              "the stale half survives. Declare all six.", file=sys.stderr)
+        return 2
+    wrong = [k for k in DERIVED_ORDER if got[k] != truth[k]]
+    if wrong:
+        fail.append("the DIAG-DERIVED read-out no longer matches what it reports on")
+        for k in wrong:
+            fail.append(f"  {k}: doc says {got[k]}, derived {truth[k]} ({truth[k] - got[k]:+d})")
+        fail.append("  replace that line with:\n    /// DIAG-DERIVED: "
+                    + " ".join(f"{k}={truth[k]}" for k in DERIVED_ORDER))
+        if "margin" in wrong and got["margin"] > truth["margin"]:
+            fail.append(f"  ⚠ the doc OVERSTATES the margin by {got['margin'] - truth['margin']} B "
+                        "— anyone sizing a new field against it is being told they can afford more "
+                        "than exists, and the overrun is a silent fleet-wide publish cliff.")
 
     if fail:
         print("FATAL: the DIAG budget arithmetic has drifted from the record it describes.",

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -297,13 +297,34 @@ if [ "$run_fw" = 1 ]; then
   # healthy board looks dead. `DIAG_CORE_MAX` is the compile-time proof it cannot get there, but its
   # operands were a hand-summed comment and had drifted 8 B in the unsafe direction while the file
   # carried three different margins in prose. This proves the declared per-field widths ARE the
-  # record's fields, and PRINTS the margin rather than saying "green". `tools/test_diag_budget.sh`
-  # proves each arm can fail.
+  # record's fields, and PRINTS the margin rather than saying "green". Its arms are proved able to
+  # fail by the step immediately below — which RUNS the harness. This sentence used to say
+  # "`tools/test_diag_budget.sh` proves each arm can fail" while nothing here executed it, and that
+  # is not a harmless wording: an audit asking "which test_*.sh appear in gate.sh" sees the name,
+  # scores the suite covered, and moves on. #400's audit of exactly that shape found four unwired
+  # suites and did not find this one. A comment that ASSERTS a property reads the same as a check
+  # that ENFORCES it — so never name a self-test here except on the line that invokes it.
   step "DIAG budget arithmetic matches the record (#306)"
   if out=$("$ROOT/tools/check_diag_budget.py" "$CLOCK/src/net/mode.rs" 2>&1); then
     printf '%s\n' "$out"; ok "diag budget"
   else
     printf '%s\n' "$out"; bad "diag budget"
+  fi
+
+  # #382: and now the sabotage harness actually RUNS. It has existed since #306 and this gate
+  # only ever MENTIONED it — the comment above said "proves each arm can fail" while nothing
+  # executed it, which is the precise distinction the merge-guard step below calls "the difference
+  # between 'the guard HAS a self-test' and 'the self-test RUNS'". 18 arms, mktemp copies only,
+  # no network, ~2 s.
+  #
+  # It is wired here rather than in a sweep because this gate's own DIAG check was just extended
+  # (the DERIVED read-out), and an unrun harness would have made those new arms decorative — a
+  # self-test nobody runs is indistinguishable from one that cannot fail.
+  step "DIAG budget checker regression suite (#306/#382)"
+  if out=$("$ROOT/tools/test_diag_budget.sh" 2>&1); then
+    printf '%s\n' "$out" | tail -1; ok "test_diag_budget"
+  else
+    printf '%s\n' "$out" | sed 's/^/        /'; bad "test_diag_budget"
   fi
 
   # #367: a host verifier `#[path]`-includes a firmware source, which reads a FILE and does not

--- a/tools/test_diag_budget.sh
+++ b/tools/test_diag_budget.sh
@@ -75,6 +75,34 @@ arm "core over budget" 1 "does NOT fit" \
 arm "checker blinded (no format string)" 2 "has gone blind" \
     'let mut rec = alloc::format!	let mut rec = notformat!'
 
+echo "== the DERIVED read-out (#382) =="
+# Arms 1-9 above all prove a declared INPUT against the source, and that is precisely why they did
+# not stop the drift they were written to stop: `fef377d` (#323) satisfied every one of them and
+# still left the read-out stale for three weeks. These arms cover the numbers a HUMAN reads.
+#
+# The overstatement direction is the dangerous one and gets its own assertion. An understated margin
+# makes a legitimate field look unaffordable (annoying, and it nearly sank #323). An OVERstated one
+# hands a designer room that does not exist — #471's 30 B three-way split "fits" in the advertised
+# 31 and puts the core 8 B past the cliff, silencing a healthy fleet. So the checker must not merely
+# go red; it must say WHICH WAY it is wrong.
+arm "read-out overstates the margin" 1 "OVERSTATES the margin by 77 B" \
+    'budget=495 margin=22	budget=495 margin=99'
+# The understatement direction must also be caught — it is safe for the cliff, not free for design.
+arm "read-out understates the margin" 1 "margin: doc says 5, derived" \
+    'budget=495 margin=22	budget=495 margin=5'
+# Deleting the line must be FATAL, not a silent pass. A check you can switch off by removing its
+# input is not a check; it is a suggestion. (Tag mangled rather than the line removed, so the arm
+# tests the checker's handling and not sed's.)
+arm "read-out declaration removed" 2 "no DIAG-DERIVED" \
+    'DIAG-DERIVED:	DIAG-DERIVEDX:'
+# A PARTIAL read-out is the realistic sloppy edit: update the terms you touched, leave the rest.
+# That is how half a stale declaration survives an otherwise honest correction.
+arm "read-out missing a term" 2 "is missing margin" \
+    ' margin=22	 '
+# Garbage must not parse as agreement.
+arm "read-out term malformed" 2 "malformed or unknown term" \
+    'margin=22	margin=twenty-two'
+
 echo "== the PROTECTED tail (unconditional push_str) =="
 # The documented hazard, verbatim: "a field appended with a bare push_str and NOT counted here
 # defeats this whole mechanism". Adding one must now be impossible to do quietly.


### PR DESCRIPTION
Found while re-deriving the DIAG budget **before** designing #471's field split — which is the only reason it was found at all. The number was wrong in the direction that invites you to spend room you do not have.

## The defect

| | |
|---|---|
| machine (`check_diag_budget.py`) | budget **495** · core **473** · margin **22 B** |
| the doc block a designer reads | `DIAG_BUDGET 495 · core **464** · margin **31 B**` |

## Root cause, exactly dated

`fef377d` (#323, 2026-08-02) widened `ota=11`→`ota=20` and `DIAG_CORE_MAX`'s second term `228`→`237`. It updated **both** — because `check_diag_budget.py` refused the build until it did — and left the prose two lines above alone, **because nothing asked**.

The drift resumed at **precisely the checker's coverage boundary, in the very next commit to touch the constant, one day after that checker landed to stop exactly this.** The checker's own docstring says it exists because the file *"simultaneously carried THREE different margins in prose — so every reader got a different answer to 'how much room is left'."* It does again. Every check it added proves a declared **input**; none looks at the numbers a **human** reads.

## Why this is not cosmetic — it is a wrong affordance

**#471 needs a three-way `mac_fail` split costing 30 B.**

- Against the advertised **31**: it fits with a byte to spare, and passes review *against this very doc block*.
- Against the real **22**: it does not fit.

Shipping it puts the core **8 B past a cliff** — `encode_publish` returns `None`, publishes **nothing**, and a fleet of healthy boards looks dead. A stale comment was one design review away from causing the exact outcome `DIAG_CORE_MAX` exists to make impossible. #471 takes the 15 B two-way split instead: **same feature, opposite design, decided entirely by which number the designer read.**

## The fix is not to correct the number

Correcting it fixes the instance and leaves the class. **A number in prose is a copy of mutable state with no invalidation channel.** So the read-out becomes a declaration and the checker owns it:

```rust
/// DIAG-DERIVED: literal=167 positional=237 tail=69 core=473 budget=495 margin=22
```

- All six re-derived; disagreement **fails the build and prints the corrected line** — a checker that says "wrong" and makes you re-derive by hand gets routed around, and being routed around is the failure being fixed.
- A **missing** declaration is FATAL, not a silent pass.
- A **partial** one is FATAL too — updating the terms you touched and leaving the rest is the realistic sloppy edit, and it is how half a stale declaration survives an honest correction.
- **Overstatement is called out specifically.** Understating the margin makes a legitimate field look unaffordable (it nearly sank #323); overstating it silences a fleet. A checker that only says "wrong" does not distinguish them.

## And the harness now actually runs

Wiring up the 5 new arms, I checked whether `tools/test_diag_budget.sh` executes. **It never has.** gate.sh *mentioned* it in prose — *"proves each arm can fail"* — and invoked nothing. That is the exact distinction the merge-guard step twenty lines below calls *"the difference between 'the guard HAS a self-test' and 'the self-test RUNS'."*

Worse, **the mention is load-bearing**: #400's audit found *four* unwired suites and missed this one, and an audit asking "which `test_*.sh` appear in gate.sh" would see that line and score it covered. So the comment is fixed too, with the rule: **never name a self-test in gate.sh except on the line that invokes it.**

## Verification

- **18/18** arms green (13 pre-existing + 5 new).
- Each new arm **sabotage-proved to fail for the right reason**, not merely to go red: stale read-out → `rc=1` naming positional/core/margin with signed deltas *and* the OVERSTATES warning; understated → `rc=1`; declaration removed → `rc=2`; a term dropped → `rc=2`; a term malformed → `rc=2`.
- The stale-read-out arm **replays the real historical drift** (`228/464/31`) and reproduces `+9/+9/−9` exactly.
- `tools/gate.sh fw` on familiar: **GATE GREEN**, new step confirmed **by name** — `DIAG budget checker regression suite (#306/#382) → PASS test_diag_budget`.
  ⚠️ I first ran `gate.sh host`, got `rc=0`, and nearly reported that as proof. The DIAG steps live under `run_fw`, so that green **never touched them**. Read the named line, not the exit code — same shape as the bug being fixed, one level up.
- The `mode.rs` change is **comment-only** (verified: no non-`///` line in the diff) — no codegen impact, no image-size delta.

Refs #382, #471, #306, #323, #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)