### PR TITLE
docs(protocol): step 2 no longer says "legacy line unchanged" — #464 narrowed it and the table did not follow

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1491,8 +1491,19 @@ boards carry it.
 | step | precondition | why |
 |---|---|---|
 | 1. firmware parses **both** generations, subscribes both topics | **merged main** | purely additive; a board that never sees an `OTA2\|` line behaves exactly as before |
-| 2. publisher **dual-stages** (legacy line unchanged + `OTA2\|` per-chip) | **merged main** | old firmware keeps reading the legacy topic it always read; new firmware prefers the per-chip line. Nothing is taken away, so nothing can be stranded |
+| 2. publisher **dual-stages** (legacy line for the CANONICAL chip only + `OTA2\|` per-chip) | **merged main** | old firmware keeps reading the legacy topic it always read; new firmware prefers the per-chip line. Nothing a legacy board could install is taken away, so nothing can be stranded |
 | 3. retire the fleet-wide `smol/ota/staged` line | **a ROLLED fleet** | the moment it stops being published, any board that cannot parse `OTA2\|` stops seeing updates — silently, since its symptom is simply never updating |
+
+> ⚠️ **Step 2 was narrowed by #464, and the wording above used to read "legacy line unchanged".**
+> Publishing *every* stage to the fleet-wide line meant an `esp32s3` staging armed every legacy C3
+> crown, each of which self-fetched ~1 MB before the #349 descriptor check refused it at finalize —
+> a guard working exactly as designed, after the cost had already been paid. `ota_publish.sh` now
+> publishes the legacy line **only when the staged image's chip is the canonical one** (see
+> `legacy_line_wanted`, and the `ota_publish.sh legacy-line <chip>` preflight).
+>
+> This does not weaken step 2's stranding argument, it sharpens it: what a legacy board needs is
+> every image **it could actually install**, and a foreign-chip image was never one of those. A
+> pre-#349 C3 still sees every C3 staging on the topic it has always read.
 
 Step 3 has a second, less obvious dependency: a crown relays the **signed M verbatim** to leaves
 over `OTAM`, so once a crown installs from an `OTA2` line it relays a 119 B M that a pre-#349 leaf


### PR DESCRIPTION
Found while closing #464.

`docs/protocol.md`'s OTA2 migration table still described step 2 as:

> publisher **dual-stages** (legacy line **unchanged** + `OTA2|` per-chip)

That stopped being true when **PR #500** landed the #464 fix. The legacy fleet-wide line is now published **only when the staged image's chip is the canonical one** (`legacy_line_wanted`, plus the `ota_publish.sh legacy-line <chip>` preflight).

**My own PR made that sentence false and did not update it** — the same under-delivery I had just finished writing up on #460: the fix shipped, and the artifact that *tells someone about the fix* did not. A migration table is precisely what an operator consults before deciding whether a step is safe to take, so a stale precondition there is not cosmetic.

## The correction sharpens step 2 rather than weakening it

Step 2's whole job is the stranding argument, and the right form of that question is *"does a legacy board still see every image **it could actually install**?"* A foreign-chip image was never one of those. A pre-#349 C3 still sees every C3 staging on the topic it has always read, so nothing is taken away.

What the old wording promised was **broader than step 2 needs**, and the extra breadth was pure cost: an `esp32s3` staging armed every legacy C3 crown, each of which self-fetched ~1 MB before #349's embedded-descriptor check refused it **at finalize** — the guard working exactly as designed, after the cost had already been paid.

A short note now records that history inline, so the next reader sees why the row is narrower than it once was instead of reading it as a typo and "restoring" it.

**Step 3 is unchanged** (retire the fleet-wide line, gated on a ROLLED fleet) and still owns the retirement that #464 proposed as its fix direction.

## Verification

- `tools/status_check.sh` → rc=0, #148's machine-checkable half intact.
- The replaced table row was asserted to match **exactly once** in the edit itself, so a silent no-op edit was not possible.
- Docs-only; no code path touched.

Refs #464, #349, #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)