### PR TITLE
fix(ota): #465 both halves — a crown stops relaying and stops claiming what no leaf can judge

### DIFF
--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -4231,6 +4231,55 @@ async fn mqtt_session(
     // install retained → the next flush retries (bounded by LEAF_OTA_MAX_RETRIES). `Announce`
     // is `Copy`, so the pair moves out cleanly.
     match (pending_leaf, *staged_raw) {
+        // #465: REFUSE to relay an announce that states NO TARGET.
+        //
+        // `ota::gate` runs #349's pre-fetch suitability check only `if let Some(t) = a.target`. A
+        // legacy `OTA|` line carries none, and that asymmetry is deliberate — "this staging did not
+        // say" is not "suitable for anyone", so a board judging its OWN self-fetch falls back to the
+        // post-download descriptor read and a new publisher can coexist with an un-rolled fleet.
+        //
+        // That reasoning does NOT survive being inherited by the relay path, and it was inherited
+        // silently. For a self-fetch the board spends ITS OWN airtime and flash-write budget on an
+        // image it will judge at finalize. For a relay the crown spends a DIFFERENT board's, on an
+        // image the leaf is structurally unable to refuse until the whole thing has arrived. The
+        // cost moved to a third party and the justification did not move with it.
+        //
+        // This is the measured incident, not a hypothetical: a v922 crown (pre-#349, so its
+        // `staged_raw` was a target-less `OTA|` announce) relayed a 1,031,008 B C3 image at the S3
+        // leaf id162, which could only refuse at the finalize descriptor read — a full megabyte of
+        // ESP-NOW airtime, ×3 under `LEAF_OTA_MAX_RETRIES`.
+        //
+        // Refusing here RESTORES the leaf's pre-fetch veto by construction: the only announces we
+        // relay are ones the leaf can judge before a single body byte moves.
+        //
+        // The install is deliberately NOT cleared. This is a property of the ANNOUNCE we currently
+        // hold, not a verdict on the leaf — when `staged_raw` refreshes to an `OTA2|` line the next
+        // flush arms normally. Clearing would turn a recoverable staleness into a lost install.
+        (Some(leaf_id), Some(ann)) if ann.target.is_none() => {
+            log::warn!(
+                "smol #465: NOT relaying build {} to leaf id{} — the announce states no target, so the leaf could not refuse it until the whole image had arrived (legacy OTA| line; install left retained for a targeted staging)",
+                ann.build,
+                leaf_id
+            );
+        }
+        // #465 defence in depth: an announce for a chip that is not even OURS has no business
+        // being served onward. Near-tautological today — post-#464 a crown only sees its own
+        // chip's staged line — which is exactly why it is worth asserting rather than assuming:
+        // #464 is a property of the PUBLISHER, and this is the consumer that would pay for the
+        // publisher changing. Unlike the arm above, this one cannot save the observed megabyte
+        // (there the image WAS the crown's chip and the leaf's was different, which the crown
+        // cannot know — see #510 rider 4 for the frame that would tell it).
+        (Some(leaf_id), Some(ann))
+            if ann.target.map(|t| t.chip) != Some(crate::net::target::SELF.chip) =>
+        {
+            log::warn!(
+                "smol #465: NOT relaying build {} to leaf id{} — image targets chip {} but this crown is {}",
+                ann.build,
+                leaf_id,
+                crate::net::target::chip_name(ann.target.map(|t| t.chip).unwrap_or(0)),
+                crate::net::target::chip_name(crate::net::target::SELF.chip)
+            );
+        }
         (Some(leaf_id), Some(ann)) => {
             *leaf_ota = Some((leaf_id, ann));
             log::info!("smol #40: ARMED relay for leaf id{} (staged build {})", leaf_id, ann.build);
@@ -4937,7 +4986,44 @@ async fn mqtt_session(
     // (stat_cache = Some). Idempotent retained publishes, bounded to the heard-leaf set.
     #[cfg(feature = "espnow")]
     if let Some(sc) = stat_cache {
+        // #465 half-1, invariant: A PROXY MUST NEVER OVERWRITE A PRINCIPAL'S OWN CLAIM.
+        //
+        // This block publishes each relayed leaf's `ota/state` ON ITS BEHALF, with
+        // `latest_version` taken from THIS CROWN's staged announce. The premise, stated in the
+        // comment above, is *"a credential-less leaf never opens MQTT, so the gateway is its
+        // proxy"*. That premise is FALSE now — the S3/C5/C6 flavors have their own sessions and
+        // publish the same retained topic. Both writers work as designed and the crown simply
+        // writes last, every flush, forever. Measured on the #398 roll: `smol/162/ota/state`
+        // `latest_version` went 1405 -> 922 AND STUCK. Not staleness — a clobber.
+        //
+        // The clean discriminator is a self-publishes bit in HELLO (filed as #510 rider 4), because
+        // the crown has NO per-leaf chip or capability knowledge: `stat_cache` yields only
+        // `(id, key, relayed-STAT)`, and STAT carries a build and a screen, never a chip. So the
+        // ruled interim "skip leaves whose chip != canonical" is not computable here yet, and a
+        // gate that cannot fire is worse than none — it reads as fixed.
+        //
+        // What IS computable is when this crown has no business making the claim AT ALL. A
+        // target-less (legacy `OTA|`) announce means "this staging did not say" — see
+        // `ota::Announce::target`. Asserting an unjudgeable build as a SPECIFIC leaf's
+        // `latest_version` is claiming knowledge that does not exist, and it is exactly what
+        // produced the 922 clobber. So: no target, no claim; the leaf's own retained value stands.
+        //
+        // Scope is narrow by construction — every post-#349 staging is an `OTA2|` line, so this
+        // fires only for a pre-#349 crown, which is precisely the v922 case that was measured. It
+        // does not change what a modern crown publishes for its credential-less same-chip leaves.
         let latest_staged = staged_raw.as_ref().map(|a| a.build);
+        // TRUE only when this crown holds an announce it may legitimately assert OF A LEAF.
+        let may_claim_for_leaves = match staged_raw.as_ref() {
+            None => false,
+            Some(a) if a.target.is_none() => {
+                log::warn!(
+                    "smol #465: NOT proxy-publishing ota/state for relayed leaves — staged build {} states no target, so it cannot be asserted of any particular leaf (legacy OTA| line)",
+                    a.build
+                );
+                false
+            }
+            Some(_) => true,
+        };
         for i in 0..sc.count() {
             // #56: the status cache is single-channel per leaf; its key column is inert here.
             let (lid, _key, val) = match sc.entry(i) {
@@ -4966,6 +5052,17 @@ async fn mqtt_session(
             }
             // State (retained) ONLY if the leaf reported a build (STAT `|<build>` field) —
             // don't clobber a self-published value with "unknown" for a leaf on old firmware.
+            // #465: `may_claim_for_leaves` gates the WHOLE publish, not just the value. Gating
+            // only the value would leave `latest_staged.unwrap_or(installed)` writing the topic
+            // anyway with "installed == latest" — a different wrong number, still overwriting a
+            // self-publishing leaf's own claim, and one that additionally HIDES an available
+            // update by rendering as up-to-date. Not writing is the only option that honours
+            // "a proxy must never overwrite a principal's own claim"; the leaf's retained value
+            // stands, which for a self-publishing flavor is the correct one and for a
+            // credential-less leaf is the crown's own last good publish.
+            if !may_claim_for_leaves {
+                continue;
+            }
             if let Some(installed) = crate::ota_mesh::stat_build(val) {
                 let latest = latest_staged.unwrap_or(installed);
                 let mut sjson = MqttScratch::new();

--- a/tools/symbol-sizes.espnow-cast-io.txt
+++ b/tools/symbol-sizes.espnow-cast-io.txt
@@ -7,7 +7,7 @@
 # source diff and no compiler complaint, so review had nothing to look at.
 #
 # Do NOT hand-edit. Re-bless, and explain the delta in the commit message.
-# 34 symbols, 194986 bytes total.
+# 34 symbols, 194994 bytes total.
 #
 # size	section	symbol
 960	.data	TxRxCxt
@@ -35,7 +35,7 @@
 1920	.bss	_RNvNvNtCs*_5clock3net14bring_up_stack13NET_RESOURCES
 98304	.bss	_RNvNvNtCs*_5clock3net9init_heap4HEAP
 4096	.bss	_RNvNvNtCs*_5clock3ota18verify_active_slot10VERIFY_BUF
-12728	.bss	_RNvNvNtCs*_5clock6___main14___embassy_main4POOL
+12736	.bss	_RNvNvNtCs*_5clock6___main14___embassy_main4POOL
 592	.bss	gChmCxt
 284	.bss	gScanStruct
 816	.bss	gWpaSm


### PR DESCRIPTION
Implements both #465 halves against the ruled invariants. **Both ruled *mechanisms* turned out to need something the crown provably does not have**, so this reaches the same invariants by a route that works — and says plainly where the ruled route is still blocked rather than shipping a gate that cannot fire.

## What the crown actually knows about a leaf

`stat_cache.entry()` yields `(id, key, relayed-STAT)`, and STAT carries a **build and a screen**. There is no chip associated with a leaf anywhere in `net/`. So both ruled mechanisms — *"skip leaves whose chip ≠ canonical"* (half-1) and *"compare `ann.target.chip` to the leaf's chip"* (half-2) — are **uncomputable here today**.

### And the ruled half-2 gate would not have fired on the incident it was ruled for

In the #398 capture: crown = **C3**, image = **C3** (922), leaf = **S3**. Any gate comparing the image's chip to the *crown's* chip **passes**. Post-#464 a crown only ever holds its own chip's staged line, so that comparison is near-tautological — **a gate that cannot fail, which is worse than no gate, because it reads as fixed.**

## The mechanism that actually explains the megabyte

`ota::gate` runs #349's pre-fetch suitability check **only** `if let Some(t) = a.target`. A legacy `OTA|` line carries no target, and that asymmetry is deliberate — *"this staging did not say"* is not *"suitable for anyone"* — so a board judging its **own** self-fetch falls back to the post-download descriptor read, letting a new publisher coexist with an un-rolled fleet.

**That justification does not survive being inherited by the relay path, and it was inherited silently:**

| | who pays | can the payer refuse early? |
|---|---|---|
| self-fetch | the board itself | yes — it judges at finalize, on its own budget |
| **relay** | **a different board** | **no** — structurally unable to refuse until all of it has arrived |

The cost moved to a third party; the justification did not move with it. The v922 crown was pre-#349, so its `staged_raw` **was** exactly such a target-less announce — which is why id162 could only refuse at finalize, after **1,031,008 B**, ×3 under `LEAF_OTA_MAX_RETRIES`.

## Half-2 — refuse to arm on a target-less announce

**This restores the leaf's pre-fetch veto by construction**: the only announces relayed are ones the leaf can judge *before a single body byte moves*. Plus defence in depth for a target that is not this crown's chip — near-tautological today, which is exactly why it's worth **asserting rather than assuming**: #464 is a property of the *publisher*, and this is the consumer who'd pay for the publisher changing.

The install is deliberately **not cleared** — this is a fact about the announce we currently hold, not a verdict on the leaf, so the next flush arms normally once `staged_raw` refreshes to an `OTA2|` line. Clearing would turn recoverable staleness into a lost install.

## Half-1 — a proxy must never overwrite a principal's own claim

Measured: `smol/162/ota/state` `latest_version` went **1405 → 922 and stuck**. Not staleness — a clobber. Same discriminator: with no target the crown cannot assert the build **of a particular leaf** at all, so it publishes no state for relayed leaves. **Discovery still publishes**, so the HA entity survives; only the unfounded claim is withheld.

⚠️ **The guard covers the whole publish, not the value.** Gating only the value leaves `latest_staged.unwrap_or(installed)` writing the topic anyway with `installed == latest` — a *different* wrong number, still overwriting the principal, and one that additionally **hides an available update** by rendering as up-to-date. I wrote the value-only version first; **reading the consuming line is what caught it.**

## Scope is narrow by construction

Every post-#349 staging is an `OTA2|` line, so **both gates fire only for a pre-#349 crown** — the measured v922 case. Nothing changes for a modern crown serving credential-less same-chip leaves.

## Still blocked — routed, not faked

An S3 leaf under a **modern** crown is not covered: the crown still cannot tell a self-publishing flavor from a credential-less one. That needs a **self-publishes bit (and the chip) in HELLO** — filed as **#510 rider 4**, since one frame decision unblocks both halves.

## One commit, not two — deliberately

Both halves live in the same file a few hundred lines apart; splitting them meant string-surgery on the working tree, and **my first attempt at exactly that tripped its own assertion**. Tonight already produced one commit message that lied because of a silent staging failure, so the trade wasn't worth it. Both halves are delimited by `#465` comments and revert cleanly by hunk.

## Verification

- `tools/gate.sh host` → **GATE GREEN**; fleet tier builds clean.
- The half-1 guard's placement **between** the discovery publish and the state publish confirmed by line number (5037 discovery → 5063 guard → state), not assumed.
- `merge-tree --write-tree` clean against `main`.

Refs #465, #349, #464, #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)