### PR TITLE
feat(dashboard): #356 ask the INVERSE question — a live fleet member with no card

### DIFF
--- a/ha/dashboard/build_control_room.py
+++ b/ha/dashboard/build_control_room.py
@@ -1197,6 +1197,7 @@ async def main():
             # The fleet explains the card counts: node boxes are per-node, so "built 33 / live 31"
             # is a node that joined since the last real run, not a mystery.
             report_fleet(nodes, dormant, roster, rejected, fleet)
+            report_unrepresented(cfg, fleet, live, view)
             return report_check(cfg, view, prev, extras, retired, retiring, st, nodes)
         if prev:
             if retiring:
@@ -1856,6 +1857,60 @@ def roster_orphans(roster, fleet):
         missing=[pid for pid in sorted((r or {}).get("peers") or {}) if pid not in (fleet or {})]
         if missing: out[cid]=missing
     return out
+
+
+def report_unrepresented(cfg, fleet, live, pending_view=None):
+    """#356: the INVERSE of #340's dead-row check — a live fleet member with NO CARD ANYWHERE.
+
+    #340 made `--check` catch *a card wired to no node*. Nothing asked the opposite question, and
+    that asymmetry is why `smol-telemetry` drifted to covering **2 of 8** members while the fleet
+    quadrupled: every new target joined a dashboard that structurally could not show it, silently,
+    and it took re-reading a months-old issue to notice.
+
+    Deliberately READ-ONLY and deliberately ACROSS EVERY VIEW. This module generates exactly one
+    view (`VIEW_PATH`) and that single-view invariant exists because two writers to one dashboard
+    already destroyed rows (#340). Reporting on a view is not writing to it, so this can answer the
+    fleet-wide question without acquiring the ownership that caused the incident. It names the view
+    that would have to change; it does not change it.
+
+    A node counts as represented if any view mentions it in either entity shape the fleet uses:
+    `smol_<id>_<metric>` (telemetry mirrors) or `smol<id>_<suffix>` (the per-node Update unique_id).
+    The trailing separator is load-bearing — without it `smol_5` matches `smol_50_ota_death` and the
+    check would report full coverage for a node that has none, which is the exact failure mode of
+    the thing it is checking.
+    """
+    views = cfg.get("views", []) or []
+    pending = json.dumps(pending_view) if pending_view else ""
+    rows = []
+    for nid in sorted(fleet):
+        pat = re.compile(r"smol_%d[_\"]|smol%d[_\"]" % (nid, nid))
+        where = [v.get("path") or v.get("title") or "<untitled>"
+                 for v in views if pat.search(json.dumps(v))]
+        # A node absent from the LIVE dashboard but present in the view this run is about to write
+        # is not a gap — it is a node that joined since the last deploy, and saving fixes it. Without
+        # this distinction the check fires every time the fleet grows, and a checker that cries wolf
+        # on normal events is one people learn to scroll past. The gap worth naming is the node that
+        # NO view carries and that THIS RUN WILL NOT ADD.
+        rows.append((nid, fleet[nid], where, bool(pending and pat.search(pending))))
+    missing = [(i, m) for i, m, w, fix in rows if not w and not fix]
+    print("  view coverage (#356 — a live member with no card is as wrong as a card with no node):")
+    for nid, m, where, fix in rows:
+        state = "live" if nid in live else "dormant"
+        mark = "  " if (where or fix) else "!!"
+        if where:
+            note = " · ".join(where)
+        elif fix:
+            note = f"(absent from the live dashboard; THIS RUN adds it to {VIEW_PATH})"
+        else:
+            note = "NO VIEW REFERENCES THIS NODE"
+        print(f"    {mark} id{nid:<4} {str(m.get('sigil') or ''):<22} {state:<8} {note}")
+    if missing:
+        live_missing = [i for i, _ in missing if i in live]
+        print(f"  !! {len(missing)} fleet member(s) appear on NO view"
+              f"{f' — {len(live_missing)} of them LIVE on the mesh right now' if live_missing else ''}.")
+        print("     A node the fleet can hear and the dashboard cannot show is invisible by")
+        print("     construction, not by accident of state. See #356.")
+    return len(missing)
 
 
 def report_fleet(nodes, dormant, roster, rejected=(), fleet=None):

--- a/ha/dashboard/test_coverage_check.py
+++ b/ha/dashboard/test_coverage_check.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Proves `report_unrepresented` (#356) can FAIL — and can stay quiet when it should.
+
+Why this exists. The defect #356 describes is a checker-shaped one: `smol-telemetry` drifted to
+covering 2 of 8 fleet members while nobody noticed, because #340's `--check` only ever asked
+"is this card wired to a node that exists?" and never the inverse. Shipping the inverse check
+without watching it go red would be the same mistake one level up — this repo has a standing rule
+that a gate must be shown failing for the right reason, not merely shown green.
+
+Three arms, all offline (no HA, no websocket, no token beyond a dummy for the module's import-time
+`os.environ["HA_TOKEN"]`):
+
+  A. real dashboard + real fleet          -> MUST find the gap (and name the LIVE ones)
+  B. same, but this run would add two     -> those two MUST stop being flagged
+  C. a fleet the dashboard fully covers   -> MUST report nothing
+
+Arm B is the one that matters for whether anyone keeps the check. Without it the check fires every
+time a node joins between deploys — a true statement about a normal event — and a checker that
+cries wolf on normal events is one people learn to scroll past. Arm C is the control: a check that
+cannot be silent is not measuring anything.
+
+The dashboard fixture is the REAL file when present (`~/Projects/ha/dashboards/…`), falling back to
+a synthetic one so this is runnable on a machine that has never deployed. The fallback is built to
+the same shape rather than to make the test pass.
+
+⚠️ NOT WIRED INTO tools/gate.sh, deliberately, and recorded here so the next auditor finds a
+decision rather than an omission: importing the generator pulls `yaml` and `websockets`, which the
+gate's CI image does not install (it deliberately runs no HA-side tooling). Wiring it would trade a
+real check for an import error. It runs where the generator runs. If the gate ever grows those deps,
+this becomes a one-line arm.
+
+Usage:  ha/dashboard/test_coverage_check.py      (exit 0 pass, 1 fail)
+"""
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+GEN = HERE / "build_control_room.py"
+
+FLEET = {i: {"sigil": s} for i, s in [
+    (5, "Obsidian Aegis"), (8, "Eldritch Jewel"), (50, "Mystic Chalice"), (51, "Ashen Vigil"),
+    (122, "watch-c6"), (162, "s3-cyd"), (176, "c5-cyd"), (236, "watch-c6"),
+]}
+LIVE = {5, 8, 50, 51, 162, 176}
+
+# The two ids the real telemetry view carries. Kept as data so a future fix to #356 makes the
+# EXPECTATIONS below fail loudly ("fixture setup") rather than the test quietly passing on a
+# dashboard that has changed underneath it.
+COVERED_BY_REAL_DASHBOARD = {5, 8, 50, 51}
+
+
+def load_module():
+    os.environ.setdefault("HA_TOKEN", "dummy-for-import")
+    spec = importlib.util.spec_from_file_location("bcr", GEN)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass  # the module guards on argv/env; the functions we need are already bound
+    except ImportError as e:
+        print(f"SKIP-IMPOSSIBLE: the generator's imports are unavailable here ({e}).", file=sys.stderr)
+        print("  This is a HARD FAIL, not a skip: a test that cannot run must not report success.",
+              file=sys.stderr)
+        sys.exit(1)
+    return mod
+
+
+def load_dashboard():
+    real = pathlib.Path.home() / "Projects/ha/dashboards/smol-mesh.dashboard.json"
+    if real.exists():
+        return json.loads(real.read_text()), f"real ({real})"
+    # Synthetic fallback, same shape: two views, one carrying a couple of nodes.
+    return {"views": [
+        {"path": "smol-control", "cards": [{"type": "markdown",
+         "content": "sensor.smol_5_heap sensor.smol_8_heap sensor.smol_50_heap sensor.smol_51_heap"}]},
+        {"path": "smol-telemetry", "cards": [{"type": "entities",
+         "entities": [{"entity": "sensor.smol_5_ota_death"}, {"entity": "sensor.smol_8_mac_health"}]}]},
+    ]}, "synthetic fallback"
+
+
+def main():
+    mod = load_module()
+    if not hasattr(mod, "report_unrepresented"):
+        print("FAIL - build_control_room.py has no report_unrepresented (#356) — this test is stale")
+        return 1
+    cfg, src = load_dashboard()
+    print(f"dashboard fixture: {src}")
+
+    covered = {i for i in FLEET if any(
+        __import__("re").search(r"smol_%d[_\"]|smol%d[_\"]" % (i, i), json.dumps(v))
+        for v in cfg.get("views", []))}
+    if covered != COVERED_BY_REAL_DASHBOARD:
+        print(f"fixture setup: the dashboard now covers {sorted(covered)}, "
+              f"expected {sorted(COVERED_BY_REAL_DASHBOARD)}.")
+        print("  If #356 has been FIXED, update COVERED_BY_REAL_DASHBOARD — do not delete the arms.")
+        return 1
+
+    fails = 0
+
+    print("\n== A. real fleet vs the live dashboard — must FIND the gap ==")
+    a = mod.report_unrepresented(cfg, FLEET, LIVE)
+    expect_a = len(FLEET) - len(COVERED_BY_REAL_DASHBOARD)
+    if a == expect_a:
+        print(f"ok   - reported {a} unrepresented")
+    else:
+        print(f"FAIL - reported {a}, expected {expect_a}"); fails += 1
+
+    print("\n== B. a pending run would add 162+176 — those must NOT be flagged ==")
+    pending = {"path": "smol-control", "cards": [{"type": "markdown",
+               "content": "sensor.smol_162_heap sensor.smol_176_heap"}]}
+    b = mod.report_unrepresented(cfg, FLEET, LIVE, pending)
+    if b == expect_a - 2:
+        print(f"ok   - reported {b}; the two this run fixes are excluded")
+    else:
+        print(f"FAIL - reported {b}, expected {expect_a - 2} — the check would cry wolf on a "
+              "node that merely joined since the last deploy"); fails += 1
+
+    print("\n== C. control — a fully covered fleet must report NOTHING ==")
+    c = mod.report_unrepresented(cfg, {i: FLEET[i] for i in COVERED_BY_REAL_DASHBOARD},
+                                 set(COVERED_BY_REAL_DASHBOARD))
+    if c == 0:
+        print("ok   - reported 0")
+    else:
+        print(f"FAIL - reported {c}, expected 0 — a check that cannot be silent measures nothing")
+        fails += 1
+
+    print("\n== D. id-boundary — smol_5 must not be satisfied by smol_50 ==")
+    only50 = {"views": [{"path": "v", "cards": [{"type": "markdown",
+              "content": "sensor.smol_50_heap"}]}]}
+    d = mod.report_unrepresented(only50, {5: {"sigil": "five"}}, {5})
+    if d == 1:
+        print("ok   - id5 correctly reported missing despite smol_50 being present")
+    else:
+        print("FAIL - id5 was matched by smol_50; the trailing separator is not doing its job, "
+              "and the check would report full coverage for a node with none"); fails += 1
+
+    print(f"\n{4 - fails} passed, {fails} failed")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Lands the **durable half** of #356 per the ruling. **@jphein — one decision for you at the bottom.**

## The asymmetry

#340 made `--check` catch *a card wired to no node*. **Nothing ever asked the opposite.** That is the whole reason `smol-telemetry` drifted to covering **2 of 8** members while the fleet quadrupled: every new target joined a dashboard that structurally could not show it, silently. A coverage gap in one direction was a build failure; in the other it was nothing at all.

## Measured, running the new check against the live dashboard

**Four fleet members appear on NO view** — id122, id162, id176, id236 — and **two of them (162 the S3, 176 the C5) are live on the mesh right now.** Both joined and took OTAs *after* #356 was filed.

```
   id5    Obsidian Aegis   live     smol-control · smol-telemetry
   id8    Eldritch Jewel   live     smol-control · smol-telemetry
   id50   Mystic Chalice   live     smol-control
   id51   Ashen Vigil      live     smol-control
!! id122  watch-c6         dormant  NO VIEW REFERENCES THIS NODE
!! id162  s3-cyd           live     NO VIEW REFERENCES THIS NODE
!! id176  c5-cyd           live     NO VIEW REFERENCES THIS NODE
!! id236  watch-c6         dormant  NO VIEW REFERENCES THIS NODE
```

## Read-only, and across every view — which is what lets it exist at all

This module generates exactly one view, and that single-view invariant isn't fussiness: **two writers to one dashboard already destroyed rows (#340)**. Reporting on a view is not writing to it, so the fleet-wide question can be answered **without acquiring the ownership that caused the incident**. The check *names* the view that would have to change; it does not change it.

## The arm that decides whether anyone keeps it

A node absent from the live dashboard but present in the view **this run is about to write** is *not* a gap — it's a node that joined since the last deploy, and saving fixes it. Without that distinction the check fires every time the fleet grows: a true statement about a normal event, and **a checker that cries wolf on normal events is one people learn to scroll past.** The gap worth naming is the node **no** view carries that **this run will not add**.

## Self-test — 4 arms, all offline

`ha/dashboard/test_coverage_check.py`:

| arm | asserts |
|---|---|
| A | finds the real gap against the live dashboard |
| B | stays quiet on nodes this run fixes |
| C | reports **nothing** on a covered fleet — *a check that cannot be silent measures nothing* |
| D | `smol_5` is **not** satisfied by `smol_50_ota_death` |

Arm D guards a load-bearing detail: without the trailing separator the check reports **full coverage for a node that has none** — precisely the failure mode of the thing it checks. It also fails on **fixture drift** rather than passing quietly: if #356 gets fixed and the dashboard covers more ids, the test says so and asks for the expectation to be updated instead of silently testing nothing.

⚠️ **Not wired into `tools/gate.sh`, deliberately**, with the reason recorded *in the test* where an auditor will find it: importing the generator pulls `yaml` and `websockets`, which the gate's CI image does not install. Wiring it would trade a real check for an import error. A **declared gap**, in the shape gate.sh already uses for its own exclusions — not an omission.

---

## 🔸 @jphein — the half that needs your ack

This does **not** fix `smol-telemetry`'s hardcoded id list. Doing that properly means **one producer**, because *"a second copy of a deterministic algorithm always loses to the original"* is this file's own stated reason for having deleted its `KNOWN` table. That was ruled correct in principle.

**But it means retiring the producer in `~/Projects/ha`, which builds your daily dashboards** — so it waits for you. The options:

- **(a)** this generator takes over `smol-telemetry` too, and the `~/Projects/ha` producer retires. Ids and sigil names then come from the HA device registry (firmware-authored), so they cannot drift. Cost: one more view under this script's control, and the single-view invariant becomes a two-view one.
- **(b)** fix it in `~/Projects/ha` instead — keeps the boundary, duplicates `discover_fleet()`/`sigil_of()`, and rebuilds the exact defect one repo over.

This PR lands what's safe now and makes the other half's absence **visible every run** instead of discoverable by archaeology.

Verified: `tools/status_check.sh` rc=0; self-test 4/4 against the real dashboard fixture; `merge-tree --write-tree` clean.

Refs #356, #340, #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)