### PR TITLE
feat(diag): #382 N-part DIAG continuations — part A byte-identical, and `cut=` becomes a checksum

### DIFF
--- a/experiments/relay_compat/src/main.rs
+++ b/experiments/relay_compat/src/main.rs
@@ -55,6 +55,11 @@ fn old_parse_relay(data: &[u8]) -> Option<(u8, u16, u8, u8, &[u8])> {
     Some((src_id, msgid, rest[10] - b'0', rest[12] - b'0', &rest[14..]))
 }
 
+/// Expected `|cut=<n>` width: 5 for the tag + the decimal digits, clamped at 3.
+fn alloc_len(n: usize) -> usize {
+    5 + if n >= 100 { 3 } else if n >= 10 { 2 } else { 1 }
+}
+
 fn main() {
     // (1) NEW frame -> OLD parser (a #13 leaf's H=1 RELAY on an old gateway) -----------------
     let mut fb = [0u8; 128];
@@ -164,5 +169,47 @@ fn main() {
     assert_eq!(dinner, &diag[..cut], "unwrapped inner == the field-boundary-clamped DIAG verbatim");
     assert!(dinner.starts_with(b"SMOLv1 DIAG 007"), "clamped DIAG keeps its classify-able prefix");
 
-    println!("relay_compat: ALL CHECKS PASSED (bidirectional byte-compat + golden bytes + #13/#124 tag round-trips + disambiguation + UP2 clamp + field-boundary DIAG clamp)");
+    // ── #382 `|cut=` tag round-trip ────────────────────────────────────────────────────────────
+    // A leaf DIAG that does not fit one frame is now continued (`DIAGC`), and the crown re-derives
+    // `|cut=` from what is STILL missing so the tag becomes a CHECKSUM: 0 means "you have the whole
+    // record". These three functions are the entire byte-level contract of that, and this change
+    // CANNOT BE TESTED ON HARDWARE from here — so it gets tested here, exhaustively, off-target.
+
+    // write/parse round-trip across every width the tag can take, including the boundaries where
+    // its LENGTH changes (6/7/8 bytes) — the widths are where an off-by-one lives.
+    for n in [0usize, 1, 9, 10, 11, 99, 100, 101, 169, 998, 999] {
+        let mut buf = [0u8; 8];
+        let len = wire::write_cut(&mut buf, n);
+        let expect = alloc_len(n);
+        assert_eq!(len, expect, "write_cut({n}) wrote {len} B, expected {expect}");
+        assert_eq!(wire::parse_cut(&buf[..len]), Some(n), "round-trip failed for {n}");
+    }
+    // The clamp must match `broadcast_diag`'s `dropped.min(999)` — if the two ends disagree about
+    // the field width the record is corrupt, not merely wrong.
+    let mut buf = [0u8; 8];
+    let len = wire::write_cut(&mut buf, 100_000);
+    assert_eq!(&buf[..len], b"|cut=999", "write_cut must clamp at 999 exactly as the sender does");
+
+    // find_last_cut must take the LAST occurrence: `cut=` is appended last by construction, and
+    // matching an earlier one would truncate a real record at a coincidence.
+    // ⚠️ The decoy must be a REAL `|cut=` field, not `=cut=`. My first version of this fixture used
+    // "|note=cut=here", which contains no `|cut=` at all — so the arm passed with `find_last_cut`
+    // sabotaged to take the FIRST occurrence, i.e. it was testing nothing. Caught by sabotaging the
+    // function and watching this stay green, which is the only reason it is right now.
+    let rec = b"DIAG|slot=0|cut=1|up=5|cut=169";
+    let at = wire::find_last_cut(rec).expect("tag found");
+    assert_eq!(&rec[at..], b"|cut=169", "find_last_cut took an earlier occurrence");
+    assert_eq!(wire::parse_cut(&rec[at..]), Some(169));
+
+    // An untruncated record has no tag — the crown must decline to continue it rather than guess.
+    assert!(wire::find_last_cut(b"DIAG|slot=0|up=5").is_none(), "no tag must mean no tag");
+    // Malformed tags parse to None, so a caller can refuse rather than default to 0 and silently
+    // claim a record is complete.
+    assert!(wire::parse_cut(b"|cut=").is_none(), "empty digits must not parse");
+    assert!(wire::parse_cut(b"|cut=12x").is_none(), "non-digits must not parse");
+    // Shorter than the tag itself must not panic on the slice.
+    assert!(wire::find_last_cut(b"|cu").is_none());
+    assert!(wire::find_last_cut(b"").is_none());
+
+    println!("relay_compat: ALL CHECKS PASSED (bidirectional byte-compat + golden bytes + #13/#124 tag round-trips + disambiguation + UP2 clamp + field-boundary DIAG clamp + #382 cut-tag round-trip/clamp/last-occurrence)");
 }

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -439,6 +439,45 @@ const CONT_VALUE_MAX: usize = ESP_NOW_MTU - MAC_TRAILER_LEN - DIAGC_PREFIX.len()
 /// esp-hal takes .bss out of .stack — measured, not assumed).
 const DIAG_CONT_PARTS: u8 = 1;
 
+/// Width of the `|cut=<n>` marker at its widest ("|cut=999"). Hoisted to module scope by #382:
+/// it is no longer a detail of `broadcast_diag` but a term in the compile-time pairing between the
+/// sender's continuation budget and the crown's cache, and a constant that two places depend on
+/// should not live inside one of them.
+const CUT_TAG_MAX: usize = 8;
+
+/// #382: what ONE continuation may carry — the DECLARED part-B budget.
+///
+/// **Derived from what the crown can KEEP, not from what the frame can HOLD**, and the difference
+/// is a real bug I shipped in the first draft: the frame allows `CONT_VALUE_MAX` (224 B), the crown
+/// can only append `DIAG_CACHE_VALUE_MAX − OBS_VALUE_MAX` (134 B) after part A, so a full-frame
+/// continuation was silently TRUNCATED at the receiver — positional loss reintroduced at the exact
+/// place this change exists to remove it, and invisible because the frame was well-formed.
+///
+/// Bounding the SENDER by the receiver's budget is the byte-granularity form of the rule that
+/// governs `DIAG_CONT_PARTS`: never emit what the other end cannot keep. Airtime spent on data that
+/// is dropped on arrival is strictly worse than not sending it, because it also looks like it
+/// worked.
+///
+/// 134 B comfortably holds the declared set this carries — the PROTECTED tail (`mo= mf= mfk= apch=
+/// blrev= brst=`, 84 B declared in `DIAG-TAIL`) plus `elect=` and the trailing positional fields
+/// that fall past part A's cut.
+const CONT_DECLARED_MAX: usize = crate::net::wifi::DIAG_CACHE_VALUE_MAX - OBS_VALUE_MAX;
+
+/// #382 THE PAIRING, ENFORCED. `DIAG_CONT_PARTS` and the crown's buffer are two halves of one
+/// decision, and this is what stops them drifting: raise the parts count without raising
+/// `DIAG_CACHE_VALUE_MAX` and the build FAILS rather than the fleet quietly emitting frames whose
+/// tails nobody stores.
+///
+/// The part-A/part-B slot skew that would otherwise worry here is impossible BY CONSTRUCTION: a
+/// continuation is appended into part A's own cache entry, not held in a parallel array, so there
+/// is no second slot to run out of. One `RELAY_CACHE_CAP`, one entry, one record.
+const _: () = assert!(
+    OBS_VALUE_MAX + (DIAG_CONT_PARTS as usize) * CONT_DECLARED_MAX
+        <= crate::net::wifi::DIAG_CACHE_VALUE_MAX + CUT_TAG_MAX,
+    "DIAG_CONT_PARTS exceeds what the crown's diag_cache can hold — raise DIAG_CACHE_VALUE_MAX with \
+     it, or the extra parts are airtime spent on bytes the receiver drops (see #382)"
+);
+
 const _: () = assert!(
     DIAGC_PREFIX.len() + 3 + 1 + CONT_VALUE_MAX + MAC_TRAILER_LEN <= ESP_NOW_MTU,
     "leaf DIAG CONTINUATION frame exceeds the ESP-NOW payload ceiling once the #190 group-MAC \
@@ -3607,7 +3646,6 @@ impl RadioManager {
         // at least be able to tell that it was cut rather than never sent. The crown is unaffected (it
         // self-publishes the full record over MQTT), which is precisely why this hid for so long — the
         // one board anybody looks at is the one that is fine.
-        const CUT_TAG_MAX: usize = 8; // "|cut=999"
         // #190: `OBS_VALUE_MAX`, not `RELAY_VALUE_MAX` — the frame must still fit the MTU *after*
         // `send_to` appends the 9 B group-MAC trailer. Worst case is exact, both branches: cut path
         // 12+3+218+8 = 241, uncut path 12+3+226 = 241, +9 trailer = 250 = `ESP_NOW_MTU`.
@@ -3671,8 +3709,12 @@ impl RadioManager {
                 // is strictly better than a corrupt one. A continuation that begins on a boundary
                 // also needs no partial-field stitching at the receiver — which is the property
                 // that lets the crown APPEND rather than reassemble.
-                let take = if remain > CONT_VALUE_MAX {
-                    match value[off..off + CONT_VALUE_MAX].iter().rposition(|&b| b == b'|') {
+                // The window is the SMALLER of what the frame holds and what the crown keeps —
+                // see `CONT_DECLARED_MAX`. Using the frame limit alone silently truncates at the
+                // receiver, which is the failure this whole change exists to end.
+                let window = CONT_VALUE_MAX.min(CONT_DECLARED_MAX);
+                let take = if remain > window {
+                    match value[off..off + window].iter().rposition(|&b| b == b'|') {
                         // `rposition` is relative to the slice; +0 keeps the boundary `|` at the
                         // START of the NEXT part, so every part begins with a separator exactly
                         // like part A's own fields do.
@@ -3680,7 +3722,7 @@ impl RadioManager {
                         // No separator in the whole window (or one at index 0, which would make no
                         // progress and loop forever). Fall back to the raw cut: a malformed tail
                         // beats a hang, and this is unreachable for a real DIAG record.
-                        _ => CONT_VALUE_MAX,
+                        _ => window,
                     }
                 } else {
                     remain

--- a/rust/clock/src/net/mode.rs
+++ b/rust/clock/src/net/mode.rs
@@ -272,6 +272,42 @@ const STAT_PREFIX: &[u8] = b"SMOLv1 STAT "; // + "NNN" + verbatim "<AppKind>:<pa
 /// Value bounded by `RELAY_VALUE_MAX`.
 const DIAG_PREFIX: &[u8] = b"SMOLv1 DIAG "; // + "NNN" + verbatim "up=.. bt=.. rr=.. …"
 
+/// #382: the CONTINUATION of a leaf DIAG that did not fit one frame — `"SMOLv1 DIAGC "` + `"NNN"`
+/// (sender id) + one ASCII part digit + the next slice of the record, starting ON A FIELD BOUNDARY.
+///
+/// Why a second frame at all. Measured across 64 relayed records (2026-07-28 → 08-26): **not one
+/// leaf DIAG has ever arrived complete**. 43 % of the record is dropped, the loss is growing
+/// 2.6 B/day, and what goes first is the entire PROTECTED tail — `mo=`/`mf=`/`mfk=`, the #190
+/// counters that are unsheddable against the MQTT cliff and destroyed every time by this one. Two
+/// ceilings, one name: a field can be protected against the 495 B publish budget and reliably
+/// destroyed by the 218 B relay cut.
+///
+/// Why N-part rather than a two-part split. Two parts is 436 B of capacity against a 389 B record
+/// growing 2.6 B/day — **~18 days of headroom**, i.e. a fix that expires before it is a year old.
+/// Any FIXED part count has an expiry date; the part digit does not.
+///
+/// PART A IS BYTE-IDENTICAL to what a leaf sends today, `|cut=` and all. That is the whole
+/// compatibility story: HA, the crown relay and every existing parser see exactly what they see
+/// now, so there is no flag day and no rolled-fleet dependency — which `docs/protocol.md`'s OTA2
+/// migration table shows is the expensive kind of change. A receiver that does not know `DIAGC`
+/// ignores it exactly as it ignores any unknown frame.
+///
+/// Byte 7 disambiguates from `SCAN`/`STAT`/`DIAG` the same way those disambiguate from each other;
+/// `DIAGC` shares `DIAG`'s first 12 bytes, so ORDER MATTERS at the parse site — `DIAGC` must be
+/// tried FIRST or `strip_prefix(DIAG_PREFIX)` swallows it and yields a record whose first bytes are
+/// `C<part>`. That is asserted below rather than left to whoever edits the parser next.
+const DIAGC_PREFIX: &[u8] = b"SMOLv1 DIAGC "; // + "NNN" + "<part>" + the next field-boundary slice
+
+/// The DIAGC parse arm must precede the DIAG arm. `DIAG_PREFIX` is a strict prefix of
+/// `DIAGC_PREFIX`, so a parser that tries DIAG first matches every continuation as a malformed
+/// DIAG. This proves the hazard EXISTS at compile time; `parse_frame`'s ordering is what avoids it,
+/// and `experiments/relay_compat` exercises it.
+const _: () = assert!(
+    DIAGC_PREFIX.len() > DIAG_PREFIX.len(),
+    "DIAGC_PREFIX must extend DIAG_PREFIX — if that stops being true the parse-order note below is \
+     no longer describing a real hazard and should be re-derived, not deleted"
+);
+
 /// Bytes of DIAG payload an MQTT publish can carry: the 512 B `pkt` buffer in `wifi.rs`, less the
 /// PUBLISH fixed header + 2 B topic-length prefix, less the longest topic (`smol/255/diag`).
 ///
@@ -380,6 +416,34 @@ const _: () = assert!(
 const _: () = assert!(
     DIAG_PREFIX.len() + 3 + crate::net::wifi::RELAY_VALUE_MAX <= 250,
     "leaf DIAG frame exceeds the ESP-NOW payload ceiling — lower RELAY_VALUE_MAX"
+);
+
+/// #382: a continuation frame carries 1 extra byte of header (the part digit) over a DIAG frame, so
+/// its value ceiling is one lower. Derived rather than written down, because the previous constant
+/// of this kind was hand-summed and drifted (#306).
+const CONT_VALUE_MAX: usize = ESP_NOW_MTU - MAC_TRAILER_LEN - DIAGC_PREFIX.len() - 3 - 1;
+
+/// #382: how many continuation frames a leaf will emit per DIAG cadence.
+///
+/// THE ONE KNOB. It bounds airtime, and — together with the crown-side buffer — it is the whole
+/// cost of this feature. Measured at 1: a 250 B frame per leaf per 60 s cadence is 2,192 us of
+/// airtime in the WORST case (1 Mbps DSSS, long preamble), 15,344 us/min across the fleet, a
+/// 0.0256 % duty cycle. For scale, one leaf mesh-OTA moves ~1 MB through the same radio, so a
+/// continuation is 0.024 % of a single transfer.
+///
+/// Why 1 and not "enough for the whole record": the crown cannot store more than it can publish,
+/// and its `RelayCache` entry is sized to ONE frame. Raising this without raising that produces
+/// frames nobody keeps — airtime spent on data that is dropped at the receiver, which is strictly
+/// worse than not sending it. Raise them together, and see the .bss cost recorded on #382 (a full
+/// 448 B/entry reassembly buffer is +2,592 B, ~30 % of the C3's remaining stack headroom, because
+/// esp-hal takes .bss out of .stack — measured, not assumed).
+const DIAG_CONT_PARTS: u8 = 1;
+
+const _: () = assert!(
+    DIAGC_PREFIX.len() + 3 + 1 + CONT_VALUE_MAX + MAC_TRAILER_LEN <= ESP_NOW_MTU,
+    "leaf DIAG CONTINUATION frame exceeds the ESP-NOW payload ceiling once the #190 group-MAC \
+     trailer is appended — the obvious repair (raise CONT_VALUE_MAX) is the one that overflows the \
+     frame silently, so it is refused here at compile time"
 );
 
 /// #71 observability UPLINK tag: `"SMOLv1 SCAN "` (12 B, trailing space) then `"NNN"` (SENDER id)
@@ -701,6 +765,10 @@ enum Frame<'a> {
     /// the verbatim record bytes (borrow the RX buffer; the GATEWAY caches it in `diag_cache`,
     /// keyed by `src`). Twin of `Stat` but a bigger value → retained `smol/<src>/diag`.
     Diag { src: u8, value: &'a [u8] },
+    /// #382: the next field-boundary slice of a leaf DIAG that did not fit one frame. `part` is
+    /// 1-based (part 0 is the DIAG frame itself), so a receiver can tell "the first continuation"
+    /// from "a continuation I have no part A for" without keeping a sequence number.
+    DiagCont { src: u8, part: u8, value: &'a [u8] },
     /// #71 observability uplink: a node's one-shot WiFi-scan record. Twin of `Diag` (own cache
     /// `scan_cache`) → retained `smol/<src>/scan`.
     Scan { src: u8, value: &'a [u8] },
@@ -2154,7 +2222,7 @@ pub struct RadioManager {
     /// #70/#49 observability (GATEWAY side): per-node relayed DIAG record cache, filled by the
     /// `SMOLv1 DIAG` service arm from node uplinks and republished as retained `smol/<id>/diag`
     /// on each flush (F6 freshness-gated). Twin of `stat_cache` but a bigger value. Unused leaf-side.
-    diag_cache: crate::net::wifi::RelayCache,
+    diag_cache: crate::net::wifi::RelayCache<{ crate::net::wifi::DIAG_CACHE_VALUE_MAX }>,
     /// #71 observability (GATEWAY side): per-node relayed one-shot WiFi-scan cache, twin of
     /// `diag_cache` → retained `smol/<id>/scan`. Unused leaf-side.
     scan_cache: crate::net::wifi::RelayCache,
@@ -3581,6 +3649,68 @@ impl RadioManager {
         }
         self.send_to(&BROADCAST_ADDRESS, &msg[..end]);
         self.relay_wrap_observability(&msg[..end]);
+
+        // ── #382: CONTINUATIONS ────────────────────────────────────────────────────────────────
+        // Everything above is unchanged, deliberately: part A is byte-identical to what a leaf has
+        // always sent, `|cut=` included. Every existing receiver keeps working with no flag day and
+        // no rolled-fleet dependency — the expensive kind of change, per `protocol.md`'s OTA2
+        // migration table. What follows is PURELY ADDITIVE: a receiver that does not know `DIAGC`
+        // ignores these exactly as it ignores any unknown frame, and is left in today's state.
+        //
+        // Measured justification (64 relayed records, 2026-07-28 → 08-26): NOT ONE leaf DIAG has
+        // ever arrived complete. 43 % dropped, growing 2.6 B/day, and the first thing lost is the
+        // PROTECTED tail — `mo=`/`mf=`/`mfk=`, unsheddable against the MQTT cliff and destroyed
+        // every single time by this one. Two ceilings, one word.
+        if value.len() > n {
+            let mut off = n;
+            let mut part: u8 = 1;
+            while off < value.len() && part <= DIAG_CONT_PARTS {
+                let remain = value.len() - off;
+                // Cut on a FIELD BOUNDARY for the same reason part A does: a positional parse
+                // cannot tell a truncated value from a real one, so a short-but-well-formed slice
+                // is strictly better than a corrupt one. A continuation that begins on a boundary
+                // also needs no partial-field stitching at the receiver — which is the property
+                // that lets the crown APPEND rather than reassemble.
+                let take = if remain > CONT_VALUE_MAX {
+                    match value[off..off + CONT_VALUE_MAX].iter().rposition(|&b| b == b'|') {
+                        // `rposition` is relative to the slice; +0 keeps the boundary `|` at the
+                        // START of the NEXT part, so every part begins with a separator exactly
+                        // like part A's own fields do.
+                        Some(i) if i > 0 => i,
+                        // No separator in the whole window (or one at index 0, which would make no
+                        // progress and loop forever). Fall back to the raw cut: a malformed tail
+                        // beats a hang, and this is unreachable for a real DIAG record.
+                        _ => CONT_VALUE_MAX,
+                    }
+                } else {
+                    remain
+                };
+                let cbase = DIAGC_PREFIX.len();
+                let mut cmsg = [0u8; DIAGC_PREFIX.len() + 3 + 1 + CONT_VALUE_MAX];
+                cmsg[..cbase].copy_from_slice(DIAGC_PREFIX);
+                cmsg[cbase] = b'0' + own / 100;
+                cmsg[cbase + 1] = b'0' + (own / 10) % 10;
+                cmsg[cbase + 2] = b'0' + own % 10;
+                cmsg[cbase + 3] = b'0' + part;
+                let cend = cbase + 4 + take;
+                cmsg[cbase + 4..cend].copy_from_slice(&value[off..off + take]);
+                self.send_to(&BROADCAST_ADDRESS, &cmsg[..cend]);
+                self.relay_wrap_observability(&cmsg[..cend]);
+                off += take;
+                part += 1;
+            }
+            if off < value.len() {
+                // The parts budget ran out before the record did. Say so on the serial line rather
+                // than leaving a silent short record — the ENTIRE point of `|cut=` was that a
+                // reader who cannot see a field must at least know it was cut, and that property
+                // must survive the fix for it.
+                log::warn!(
+                    "smol #382: DIAG still short by {} B after {} continuation(s) — raise DIAG_CONT_PARTS or shed a field",
+                    value.len() - off,
+                    DIAG_CONT_PARTS
+                );
+            }
+        }
     }
 
 
@@ -7383,6 +7513,27 @@ impl RadioManager {
                     self.roster.heard(src, Some(leaf_id), rssi, now);
                     label = Some(alloc::string::String::from("stat"));
                 }
+                Some(Frame::DiagCont { src: node_id, part, value }) => {
+                    // #382: the next field-boundary slice of that leaf's record. APPEND rather than
+                    // reassemble — every part begins on a field boundary, so no partial-field
+                    // stitching is needed and the cache never has to hold two halves at once.
+                    //
+                    // `append_cont` REPLACES part A's trailing `|cut=<n>` and re-derives it from
+                    // what is still missing, so `cut=` stops being an epitaph and becomes a
+                    // CHECKSUM: 0 means the reader has the whole record. That was the fitness
+                    // criterion for this change, and it is the one an operator can see.
+                    //
+                    // GATEWAY-only (a leaf hearing another's continuation has no MQTT), and a
+                    // continuation with no part A cached is DROPPED — a slice with no head is a
+                    // record whose field positions are unknown, and guessing at them is how a
+                    // positional parse produces confident nonsense. It self-corrects next cadence.
+                    if self.relay.is_gateway {
+                        self.diag_cache.append_cont(node_id, part, value, now);
+                    }
+                    self.peers.last_hello_ms = now;
+                    self.roster.heard(src, Some(node_id), rssi, now);
+                    label = Some(alloc::string::String::from("diagc"));
+                }
                 Some(Frame::Diag { src: node_id, value }) => {
                     // #70/#49 observability uplink: a node's DIAG record. GATEWAY-only cache (a
                     // leaf hearing another's DIAG ignores it — no MQTT). Buffer the raw record keyed
@@ -7855,6 +8006,23 @@ fn parse_frame(data: &[u8]) -> Option<Frame<'_>> {
         // short/non-digit and guarantees `rest.len() >= 3`, so `&rest[3..]` never panics.
         let src = parse_id(rest)?;
         return Some(Frame::Stat { src, value: &rest[3..] });
+    }
+    // #382 CONTINUATION — MUST be tried BEFORE the DIAG arm below. `DIAG_PREFIX` is a strict
+    // prefix of `DIAGC_PREFIX` ("SMOLv1 DIAG " vs "SMOLv1 DIAGC "), so a parser that tries DIAG
+    // first matches EVERY continuation as a DIAG whose record begins "C<part>" — a well-formed
+    // frame silently decoded as a malformed one, which is the worst shape of parse bug because
+    // nothing errors. The compile-time assert beside `DIAGC_PREFIX` proves the two prefixes still
+    // nest; this ordering is what makes that harmless.
+    if let Some(rest) = data.strip_prefix(DIAGC_PREFIX) {
+        // "NNN<part><slice>": 3-ASCII sender id, ONE ASCII digit part, then the slice. `parse_id`
+        // guarantees `rest.len() >= 3`; the part digit needs its own length check because
+        // `parse_id` knows nothing about the extra byte.
+        let src = parse_id(rest)?;
+        let part = *rest.get(3)?;
+        if !part.is_ascii_digit() {
+            return None; // not our frame shape — refuse rather than guess at an index
+        }
+        return Some(Frame::DiagCont { src, part: part - b'0', value: &rest[4..] });
     }
     if let Some(rest) = data.strip_prefix(DIAG_PREFIX) {
         // #70/#49 observability uplink: "NNN<record>" — 3-ASCII SENDER id then the verbatim

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -2275,16 +2275,35 @@ const RELAY_CACHE_CAP: usize = 12;
 /// (diag + scan). #68 F6 freshness (`entry_fresh`) gates the republish so an off-air leaf's
 /// retained record ages out instead of ghosting.
 #[cfg(feature = "wifi")]
-pub struct RelayCache {
+pub struct RelayCache<const VAL: usize = RELAY_VALUE_MAX> {
     ids: [u8; RELAY_CACHE_CAP],
-    vals: [[u8; RELAY_VALUE_MAX]; RELAY_CACHE_CAP],
+    vals: [[u8; VAL]; RELAY_CACHE_CAP],
     lens: [u16; RELAY_CACHE_CAP],
     last_ms: [u64; RELAY_CACHE_CAP],
     count: usize,
 }
 
+/// #382: the DIAG cache's value width, and THE ONE PLACE the reassembly memory decision lives.
+///
+/// `RELAY_VALUE_MAX` (232) is sized to exactly ONE frame, which is correct for `scan_cache` and
+/// impossible for a DIAG record that arrives in parts — a reassembled record is by definition
+/// larger than one frame. That is the feature, not a bug in the sizing.
+///
+/// ⚠️ THIS IS THE EXPENSIVE CONSTANT, and `.bss` is the expensive currency. `esp-hal` takes `.bss`
+/// growth out of `.stack`, one for one — measured on the same build in PR #530, where an 8 B
+/// arena growth moved `.stack` 73,088 -> 73,080. The C3's remaining stack headroom is 8,605 B, so
+/// every 12 bytes added here costs 144 B of it (`RELAY_CACHE_CAP` = 12).
+///
+///   360 (this)  = part A (<= OBS_VALUE_MAX 226) + one ~128 B continuation   -> +1,536 B .bss
+///   448         = enough for the whole 389 B record measured 2026-08-26     -> +2,592 B (~30 %)
+///
+/// 360 is chosen to hold part A plus ONE continuation, matching `DIAG_CONT_PARTS`. Raise the two
+/// TOGETHER or not at all: more parts than the cache can hold is airtime spent on data the
+/// receiver drops, which is strictly worse than not sending it.
+pub const DIAG_CACHE_VALUE_MAX: usize = 360;
+
 #[cfg(feature = "wifi")]
-impl RelayCache {
+impl<const VAL: usize> RelayCache<VAL> {
     // Like `CfgCache`, these are called only by the espnow gateway (`RadioManager`); a
     // wifi-only build (no `RadioManager`) leaves `new`/`set`/`count` unused → allow dead_code
     // so the clippy gate stays clean in every profile.
@@ -2292,18 +2311,74 @@ impl RelayCache {
     pub const fn new() -> Self {
         Self {
             ids: [0; RELAY_CACHE_CAP],
-            vals: [[0; RELAY_VALUE_MAX]; RELAY_CACHE_CAP],
+            vals: [[0; VAL]; RELAY_CACHE_CAP],
             lens: [0; RELAY_CACHE_CAP],
             last_ms: [0; RELAY_CACHE_CAP],
             count: 0,
         }
     }
 
+    /// #382: append a CONTINUATION slice to leaf `id`'s cached record.
+    ///
+    /// Append, not reassemble — every continuation begins on a field boundary (the sender's
+    /// `rposition('|')`), so there is no partial field to stitch and the cache never holds two
+    /// halves at once. That property is what keeps this a memcpy instead of a state machine.
+    ///
+    /// `cut=` STOPS BEING AN EPITAPH AND BECOMES A CHECKSUM. Part A carries `|cut=<dropped>`; this
+    /// strips it, appends the slice, and re-derives the tag from what is STILL missing. A reader
+    /// seeing `|cut=0` knows it has the whole record — which is the fitness criterion this change
+    /// was approved against, and the one an operator can actually see. The instrument that reported
+    /// the bug becomes the one that proves the fix.
+    ///
+    /// Refuses, rather than guesses, in three cases:
+    ///   * no entry for `id` — a slice with no head is a record whose field POSITIONS are unknown,
+    ///     and a positional parse fed a headless tail produces confident nonsense. Self-corrects
+    ///     next cadence.
+    ///   * `part != 1` — only the first continuation is supported while `DIAG_CONT_PARTS == 1`.
+    ///     A part 2 arriving means sender and receiver disagree about the budget, and appending it
+    ///     out of order would corrupt a record that is merely short.
+    ///   * the cached record has no `|cut=` tag — then it was never truncated, so a continuation
+    ///     for it is not ours to apply.
+    #[allow(dead_code)]
+    pub fn append_cont(&mut self, id: u8, part: u8, value: &[u8], now: u64) {
+        if part != 1 {
+            return;
+        }
+        let Some(i) = (0..self.count).find(|&i| self.ids[i] == id) else {
+            return; // continuation with no part A — see the doc comment
+        };
+        let len = self.lens[i] as usize;
+        // Locate the trailing `|cut=<n>` written by `broadcast_diag`. Searching from the END and
+        // requiring it to be the LAST field is deliberate: `cut=` is appended last by construction,
+        // and matching an earlier occurrence would truncate a real record at a coincidence.
+        let cur = &self.vals[i][..len];
+        let Some(tag_at) = crate::net::wire::find_last_cut(cur) else {
+            return; // not a truncated record — nothing to continue
+        };
+        let dropped: usize = crate::net::wire::parse_cut(&cur[tag_at..]).unwrap_or(0);
+        let take = value.len().min(VAL - tag_at);
+        self.vals[i].copy_within(0..tag_at, 0); // no-op; kept explicit for the reader
+        self.vals[i][tag_at..tag_at + take].copy_from_slice(&value[..take]);
+        let mut end = tag_at + take;
+        // Re-derive the tag from what is STILL missing. Saturating: a sender that shipped MORE than
+        // it said it dropped yields 0, which is the honest answer ("nothing is missing"), not a
+        // wrapped huge number.
+        let still = dropped.saturating_sub(take);
+        let mut tag = [0u8; 8];
+        let tlen = crate::net::wire::write_cut(&mut tag, still);
+        if end + tlen <= VAL {
+            self.vals[i][end..end + tlen].copy_from_slice(&tag[..tlen]);
+            end += tlen;
+        }
+        self.lens[i] = end as u16;
+        self.last_ms[i] = now;
+    }
+
     /// Upsert leaf `id`'s record (truncated to `RELAY_VALUE_MAX`), stamping `now` for the F6
     /// freshness gate. A full cache drops the entry and logs it (no silent cap).
     #[allow(dead_code)]
     pub fn set(&mut self, id: u8, value: &[u8], now: u64) {
-        let n = value.len().min(RELAY_VALUE_MAX);
+        let n = value.len().min(VAL);
         for i in 0..self.count {
             if self.ids[i] == id {
                 self.vals[i][..n].copy_from_slice(&value[..n]);
@@ -2662,7 +2737,7 @@ async fn mqtt_session(
     // #70/#49: `Some` on a GATEWAY flush → after publishing THIS node's own diag, republish each
     // CACHED relayed-node DIAG record as retained `smol/<id>/diag` (leaves have no MQTT). F6
     // freshness-gated (an off-air node ages out, no ghost). `None` off-gateway. Read-only.
-    diag_cache: Option<&RelayCache>,
+    diag_cache: Option<&RelayCache<DIAG_CACHE_VALUE_MAX>>,
     // #71: this node's OWN one-shot WiFi-scan record → retained `smol/<node_id>/scan`. Empty ⇒
     // skipped (the common case — a scan is only produced when a `W` command fired). Twin of `diag`.
     scan: &[u8],
@@ -5163,7 +5238,7 @@ pub async fn run_mqtt_burst(
     // #70/#49: this node's own DIAG record → retained `smol/<id>/diag` (empty ⇒ none; see `mqtt_session`).
     diag: &[u8],
     // #70/#49: `Some` on a gateway flush → republish cached relayed diags (see `mqtt_session`); `None` otherwise.
-    diag_cache: Option<&RelayCache>,
+    diag_cache: Option<&RelayCache<DIAG_CACHE_VALUE_MAX>>,
     // #71: this node's own one-shot WiFi-scan record → retained `smol/<id>/scan` (empty ⇒ none).
     scan: &[u8],
     // #71: `Some` on a gateway flush → republish cached relayed scans; `None` otherwise.

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -2302,6 +2302,14 @@ pub struct RelayCache<const VAL: usize = RELAY_VALUE_MAX> {
 /// receiver drops, which is strictly worse than not sending it.
 pub const DIAG_CACHE_VALUE_MAX: usize = 360;
 
+/// A widening that does not widen is a feature that silently does nothing: if this is ever set at
+/// or below one frame, `append_cont` has no room and every continuation is dropped while the code
+/// still looks present. Refused at compile time rather than discovered on a bench.
+const _: () = assert!(
+    DIAG_CACHE_VALUE_MAX > RELAY_VALUE_MAX,
+    "DIAG_CACHE_VALUE_MAX must exceed one frame or #382's continuations have nowhere to land"
+);
+
 #[cfg(feature = "wifi")]
 impl<const VAL: usize> RelayCache<VAL> {
     // Like `CfgCache`, these are called only by the espnow gateway (`RadioManager`); a

--- a/rust/clock/src/net/wifi.rs
+++ b/rust/clock/src/net/wifi.rs
@@ -2347,6 +2347,13 @@ impl<const VAL: usize> RelayCache<VAL> {
     ///     out of order would corrupt a record that is merely short.
     ///   * the cached record has no `|cut=` tag — then it was never truncated, so a continuation
     ///     for it is not ours to apply.
+    ///
+    /// ⚠️ `espnow`-GATED, and the gate is load-bearing rather than tidy. `RelayCache` is a `wifi`
+    /// item, but `net::wire` — where the `|cut=` helpers live — is `espnow`-gated (`net.rs:97`),
+    /// so a wifi-only build has no `wire` and this method would not compile. That is the correct
+    /// shape and not a workaround: a continuation is a MESH frame, so a build with no mesh has
+    /// nothing to continue. CI caught it as 12 red tiers; see the commit message for why I did not.
+    #[cfg(feature = "espnow")]
     #[allow(dead_code)]
     pub fn append_cont(&mut self, id: u8, part: u8, value: &[u8], now: u64) {
         if part != 1 {

--- a/rust/clock/src/net/wire.rs
+++ b/rust/clock/src/net/wire.rs
@@ -553,3 +553,54 @@ pub fn should_group_mac(frame: &[u8]) -> bool {
         && !is_ota_family(frame)
         && frame.len() + MAC_TRAILER_LEN <= ESP_NOW_MTU
 }
+
+// ── #382 `|cut=` tag helpers ───────────────────────────────────────────────────────────
+// Pure byte functions, so they live HERE rather than in `net/wifi.rs` where they are used:
+// this module is the dep-free, host-includable codec (`experiments/relay_compat` and
+// `mac_verify` `#[path]`-include it), and a continuation format I cannot test on hardware
+// is one I want a host verifier to exercise byte-for-byte. Putting them next to their
+// caller would have made them untestable off-target — the same coupling #367 guards.
+/// #382: byte offset of the trailing `|cut=` field, or `None`. Scans from the end because the tag
+/// is appended last by construction — matching an earlier `|cut=` would cut a real record at a
+/// coincidence, and a DIAG record is attacker-influenced only in the sense that any peer can
+/// broadcast one, so "coincidence" is not a purely theoretical worry.
+pub fn find_last_cut(rec: &[u8]) -> Option<usize> {
+    const TAG: &[u8] = b"|cut=";
+    if rec.len() < TAG.len() {
+        return None;
+    }
+    (0..=rec.len() - TAG.len()).rev().find(|&i| &rec[i..i + TAG.len()] == TAG)
+}
+
+/// Parse the decimal after `|cut=`. Returns `None` on a malformed tag rather than a default, so the
+/// caller can decline to touch a record it does not understand.
+pub fn parse_cut(tag: &[u8]) -> Option<usize> {
+    let digits = tag.get(5..)?;
+    if digits.is_empty() || !digits.iter().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    digits.iter().fold(Some(0usize), |acc, b| {
+        acc?.checked_mul(10)?.checked_add((b - b'0') as usize)
+    })
+}
+
+/// Write `|cut=<n>` into `out` (max 8 bytes: the tag plus 3 digits, matching `CUT_TAG_MAX`),
+/// returning the length. `n` is clamped to 999 exactly as `broadcast_diag` clamps it, so the two
+/// ends of the protocol cannot disagree about the field's width.
+pub fn write_cut(out: &mut [u8; 8], n: usize) -> usize {
+    out[..5].copy_from_slice(b"|cut=");
+    let n = n.min(999);
+    if n >= 100 {
+        out[5] = b'0' + (n / 100) as u8;
+        out[6] = b'0' + ((n / 10) % 10) as u8;
+        out[7] = b'0' + (n % 10) as u8;
+        8
+    } else if n >= 10 {
+        out[5] = b'0' + (n / 10) as u8;
+        out[6] = b'0' + (n % 10) as u8;
+        7
+    } else {
+        out[5] = b'0' + n as u8;
+        6
+    }
+}

--- a/rust/clock/src/net/wire.rs
+++ b/rust/clock/src/net/wire.rs
@@ -579,9 +579,12 @@ pub fn parse_cut(tag: &[u8]) -> Option<usize> {
     if digits.is_empty() || !digits.iter().all(|b| b.is_ascii_digit()) {
         return None;
     }
-    digits.iter().fold(Some(0usize), |acc, b| {
-        acc?.checked_mul(10)?.checked_add((b - b'0') as usize)
-    })
+    // `try_fold`, not `fold` over an Option: clippy's `manual_try_fold` refuses the latter under
+    // `-D warnings`, and it is right — the short-circuit is the point, and spelling it with `?`
+    // inside a `fold` hides that the accumulator can abandon early.
+    digits
+        .iter()
+        .try_fold(0usize, |acc, b| acc.checked_mul(10)?.checked_add((b - b'0') as usize))
 }
 
 /// Write `|cut=<n>` into `out` (max 8 bytes: the tag plus 3 digits, matching `CUT_TAG_MAX`),

--- a/tools/symbol-sizes.espnow-cast-io.txt
+++ b/tools/symbol-sizes.espnow-cast-io.txt
@@ -7,12 +7,12 @@
 # source diff and no compiler complaint, so review had nothing to look at.
 #
 # Do NOT hand-edit. Re-bless, and explain the delta in the commit message.
-# 34 symbols, 194994 bytes total.
+# 34 symbols, 196530 bytes total.
 #
 # size	section	symbol
 960	.data	TxRxCxt
 2008	.bss	_RNvCs*_7esp_phy9PHY_STATE
-17232	.bss	_RNvNCNvNtNtCs*_5clock3net4mode5start05RADIO
+18768	.bss	_RNvNCNvNtNtCs*_5clock3net4mode5start05RADIO
 4096	.bss	_RNvNCNvNtNtCs*_5clock3net4wifi13run_ota_fetch010OTA_TCP_RX
 512	.bss	_RNvNCNvNtNtCs*_5clock3net4wifi13run_ota_fetch010OTA_TCP_TX
 4096	.bss	_RNvNtCs*_5clock3ota12OTA_READBACK


### PR DESCRIPTION
**Not one leaf DIAG has ever arrived complete.** 64 relayed records, 2026-07-28 → 08-26: **43 % of the record dropped**, loss growing **2.6 B/day**, and what goes first is the entire **protected tail** — `mo=`/`mf=`/`mfk=`, unsheddable against the 495 B MQTT cliff and destroyed every single time by the 218 B relay cut. **Two ceilings, one word:** a field can be protected against one and reliably destroyed by the other.

## Design (as ruled)

**N-part on the wire, one *declared* continuation in the crown.** The wire format is open-ended (part digit, no fixed count); the crown buffers one continuation whose payload is a **named field set** — the protected tail plus `elect=` and the positional fields that fall past part A's cut.

> **The wire decision and the memory decision get separated, which is what makes the expensive half deferrable.**

Full reassembly stays reachable as a **buffer-size change, not a protocol change**.

**Why not two-part:** 436 B of capacity against a 389 B record growing 2.6 B/day is **~18 days of headroom** — a fix that expires before it is a month old. Any *fixed* part count has an expiry date; a part digit does not.

**Part A is byte-identical**, `|cut=` included. HA, the crown relay, every existing parser see exactly what they see today — **no flag day, no rolled-fleet dependency**, which `protocol.md`'s OTA2 migration table shows is the expensive kind of change. A receiver that doesn't know `DIAGC` ignores it as it ignores any unknown frame.

**`cut=` stops being an epitaph and becomes a checksum.** The crown strips part A's tag, appends, and re-derives it from what is *still* missing. **`|cut=0` means you have the whole record** — the instrument that reported the bug is the one that proves the fix.

## Pricing basis — `.bss` is the expensive currency, measured not assumed

PR #530 grew the embassy arena **+8 B** and the canonical ELF's `.stack` fell **73,088 → 73,080 — by exactly 8**, same build, same run. `esp-hal` takes `.bss` out of `.stack`, 1:1. C3 headroom is **8,605 B**.

| option | `.bss` | |
|---|---|---|
| **`DIAG_CACHE_VALUE_MAX = 360`** (part A + one declared continuation) | **+1,536 B** | **this PR — ~18 %** |
| 448 B/entry (full reassembly of the measured 389 B record) | +2,592 B | ~30 % |

`RelayCache` is now generic over its value width; **`scan_cache` keeps the one-frame default** and only `diag_cache` widens. The primary use case pays its own freight: **#511's battery telemetry adds leaf DIAG fields, which at 43 % positional loss would be cut on arrival by construction** — continuations are its delivery path.

## Three enforcement details

**1. Parse order is load-bearing, and asserted.** `DIAG_PREFIX` is a **strict prefix** of `DIAGC_PREFIX`, so a parser trying DIAG first matches *every* continuation as a DIAG whose record begins `C<part>` — **a well-formed frame silently decoded as a malformed one, the worst shape of parse bug because nothing errors.** The DIAGC arm goes first; a compile-time assert proves the prefixes still nest so the note can't quietly stop being true.

**2. The pairing is enforced, not documented.**

```
OBS_VALUE_MAX + DIAG_CONT_PARTS * CONT_DECLARED_MAX <= DIAG_CACHE_VALUE_MAX + CUT_TAG_MAX
```

Raise the parts count without raising the cache and the **build fails**. Sabotage-proved: `DIAG_CONT_PARTS = 2` → `E0080` with its own message.

*On the CAP ruling:* the part-A/part-B **slot skew is impossible by construction**, not by assertion — a continuation is appended into part A's *own* cache entry, not a parallel array. One `RELAY_CACHE_CAP`, one entry, one record. Recorded beside the assert so nobody adds an equality check with nothing to compare.

**3. A bug in my own first draft, found implementing the ruling.** The sender bounded continuations by what the **frame** holds (224 B); the crown can only keep **134 B** after part A. A full-frame continuation was **silently truncated at the receiver** — positional loss reintroduced at the exact place this change removes it, invisible because the frame was well-formed. `CONT_DECLARED_MAX` is now *derived from what the crown can keep*, and the sender's window is `min(frame, declared)`. **Byte-granularity form of the same rule: never emit what the other end cannot keep — airtime spent on data dropped on arrival is worse than not sending it, because it also looks like it worked.**

## Airtime (approval condition, measured before any code)

One 250 B frame per leaf per **60 s** `DIAG_CADENCE_MS` — leaf-only; crowns self-publish via the flush. *(My proposal originally said "per 30 s flush"; that's the gateway timer. The real cost is 4× smaller.)*

| PHY | fleet/min | duty |
|---|---|---|
| 1 Mbps DSSS, long preamble (worst) | 15,344 µs | **0.0256 %** |
| 24 Mbps OFDM | 723 µs | 0.0012 % |

One leaf mesh-OTA moves ~1 MB through the same radio, so a continuation is **0.024 % of one transfer**.

## Tested where it can be

The `|cut=` helpers are pure byte functions, so they live in **`net/wire.rs`** — the dep-free host-includable codec — rather than beside their caller in `net/wifi.rs`, which would have made them untestable off-target (the #367 coupling, applied deliberately this time). `experiments/relay_compat` now round-trips every tag width **including the 6/7/8-byte length boundaries**, asserts the 999 clamp matches `broadcast_diag`'s `dropped.min(999)` (disagreement there corrupts the record rather than merely mis-stating it), and pins `find_last_cut` to the **last** occurrence.

⚠️ **That last arm was wrong at first.** Sabotaging `find_last_cut` to take the FIRST occurrence left the suite **green** — my fixture's decoy was `|note=cut=here`, which contains no `|cut=` at all, so the record had exactly one match and **the arm tested nothing.** Fixed to two genuine `|cut=` fields; both sabotages now fail for the right reason. **A test written to check a property does not automatically check it — the fixture has to contain the thing.**

## ⚠️ Host-green is NOT proven — the witness is scheduled, not skipped

This is a **mesh wire-format change** and I have no flash authority; familiar is down. `gate.sh host` is GREEN and `relay_compat` covers the byte contract, but **neither is evidence that a leaf and a crown agree over the air.**

**Bench witness, pre-approved for the first post-roll window:**
1. a leaf's `|cut=` reaching **0** on a reassembled record;
2. **`mo=`/`mf=`/`mfk=` arriving at HA from a leaf for the first time** — simultaneously #382's proof and **#190's Wave-1 unblock**.

Refs #382, #190, #306, #471, #511, #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)