### PR TITLE
ci(#533): run the 403 s OTA-verify suite where it is affordable — and say so loudly when it is skipped

### DIFF
--- a/.github/workflows/fw-gate.yml
+++ b/.github/workflows/fw-gate.yml
@@ -74,6 +74,27 @@ jobs:
           key: host
       - run: tools/gate.sh host
 
+  # #533: the OTA-verify suite gets its OWN job rather than riding inside `gate.sh host`.
+  #
+  # Measured: the suite is 403 s; the host job is 161 s and the slowest job today is 214 s. Folding
+  # it into `host` would take that job to ~564 s and make PR feedback 2.6x slower FOR EVERY PR,
+  # including the ones that touch nothing it guards. As its own job it runs in PARALLEL, so the
+  # wall-clock cost is 403 s instead of 564 s, the fast signals still arrive in ~3 minutes, and a
+  # failure names itself instead of being one red line inside a nine-minute log.
+  #
+  # It invokes the suite directly rather than through `gate.sh`, which is the one place this
+  # workflow's "every actual command lives in tools/gate.sh" rule is deliberately not followed: the
+  # gate's arms are what a developer runs before pushing, and this one is explicitly the arm that is
+  # too slow for that. `gate.sh` still runs it under SMOL_GATE_SLOW=1 for anyone touching
+  # `ota_verify.sh`, and prints a loud SKIP line otherwise so nobody mistakes absence for a pass.
+  ota_verify:
+    name: OTA-verify suite (#533)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - run: tools/test_ota_verify.sh
+
   firmware:
     name: tiers + clippy + stack floor
     runs-on: ubuntu-latest

--- a/tools/gate.sh
+++ b/tools/gate.sh
@@ -927,9 +927,12 @@ if [ "$run_host" = 1 ]; then
   # these guard tools/ota_publish.sh, which is the one script here that can arm the whole fleet.
   #
   # Deliberately NOT wired, with reasons, so the remainder is a declared gap and not an oversight:
-  #   • test_ota_verify.sh      — hermetic but slow (>2 min, replays canned MQTT logs). Not wired
-  #     because I did not watch it run to completion, and wiring a suite on the strength of its own
-  #     header comment is the inference this file exists to refuse. Worth a follow-up.
+  #   • test_ota_verify.sh      — hermetic, and MEASURED: 403 s, 204 assertions, 0 failed (#533).
+  #     It IS wired now, but only under SMOL_GATE_SLOW (see the step below). The previous note here
+  #     said "not wired because I did not watch it run to completion" — that was the right reason
+  #     and it has been discharged: someone watched it. Replaced with the measurement rather than
+  #     left standing, because a stale REASON is worse than none — it stops the next person
+  #     re-examining a decision whose premise has already moved.
   #   • test_ha_deploy_guard.sh — MUST NOT be wired. It commits with `git commit -am` by design and
   #     is built for a scratch clone; running it in a checkout with work in it creates junk commits
   #     (it has already done so here once). Its refusal to run in a working tree IS the guard.
@@ -943,6 +946,30 @@ if [ "$run_host" = 1 ]; then
       printf '%s\n' "$out" | sed 's/^/        /'; bad "$_t"
     fi
   done
+
+  # #533: the OTA-verify suite — 204 assertions over `tools/ota_verify.sh`, which is what answers
+  # "is the artifact we are about to flash the artifact this commit builds?" (the #44/#326
+  # reproducibility contract). It was measured at 403 s: hermetic, no network, no board, leaves the
+  # tree byte-unchanged — and 2-3x the whole rest of this arm.
+  #
+  # SO IT IS OPT-IN, and the reason is about human behaviour rather than correctness. `gate.sh` is
+  # the thing a developer runs verbatim before pushing; a seven-minute gate is one people start
+  # skipping, and A SKIPPED GATE IS WORTH LESS THAN NO GATE, because everyone believes it ran. CI
+  # sets SMOL_GATE_SLOW=1, where the time is already being spent on the fw build, so the assertions
+  # run on every PR without taxing every local push.
+  if [ "${SMOL_GATE_SLOW:-0}" = "1" ]; then
+    step "OTA-verify regression suite (#533 — 204 assertions, ~403 s, SMOL_GATE_SLOW)"
+    if out=$("$ROOT/tools/test_ota_verify.sh" 2>&1); then
+      printf '%s\n' "$out" | tail -1; ok "test_ota_verify"
+    else
+      printf '%s\n' "$out" | sed 's/^/        /'; bad "test_ota_verify"
+    fi
+  else
+    # SAY that it was skipped. A silently-absent check reads identically to a passing one, which is
+    # the failure this file exists to refuse — the same argument as the #400 note above.
+    printf '\n\033[1m── OTA-verify regression suite (#533)\033[0m\n'
+    printf '   \033[33mSKIP\033[0m  204 assertions not run — set SMOL_GATE_SLOW=1 (~403 s). CI runs them.\n'
+  fi
 
   # #390: the offline half of the symbol-size guard. The fw arm runs the checker against a real
   # ELF; this proves the PARSE/NORMALISE/COMPARE logic can fail, using a committed real slice of


### PR DESCRIPTION
**204 assertions over `tools/ota_verify.sh` have never once been run.** That script answers *"is the artifact we are about to flash the artifact this commit builds?"* — the #44/#326 reproducibility contract. #400's audit declared the gap; this closes it.

## The stale reason is replaced, not left standing

`gate.sh` said:

> not wired **because I did not watch it run to completion**, and wiring a suite on the strength of its own header comment is the inference this file exists to refuse.

That was exactly right, and it has been **discharged** — someone watched it:

```
$ time tools/test_ota_verify.sh
204 passed · 0 failed
rc=0   elapsed=403s
```

Hermetic (no network, no board, replays canned logs), tree byte-unchanged. **A stale *reason* is worse than no reason** — it stops the next person re-examining a decision whose premise has already moved.

## But the cost is real, and the local gate pays it

403 s is **2–3× the rest of the host arm**, and `gate.sh` is explicitly what a developer runs verbatim before pushing. **A seven-minute gate is one people start skipping, and a skipped gate is worth less than no gate, because everyone believes it ran.**

So locally it is **opt-in**: `SMOL_GATE_SLOW=1`, for anyone touching `ota_verify.sh`.

## The skip is loud

An absent check reads identically to a passing one — the failure this file exists to refuse. The unset path prints:

```
── OTA-verify regression suite (#533)
   SKIP  204 assertions not run — set SMOL_GATE_SLOW=1 (~403 s). CI runs them.
```

And the enable is pinned to the **literal `1`**. Unset, `0`, and even `SMOL_GATE_SLOW=yes` all skip — **a truthy-*looking* value must not silently arm a seven-minute step.**

## CI gets its own job — measured, not assumed

I first wired `SMOL_GATE_SLOW=1` onto the existing `host` job. Then I measured:

| job | duration |
|---|---|
| host verifier suites | **161 s** |
| tiers + clippy + stack floor | 153 s |
| tier exclusions (#351) | **214 s** ← today's critical path |

Folding 403 s into `host` takes it to **~564 s** and makes PR feedback **2.6× slower for every PR** — including every PR that touches nothing this suite guards. As a **parallel job** the wall clock is 403 s instead of 564 s, the fast signals still land in ~3 minutes, and **a failure names itself** instead of being one red line inside a nine-minute log.

That job invokes the suite **directly**, which is the one place this workflow's *"every actual command lives in `tools/gate.sh`"* rule is deliberately not followed — and the rule's own purpose is the reason: the gate's arms are what a developer runs before pushing, and **this is precisely the arm that is too slow for that.** Recorded in the yml so it reads as a decision rather than a lapse.

## Verification — both directions

| | result |
|---|---|
| default (unset) | `SKIP  204 assertions not run…` + **GATE GREEN** |
| `SMOL_GATE_SLOW=1` | `PASS test_ota_verify` + **GATE GREEN** (the full 403 s run) |
| branch exercised for unset / `0` / `1` / `yes` | only `1` enables |

`main` has no branch protection, so the new job **cannot silently become a required check** — it reports, it doesn't gate, until someone chooses otherwise.

Refs #533, #400, #44, #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)