### PR TITLE
fix(ha): qualify the mac-fail label — it was true in the repo and false on the fleet

### DIFF
--- a/ha/packages/smol_telemetry.yaml
+++ b/ha/packages/smol_telemetry.yaml
@@ -108,7 +108,21 @@ mqtt:
     # BENIGN class. A non-zero, climbing value here is EXPECTED on a mixed fleet and is not a
     # fault — see the #471 note above. `startswith('mf=')` does NOT match `mfk=` ("mfk" != "mf="),
     # verified rather than assumed, so this picker is unchanged by the split.
-    - name: "smol 8 mac fail (unkeyed, benign)"
+    #
+    # ⚠ THE QUALIFIER IN THE NAME IS LOAD-BEARING UNTIL THE FLEET CATCHES UP. A DIAG key's MEANING
+    # lives in firmware; its LABEL lives here; and the two ship on completely different cadences —
+    # a canary plus a fleet roll versus a config reload. So a rename in the FAST artifact silently
+    # reinterprets data produced by the SLOW one.
+    #
+    # That is not hypothetical: build 1447 was staged from a commit that PREDATES #471
+    # (`git merge-base --is-ancestor 4639e0c d1c1da5` → false), so on the fleet as rolled, `mf=`
+    # is still the five-cause fold. Calling it "benign" without the qualifier would put a genuine
+    # wrong-key or bad-tag event under a tile that dismisses it — the exact inversion of what the
+    # split is for.
+    #
+    # RETIRE THE QUALIFIER once every member reports a build >= the first #471 image; at that point
+    # it is merely redundant rather than wrong, which is the right direction for a caveat to age.
+    - name: "smol 8 mac fail (unkeyed, benign — on builds ≥ #471)"
       unique_id: smol_8_mac_fail_mirror
       state_topic: "smol/8/diag"
       entity_category: diagnostic


### PR DESCRIPTION
Ruling (b) on the mislabel I introduced in #528. The roll is complete (3/3 on `1447`), so this no longer touches a live rollout.

## The defect

#528 relabelled the sensor to **`mac fail (unkeyed, benign)`**. Correct for firmware carrying #471's split — **wrong for the fleet as it actually runs.**

```
$ git merge-base --is-ancestor 4639e0c d1c1da5      # → false
    d1c1da5   17:30   the pinned stage tip for 1447
    4639e0c   18:45   #471's mac_fail split
```

**Build `1447` predates #471.** So on the rolled fleet `mf=` is still the five-cause fold, and a genuine wrong-key or bad-tag event lands under a tile that says **benign**. That **points the wrong way** — it makes an *actionable* event look dismissible, the precise inversion of what #471 exists to remove. I caused it by renaming to match the repo while the fleet had not caught up.

## The fix

`mac fail (unkeyed, benign — on builds ≥ #471)` — **true on both firmwares**, so it needs no re-edit when the fleet advances. The qualifier retires at the next roll, at which point it is merely *redundant* rather than *wrong*. **That is the right direction for a caveat to age.**

## The general shape — recorded in the YAML, not just here

Deliberately placed beside the label, because the next person to rename a DIAG key will be reading that file and not this PR:

> A DIAG key's **meaning** lives in firmware; its **label** lives in HA; the two ship on completely different cadences — a canary plus a fleet roll versus a config reload. **A rename in the fast artifact silently reinterprets data produced by the slow one.**

**Rule:** a label change that reinterprets an existing field must either *name the firmware it assumes*, or *ship no earlier than the build that makes it true*.

The sibling `mac fail keyed` sensor already satisfies the second form — it defaults to `unknown`, never `0`, so *"this build predates #471"* cannot be misread as *"zero forgery attempts."* This brings its twin up to the same standard.

## Provenance

Found by checking the stage's ancestry **during the roll**, against my own rename — the divergence was introduced and caught inside the hour. Cross-referenced on #471 with the firmware-dependency note.

Verified: `tools/status_check.sh` rc=0; YAML parses; the replaced name matched exactly once (asserted in the edit, so a silent no-op was impossible).

Refs #471, #528, #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)