### PR TITLE
fix(ota): #517 — per-chip MAX_IMAGE_SIZE (an S3 fleet image can use its 6 MiB slot)

### DIFF
--- a/rust/clock/src/ota.rs
+++ b/rust/clock/src/ota.rs
@@ -107,9 +107,26 @@ fn host_allowed(host: &str) -> bool {
     matches!(cfg.and_then(|c| c.ota_host), Some(ovr) if parse_ipv4(host) == Some(ovr))
 }
 
-/// Max image = one app slot (`ota_0`/`ota_1` size from `partitions-ota.csv`). An
-/// announce larger than this is refused before any flash op; also cross-checked vs
-/// the HTTP `Content-Length`.
+/// Max image = one app slot (`ota_0`/`ota_1`), and it is a **per-chip** fact,
+/// not a fleet constant (#517). The C3's `partitions-ota.csv` slot is
+/// `0x1F_0000` (1,984 KiB); the S3's `partitions-ota-s3.csv` slot is
+/// `0x60_0000` (6,144 KiB). One shared `0x1F_0000` capped every S3 fleet image
+/// at the C3's ceiling despite the S3 having 3× the slot — refused at the
+/// announce gate before flash geometry was ever consulted (found staging the
+/// #495 canary; the same chip-scoped-as-scalar shape as the #349 descriptor).
+///
+/// cfg'd on the chip because the gate runs at announce time (no partition read
+/// yet) and the chip implies the board class in the fleet today — the same
+/// grain as `sensors::BattGpio` and the S3 panel arm. When a second board on a
+/// chip has a different table, this becomes a runtime read of the OWN slot at
+/// boot; until then a per-chip const is honest and the announce gate stays
+/// allocation-free.
+///
+/// An announce larger than this is refused before any flash op; also
+/// cross-checked vs the HTTP `Content-Length`.
+#[cfg(feature = "esp32s3")]
+pub const MAX_IMAGE_SIZE: u32 = 0x60_0000;
+#[cfg(not(feature = "esp32s3"))]
 pub const MAX_IMAGE_SIZE: u32 = 0x1F_0000;
 
 /// Streaming chunk cap. The ESP32-C3 has ~400 KB SRAM vs a ~600 KB image, so the


### PR DESCRIPTION
Closes #517. One of #518's four cross-chip-serve components — and the one that was a standalone bug in its own right.

**The defect:** `MAX_IMAGE_SIZE = 0x1F_0000` (the C3's 1,984 KiB slot) was a single fleet-wide const, but it's a **per-chip** fact. The S3's `partitions-ota-s3.csv` slots are 6,144 KiB each, yet an S3 fleet image was refused at the announce gate the instant it grew past the C3's ceiling — before flash geometry was ever consulted. Found while staging the #495 canary; the same chip-scoped-fact-baked-as-a-scalar shape as the #349 descriptor.

**The fix:** cfg on the chip — `esp32s3 → 0x60_0000`, else `0x1F_0000`. The gate runs at announce time (no partition read yet) and the chip implies the board class in the fleet today (same grain as `sensors::BattGpio` and the S3 panel arm), so a per-chip const is both honest and allocation-free. When a second board on a chip has a different table, this becomes a boot-time read of the own slot; noted at the const, not silently absent.

**Both consumers inherit it:** the announce gate (`ota.rs::gate`) and the mesh-leaf size check (`ota_mesh.rs`). DIAG width bound unaffected (6.29M and 2.03M are both 7 digits).

**Verified:** C3 tier `cargo check --features espnow,cast,io` green; S3 `esp32s3,espnow,cast,io` release build green.

The crown's slot-sourced serve keeps the same implicit bound until the windowed serve lands — tracked on #518, not silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)